### PR TITLE
feat: add Tailscale network support with env-based config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,7 @@ dependencies = [
  "axum",
  "core-engine",
  "core-service",
+ "dotenvy",
  "futures-util",
  "infra",
  "sea-orm-migration",

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,12 @@
+# Runtime environment: development | production
+# In production, CORS_ORIGIN must be explicitly set
+# RUST_ENV=production
+
+# Server bind address
+SERVER_HOST=0.0.0.0
+SERVER_PORT=8080
+
+# CORS allowed origins
+# Use "*" to allow all origins (dev only), or comma-separated list:
+# CORS_ORIGIN=https://atmos.example.com,https://app.example.com
+CORS_ORIGIN=*

--- a/apps/api/Cargo.toml
+++ b/apps/api/Cargo.toml
@@ -23,3 +23,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 futures-util = "0.3"
 uuid = { version = "1.0", features = ["v4"] }
 sea-orm-migration = "1.1"
+dotenvy = "0.15"

--- a/apps/api/src/config/mod.rs
+++ b/apps/api/src/config/mod.rs
@@ -1,1 +1,78 @@
-// Configuration module - reserved for future use
+use std::env;
+use std::net::SocketAddr;
+
+use tower_http::cors::{AllowOrigin, Any, CorsLayer};
+use tracing::info;
+
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    pub host: String,
+    pub port: u16,
+    pub cors_origins: CorsOriginConfig,
+}
+
+#[derive(Debug, Clone)]
+pub enum CorsOriginConfig {
+    Any,
+    List(Vec<String>),
+}
+
+impl ServerConfig {
+    pub fn from_env() -> Self {
+        let host = env::var("SERVER_HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
+        let port = env::var("SERVER_PORT")
+            .ok()
+            .and_then(|p| p.parse().ok())
+            .unwrap_or(8080);
+
+        let is_production = env::var("RUST_ENV")
+            .map(|v| v == "production")
+            .unwrap_or(false);
+
+        let cors_origins = match env::var("CORS_ORIGIN") {
+            Ok(val) if val == "*" => CorsOriginConfig::Any,
+            Ok(val) if !val.is_empty() => {
+                let origins: Vec<String> = val.split(',').map(|s| s.trim().to_string()).collect();
+                CorsOriginConfig::List(origins)
+            }
+            _ if is_production => {
+                panic!("CORS_ORIGIN must be explicitly set in production (do not use \"*\")");
+            }
+            _ => CorsOriginConfig::Any,
+        };
+
+        let config = Self {
+            host,
+            port,
+            cors_origins,
+        };
+
+        info!("Server config: {}:{}", config.host, config.port);
+        info!("CORS origins: {:?}", config.cors_origins);
+
+        config
+    }
+
+    pub fn socket_addr(&self) -> SocketAddr {
+        format!("{}:{}", self.host, self.port)
+            .parse()
+            .expect("Invalid SERVER_HOST or SERVER_PORT")
+    }
+
+    pub fn cors_layer(&self) -> CorsLayer {
+        let layer = CorsLayer::new()
+            .allow_methods(Any)
+            .allow_headers(Any);
+
+        match &self.cors_origins {
+            CorsOriginConfig::Any => layer.allow_origin(Any),
+            CorsOriginConfig::List(origins) => {
+                let origins: Vec<_> = origins
+                    .iter()
+                    .map(|o| o.parse().expect("Invalid CORS origin"))
+                    .collect();
+                layer.allow_origin(AllowOrigin::list(origins))
+            }
+        }
+    }
+}

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -9,6 +9,7 @@ mod utils;
 use std::sync::Arc;
 
 use app_state::AppState;
+use config::ServerConfig;
 use core_engine::TestEngine;
 use core_service::{MessagePushService, ProjectService, TerminalService, TestService, WorkspaceService, WsMessageService};
 use infra::{DbConnection, Migrator, WsServiceConfig};
@@ -19,6 +20,9 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenvy::from_filename("apps/api/.env").ok();
+    dotenvy::dotenv().ok();
+
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
@@ -93,18 +97,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _heartbeat_task = app_state.ws_service.start_heartbeat();
     info!("WebSocket service started with heartbeat (timeout: 30s)");
 
-    let cors = tower_http::cors::CorsLayer::new()
-        .allow_origin(tower_http::cors::Any)
-        .allow_methods(tower_http::cors::Any)
-        .allow_headers(tower_http::cors::Any);
+    let server_config = ServerConfig::from_env();
+    let cors = server_config.cors_layer();
 
     let app = api::routes()
         .with_state(app_state)
         .layer(TraceLayer::new_for_http())
         .layer(cors);
 
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await?;
-    info!("Server listening on http://0.0.0.0:8080");
+    let addr = server_config.socket_addr();
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    info!("Server listening on http://{}", addr);
 
     // Serve with graceful shutdown — ensures PTY resources are cleaned up
     // when the process receives SIGTERM/SIGINT (e.g., during hot-reload).

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,5 @@
+# Backend API URL (REST)
+# NEXT_PUBLIC_API_URL=http://100.x.x.x:8080
+
+# Backend WebSocket URL
+# NEXT_PUBLIC_WS_URL=ws://100.x.x.x:8080

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -3,8 +3,23 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
+const isDev = process.env.NODE_ENV === "development";
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  allowedDevOrigins: ["*"],
+  async headers() {
+    if (!isDev) return [];
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "Access-Control-Allow-Origin", value: "*" },
+          { key: "Access-Control-Allow-Methods", value: "GET, POST, PUT, DELETE, OPTIONS" },
+          { key: "Access-Control-Allow-Headers", value: "Content-Type, Authorization" },
+        ],
+      },
+    ];
+  },
 };
 
 export default withNextIntl(nextConfig);

--- a/apps/web/src/api/rest-api.ts
+++ b/apps/web/src/api/rest-api.ts
@@ -5,7 +5,20 @@
  * or when WebSocket is not available.
  */
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+const getApiBase = (): string => {
+  if (process.env.NEXT_PUBLIC_API_URL) {
+    return process.env.NEXT_PUBLIC_API_URL;
+  }
+  if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
+    const isLocal = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+    if (!isLocal) {
+      return `${window.location.protocol}//${window.location.hostname}:8080`;
+    }
+  }
+  return 'http://localhost:8080';
+};
+
+const API_BASE = getApiBase();
 
 // ===== Types =====
 

--- a/apps/web/src/components/terminal/Terminal.tsx
+++ b/apps/web/src/components/terminal/Terminal.tsx
@@ -67,7 +67,18 @@ const Terminal = ({
 
   // For NEW panes: use terminal_name to CREATE a new tmux window
   // For EXISTING panes: use tmux_window_name to ATTACH to existing tmux window
-  const baseWsUrl = `${process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:8080"}/ws/terminal/${sessionId}`;
+  const getTerminalWsUrl = () => {
+    if (process.env.NEXT_PUBLIC_WS_URL) return process.env.NEXT_PUBLIC_WS_URL;
+    if (typeof window !== "undefined" && process.env.NODE_ENV === "development") {
+      const isLocal = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1";
+      if (!isLocal) {
+        const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+        return `${protocol}//${window.location.hostname}:8080`;
+      }
+    }
+    return "ws://localhost:8080";
+  };
+  const baseWsUrl = `${getTerminalWsUrl()}/ws/terminal/${sessionId}`;
   const wsParams = new URLSearchParams({
     workspace_id: workspaceId,
   });

--- a/apps/web/src/hooks/use-websocket.ts
+++ b/apps/web/src/hooks/use-websocket.ts
@@ -144,9 +144,18 @@ const getWsUrl = (): string => {
     return 'ws://localhost:8080/ws';
   }
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-  // 在开发环境中使用后端端口
-  const host = process.env.NODE_ENV === 'development' ? 'localhost:8080' : window.location.host;
-  return `${protocol}//${host}/ws`;
+  // 优先使用环境变量，支持 Tailscale 等内网穿透场景
+  if (process.env.NEXT_PUBLIC_WS_URL) {
+    return `${process.env.NEXT_PUBLIC_WS_URL}/ws`;
+  }
+  // 在开发环境中：如果通过非 localhost 访问（如 Tailscale），使用当前 host + 后端端口
+  if (process.env.NODE_ENV === 'development') {
+    const host = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
+      ? 'localhost:8080'
+      : `${window.location.hostname}:8080`;
+    return `${protocol}//${host}/ws`;
+  }
+  return `${protocol}//${window.location.host}/ws`;
 };
 
 export const useWebSocketStore = create<WebSocketStore>((set, get) => ({


### PR DESCRIPTION
## Summary

Support accessing ATMOS via Tailscale (or other LAN/VPN tools) from mobile devices.

## Changes

### Backend (`apps/api`)
- Add `dotenvy` for `.env` file loading
- Extract server config into `ServerConfig` with env vars:
  - `SERVER_HOST` (default: `0.0.0.0`)
  - `SERVER_PORT` (default: `8080`)
  - `CORS_ORIGIN` (default: `*` in dev, **must set in production**)
  - `RUST_ENV` (`production` enforces explicit CORS_ORIGIN)

### Frontend (`apps/web`)
- WebSocket URL auto-detects `window.location.hostname` for non-localhost access
- REST API URL auto-detects similarly
- Terminal WebSocket URL auto-detects similarly
- Support `NEXT_PUBLIC_API_URL` / `NEXT_PUBLIC_WS_URL` env overrides
- CORS headers in `next.config.ts` only apply in development mode
- Add `allowedDevOrigins` for Next.js dev server

### Config files
- `apps/api/.env.example`
- `apps/web/.env.example`

## Production Safety
- `RUST_ENV=production` requires explicit `CORS_ORIGIN` (panics otherwise)
- Frontend CORS headers stripped in production build