### PR TITLE
Fix ChartContainer props forwarding; consolidate TokenUsageUpdate and monthly totals; vendor tokscale-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4869,6 +4869,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4946,6 +4955,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sea-bae"
@@ -5321,6 +5336,32 @@ dependencies = [
  "cfg-if",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6602,7 +6643,6 @@ dependencies = [
 [[package]]
 name = "tokscale-core"
 version = "2.0.0"
-source = "git+https://github.com/junhoyeo/tokscale?rev=dcda94dd999ec4feca10cb97aaee9b4b4fb28b97#dcda94dd999ec4feca10cb97aaee9b4b4fb28b97"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -6612,7 +6652,9 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serial_test",
  "simd-json",
+ "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "walkdir",

--- a/apps/web/src/components/ui/chart.tsx
+++ b/apps/web/src/components/ui/chart.tsx
@@ -33,6 +33,7 @@ export function ChartContainer({
   className,
   children,
   config,
+  ...props
 }: React.ComponentProps<"div"> & {
   config: ChartConfig;
 }) {
@@ -47,6 +48,7 @@ export function ChartContainer({
           "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/70 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-default-legend]:flex [&_.recharts-default-legend]:flex-wrap [&_.recharts-default-legend]:gap-4 [&_.recharts-layer:focus-visible]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-text]:fill-foreground [&_.recharts-tooltip-label]:text-muted-foreground",
           className
         )}
+        {...props}
       >
         {children}
       </div>
@@ -151,4 +153,3 @@ export function ChartLegendContent({
     </div>
   );
 }
-

--- a/crates/token-usage/Cargo.toml
+++ b/crates/token-usage/Cargo.toml
@@ -9,4 +9,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
 tokio = { version = "1.0", features = ["sync", "time", "macros", "rt"] }
-tokscale-core = { git = "https://github.com/junhoyeo/tokscale", package = "tokscale-core", rev = "dcda94dd999ec4feca10cb97aaee9b4b4fb28b97" }
+tokscale-core = { path = "../../vendor/tokscale-core" }

--- a/crates/token-usage/src/models.rs
+++ b/crates/token-usage/src/models.rs
@@ -163,6 +163,5 @@ pub struct TokenUsageOverview {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TokenUsageUpdate {
-    pub query: TokenUsageQuery,
     pub overview: TokenUsageOverview,
 }

--- a/crates/token-usage/src/service.rs
+++ b/crates/token-usage/src/service.rs
@@ -129,7 +129,6 @@ impl TokenUsageService {
         }
 
         self.publish_update(TokenUsageUpdate {
-            query,
             overview: overview.clone(),
         });
 
@@ -281,20 +280,27 @@ fn build_monthly_usage(report: &tokscale_core::MonthlyReport) -> Vec<MonthlyToke
     report
         .entries
         .iter()
-        .map(|entry| MonthlyTokenUsage {
-            month: entry.month.clone(),
-            breakdown: TokenBreakdown {
+        .map(|entry| {
+            let total_tokens = entry.input + entry.output + entry.cache_read + entry.cache_write;
+            let breakdown = TokenBreakdown {
                 input_tokens: entry.input,
                 output_tokens: entry.output,
                 cache_read_tokens: entry.cache_read,
                 cache_write_tokens: entry.cache_write,
+                // tokscale_core::MonthlyUsage does not currently expose reasoning tokens.
+                // Keep this explicit so a future upstream field addition is easy to spot.
                 reasoning_tokens: 0,
-                total_tokens: entry.input + entry.output + entry.cache_read + entry.cache_write,
-            },
-            total_tokens: entry.input + entry.output + entry.cache_read + entry.cache_write,
-            total_cost_usd: finite_cost(entry.cost),
-            message_count: entry.message_count,
-            models: entry.models.clone(),
+                total_tokens,
+            };
+
+            MonthlyTokenUsage {
+                month: entry.month.clone(),
+                total_tokens,
+                breakdown,
+                total_cost_usd: finite_cost(entry.cost),
+                message_count: entry.message_count,
+                models: entry.models.clone(),
+            }
         })
         .collect()
 }

--- a/crates/token-usage/src/tests.rs
+++ b/crates/token-usage/src/tests.rs
@@ -87,9 +87,14 @@ async fn get_overview_publishes_updates_for_fresh_fetches() {
     let update = updates.recv().await.unwrap();
 
     assert_eq!(overview.summary.total_messages, 3);
-    assert_eq!(update.query.year.as_deref(), Some("2026"));
+    assert_eq!(update.overview.query.year.as_deref(), Some("2026"));
     assert_eq!(update.overview.by_model.len(), 2);
-    assert_eq!(update.overview.by_day[1].by_client[0].breakdown.total_tokens, 210);
+    assert_eq!(
+        update.overview.by_day[1].by_client[0]
+            .breakdown
+            .total_tokens,
+        210
+    );
     assert_eq!(calls.load(Ordering::SeqCst), 1);
 }
 

--- a/vendor/tokscale-core/Cargo.toml
+++ b/vendor/tokscale-core/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "tokscale-core"
+version = "2.0.0"
+edition = "2021"
+authors = ["Junho Yeo <hello@junho.io>"]
+license = "MIT"
+repository = "https://github.com/junhoyeo/tokscale"
+description = "Core library for tokscale - session parsing, scanning, aggregation, pricing"
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+rayon = "1.10"
+simd-json = "0.14"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+walkdir = "2"
+chrono = { version = "0.4", features = ["serde"] }
+thiserror = "2"
+reqwest = { version = "0.12", features = ["json", "native-tls-vendored"], default-features = false }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync", "fs"] }
+dirs = "5"
+once_cell = "1"
+rusqlite = { version = "0.32", features = ["bundled"] }
+
+[dev-dependencies]
+tempfile = "3"
+serial_test = "3"

--- a/vendor/tokscale-core/LICENSE
+++ b/vendor/tokscale-core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Junho Yeo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/tokscale-core/src/aggregator.rs
+++ b/vendor/tokscale-core/src/aggregator.rs
@@ -1,0 +1,954 @@
+//! Parallel aggregation of session data
+//!
+//! Uses rayon for parallel map-reduce operations.
+
+use crate::sessions::UnifiedMessage;
+use crate::{
+    ClientContribution, DailyContribution, DailyTotals, DataSummary, GraphMeta, GraphResult,
+    TokenBreakdown, YearSummary,
+};
+use rayon::prelude::*;
+use std::collections::HashMap;
+
+/// Aggregate messages into daily contributions
+pub fn aggregate_by_date(messages: Vec<UnifiedMessage>) -> Vec<DailyContribution> {
+    if messages.is_empty() {
+        return Vec::new();
+    }
+
+    // Estimate unique days (typically 1-365) - use message count / 10 as heuristic
+    let estimated_days = (messages.len() / 10).clamp(30, 400);
+
+    // Parallel aggregation using fold/reduce pattern
+    let daily_map: HashMap<String, DayAccumulator> = messages
+        .into_par_iter()
+        .fold(
+            || HashMap::with_capacity(estimated_days),
+            |mut acc: HashMap<String, DayAccumulator>, msg| {
+                let entry = acc.entry(msg.date.clone()).or_default();
+                entry.add_message(&msg);
+                acc
+            },
+        )
+        .reduce(
+            || HashMap::with_capacity(estimated_days),
+            |mut a, b| {
+                for (date, acc) in b {
+                    a.entry(date).or_default().merge(acc);
+                }
+                a
+            },
+        );
+
+    // Convert to sorted vector with pre-allocated capacity
+    let mut contributions: Vec<DailyContribution> = Vec::with_capacity(daily_map.len());
+    contributions.extend(
+        daily_map
+            .into_iter()
+            .map(|(date, acc)| acc.into_contribution(date)),
+    );
+
+    // Sort by date
+    contributions.sort_by(|a, b| a.date.cmp(&b.date));
+
+    // Calculate intensities based on max cost
+    calculate_intensities(&mut contributions);
+
+    contributions
+}
+
+/// Calculate summary statistics
+pub fn calculate_summary(contributions: &[DailyContribution]) -> DataSummary {
+    let total_tokens: i64 = contributions.iter().map(|c| c.totals.tokens).sum();
+    let total_cost: f64 = contributions.iter().map(|c| c.totals.cost).sum();
+    let active_days = contributions.iter().filter(|c| c.totals.tokens > 0).count() as i32;
+    let max_cost = contributions
+        .iter()
+        .map(|c| c.totals.cost)
+        .fold(0.0, f64::max);
+
+    let mut clients_set = std::collections::HashSet::with_capacity(5);
+    let mut models_set = std::collections::HashSet::with_capacity(20);
+
+    for c in contributions {
+        for s in &c.clients {
+            clients_set.insert(s.client.clone());
+            models_set.insert(s.model_id.clone());
+        }
+    }
+
+    DataSummary {
+        total_tokens,
+        total_cost,
+        total_days: contributions.len() as i32,
+        active_days,
+        average_per_day: if active_days > 0 {
+            total_cost / active_days as f64
+        } else {
+            0.0
+        },
+        max_cost_in_single_day: max_cost,
+        clients: clients_set.into_iter().collect(),
+        models: models_set.into_iter().collect(),
+    }
+}
+
+/// Calculate year summaries
+pub fn calculate_years(contributions: &[DailyContribution]) -> Vec<YearSummary> {
+    let mut years_map: HashMap<String, YearAccumulator> = HashMap::with_capacity(5);
+
+    for c in contributions {
+        // Guard against short/invalid date strings
+        if c.date.len() < 4 {
+            eprintln!(
+                "Warning: Skipping contribution with invalid date '{}' ({} tokens, ${:.4} cost)",
+                c.date, c.totals.tokens, c.totals.cost
+            );
+            continue;
+        }
+        let year = &c.date[0..4];
+        let entry = years_map.entry(year.to_string()).or_default();
+        entry.tokens += c.totals.tokens;
+        entry.cost += c.totals.cost;
+
+        if entry.start.is_empty() || c.date < entry.start {
+            entry.start = c.date.clone();
+        }
+        if entry.end.is_empty() || c.date > entry.end {
+            entry.end = c.date.clone();
+        }
+    }
+
+    let mut years: Vec<YearSummary> = Vec::with_capacity(years_map.len());
+    years.extend(years_map.into_iter().map(|(year, acc)| YearSummary {
+        year,
+        total_tokens: acc.tokens,
+        total_cost: acc.cost,
+        range_start: acc.start,
+        range_end: acc.end,
+    }));
+
+    years.sort_by(|a, b| a.year.cmp(&b.year));
+    years
+}
+
+/// Generate complete graph result
+pub fn generate_graph_result(
+    contributions: Vec<DailyContribution>,
+    processing_time_ms: u32,
+) -> GraphResult {
+    let summary = calculate_summary(&contributions);
+    let years = calculate_years(&contributions);
+
+    let date_range_start = contributions
+        .first()
+        .map(|c| c.date.clone())
+        .unwrap_or_default();
+    let date_range_end = contributions
+        .last()
+        .map(|c| c.date.clone())
+        .unwrap_or_default();
+
+    GraphResult {
+        meta: GraphMeta {
+            generated_at: chrono::Utc::now().to_rfc3339(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            date_range_start,
+            date_range_end,
+            processing_time_ms,
+        },
+        summary,
+        years,
+        contributions,
+    }
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+struct DayAccumulator {
+    totals: DailyTotals,
+    token_breakdown: TokenBreakdown,
+    clients: HashMap<String, ClientContribution>,
+}
+
+impl Default for DayAccumulator {
+    fn default() -> Self {
+        Self {
+            totals: DailyTotals::default(),
+            token_breakdown: TokenBreakdown::default(),
+            clients: HashMap::with_capacity(8),
+        }
+    }
+}
+
+impl DayAccumulator {
+    fn add_message(&mut self, msg: &UnifiedMessage) {
+        let total_tokens = msg
+            .tokens
+            .input
+            .saturating_add(msg.tokens.output)
+            .saturating_add(msg.tokens.cache_read)
+            .saturating_add(msg.tokens.cache_write)
+            .saturating_add(msg.tokens.reasoning);
+
+        self.totals.tokens = self.totals.tokens.saturating_add(total_tokens);
+        self.totals.cost += msg.cost;
+        self.totals.messages = self.totals.messages.saturating_add(1);
+
+        self.token_breakdown.input = self.token_breakdown.input.saturating_add(msg.tokens.input);
+        self.token_breakdown.output = self
+            .token_breakdown
+            .output
+            .saturating_add(msg.tokens.output);
+        self.token_breakdown.cache_read = self
+            .token_breakdown
+            .cache_read
+            .saturating_add(msg.tokens.cache_read);
+        self.token_breakdown.cache_write = self
+            .token_breakdown
+            .cache_write
+            .saturating_add(msg.tokens.cache_write);
+        self.token_breakdown.reasoning = self
+            .token_breakdown
+            .reasoning
+            .saturating_add(msg.tokens.reasoning);
+
+        // Update client contribution
+        let key = format!(
+            "{}:{}",
+            msg.client,
+            crate::normalize_model_for_grouping(&msg.model_id)
+        );
+        let client_entry = self
+            .clients
+            .entry(key)
+            .or_insert_with(|| ClientContribution {
+                client: msg.client.clone(),
+                model_id: crate::normalize_model_for_grouping(&msg.model_id),
+                provider_id: msg.provider_id.clone(),
+                tokens: TokenBreakdown::default(),
+                cost: 0.0,
+                messages: 0,
+            });
+
+        // Merge provider_id if different provider contributes to same client+model
+        if !client_entry
+            .provider_id
+            .split(", ")
+            .any(|p| p == msg.provider_id)
+        {
+            client_entry.provider_id = format!("{}, {}", client_entry.provider_id, msg.provider_id);
+        }
+
+        client_entry.tokens.input = client_entry.tokens.input.saturating_add(msg.tokens.input);
+        client_entry.tokens.output = client_entry.tokens.output.saturating_add(msg.tokens.output);
+        client_entry.tokens.cache_read = client_entry
+            .tokens
+            .cache_read
+            .saturating_add(msg.tokens.cache_read);
+        client_entry.tokens.cache_write = client_entry
+            .tokens
+            .cache_write
+            .saturating_add(msg.tokens.cache_write);
+        client_entry.tokens.reasoning = client_entry
+            .tokens
+            .reasoning
+            .saturating_add(msg.tokens.reasoning);
+        client_entry.cost += msg.cost;
+        client_entry.messages = client_entry.messages.saturating_add(1);
+
+        // Normalize provider order for deterministic output
+        let mut providers: Vec<&str> = client_entry.provider_id.split(", ").collect();
+        providers.sort_unstable();
+        providers.dedup();
+        client_entry.provider_id = providers.join(", ");
+    }
+
+    fn merge(&mut self, other: DayAccumulator) {
+        self.totals.tokens = self.totals.tokens.saturating_add(other.totals.tokens);
+        self.totals.cost += other.totals.cost;
+        self.totals.messages = self.totals.messages.saturating_add(other.totals.messages);
+
+        self.token_breakdown.input = self
+            .token_breakdown
+            .input
+            .saturating_add(other.token_breakdown.input);
+        self.token_breakdown.output = self
+            .token_breakdown
+            .output
+            .saturating_add(other.token_breakdown.output);
+        self.token_breakdown.cache_read = self
+            .token_breakdown
+            .cache_read
+            .saturating_add(other.token_breakdown.cache_read);
+        self.token_breakdown.cache_write = self
+            .token_breakdown
+            .cache_write
+            .saturating_add(other.token_breakdown.cache_write);
+        self.token_breakdown.reasoning = self
+            .token_breakdown
+            .reasoning
+            .saturating_add(other.token_breakdown.reasoning);
+
+        for (key, client_contrib) in other.clients {
+            let entry = self
+                .clients
+                .entry(key)
+                .or_insert_with(|| ClientContribution {
+                    client: client_contrib.client.clone(),
+                    model_id: client_contrib.model_id.clone(),
+                    provider_id: client_contrib.provider_id.clone(),
+                    tokens: TokenBreakdown::default(),
+                    cost: 0.0,
+                    messages: 0,
+                });
+
+            // Merge provider_ids from parallel reduction
+            for provider in client_contrib.provider_id.split(", ") {
+                if !entry.provider_id.split(", ").any(|p| p == provider) {
+                    entry.provider_id = format!("{}, {}", entry.provider_id, provider);
+                }
+            }
+
+            entry.tokens.input = entry
+                .tokens
+                .input
+                .saturating_add(client_contrib.tokens.input);
+            entry.tokens.output = entry
+                .tokens
+                .output
+                .saturating_add(client_contrib.tokens.output);
+            entry.tokens.cache_read = entry
+                .tokens
+                .cache_read
+                .saturating_add(client_contrib.tokens.cache_read);
+            entry.tokens.cache_write = entry
+                .tokens
+                .cache_write
+                .saturating_add(client_contrib.tokens.cache_write);
+            entry.tokens.reasoning = entry
+                .tokens
+                .reasoning
+                .saturating_add(client_contrib.tokens.reasoning);
+            entry.cost += client_contrib.cost;
+            entry.messages = entry.messages.saturating_add(client_contrib.messages);
+        }
+
+        // Normalize provider order for deterministic output
+        for entry in self.clients.values_mut() {
+            let mut providers: Vec<&str> = entry.provider_id.split(", ").collect();
+            providers.sort_unstable();
+            providers.dedup();
+            entry.provider_id = providers.join(", ");
+        }
+    }
+
+    fn into_contribution(self, date: String) -> DailyContribution {
+        let token_breakdown = TokenBreakdown {
+            input: self.token_breakdown.input.max(0),
+            output: self.token_breakdown.output.max(0),
+            cache_read: self.token_breakdown.cache_read.max(0),
+            cache_write: self.token_breakdown.cache_write.max(0),
+            reasoning: self.token_breakdown.reasoning.max(0),
+        };
+
+        let clients: Vec<ClientContribution> = self
+            .clients
+            .into_values()
+            .map(|mut s| {
+                s.tokens.input = s.tokens.input.max(0);
+                s.tokens.output = s.tokens.output.max(0);
+                s.tokens.cache_read = s.tokens.cache_read.max(0);
+                s.tokens.cache_write = s.tokens.cache_write.max(0);
+                s.tokens.reasoning = s.tokens.reasoning.max(0);
+                s.cost = s.cost.max(0.0);
+                s
+            })
+            .collect();
+
+        DailyContribution {
+            date,
+            totals: DailyTotals {
+                tokens: self.totals.tokens.max(0),
+                cost: self.totals.cost.max(0.0),
+                messages: self.totals.messages.max(0),
+            },
+            intensity: 0,
+            token_breakdown,
+            clients,
+        }
+    }
+}
+
+#[derive(Default)]
+struct YearAccumulator {
+    tokens: i64,
+    cost: f64,
+    start: String,
+    end: String,
+}
+
+fn calculate_intensities(contributions: &mut [DailyContribution]) {
+    let max_cost = contributions
+        .iter()
+        .map(|c| c.totals.cost)
+        .fold(0.0, f64::max);
+
+    if max_cost == 0.0 {
+        return;
+    }
+
+    for c in contributions.iter_mut() {
+        let ratio = c.totals.cost / max_cost;
+        c.intensity = if ratio >= 0.75 {
+            4
+        } else if ratio >= 0.5 {
+            3
+        } else if ratio >= 0.25 {
+            2
+        } else if ratio > 0.0 {
+            1
+        } else {
+            0
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Utc};
+
+    // Helper function to create mock UnifiedMessage
+    fn mock_unified_message(
+        date: &str,
+        tokens: i64,
+        cost: f64,
+        model: &str,
+        client: &str,
+    ) -> UnifiedMessage {
+        // Parse date string to timestamp
+        let datetime = format!("{}T00:00:00Z", date)
+            .parse::<DateTime<Utc>>()
+            .unwrap();
+        let timestamp = datetime.timestamp_millis();
+
+        UnifiedMessage {
+            client: client.to_string(),
+            model_id: model.to_string(),
+            provider_id: "test-provider".to_string(),
+            session_id: "test-session".to_string(),
+            timestamp,
+            date: date.to_string(),
+            tokens: TokenBreakdown {
+                input: tokens / 2,
+                output: tokens / 2,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            cost,
+            agent: None,
+            dedup_key: None,
+        }
+    }
+
+    #[test]
+    fn test_aggregate_by_date_empty() {
+        let messages = Vec::new();
+        let result = aggregate_by_date(messages);
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn test_aggregate_by_date_single_message() {
+        let messages = vec![mock_unified_message(
+            "2024-01-01",
+            1000,
+            0.05,
+            "claude-3-5-sonnet",
+            "opencode",
+        )];
+
+        let result = aggregate_by_date(messages);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].date, "2024-01-01");
+        assert_eq!(result[0].totals.tokens, 1000);
+        assert_eq!(result[0].totals.cost, 0.05);
+        assert_eq!(result[0].totals.messages, 1);
+    }
+
+    #[test]
+    fn test_aggregate_by_date_multiple_dates() {
+        let messages = vec![
+            mock_unified_message("2024-01-01", 1000, 0.05, "claude-3-5-sonnet", "opencode"),
+            mock_unified_message("2024-01-02", 2000, 0.10, "gpt-4", "claude"),
+            mock_unified_message("2024-01-03", 1500, 0.08, "claude-3-5-sonnet", "opencode"),
+        ];
+
+        let result = aggregate_by_date(messages);
+        assert_eq!(result.len(), 3);
+
+        // Verify sorted by date
+        assert_eq!(result[0].date, "2024-01-01");
+        assert_eq!(result[1].date, "2024-01-02");
+        assert_eq!(result[2].date, "2024-01-03");
+
+        // Verify totals
+        assert_eq!(result[0].totals.tokens, 1000);
+        assert_eq!(result[1].totals.tokens, 2000);
+        assert_eq!(result[2].totals.tokens, 1500);
+    }
+
+    #[test]
+    fn test_aggregate_by_date_same_date_aggregation() {
+        let messages = vec![
+            mock_unified_message("2024-01-01", 1000, 0.05, "claude-3-5-sonnet", "opencode"),
+            mock_unified_message("2024-01-01", 2000, 0.10, "gpt-4", "claude"),
+            mock_unified_message("2024-01-01", 1500, 0.08, "claude-3-5-sonnet", "opencode"),
+        ];
+
+        let result = aggregate_by_date(messages);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].date, "2024-01-01");
+        assert_eq!(result[0].totals.tokens, 4500);
+        assert!((result[0].totals.cost - 0.23).abs() < 0.0001);
+        assert_eq!(result[0].totals.messages, 3);
+    }
+
+    #[test]
+    fn test_aggregate_by_date_token_breakdown() {
+        let mut msg =
+            mock_unified_message("2024-01-01", 1000, 0.05, "claude-3-5-sonnet", "opencode");
+        msg.tokens = TokenBreakdown {
+            input: 600,
+            output: 300,
+            cache_read: 50,
+            cache_write: 40,
+            reasoning: 10,
+        };
+
+        let result = aggregate_by_date(vec![msg]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].token_breakdown.input, 600);
+        assert_eq!(result[0].token_breakdown.output, 300);
+        assert_eq!(result[0].token_breakdown.cache_read, 50);
+        assert_eq!(result[0].token_breakdown.cache_write, 40);
+        assert_eq!(result[0].token_breakdown.reasoning, 10);
+    }
+
+    #[test]
+    fn test_calculate_summary_empty() {
+        let contributions = Vec::new();
+        let summary = calculate_summary(&contributions);
+
+        assert_eq!(summary.total_tokens, 0);
+        assert_eq!(summary.total_cost, 0.0);
+        assert_eq!(summary.total_days, 0);
+        assert_eq!(summary.active_days, 0);
+        assert_eq!(summary.average_per_day, 0.0);
+        assert_eq!(summary.max_cost_in_single_day, 0.0);
+    }
+
+    #[test]
+    fn test_calculate_summary_single_day() {
+        let messages = vec![mock_unified_message(
+            "2024-01-01",
+            1000,
+            0.05,
+            "claude-3-5-sonnet",
+            "opencode",
+        )];
+        let contributions = aggregate_by_date(messages);
+        let summary = calculate_summary(&contributions);
+
+        assert_eq!(summary.total_tokens, 1000);
+        assert_eq!(summary.total_cost, 0.05);
+        assert_eq!(summary.total_days, 1);
+        assert_eq!(summary.active_days, 1);
+        assert_eq!(summary.average_per_day, 0.05);
+        assert_eq!(summary.max_cost_in_single_day, 0.05);
+    }
+
+    #[test]
+    fn test_calculate_summary_multiple_days() {
+        let messages = vec![
+            mock_unified_message("2024-01-01", 1000, 0.05, "claude-3-5-sonnet", "opencode"),
+            mock_unified_message("2024-01-02", 2000, 0.10, "gpt-4", "claude"),
+            mock_unified_message("2024-01-03", 1500, 0.08, "claude-3-5-sonnet", "opencode"),
+        ];
+        let contributions = aggregate_by_date(messages);
+        let summary = calculate_summary(&contributions);
+
+        assert_eq!(summary.total_tokens, 4500);
+        assert!((summary.total_cost - 0.23).abs() < 0.0001);
+        assert_eq!(summary.total_days, 3);
+        assert_eq!(summary.active_days, 3);
+        assert!((summary.average_per_day - 0.23 / 3.0).abs() < 0.0001);
+        assert!((summary.max_cost_in_single_day - 0.10).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_calculate_summary_with_zero_token_days() {
+        let contributions = vec![
+            DailyContribution {
+                date: "2024-01-01".to_string(),
+                totals: DailyTotals {
+                    tokens: 1000,
+                    cost: 0.05,
+                    messages: 1,
+                },
+                intensity: 0,
+                token_breakdown: TokenBreakdown::default(),
+                clients: Vec::new(),
+            },
+            DailyContribution {
+                date: "2024-01-02".to_string(),
+                totals: DailyTotals {
+                    tokens: 0,
+                    cost: 0.0,
+                    messages: 0,
+                },
+                intensity: 0,
+                token_breakdown: TokenBreakdown::default(),
+                clients: Vec::new(),
+            },
+        ];
+
+        let summary = calculate_summary(&contributions);
+        assert_eq!(summary.total_days, 2);
+        assert_eq!(summary.active_days, 1);
+        assert!((summary.average_per_day - 0.05).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_calculate_years_empty() {
+        let contributions = Vec::new();
+        let years = calculate_years(&contributions);
+        assert_eq!(years.len(), 0);
+    }
+
+    #[test]
+    fn test_calculate_years_single_year() {
+        let messages = vec![
+            mock_unified_message("2024-01-01", 1000, 0.05, "claude-3-5-sonnet", "opencode"),
+            mock_unified_message("2024-06-15", 2000, 0.10, "gpt-4", "claude"),
+            mock_unified_message("2024-12-31", 1500, 0.08, "claude-3-5-sonnet", "opencode"),
+        ];
+        let contributions = aggregate_by_date(messages);
+        let years = calculate_years(&contributions);
+
+        assert_eq!(years.len(), 1);
+        assert_eq!(years[0].year, "2024");
+        assert_eq!(years[0].total_tokens, 4500);
+        assert!((years[0].total_cost - 0.23).abs() < 0.0001);
+        assert_eq!(years[0].range_start, "2024-01-01");
+        assert_eq!(years[0].range_end, "2024-12-31");
+    }
+
+    #[test]
+    fn test_calculate_years_multiple_years() {
+        let messages = vec![
+            mock_unified_message("2023-12-31", 1000, 0.05, "claude-3-5-sonnet", "opencode"),
+            mock_unified_message("2024-01-01", 2000, 0.10, "gpt-4", "claude"),
+            mock_unified_message("2024-06-15", 1500, 0.08, "claude-3-5-sonnet", "opencode"),
+            mock_unified_message("2025-01-01", 3000, 0.15, "gpt-4", "claude"),
+        ];
+        let contributions = aggregate_by_date(messages);
+        let years = calculate_years(&contributions);
+
+        assert_eq!(years.len(), 3);
+
+        // Verify sorted by year
+        assert_eq!(years[0].year, "2023");
+        assert_eq!(years[1].year, "2024");
+        assert_eq!(years[2].year, "2025");
+
+        // Verify 2024 aggregation
+        assert_eq!(years[1].total_tokens, 3500);
+        assert!((years[1].total_cost - 0.18).abs() < 0.0001);
+        assert_eq!(years[1].range_start, "2024-01-01");
+        assert_eq!(years[1].range_end, "2024-06-15");
+    }
+
+    #[test]
+    fn test_calculate_years_year_boundary() {
+        let messages = vec![
+            mock_unified_message("2024-12-31", 1000, 0.05, "claude-3-5-sonnet", "opencode"),
+            mock_unified_message("2025-01-01", 2000, 0.10, "gpt-4", "claude"),
+        ];
+        let contributions = aggregate_by_date(messages);
+        let years = calculate_years(&contributions);
+
+        assert_eq!(years.len(), 2);
+        assert_eq!(years[0].year, "2024");
+        assert_eq!(years[0].total_tokens, 1000);
+        assert_eq!(years[1].year, "2025");
+        assert_eq!(years[1].total_tokens, 2000);
+    }
+
+    #[test]
+    fn test_calculate_years_invalid_date() {
+        let contributions = vec![DailyContribution {
+            date: "abc".to_string(), // Invalid date (less than 4 chars)
+            totals: DailyTotals {
+                tokens: 1000,
+                cost: 0.05,
+                messages: 1,
+            },
+            intensity: 0,
+            token_breakdown: TokenBreakdown::default(),
+            clients: Vec::new(),
+        }];
+
+        let years = calculate_years(&contributions);
+        assert_eq!(years.len(), 0); // Should skip invalid dates
+    }
+
+    #[test]
+    fn test_generate_graph_result_empty() {
+        let contributions = Vec::new();
+        let result = generate_graph_result(contributions, 100);
+
+        assert_eq!(result.contributions.len(), 0);
+        assert_eq!(result.summary.total_tokens, 0);
+        assert_eq!(result.years.len(), 0);
+        assert_eq!(result.meta.processing_time_ms, 100);
+        assert_eq!(result.meta.date_range_start, "");
+        assert_eq!(result.meta.date_range_end, "");
+    }
+
+    #[test]
+    fn test_generate_graph_result_with_data() {
+        let messages = vec![
+            mock_unified_message("2024-01-01", 1000, 0.05, "claude-3-5-sonnet", "opencode"),
+            mock_unified_message("2024-01-02", 2000, 0.10, "gpt-4", "claude"),
+        ];
+        let contributions = aggregate_by_date(messages);
+        let result = generate_graph_result(contributions, 150);
+
+        assert_eq!(result.contributions.len(), 2);
+        assert_eq!(result.summary.total_tokens, 3000);
+        assert_eq!(result.years.len(), 1);
+        assert_eq!(result.meta.processing_time_ms, 150);
+        assert_eq!(result.meta.date_range_start, "2024-01-01");
+        assert_eq!(result.meta.date_range_end, "2024-01-02");
+        assert_eq!(result.meta.version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn test_calculate_intensities_empty() {
+        let mut contributions = Vec::new();
+        calculate_intensities(&mut contributions);
+        assert_eq!(contributions.len(), 0);
+    }
+
+    #[test]
+    fn test_calculate_intensities_zero_cost() {
+        let mut contributions = vec![
+            DailyContribution {
+                date: "2024-01-01".to_string(),
+                totals: DailyTotals {
+                    tokens: 1000,
+                    cost: 0.0,
+                    messages: 1,
+                },
+                intensity: 0,
+                token_breakdown: TokenBreakdown::default(),
+                clients: Vec::new(),
+            },
+            DailyContribution {
+                date: "2024-01-02".to_string(),
+                totals: DailyTotals {
+                    tokens: 2000,
+                    cost: 0.0,
+                    messages: 1,
+                },
+                intensity: 0,
+                token_breakdown: TokenBreakdown::default(),
+                clients: Vec::new(),
+            },
+        ];
+
+        calculate_intensities(&mut contributions);
+        assert_eq!(contributions[0].intensity, 0);
+        assert_eq!(contributions[1].intensity, 0);
+    }
+
+    #[test]
+    fn test_calculate_intensities_levels() {
+        let mut contributions = vec![
+            DailyContribution {
+                date: "2024-01-01".to_string(),
+                totals: DailyTotals {
+                    tokens: 1000,
+                    cost: 1.0, // 100% of max
+                    messages: 1,
+                },
+                intensity: 0,
+                token_breakdown: TokenBreakdown::default(),
+                clients: Vec::new(),
+            },
+            DailyContribution {
+                date: "2024-01-02".to_string(),
+                totals: DailyTotals {
+                    tokens: 800,
+                    cost: 0.8, // 80% of max (>= 0.75)
+                    messages: 1,
+                },
+                intensity: 0,
+                token_breakdown: TokenBreakdown::default(),
+                clients: Vec::new(),
+            },
+            DailyContribution {
+                date: "2024-01-03".to_string(),
+                totals: DailyTotals {
+                    tokens: 600,
+                    cost: 0.6, // 60% of max (>= 0.5)
+                    messages: 1,
+                },
+                intensity: 0,
+                token_breakdown: TokenBreakdown::default(),
+                clients: Vec::new(),
+            },
+            DailyContribution {
+                date: "2024-01-04".to_string(),
+                totals: DailyTotals {
+                    tokens: 300,
+                    cost: 0.3, // 30% of max (>= 0.25)
+                    messages: 1,
+                },
+                intensity: 0,
+                token_breakdown: TokenBreakdown::default(),
+                clients: Vec::new(),
+            },
+            DailyContribution {
+                date: "2024-01-05".to_string(),
+                totals: DailyTotals {
+                    tokens: 100,
+                    cost: 0.1, // 10% of max (> 0.0)
+                    messages: 1,
+                },
+                intensity: 0,
+                token_breakdown: TokenBreakdown::default(),
+                clients: Vec::new(),
+            },
+        ];
+
+        calculate_intensities(&mut contributions);
+
+        assert_eq!(contributions[0].intensity, 4); // 100%
+        assert_eq!(contributions[1].intensity, 4); // 80%
+        assert_eq!(contributions[2].intensity, 3); // 60%
+        assert_eq!(contributions[3].intensity, 2); // 30%
+        assert_eq!(contributions[4].intensity, 1); // 10%
+    }
+
+    #[test]
+    fn test_calculate_intensities_boundary_values() {
+        let mut contributions = vec![
+            DailyContribution {
+                date: "2024-01-01".to_string(),
+                totals: DailyTotals {
+                    tokens: 1000,
+                    cost: 1.0,
+                    messages: 1,
+                },
+                intensity: 0,
+                token_breakdown: TokenBreakdown::default(),
+                clients: Vec::new(),
+            },
+            DailyContribution {
+                date: "2024-01-02".to_string(),
+                totals: DailyTotals {
+                    tokens: 750,
+                    cost: 0.75, // Exactly 0.75 (should be level 4)
+                    messages: 1,
+                },
+                intensity: 0,
+                token_breakdown: TokenBreakdown::default(),
+                clients: Vec::new(),
+            },
+            DailyContribution {
+                date: "2024-01-03".to_string(),
+                totals: DailyTotals {
+                    tokens: 500,
+                    cost: 0.5, // Exactly 0.5 (should be level 3)
+                    messages: 1,
+                },
+                intensity: 0,
+                token_breakdown: TokenBreakdown::default(),
+                clients: Vec::new(),
+            },
+            DailyContribution {
+                date: "2024-01-04".to_string(),
+                totals: DailyTotals {
+                    tokens: 250,
+                    cost: 0.25, // Exactly 0.25 (should be level 2)
+                    messages: 1,
+                },
+                intensity: 0,
+                token_breakdown: TokenBreakdown::default(),
+                clients: Vec::new(),
+            },
+        ];
+
+        calculate_intensities(&mut contributions);
+
+        assert_eq!(contributions[0].intensity, 4);
+        assert_eq!(contributions[1].intensity, 4); // >= 0.75
+        assert_eq!(contributions[2].intensity, 3); // >= 0.5
+        assert_eq!(contributions[3].intensity, 2); // >= 0.25
+    }
+
+    #[test]
+    fn test_aggregate_by_date_preserves_sources() {
+        let messages = vec![
+            mock_unified_message("2024-01-01", 1000, 0.05, "claude-3-5-sonnet", "opencode"),
+            mock_unified_message("2024-01-01", 2000, 0.10, "gpt-4", "claude"),
+        ];
+
+        let result = aggregate_by_date(messages);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].clients.len(), 2);
+
+        // Verify both clients are present
+        let client_names: Vec<&str> = result[0]
+            .clients
+            .iter()
+            .map(|s| s.client.as_str())
+            .collect();
+        assert!(client_names.contains(&"opencode"));
+        assert!(client_names.contains(&"claude"));
+    }
+
+    #[test]
+    fn test_aggregate_by_date_large_dataset() {
+        // Test with 100 messages across 10 days
+        let mut messages = Vec::new();
+        for day in 1..=10 {
+            for _msg in 0..10 {
+                let date = format!("2024-01-{:02}", day);
+                messages.push(mock_unified_message(
+                    &date,
+                    1000,
+                    0.05,
+                    "claude-3-5-sonnet",
+                    "opencode",
+                ));
+            }
+        }
+
+        let result = aggregate_by_date(messages);
+        assert_eq!(result.len(), 10);
+
+        // Each day should have 10 messages aggregated
+        for contribution in &result {
+            assert_eq!(contribution.totals.messages, 10);
+            assert_eq!(contribution.totals.tokens, 10000);
+            assert!((contribution.totals.cost - 0.5).abs() < 0.0001);
+        }
+    }
+}

--- a/vendor/tokscale-core/src/clients.rs
+++ b/vendor/tokscale-core/src/clients.rs
@@ -1,0 +1,400 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathRoot {
+    Home,
+    XdgData,
+    EnvVar {
+        var: &'static str,
+        fallback_relative: &'static str,
+    },
+}
+
+impl PathRoot {
+    pub fn resolve(&self, home_dir: &str) -> String {
+        match self {
+            PathRoot::Home => home_dir.to_string(),
+            PathRoot::XdgData => std::env::var("XDG_DATA_HOME")
+                .unwrap_or_else(|_| format!("{}/.local/share", home_dir)),
+            PathRoot::EnvVar {
+                var,
+                fallback_relative,
+            } => {
+                std::env::var(var).unwrap_or_else(|_| format!("{}/{}", home_dir, fallback_relative))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ClientDef {
+    pub id: &'static str,
+    pub root: PathRoot,
+    pub relative_path: &'static str,
+    pub pattern: &'static str,
+    pub headless: bool,
+    pub parse_local: bool,
+}
+
+impl ClientDef {
+    pub fn resolve_path(&self, home_dir: &str) -> String {
+        format!("{}/{}", self.root.resolve(home_dir), self.relative_path)
+    }
+}
+
+macro_rules! define_clients {
+    ( $( $variant:ident = $index:expr => { id: $id:expr, root: $root:expr, relative: $rel:expr, pattern: $pat:expr, headless: $hl:expr, parse_local: $pl:expr } ),+ $(,)? ) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[repr(usize)]
+        pub enum ClientId {
+            $( $variant = $index ),+
+        }
+
+        impl ClientId {
+            pub const COUNT: usize = [ $( $index ),+ ].len();
+            pub const ALL: [ClientId; Self::COUNT] = [ $( ClientId::$variant ),+ ];
+
+            pub fn data(&self) -> &'static ClientDef {
+                &CLIENTS[*self as usize]
+            }
+
+            pub fn as_str(&self) -> &'static str {
+                self.data().id
+            }
+
+            pub fn file_pattern(&self) -> &'static str {
+                self.data().pattern
+            }
+
+            pub fn supports_headless(&self) -> bool {
+                self.data().headless
+            }
+
+            pub fn parse_local(&self) -> bool {
+                self.data().parse_local
+            }
+
+            pub fn iter() -> impl Iterator<Item = ClientId> {
+                Self::ALL.iter().copied()
+            }
+
+            #[allow(clippy::should_implement_trait)]
+            pub fn from_str(s: &str) -> Option<ClientId> {
+                Self::ALL.iter().copied().find(|c| c.as_str() == s)
+            }
+        }
+
+        pub const CLIENTS: [ClientDef; ClientId::COUNT] = [
+            $( ClientDef {
+                id: $id,
+                root: $root,
+                relative_path: $rel,
+                pattern: $pat,
+                headless: $hl,
+                parse_local: $pl,
+            } ),+
+        ];
+
+        const _: () = {
+            let mut i = 0;
+            $(
+                assert!($index == i, "ClientId indices must be sequential");
+                i += 1;
+                let _ = i;
+            )+
+        };
+    };
+}
+
+define_clients!(
+    OpenCode = 0 => {
+        id: "opencode",
+        root: PathRoot::XdgData,
+        relative: "opencode/storage/message",
+        pattern: "*.json",
+        headless: false,
+        parse_local: true
+    },
+    Claude = 1 => {
+        id: "claude",
+        root: PathRoot::Home,
+        relative: ".claude/projects",
+        pattern: "*.jsonl",
+        headless: false,
+        parse_local: true
+    },
+    Codex = 2 => {
+        id: "codex",
+        root: PathRoot::EnvVar {
+            var: "CODEX_HOME",
+            fallback_relative: ".codex",
+        },
+        relative: "sessions",
+        pattern: "*.jsonl",
+        headless: true,
+        parse_local: true
+    },
+    Cursor = 3 => {
+        id: "cursor",
+        root: PathRoot::Home,
+        relative: ".config/tokscale/cursor-cache",
+        pattern: "usage*.csv",
+        headless: false,
+        parse_local: false
+    },
+    Gemini = 4 => {
+        id: "gemini",
+        root: PathRoot::Home,
+        relative: ".gemini/tmp",
+        pattern: "*.json",
+        headless: false,
+        parse_local: true
+    },
+    Amp = 5 => {
+        id: "amp",
+        root: PathRoot::XdgData,
+        relative: "amp/threads",
+        pattern: "T-*.json",
+        headless: false,
+        parse_local: true
+    },
+    Droid = 6 => {
+        id: "droid",
+        root: PathRoot::Home,
+        relative: ".factory/sessions",
+        pattern: "*.settings.json",
+        headless: false,
+        parse_local: true
+    },
+    OpenClaw = 7 => {
+        id: "openclaw",
+        root: PathRoot::Home,
+        relative: ".openclaw/agents",
+        pattern: "*.jsonl",
+        headless: false,
+        parse_local: true
+    },
+    Pi = 8 => {
+        id: "pi",
+        root: PathRoot::Home,
+        relative: ".pi/agent/sessions",
+        pattern: "*.jsonl",
+        headless: false,
+        parse_local: true
+    },
+    Kimi = 9 => {
+        id: "kimi",
+        root: PathRoot::Home,
+        relative: ".kimi/sessions",
+        pattern: "wire.jsonl",
+        headless: false,
+        parse_local: true
+    },
+    Qwen = 10 => {
+        id: "qwen",
+        root: PathRoot::Home,
+        relative: ".qwen/projects",
+        pattern: "*.jsonl",
+        headless: false,
+        parse_local: true
+    },
+    RooCode = 11 => {
+        id: "roocode",
+        root: PathRoot::Home,
+        relative: ".config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks",
+        pattern: "ui_messages.json",
+        headless: false,
+        parse_local: true
+    },
+    KiloCode = 12 => {
+        id: "kilocode",
+        root: PathRoot::Home,
+        relative: ".config/Code/User/globalStorage/kilocode.kilo-code/tasks",
+        pattern: "ui_messages.json",
+        headless: false,
+        parse_local: true
+    },
+    Mux = 13 => {
+        id: "mux",
+        root: PathRoot::Home,
+        relative: ".mux/sessions",
+        pattern: "session-usage.json",
+        headless: false,
+        parse_local: true
+    }
+);
+
+pub struct ClientCounts {
+    counts: [i32; ClientId::COUNT],
+}
+
+impl ClientCounts {
+    pub fn new() -> Self {
+        Self {
+            counts: [0; ClientId::COUNT],
+        }
+    }
+
+    pub fn get(&self, client: ClientId) -> i32 {
+        self.counts[client as usize]
+    }
+
+    pub fn set(&mut self, client: ClientId, value: i32) {
+        self.counts[client as usize] = value;
+    }
+
+    pub fn add(&mut self, client: ClientId, value: i32) {
+        self.counts[client as usize] += value;
+    }
+}
+
+impl Default for ClientCounts {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn restore_env(var: &str, previous: Option<String>) {
+        match previous {
+            Some(value) => unsafe { std::env::set_var(var, value) },
+            None => unsafe { std::env::remove_var(var) },
+        }
+    }
+
+    #[test]
+    fn test_client_id_count() {
+        assert_eq!(ClientId::COUNT, 14);
+    }
+
+    #[test]
+    fn test_client_id_all_len_matches_count() {
+        assert_eq!(ClientId::ALL.len(), ClientId::COUNT);
+    }
+
+    #[test]
+    fn test_client_id_string_round_trip() {
+        for client in ClientId::iter() {
+            let id = client.as_str();
+            assert_eq!(ClientId::from_str(id), Some(client));
+        }
+    }
+
+    #[test]
+    fn test_path_root_home_resolves_to_home_dir() {
+        let home = "/tmp/home";
+        assert_eq!(PathRoot::Home.resolve(home), home);
+    }
+
+    #[test]
+    fn test_path_root_xdg_data_uses_env_var_when_set() {
+        let _guard = env_lock().lock().unwrap();
+        let previous = std::env::var("XDG_DATA_HOME").ok();
+        unsafe { std::env::set_var("XDG_DATA_HOME", "/tmp/xdg-data-home") };
+
+        let resolved = PathRoot::XdgData.resolve("/tmp/home");
+        assert_eq!(resolved, "/tmp/xdg-data-home");
+
+        restore_env("XDG_DATA_HOME", previous);
+    }
+
+    #[test]
+    fn test_path_root_xdg_data_falls_back_when_unset() {
+        let _guard = env_lock().lock().unwrap();
+        let previous = std::env::var("XDG_DATA_HOME").ok();
+        unsafe { std::env::remove_var("XDG_DATA_HOME") };
+
+        let resolved = PathRoot::XdgData.resolve("/tmp/home");
+        assert_eq!(resolved, "/tmp/home/.local/share");
+
+        restore_env("XDG_DATA_HOME", previous);
+    }
+
+    #[test]
+    fn test_path_root_env_var_uses_env_when_set() {
+        let _guard = env_lock().lock().unwrap();
+        let var = "TOKSCALE_TEST_PATH_ROOT";
+        let previous = std::env::var(var).ok();
+        unsafe { std::env::set_var(var, "/tmp/custom-root") };
+
+        let root = PathRoot::EnvVar {
+            var,
+            fallback_relative: ".fallback",
+        };
+        let resolved = root.resolve("/tmp/home");
+        assert_eq!(resolved, "/tmp/custom-root");
+
+        restore_env(var, previous);
+    }
+
+    #[test]
+    fn test_path_root_env_var_falls_back_when_unset() {
+        let _guard = env_lock().lock().unwrap();
+        let var = "TOKSCALE_TEST_PATH_ROOT";
+        let previous = std::env::var(var).ok();
+        unsafe { std::env::remove_var(var) };
+
+        let root = PathRoot::EnvVar {
+            var,
+            fallback_relative: ".fallback",
+        };
+        let resolved = root.resolve("/tmp/home");
+        assert_eq!(resolved, "/tmp/home/.fallback");
+
+        restore_env(var, previous);
+    }
+
+    #[test]
+    fn test_client_def_resolve_path_combines_root_and_relative() {
+        let client = ClientDef {
+            id: "test",
+            root: PathRoot::Home,
+            relative_path: ".test/sessions",
+            pattern: "*.jsonl",
+            headless: false,
+            parse_local: true,
+        };
+
+        assert_eq!(client.resolve_path("/tmp/home"), "/tmp/home/.test/sessions");
+    }
+
+    #[test]
+    fn test_client_id_iter_yields_all_in_order() {
+        let all: Vec<ClientId> = ClientId::iter().collect();
+        assert_eq!(all, ClientId::ALL);
+    }
+
+    #[test]
+    fn test_client_counts_get_set_add_work() {
+        let mut counts = ClientCounts::new();
+
+        assert_eq!(counts.get(ClientId::Claude), 0);
+        counts.set(ClientId::Claude, 3);
+        assert_eq!(counts.get(ClientId::Claude), 3);
+        counts.add(ClientId::Claude, 2);
+        assert_eq!(counts.get(ClientId::Claude), 5);
+    }
+
+    #[test]
+    fn test_codex_root_uses_codex_home_env_var() {
+        assert_eq!(
+            ClientId::Codex.data().root,
+            PathRoot::EnvVar {
+                var: "CODEX_HOME",
+                fallback_relative: ".codex",
+            }
+        );
+    }
+
+    #[test]
+    fn test_cursor_parse_local_is_false() {
+        assert!(!ClientId::Cursor.data().parse_local);
+    }
+}

--- a/vendor/tokscale-core/src/lib.rs
+++ b/vendor/tokscale-core/src/lib.rs
@@ -1,0 +1,1665 @@
+#![deny(clippy::all)]
+
+mod aggregator;
+pub mod clients;
+mod parser;
+pub mod pricing;
+pub mod scanner;
+pub mod sessions;
+
+pub use aggregator::*;
+pub use clients::{ClientCounts, ClientDef, ClientId, PathRoot};
+pub use parser::*;
+pub use scanner::*;
+pub use sessions::UnifiedMessage;
+
+use rayon::prelude::*;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+pub fn normalize_model_for_grouping(model_id: &str) -> String {
+    let mut name = model_id.to_lowercase();
+
+    if name.len() > 9 {
+        let potential_date = &name[name.len() - 8..];
+        if potential_date.chars().all(|c| c.is_ascii_digit())
+            && name.as_bytes()[name.len() - 9] == b'-'
+        {
+            name = name[..name.len() - 9].to_string();
+        }
+    }
+
+    if name.contains("claude") {
+        let chars: Vec<char> = name.chars().collect();
+        let mut result = String::with_capacity(name.len());
+        for i in 0..chars.len() {
+            if chars[i] == '.'
+                && i > 0
+                && i < chars.len() - 1
+                && chars[i - 1].is_ascii_digit()
+                && chars[i + 1].is_ascii_digit()
+            {
+                result.push('-');
+            } else {
+                result.push(chars[i]);
+            }
+        }
+        name = result;
+    }
+
+    name
+}
+
+fn retain_for_requested_clients(
+    client: &str,
+    model_id: &str,
+    provider_id: &str,
+    requested: &HashSet<&str>,
+) -> bool {
+    requested.contains(client)
+        || (requested.contains("synthetic")
+            && sessions::synthetic::matches_synthetic_filter(client, model_id, provider_id))
+}
+
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
+pub enum GroupBy {
+    Model,
+    #[default]
+    ClientModel,
+    ClientProviderModel,
+}
+
+impl std::fmt::Display for GroupBy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GroupBy::Model => write!(f, "model"),
+            GroupBy::ClientModel => write!(f, "client,model"),
+            GroupBy::ClientProviderModel => write!(f, "client,provider,model"),
+        }
+    }
+}
+
+impl std::str::FromStr for GroupBy {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let normalized: String = s.split(',').map(|p| p.trim()).collect::<Vec<_>>().join(",");
+        match normalized.to_lowercase().as_str() {
+            "model" => Ok(GroupBy::Model),
+            "client,model" | "client-model" => Ok(GroupBy::ClientModel),
+            "client,provider,model" | "client-provider-model" => Ok(GroupBy::ClientProviderModel),
+            _ => Err(format!(
+                "Invalid group-by value: '{}'. Valid options: model, client,model, client,provider,model",
+                s
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct TokenBreakdown {
+    pub input: i64,
+    pub output: i64,
+    pub cache_read: i64,
+    pub cache_write: i64,
+    pub reasoning: i64,
+}
+
+impl TokenBreakdown {
+    pub fn total(&self) -> i64 {
+        self.input + self.output + self.cache_read + self.cache_write + self.reasoning
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ParsedMessage {
+    pub client: String,
+    pub model_id: String,
+    pub provider_id: String,
+    pub session_id: String,
+    pub timestamp: i64,
+    pub date: String,
+    pub input: i64,
+    pub output: i64,
+    pub cache_read: i64,
+    pub cache_write: i64,
+    pub reasoning: i64,
+    pub agent: Option<String>,
+}
+
+pub struct ParsedMessages {
+    pub messages: Vec<ParsedMessage>,
+    pub counts: ClientCounts,
+    pub processing_time_ms: u32,
+}
+
+impl Clone for ParsedMessages {
+    fn clone(&self) -> Self {
+        let mut counts = ClientCounts::new();
+        for client in ClientId::iter() {
+            counts.set(client, self.counts.get(client));
+        }
+
+        Self {
+            messages: self.messages.clone(),
+            counts,
+            processing_time_ms: self.processing_time_ms,
+        }
+    }
+}
+
+impl std::fmt::Debug for ParsedMessages {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug = f.debug_struct("ParsedMessages");
+        debug.field("messages", &self.messages);
+        for client in ClientId::iter() {
+            debug.field(client.as_str(), &self.counts.get(client));
+        }
+        debug.field("processing_time_ms", &self.processing_time_ms);
+        debug.finish()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LocalParseOptions {
+    pub home_dir: Option<String>,
+    pub clients: Option<Vec<String>>,
+    pub since: Option<String>,
+    pub until: Option<String>,
+    pub year: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct DailyTotals {
+    pub tokens: i64,
+    pub cost: f64,
+    pub messages: i32,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ClientContribution {
+    pub client: String,
+    pub model_id: String,
+    pub provider_id: String,
+    pub tokens: TokenBreakdown,
+    pub cost: f64,
+    pub messages: i32,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DailyContribution {
+    pub date: String,
+    pub totals: DailyTotals,
+    pub intensity: u8,
+    pub token_breakdown: TokenBreakdown,
+    pub clients: Vec<ClientContribution>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct YearSummary {
+    pub year: String,
+    pub total_tokens: i64,
+    pub total_cost: f64,
+    pub range_start: String,
+    pub range_end: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DataSummary {
+    pub total_tokens: i64,
+    pub total_cost: f64,
+    pub total_days: i32,
+    pub active_days: i32,
+    pub average_per_day: f64,
+    pub max_cost_in_single_day: f64,
+    pub clients: Vec<String>,
+    pub models: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct GraphMeta {
+    pub generated_at: String,
+    pub version: String,
+    pub date_range_start: String,
+    pub date_range_end: String,
+    pub processing_time_ms: u32,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct GraphResult {
+    pub meta: GraphMeta,
+    pub summary: DataSummary,
+    pub years: Vec<YearSummary>,
+    pub contributions: Vec<DailyContribution>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReportOptions {
+    pub home_dir: Option<String>,
+    pub clients: Option<Vec<String>>,
+    pub since: Option<String>,
+    pub until: Option<String>,
+    pub year: Option<String>,
+    pub group_by: GroupBy,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ModelUsage {
+    pub client: String,
+    pub merged_clients: Option<String>,
+    pub model: String,
+    pub provider: String,
+    pub input: i64,
+    pub output: i64,
+    pub cache_read: i64,
+    pub cache_write: i64,
+    pub reasoning: i64,
+    pub message_count: i32,
+    pub cost: f64,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct MonthlyUsage {
+    pub month: String,
+    pub models: Vec<String>,
+    pub input: i64,
+    pub output: i64,
+    pub cache_read: i64,
+    pub cache_write: i64,
+    pub message_count: i32,
+    pub cost: f64,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ModelReport {
+    pub entries: Vec<ModelUsage>,
+    pub total_input: i64,
+    pub total_output: i64,
+    pub total_cache_read: i64,
+    pub total_cache_write: i64,
+    pub total_messages: i32,
+    pub total_cost: f64,
+    pub processing_time_ms: u32,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct MonthlyReport {
+    pub entries: Vec<MonthlyUsage>,
+    pub total_cost: f64,
+    pub processing_time_ms: u32,
+}
+
+pub fn get_home_dir_string(home_dir_option: &Option<String>) -> Result<String, String> {
+    home_dir_option
+        .clone()
+        .or_else(|| std::env::var("HOME").ok())
+        .or_else(|| dirs::home_dir().map(|p| p.to_string_lossy().into_owned()))
+        .ok_or_else(|| {
+            "HOME directory not specified and could not determine home directory".to_string()
+        })
+}
+
+fn parse_all_messages_with_pricing(
+    home_dir: &str,
+    clients: &[String],
+    pricing: Option<&pricing::PricingService>,
+) -> Vec<UnifiedMessage> {
+    let scan_result = scanner::scan_all_clients(home_dir, clients);
+    let headless_roots = scanner::headless_roots(home_dir);
+    let mut all_messages: Vec<UnifiedMessage> = Vec::new();
+    let include_all = clients.is_empty();
+    let include_synthetic = include_all || clients.iter().any(|c| c == "synthetic");
+
+    // Parse OpenCode: read both SQLite (1.2+) and legacy JSON, deduplicate by message ID
+    let mut opencode_seen: HashSet<String> = HashSet::new();
+
+    if let Some(db_path) = &scan_result.opencode_db {
+        let sqlite_messages: Vec<UnifiedMessage> =
+            sessions::opencode::parse_opencode_sqlite(db_path)
+                .into_iter()
+                .map(|mut msg| {
+                    apply_pricing_if_available(&mut msg, pricing);
+                    if let Some(ref key) = msg.dedup_key {
+                        opencode_seen.insert(key.clone());
+                    }
+                    msg
+                })
+                .collect();
+        all_messages.extend(sqlite_messages);
+    }
+
+    let opencode_messages: Vec<UnifiedMessage> = scan_result
+        .get(ClientId::OpenCode)
+        .par_iter()
+        .filter_map(|path| {
+            let mut msg = sessions::opencode::parse_opencode_file(path)?;
+            apply_pricing_if_available(&mut msg, pricing);
+            Some(msg)
+        })
+        .collect();
+    all_messages.extend(opencode_messages.into_iter().filter(|msg| {
+        msg.dedup_key
+            .as_ref()
+            .is_none_or(|key| opencode_seen.insert(key.clone()))
+    }));
+
+    let claude_messages_raw: Vec<(String, UnifiedMessage)> = scan_result
+        .get(ClientId::Claude)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::claudecode::parse_claude_file(path)
+                .into_iter()
+                .map(|mut msg| {
+                    let dedup_key = msg.dedup_key.clone().unwrap_or_default();
+                    apply_pricing_if_available(&mut msg, pricing);
+                    (dedup_key, msg)
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    let mut seen_keys: HashSet<String> = HashSet::new();
+    let claude_messages: Vec<UnifiedMessage> = claude_messages_raw
+        .into_iter()
+        .filter(|(key, _)| key.is_empty() || seen_keys.insert(key.clone()))
+        .map(|(_, msg)| msg)
+        .collect();
+    all_messages.extend(claude_messages);
+
+    let codex_messages: Vec<UnifiedMessage> = scan_result
+        .get(ClientId::Codex)
+        .par_iter()
+        .flat_map(|path| {
+            let is_headless = is_headless_path(path, &headless_roots);
+            sessions::codex::parse_codex_file(path)
+                .into_iter()
+                .map(|mut msg| {
+                    apply_headless_agent(&mut msg, is_headless);
+                    apply_pricing_if_available(&mut msg, pricing);
+                    msg
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    all_messages.extend(codex_messages);
+
+    let gemini_messages: Vec<UnifiedMessage> = scan_result
+        .get(ClientId::Gemini)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::gemini::parse_gemini_file(path)
+                .into_iter()
+                .map(|mut msg| {
+                    apply_pricing_if_available(&mut msg, pricing);
+                    msg
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    all_messages.extend(gemini_messages);
+
+    let cursor_messages: Vec<UnifiedMessage> = scan_result
+        .get(ClientId::Cursor)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::cursor::parse_cursor_file(path)
+                .into_iter()
+                .map(|mut msg| {
+                    apply_pricing_if_available(&mut msg, pricing);
+                    msg
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    all_messages.extend(cursor_messages);
+
+    let amp_messages: Vec<UnifiedMessage> = scan_result
+        .get(ClientId::Amp)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::amp::parse_amp_file(path)
+                .into_iter()
+                .map(|mut msg| {
+                    apply_pricing_if_available(&mut msg, pricing);
+                    msg
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    all_messages.extend(amp_messages);
+
+    let droid_messages: Vec<UnifiedMessage> = scan_result
+        .get(ClientId::Droid)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::droid::parse_droid_file(path)
+                .into_iter()
+                .map(|mut msg| {
+                    apply_pricing_if_available(&mut msg, pricing);
+                    msg
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    all_messages.extend(droid_messages);
+
+    let openclaw_messages: Vec<UnifiedMessage> = scan_result
+        .get(ClientId::OpenClaw)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::openclaw::parse_openclaw_transcript(path)
+                .into_iter()
+                .map(|mut msg| {
+                    apply_pricing_if_available(&mut msg, pricing);
+                    msg
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    all_messages.extend(openclaw_messages);
+
+    let pi_messages: Vec<UnifiedMessage> = scan_result
+        .get(ClientId::Pi)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::pi::parse_pi_file(path)
+                .into_iter()
+                .map(|mut msg| {
+                    apply_pricing_if_available(&mut msg, pricing);
+                    msg
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    all_messages.extend(pi_messages);
+
+    let kimi_messages: Vec<UnifiedMessage> = scan_result
+        .get(ClientId::Kimi)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::kimi::parse_kimi_file(path)
+                .into_iter()
+                .map(|mut msg| {
+                    apply_pricing_if_available(&mut msg, pricing);
+                    msg
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    all_messages.extend(kimi_messages);
+
+    // Parse Qwen files
+    let qwen_messages: Vec<UnifiedMessage> = scan_result
+        .get(ClientId::Qwen)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::qwen::parse_qwen_file(path)
+                .into_iter()
+                .map(|mut msg| {
+                    apply_pricing_if_available(&mut msg, pricing);
+                    msg
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    all_messages.extend(qwen_messages);
+
+    let roocode_messages: Vec<UnifiedMessage> = scan_result
+        .get(ClientId::RooCode)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::roocode::parse_roocode_file(path)
+                .into_iter()
+                .map(|mut msg| {
+                    apply_pricing_if_available(&mut msg, pricing);
+                    msg
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    all_messages.extend(roocode_messages);
+
+    let kilocode_messages: Vec<UnifiedMessage> = scan_result
+        .get(ClientId::KiloCode)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::kilocode::parse_kilocode_file(path)
+                .into_iter()
+                .map(|mut msg| {
+                    apply_pricing_if_available(&mut msg, pricing);
+                    msg
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    all_messages.extend(kilocode_messages);
+
+    let mux_messages: Vec<UnifiedMessage> = scan_result
+        .get(ClientId::Mux)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::mux::parse_mux_file(path)
+                .into_iter()
+                .map(|mut msg| {
+                    apply_pricing_if_available(&mut msg, pricing);
+                    msg
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    all_messages.extend(mux_messages);
+
+    if include_synthetic {
+        if let Some(db_path) = &scan_result.synthetic_db {
+            let synthetic_messages: Vec<UnifiedMessage> =
+                sessions::synthetic::parse_octofriend_sqlite(db_path)
+                    .into_iter()
+                    .map(|mut msg| {
+                        apply_pricing_if_available(&mut msg, pricing);
+                        msg
+                    })
+                    .collect();
+            all_messages.extend(synthetic_messages);
+        }
+    }
+
+    // Filter BEFORE normalization so retain_for_requested_clients can see
+    // original model/provider prefixes (e.g. "accounts/fireworks/models/…")
+    // that is_synthetic_gateway relies on for gateway detection.
+    if !include_all {
+        let requested: HashSet<&str> = clients.iter().map(String::as_str).collect();
+        all_messages.retain(|msg| {
+            retain_for_requested_clients(&msg.client, &msg.model_id, &msg.provider_id, &requested)
+        });
+    }
+
+    if include_synthetic {
+        for msg in &mut all_messages {
+            sessions::synthetic::normalize_synthetic_gateway_fields(
+                &mut msg.model_id,
+                &mut msg.provider_id,
+            );
+        }
+    }
+
+    all_messages
+}
+
+fn filter_unified_messages(
+    messages: Vec<UnifiedMessage>,
+    options: &LocalParseOptions,
+) -> Vec<UnifiedMessage> {
+    let mut filtered = messages;
+
+    if let Some(year) = &options.year {
+        let year_prefix = format!("{}-", year);
+        filtered.retain(|m| m.date.starts_with(&year_prefix));
+    }
+
+    if let Some(since) = &options.since {
+        filtered.retain(|m| m.date.as_str() >= since.as_str());
+    }
+
+    if let Some(until) = &options.until {
+        filtered.retain(|m| m.date.as_str() <= until.as_str());
+    }
+
+    filtered
+}
+
+pub async fn get_model_report(options: ReportOptions) -> Result<ModelReport, String> {
+    let start = Instant::now();
+
+    let home_dir = get_home_dir_string(&options.home_dir)?;
+
+    let clients: Vec<String> = options.clients.clone().unwrap_or_else(|| {
+        let mut clients: Vec<String> = ClientId::ALL
+            .iter()
+            .map(|c| c.as_str().to_string())
+            .collect();
+        clients.push("synthetic".to_string());
+        clients
+    });
+
+    let pricing = pricing::PricingService::get_or_init().await?;
+    let all_messages = parse_all_messages_with_pricing(&home_dir, &clients, Some(&pricing));
+
+    let filtered = filter_messages_for_report(all_messages, &options);
+
+    let mut model_map: HashMap<String, ModelUsage> = HashMap::new();
+    let group_by = &options.group_by;
+
+    for msg in filtered {
+        let normalized = normalize_model_for_grouping(&msg.model_id);
+        let key = match group_by {
+            GroupBy::Model => normalized.clone(),
+            GroupBy::ClientModel => format!("{}:{}", msg.client, normalized),
+            GroupBy::ClientProviderModel => {
+                format!("{}:{}:{}", msg.client, msg.provider_id, normalized)
+            }
+        };
+        let entry = model_map.entry(key).or_insert_with(|| ModelUsage {
+            client: msg.client.clone(),
+            merged_clients: if *group_by == GroupBy::Model {
+                Some(msg.client.clone())
+            } else {
+                None
+            },
+            model: normalized.clone(),
+            provider: msg.provider_id.clone(),
+            input: 0,
+            output: 0,
+            cache_read: 0,
+            cache_write: 0,
+            reasoning: 0,
+            message_count: 0,
+            cost: 0.0,
+        });
+
+        if *group_by == GroupBy::Model {
+            if !entry.client.split(", ").any(|s| s == msg.client) {
+                entry.client = format!("{}, {}", entry.client, msg.client);
+            }
+
+            if let Some(merged_clients) = &mut entry.merged_clients {
+                if !merged_clients.split(", ").any(|s| s == msg.client) {
+                    *merged_clients = format!("{}, {}", merged_clients, msg.client);
+                }
+            }
+        }
+
+        if *group_by != GroupBy::ClientProviderModel
+            && !entry.provider.split(", ").any(|p| p == msg.provider_id)
+        {
+            entry.provider = format!("{}, {}", entry.provider, msg.provider_id);
+        }
+
+        entry.input += msg.tokens.input;
+        entry.output += msg.tokens.output;
+        entry.cache_read += msg.tokens.cache_read;
+        entry.cache_write += msg.tokens.cache_write;
+        entry.reasoning += msg.tokens.reasoning;
+        entry.message_count += 1;
+        entry.cost += msg.cost;
+    }
+
+    let mut entries: Vec<ModelUsage> = model_map
+        .into_values()
+        .map(|mut entry| {
+            // Normalize provider order for deterministic output
+            let mut providers: Vec<&str> = entry.provider.split(", ").collect();
+            providers.sort_unstable();
+            providers.dedup();
+            entry.provider = providers.join(", ");
+            entry
+        })
+        .collect();
+    entries.sort_by(|a, b| match (a.cost.is_nan(), b.cost.is_nan()) {
+        (true, true) => std::cmp::Ordering::Equal,
+        (true, false) => std::cmp::Ordering::Greater,
+        (false, true) => std::cmp::Ordering::Less,
+        (false, false) => b
+            .cost
+            .partial_cmp(&a.cost)
+            .unwrap_or(std::cmp::Ordering::Equal),
+    });
+
+    let total_input: i64 = entries.iter().map(|e| e.input).sum();
+    let total_output: i64 = entries.iter().map(|e| e.output).sum();
+    let total_cache_read: i64 = entries.iter().map(|e| e.cache_read).sum();
+    let total_cache_write: i64 = entries.iter().map(|e| e.cache_write).sum();
+    let total_messages: i32 = entries.iter().map(|e| e.message_count).sum();
+    let total_cost: f64 = entries.iter().map(|e| e.cost).sum();
+
+    Ok(ModelReport {
+        entries,
+        total_input,
+        total_output,
+        total_cache_read,
+        total_cache_write,
+        total_messages,
+        total_cost,
+        processing_time_ms: start.elapsed().as_millis() as u32,
+    })
+}
+
+#[derive(Default)]
+struct MonthAggregator {
+    models: HashSet<String>,
+    input: i64,
+    output: i64,
+    cache_read: i64,
+    cache_write: i64,
+    message_count: i32,
+    cost: f64,
+}
+
+pub async fn get_monthly_report(options: ReportOptions) -> Result<MonthlyReport, String> {
+    let start = Instant::now();
+
+    let home_dir = get_home_dir_string(&options.home_dir)?;
+
+    let clients: Vec<String> = options.clients.clone().unwrap_or_else(|| {
+        let mut clients: Vec<String> = ClientId::ALL
+            .iter()
+            .map(|c| c.as_str().to_string())
+            .collect();
+        clients.push("synthetic".to_string());
+        clients
+    });
+
+    let pricing = pricing::PricingService::get_or_init().await?;
+    let all_messages = parse_all_messages_with_pricing(&home_dir, &clients, Some(&pricing));
+
+    let filtered = filter_messages_for_report(all_messages, &options);
+
+    let mut month_map: HashMap<String, MonthAggregator> = HashMap::new();
+
+    for msg in filtered {
+        let month = if msg.date.len() >= 7 {
+            msg.date[..7].to_string()
+        } else {
+            continue;
+        };
+
+        let entry = month_map.entry(month).or_default();
+
+        entry
+            .models
+            .insert(normalize_model_for_grouping(&msg.model_id));
+        entry.input += msg.tokens.input;
+        entry.output += msg.tokens.output;
+        entry.cache_read += msg.tokens.cache_read;
+        entry.cache_write += msg.tokens.cache_write;
+        entry.message_count += 1;
+        entry.cost += msg.cost;
+    }
+
+    let mut entries: Vec<MonthlyUsage> = month_map
+        .into_iter()
+        .map(|(month, agg)| MonthlyUsage {
+            month,
+            models: agg.models.into_iter().collect(),
+            input: agg.input,
+            output: agg.output,
+            cache_read: agg.cache_read,
+            cache_write: agg.cache_write,
+            message_count: agg.message_count,
+            cost: agg.cost,
+        })
+        .collect();
+
+    entries.sort_by(|a, b| a.month.cmp(&b.month));
+
+    let total_cost: f64 = entries.iter().map(|e| e.cost).sum();
+
+    Ok(MonthlyReport {
+        entries,
+        total_cost,
+        processing_time_ms: start.elapsed().as_millis() as u32,
+    })
+}
+
+pub async fn generate_graph(options: ReportOptions) -> Result<GraphResult, String> {
+    let start = Instant::now();
+
+    let home_dir = get_home_dir_string(&options.home_dir)?;
+
+    let clients: Vec<String> = options.clients.clone().unwrap_or_else(|| {
+        let mut clients: Vec<String> = ClientId::ALL
+            .iter()
+            .map(|c| c.as_str().to_string())
+            .collect();
+        clients.push("synthetic".to_string());
+        clients
+    });
+
+    let pricing = pricing::PricingService::get_or_init().await?;
+    let all_messages = parse_all_messages_with_pricing(&home_dir, &clients, Some(&pricing));
+
+    let filtered = filter_messages_for_report(all_messages, &options);
+
+    let contributions = aggregator::aggregate_by_date(filtered);
+
+    let processing_time_ms = start.elapsed().as_millis() as u32;
+    let result = aggregator::generate_graph_result(contributions, processing_time_ms);
+
+    Ok(result)
+}
+
+fn filter_messages_for_report(
+    messages: Vec<UnifiedMessage>,
+    options: &ReportOptions,
+) -> Vec<UnifiedMessage> {
+    let mut filtered = messages;
+
+    if let Some(year) = &options.year {
+        let year_prefix = format!("{}-", year);
+        filtered.retain(|m| m.date.starts_with(&year_prefix));
+    }
+
+    if let Some(since) = &options.since {
+        filtered.retain(|m| m.date.as_str() >= since.as_str());
+    }
+
+    if let Some(until) = &options.until {
+        filtered.retain(|m| m.date.as_str() <= until.as_str());
+    }
+
+    filtered
+}
+
+fn is_headless_path(path: &Path, headless_roots: &[PathBuf]) -> bool {
+    headless_roots.iter().any(|root| path.starts_with(root))
+}
+
+fn apply_headless_agent(message: &mut UnifiedMessage, is_headless: bool) {
+    if is_headless && message.agent.is_none() {
+        message.agent = Some("headless".to_string());
+    }
+}
+
+fn apply_pricing_if_available(
+    message: &mut UnifiedMessage,
+    pricing: Option<&pricing::PricingService>,
+) {
+    let Some(pricing) = pricing else {
+        return;
+    };
+
+    let calculated_cost = if message.client.eq_ignore_ascii_case("gemini") {
+        pricing.calculate_cost(
+            &message.model_id,
+            message.tokens.input,
+            message.tokens.output + message.tokens.reasoning,
+            0,
+            0,
+            0,
+        )
+    } else {
+        pricing.calculate_cost(
+            &message.model_id,
+            message.tokens.input,
+            message.tokens.output,
+            message.tokens.cache_read,
+            message.tokens.cache_write,
+            message.tokens.reasoning,
+        )
+    };
+
+    if calculated_cost > 0.0 {
+        message.cost = calculated_cost;
+    }
+}
+
+pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages, String> {
+    let start = Instant::now();
+
+    let home_dir = get_home_dir_string(&options.home_dir)?;
+
+    let clients: Vec<String> = options.clients.clone().unwrap_or_else(|| {
+        let mut clients: Vec<String> = ClientId::iter()
+            .filter(|c| c.parse_local())
+            .map(|c| c.as_str().to_string())
+            .collect();
+        clients.push("synthetic".to_string());
+        clients
+    });
+    let include_all = clients.is_empty();
+    let include_synthetic = include_all || clients.iter().any(|c| c == "synthetic");
+
+    let scan_result = scanner::scan_all_clients(&home_dir, &clients);
+    let headless_roots = scanner::headless_roots(&home_dir);
+
+    let mut messages: Vec<ParsedMessage> = Vec::new();
+
+    // Parse OpenCode: read both SQLite (1.2+) and legacy JSON, deduplicate by message ID
+    let mut counts = ClientCounts::new();
+
+    let opencode_count: i32 = {
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut count: i32 = 0;
+
+        if let Some(db_path) = &scan_result.opencode_db {
+            let sqlite_msgs: Vec<(String, ParsedMessage)> =
+                sessions::opencode::parse_opencode_sqlite(db_path)
+                    .into_iter()
+                    .map(|msg| {
+                        let key = msg.dedup_key.clone().unwrap_or_default();
+                        (key, unified_to_parsed(&msg))
+                    })
+                    .collect();
+            count += sqlite_msgs.len() as i32;
+            for (key, parsed) in sqlite_msgs {
+                if !key.is_empty() {
+                    seen.insert(key);
+                }
+                messages.push(parsed);
+            }
+        }
+
+        let json_msgs: Vec<(String, ParsedMessage)> = scan_result
+            .get(ClientId::OpenCode)
+            .par_iter()
+            .filter_map(|path| {
+                let msg = sessions::opencode::parse_opencode_file(path)?;
+                let key = msg.dedup_key.clone().unwrap_or_default();
+                Some((key, unified_to_parsed(&msg)))
+            })
+            .collect();
+        let deduped: Vec<ParsedMessage> = json_msgs
+            .into_iter()
+            .filter(|(key, _)| key.is_empty() || seen.insert(key.clone()))
+            .map(|(_, msg)| msg)
+            .collect();
+        count += deduped.len() as i32;
+        messages.extend(deduped);
+
+        count
+    };
+    counts.set(ClientId::OpenCode, opencode_count);
+
+    let claude_msgs_raw: Vec<(String, ParsedMessage)> = scan_result
+        .get(ClientId::Claude)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::claudecode::parse_claude_file(path)
+                .into_iter()
+                .map(|msg| {
+                    let dedup_key = msg.dedup_key.clone().unwrap_or_default();
+                    (dedup_key, unified_to_parsed(&msg))
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    let mut seen_keys: HashSet<String> = HashSet::new();
+    let claude_msgs: Vec<ParsedMessage> = claude_msgs_raw
+        .into_iter()
+        .filter(|(key, _)| key.is_empty() || seen_keys.insert(key.clone()))
+        .map(|(_, msg)| msg)
+        .collect();
+    let claude_count = claude_msgs.len() as i32;
+    counts.set(ClientId::Claude, claude_count);
+    messages.extend(claude_msgs);
+
+    let codex_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::Codex)
+        .par_iter()
+        .flat_map(|path| {
+            let is_headless = is_headless_path(path, &headless_roots);
+            sessions::codex::parse_codex_file(path)
+                .into_iter()
+                .map(|mut msg| {
+                    apply_headless_agent(&mut msg, is_headless);
+                    unified_to_parsed(&msg)
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let codex_count = codex_msgs.len() as i32;
+    counts.set(ClientId::Codex, codex_count);
+    messages.extend(codex_msgs);
+
+    let gemini_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::Gemini)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::gemini::parse_gemini_file(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let gemini_count = gemini_msgs.len() as i32;
+    counts.set(ClientId::Gemini, gemini_count);
+    messages.extend(gemini_msgs);
+
+    let amp_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::Amp)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::amp::parse_amp_file(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let amp_count = amp_msgs.len() as i32;
+    counts.set(ClientId::Amp, amp_count);
+    messages.extend(amp_msgs);
+
+    let droid_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::Droid)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::droid::parse_droid_file(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let droid_count = droid_msgs.len() as i32;
+    counts.set(ClientId::Droid, droid_count);
+    messages.extend(droid_msgs);
+
+    let openclaw_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::OpenClaw)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::openclaw::parse_openclaw_transcript(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let openclaw_count = openclaw_msgs.len() as i32;
+    counts.set(ClientId::OpenClaw, openclaw_count);
+    messages.extend(openclaw_msgs);
+
+    let pi_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::Pi)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::pi::parse_pi_file(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let pi_count = pi_msgs.len() as i32;
+    counts.set(ClientId::Pi, pi_count);
+    messages.extend(pi_msgs);
+
+    // Parse Kimi wire.jsonl files in parallel
+    let kimi_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::Kimi)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::kimi::parse_kimi_file(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let kimi_count = kimi_msgs.len() as i32;
+    counts.set(ClientId::Kimi, kimi_count);
+    messages.extend(kimi_msgs);
+
+    // Parse Qwen JSONL files in parallel
+    let qwen_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::Qwen)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::qwen::parse_qwen_file(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let qwen_count = qwen_msgs.len() as i32;
+    counts.set(ClientId::Qwen, qwen_count);
+    messages.extend(qwen_msgs);
+
+    let roocode_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::RooCode)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::roocode::parse_roocode_file(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let roocode_count = roocode_msgs.len() as i32;
+    counts.set(ClientId::RooCode, roocode_count);
+    messages.extend(roocode_msgs);
+
+    let kilocode_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::KiloCode)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::kilocode::parse_kilocode_file(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let kilocode_count = kilocode_msgs.len() as i32;
+    counts.set(ClientId::KiloCode, kilocode_count);
+    messages.extend(kilocode_msgs);
+
+    let mux_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::Mux)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::mux::parse_mux_file(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let mux_count = mux_msgs.len() as i32;
+    counts.set(ClientId::Mux, mux_count);
+    messages.extend(mux_msgs);
+
+    if include_synthetic {
+        if let Some(db_path) = &scan_result.synthetic_db {
+            let synthetic_msgs: Vec<ParsedMessage> =
+                sessions::synthetic::parse_octofriend_sqlite(db_path)
+                    .into_iter()
+                    .map(|msg| unified_to_parsed(&msg))
+                    .collect();
+            messages.extend(synthetic_msgs);
+        }
+    }
+
+    // Filter BEFORE normalization (see parse_all_messages_with_pricing).
+    if !include_all {
+        let requested: HashSet<&str> = clients.iter().map(String::as_str).collect();
+        messages.retain(|msg| {
+            retain_for_requested_clients(&msg.client, &msg.model_id, &msg.provider_id, &requested)
+        });
+    }
+
+    if include_synthetic {
+        for msg in &mut messages {
+            sessions::synthetic::normalize_synthetic_gateway_fields(
+                &mut msg.model_id,
+                &mut msg.provider_id,
+            );
+        }
+    }
+
+    let filtered = filter_parsed_messages(messages, &options);
+
+    Ok(ParsedMessages {
+        messages: filtered,
+        counts,
+        processing_time_ms: start.elapsed().as_millis() as u32,
+    })
+}
+
+pub async fn parse_local_unified_messages(
+    options: LocalParseOptions,
+) -> Result<Vec<UnifiedMessage>, String> {
+    let home_dir = get_home_dir_string(&options.home_dir)?;
+
+    let clients: Vec<String> = options.clients.clone().unwrap_or_else(|| {
+        let mut clients: Vec<String> = ClientId::iter()
+            .filter(|c| c.parse_local())
+            .map(|c| c.as_str().to_string())
+            .collect();
+        clients.push("synthetic".to_string());
+        clients
+    });
+
+    let pricing = pricing::PricingService::load_cached_any_age();
+    let messages = parse_all_messages_with_pricing(&home_dir, &clients, pricing.as_ref());
+
+    Ok(filter_unified_messages(messages, &options))
+}
+
+fn unified_to_parsed(msg: &UnifiedMessage) -> ParsedMessage {
+    ParsedMessage {
+        client: msg.client.clone(),
+        model_id: msg.model_id.clone(),
+        provider_id: msg.provider_id.clone(),
+        session_id: msg.session_id.clone(),
+        timestamp: msg.timestamp,
+        date: msg.date.clone(),
+        input: msg.tokens.input,
+        output: msg.tokens.output,
+        cache_read: msg.tokens.cache_read,
+        cache_write: msg.tokens.cache_write,
+        reasoning: msg.tokens.reasoning,
+        agent: msg.agent.clone(),
+    }
+}
+
+fn filter_parsed_messages(
+    messages: Vec<ParsedMessage>,
+    options: &LocalParseOptions,
+) -> Vec<ParsedMessage> {
+    let mut filtered = messages;
+
+    if let Some(year) = &options.year {
+        let year_prefix = format!("{}-", year);
+        filtered.retain(|m| m.date.starts_with(&year_prefix));
+    }
+
+    if let Some(since) = &options.since {
+        filtered.retain(|m| m.date.as_str() >= since.as_str());
+    }
+
+    if let Some(until) = &options.until {
+        filtered.retain(|m| m.date.as_str() <= until.as_str());
+    }
+
+    filtered
+}
+
+pub fn parsed_to_unified(msg: &ParsedMessage, cost: f64) -> UnifiedMessage {
+    UnifiedMessage {
+        client: msg.client.clone(),
+        model_id: msg.model_id.clone(),
+        provider_id: msg.provider_id.clone(),
+        session_id: msg.session_id.clone(),
+        timestamp: msg.timestamp,
+        date: msg.date.clone(),
+        tokens: TokenBreakdown {
+            input: msg.input,
+            output: msg.output,
+            cache_read: msg.cache_read,
+            cache_write: msg.cache_write,
+            reasoning: msg.reasoning,
+        },
+        cost,
+        agent: msg.agent.clone(),
+        dedup_key: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        apply_pricing_if_available, normalize_model_for_grouping, parse_all_messages_with_pricing,
+        parse_local_clients, pricing, retain_for_requested_clients, ClientId, GroupBy,
+        LocalParseOptions, TokenBreakdown, UnifiedMessage,
+    };
+    use std::collections::{HashMap, HashSet};
+    use std::str::FromStr;
+
+    #[test]
+    fn test_normalize_model_for_grouping() {
+        assert_eq!(
+            normalize_model_for_grouping("claude-opus-4-5-20251101"),
+            "claude-opus-4-5"
+        );
+        assert_eq!(
+            normalize_model_for_grouping("claude-sonnet-4-5-20250929"),
+            "claude-sonnet-4-5"
+        );
+        assert_eq!(
+            normalize_model_for_grouping("claude-sonnet-4-20250514"),
+            "claude-sonnet-4"
+        );
+
+        assert_eq!(
+            normalize_model_for_grouping("claude-opus-4.5"),
+            "claude-opus-4-5"
+        );
+        assert_eq!(
+            normalize_model_for_grouping("claude-sonnet-4.5"),
+            "claude-sonnet-4-5"
+        );
+        assert_eq!(
+            normalize_model_for_grouping("claude-opus-4.6"),
+            "claude-opus-4-6"
+        );
+
+        assert_eq!(normalize_model_for_grouping("gpt-5.2"), "gpt-5.2");
+        assert_eq!(
+            normalize_model_for_grouping("gemini-2.5-pro"),
+            "gemini-2.5-pro"
+        );
+
+        assert_eq!(
+            normalize_model_for_grouping("claude-opus-4-5-high"),
+            "claude-opus-4-5-high"
+        );
+        assert_eq!(
+            normalize_model_for_grouping("claude-opus-4-5-thinking-high"),
+            "claude-opus-4-5-thinking-high"
+        );
+        assert_eq!(
+            normalize_model_for_grouping("claude-sonnet-4-5-high"),
+            "claude-sonnet-4-5-high"
+        );
+
+        assert_eq!(
+            normalize_model_for_grouping("claude-4-sonnet"),
+            "claude-4-sonnet"
+        );
+        assert_eq!(
+            normalize_model_for_grouping("claude-4-opus-thinking"),
+            "claude-4-opus-thinking"
+        );
+
+        assert_eq!(normalize_model_for_grouping("big-pickle"), "big-pickle");
+        assert_eq!(normalize_model_for_grouping("grok-code"), "grok-code");
+
+        assert_eq!(
+            normalize_model_for_grouping("claude-opus-4.5-20251101"),
+            "claude-opus-4-5"
+        );
+    }
+
+    #[test]
+    fn test_group_by_from_str_valid_values() {
+        assert_eq!(GroupBy::from_str("model").unwrap(), GroupBy::Model);
+        assert_eq!(
+            GroupBy::from_str("client,model").unwrap(),
+            GroupBy::ClientModel
+        );
+        assert_eq!(
+            GroupBy::from_str("client-model").unwrap(),
+            GroupBy::ClientModel
+        );
+        assert_eq!(
+            GroupBy::from_str("client,provider,model").unwrap(),
+            GroupBy::ClientProviderModel
+        );
+        assert_eq!(
+            GroupBy::from_str("client-provider-model").unwrap(),
+            GroupBy::ClientProviderModel
+        );
+        assert!(GroupBy::from_str("unknown").is_err());
+    }
+
+    #[test]
+    fn test_group_by_default_is_client_model() {
+        assert_eq!(GroupBy::default(), GroupBy::ClientModel);
+    }
+
+    #[test]
+    fn test_group_by_display_round_trips_with_from_str() {
+        let variants = [
+            GroupBy::Model,
+            GroupBy::ClientModel,
+            GroupBy::ClientProviderModel,
+        ];
+
+        for variant in variants {
+            let rendered = variant.to_string();
+            let parsed = GroupBy::from_str(&rendered).unwrap();
+            assert_eq!(parsed, variant);
+        }
+    }
+
+    #[test]
+    fn test_group_by_from_str_whitespace_handling() {
+        assert_eq!(
+            GroupBy::from_str("client, model").unwrap(),
+            GroupBy::ClientModel
+        );
+        assert_eq!(GroupBy::from_str(" model ").unwrap(), GroupBy::Model);
+        assert_eq!(
+            GroupBy::from_str("client , provider , model").unwrap(),
+            GroupBy::ClientProviderModel
+        );
+    }
+
+    #[test]
+    fn test_retain_for_requested_clients_keeps_original_client_matches() {
+        let requested: HashSet<&str> = HashSet::from(["opencode"]);
+        assert!(retain_for_requested_clients(
+            "opencode",
+            "gpt-4o",
+            "anthropic",
+            &requested
+        ));
+        assert!(!retain_for_requested_clients(
+            "claude",
+            "gpt-4o",
+            "anthropic",
+            &requested
+        ));
+    }
+
+    #[test]
+    fn test_retain_for_requested_clients_accepts_synthetic_gateway_traffic() {
+        let requested: HashSet<&str> = HashSet::from(["synthetic"]);
+        assert!(retain_for_requested_clients(
+            "opencode",
+            "hf:deepseek-ai/DeepSeek-V3-0324",
+            "unknown",
+            &requested
+        ));
+        assert!(retain_for_requested_clients(
+            "synthetic",
+            "deepseek-v3-0324",
+            "synthetic",
+            &requested
+        ));
+        assert!(!retain_for_requested_clients(
+            "opencode",
+            "gpt-4o",
+            "anthropic",
+            &requested
+        ));
+    }
+
+    #[test]
+    fn test_cursor_parse_path_reprices_zero_cost_composer_1_5_rows() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let cursor_cache_dir = temp_dir.path().join(".config/tokscale/cursor-cache");
+        std::fs::create_dir_all(&cursor_cache_dir).unwrap();
+
+        let csv = r#"Date,Kind,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Total Tokens,Cost
+"2026-03-04T12:00:00.000Z","Included","Composer 1.5","No","1200","1000","5000","2000","8000","0""#;
+        std::fs::write(cursor_cache_dir.join("usage.csv"), csv).unwrap();
+
+        let pricing = pricing::PricingService::new(HashMap::new(), HashMap::new());
+        let messages = parse_all_messages_with_pricing(
+            temp_dir.path().to_str().unwrap(),
+            &["cursor".to_string()],
+            Some(&pricing),
+        );
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, "cursor");
+        assert_eq!(messages[0].model_id, "Composer 1.5");
+        assert!(messages[0].cost > 0.0);
+    }
+
+    #[test]
+    fn test_apply_pricing_if_available_keeps_existing_cost_without_pricing() {
+        let mut msg = UnifiedMessage::new_with_agent(
+            "roocode",
+            "gpt-4o",
+            "provider",
+            "session-1",
+            1_733_011_200_000,
+            TokenBreakdown {
+                input: 10,
+                output: 5,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            0.42,
+            Some("planner".to_string()),
+        );
+
+        apply_pricing_if_available(&mut msg, None);
+
+        assert_eq!(msg.cost, 0.42);
+    }
+
+    #[test]
+    fn test_apply_pricing_if_available_overrides_cost_when_pricing_exists() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "gpt-4o".into(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(0.001),
+                output_cost_per_token: Some(0.002),
+                ..Default::default()
+            },
+        );
+        let pricing = pricing::PricingService::new(litellm, HashMap::new());
+
+        let mut msg = UnifiedMessage::new(
+            "codex",
+            "gpt-4o",
+            "provider",
+            "session-1",
+            1_733_011_200_000,
+            TokenBreakdown {
+                input: 10,
+                output: 5,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            0.0,
+        );
+
+        apply_pricing_if_available(&mut msg, Some(&pricing));
+
+        assert_eq!(msg.cost, 0.02);
+    }
+
+    #[test]
+    fn test_apply_pricing_if_available_uses_reasoning_for_gemini() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "gemini-2.5-pro".into(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(0.001),
+                output_cost_per_token: Some(0.002),
+                ..Default::default()
+            },
+        );
+        let pricing = pricing::PricingService::new(litellm, HashMap::new());
+
+        let mut msg = UnifiedMessage::new(
+            "gemini",
+            "gemini-2.5-pro",
+            "google",
+            "session-1",
+            1_733_011_200_000,
+            TokenBreakdown {
+                input: 10,
+                output: 5,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 7,
+            },
+            0.0,
+        );
+
+        apply_pricing_if_available(&mut msg, Some(&pricing));
+
+        assert_eq!(msg.cost, 0.034);
+    }
+
+    #[test]
+    fn test_parse_all_messages_with_pricing_keeps_gateway_message_under_synthetic_filter() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let message_dir = temp_dir
+            .path()
+            .join(".local/share/opencode/storage/message/project-1");
+        std::fs::create_dir_all(&message_dir).unwrap();
+        std::fs::write(
+            message_dir.join("msg_001.json"),
+            r#"{"id":"msg-1","sessionID":"session-1","role":"assistant","modelID":"hf:deepseek-ai/DeepSeek-V3-0324","providerID":"unknown","cost":0,"tokens":{"input":10,"output":5,"reasoning":0,"cache":{"read":0,"write":0}},"time":{"created":1733011200000}}"#,
+        )
+        .unwrap();
+
+        let pricing = pricing::PricingService::new(HashMap::new(), HashMap::new());
+        let messages = parse_all_messages_with_pricing(
+            temp_dir.path().to_str().unwrap(),
+            &["synthetic".to_string()],
+            Some(&pricing),
+        );
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, "opencode");
+        assert_eq!(messages[0].model_id, "deepseek-v3-0324");
+        assert_eq!(messages[0].provider_id, "synthetic");
+    }
+
+    #[test]
+    fn test_parse_local_clients_preserves_gateway_message_client_counts() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let message_dir = temp_dir
+            .path()
+            .join(".local/share/opencode/storage/message/project-1");
+        std::fs::create_dir_all(&message_dir).unwrap();
+        std::fs::write(
+            message_dir.join("msg_001.json"),
+            r#"{"id":"msg-1","sessionID":"session-1","role":"assistant","modelID":"accounts/fireworks/models/deepseek-v3-0324","providerID":"fireworks","cost":0,"tokens":{"input":10,"output":5,"reasoning":0,"cache":{"read":0,"write":0}},"time":{"created":1733011200000}}"#,
+        )
+        .unwrap();
+
+        let parsed = parse_local_clients(LocalParseOptions {
+            home_dir: Some(temp_dir.path().to_str().unwrap().to_string()),
+            clients: Some(vec!["opencode".to_string(), "synthetic".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+        })
+        .unwrap();
+
+        assert_eq!(parsed.counts.get(ClientId::OpenCode), 1);
+        assert_eq!(parsed.messages.len(), 1);
+        assert_eq!(parsed.messages[0].client, "opencode");
+        assert_eq!(parsed.messages[0].model_id, "deepseek-v3-0324");
+        assert_eq!(parsed.messages[0].provider_id, "fireworks");
+    }
+
+    #[test]
+    fn test_parse_all_messages_fireworks_provider_kept_under_synthetic_only_filter() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let message_dir = temp_dir
+            .path()
+            .join(".local/share/opencode/storage/message/project-1");
+        std::fs::create_dir_all(&message_dir).unwrap();
+        std::fs::write(
+            message_dir.join("msg_001.json"),
+            r#"{"id":"msg-1","sessionID":"session-1","role":"assistant","modelID":"accounts/fireworks/models/deepseek-v3-0324","providerID":"fireworks","cost":0.1,"tokens":{"input":10,"output":5,"reasoning":0,"cache":{"read":0,"write":0}},"time":{"created":1733011200000}}"#,
+        )
+        .unwrap();
+
+        let pricing = pricing::PricingService::new(HashMap::new(), HashMap::new());
+        let messages = parse_all_messages_with_pricing(
+            temp_dir.path().to_str().unwrap(),
+            &["synthetic".to_string()],
+            Some(&pricing),
+        );
+
+        assert_eq!(
+            messages.len(),
+            1,
+            "fireworks gateway message must not be dropped when filtering for synthetic"
+        );
+        assert_eq!(messages[0].client, "opencode");
+        assert_eq!(messages[0].model_id, "deepseek-v3-0324");
+        assert_eq!(messages[0].provider_id, "fireworks");
+    }
+
+    #[test]
+    fn test_parse_local_clients_fireworks_provider_kept_under_synthetic_only_filter() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let message_dir = temp_dir
+            .path()
+            .join(".local/share/opencode/storage/message/project-1");
+        std::fs::create_dir_all(&message_dir).unwrap();
+        std::fs::write(
+            message_dir.join("msg_001.json"),
+            r#"{"id":"msg-1","sessionID":"session-1","role":"assistant","modelID":"accounts/fireworks/models/deepseek-v3-0324","providerID":"fireworks","cost":0.1,"tokens":{"input":10,"output":5,"reasoning":0,"cache":{"read":0,"write":0}},"time":{"created":1733011200000}}"#,
+        )
+        .unwrap();
+
+        let parsed = parse_local_clients(LocalParseOptions {
+            home_dir: Some(temp_dir.path().to_str().unwrap().to_string()),
+            clients: Some(vec!["synthetic".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+        })
+        .unwrap();
+
+        assert_eq!(
+            parsed.messages.len(),
+            1,
+            "fireworks gateway message must not be dropped when filtering for synthetic only"
+        );
+        assert_eq!(parsed.messages[0].client, "opencode");
+        assert_eq!(parsed.messages[0].model_id, "deepseek-v3-0324");
+        assert_eq!(parsed.messages[0].provider_id, "fireworks");
+    }
+}

--- a/vendor/tokscale-core/src/parser.rs
+++ b/vendor/tokscale-core/src/parser.rs
@@ -1,0 +1,268 @@
+//! SIMD-accelerated JSON parser
+//!
+//! Uses simd-json for fast JSON parsing with SIMD instructions.
+
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+/// Parse a JSON file using SIMD-accelerated parsing
+pub fn parse_json_file<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T, ParseError> {
+    let mut data = fs::read(path).map_err(|e| ParseError::IoError(e.to_string()))?;
+
+    simd_json::from_slice(&mut data).map_err(|e| ParseError::JsonError(e.to_string()))
+}
+
+/// Parse a JSONL file (one JSON object per line)
+pub fn parse_jsonl_file<T, F>(path: &Path, mut process: F) -> Result<(), ParseError>
+where
+    T: serde::de::DeserializeOwned,
+    F: FnMut(T),
+{
+    let file = fs::File::open(path).map_err(|e| ParseError::IoError(e.to_string()))?;
+    let reader = BufReader::new(file);
+    let mut buffer = Vec::with_capacity(4096);
+
+    for line in reader.lines() {
+        let line = line.map_err(|e| ParseError::IoError(e.to_string()))?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        buffer.clear();
+        buffer.extend_from_slice(trimmed.as_bytes());
+
+        match simd_json::from_slice::<T>(&mut buffer) {
+            Ok(value) => process(value),
+            Err(_) => continue,
+        }
+    }
+
+    Ok(())
+}
+
+/// Parse error types
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    #[error("IO error: {0}")]
+    IoError(String),
+
+    #[error("JSON parse error: {0}")]
+    JsonError(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use std::fs::File;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct TestStruct {
+        name: String,
+        value: i32,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct NestedStruct {
+        id: String,
+        data: InnerData,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct InnerData {
+        tokens: i64,
+        cost: f64,
+    }
+
+    #[test]
+    fn test_parse_json_file_simple() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("test.json");
+
+        let mut file = File::create(&file_path).unwrap();
+        file.write_all(br#"{"name": "test", "value": 42}"#).unwrap();
+
+        let result: TestStruct = parse_json_file(&file_path).unwrap();
+        assert_eq!(result.name, "test");
+        assert_eq!(result.value, 42);
+    }
+
+    #[test]
+    fn test_parse_json_file_nested() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("nested.json");
+
+        let mut file = File::create(&file_path).unwrap();
+        file.write_all(br#"{"id": "session-001", "data": {"tokens": 1000, "cost": 0.05}}"#)
+            .unwrap();
+
+        let result: NestedStruct = parse_json_file(&file_path).unwrap();
+        assert_eq!(result.id, "session-001");
+        assert_eq!(result.data.tokens, 1000);
+        assert_eq!(result.data.cost, 0.05);
+    }
+
+    #[test]
+    fn test_parse_json_file_unicode() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("unicode.json");
+
+        let mut file = File::create(&file_path).unwrap();
+        file.write_all(r#"{"name": "테스트", "value": 100}"#.as_bytes())
+            .unwrap();
+
+        let result: TestStruct = parse_json_file(&file_path).unwrap();
+        assert_eq!(result.name, "테스트");
+        assert_eq!(result.value, 100);
+    }
+
+    #[test]
+    fn test_parse_json_file_not_found() {
+        let result: Result<TestStruct, _> = parse_json_file(Path::new("/nonexistent/file.json"));
+        assert!(matches!(result, Err(ParseError::IoError(_))));
+    }
+
+    #[test]
+    fn test_parse_json_file_invalid_json() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("invalid.json");
+
+        let mut file = File::create(&file_path).unwrap();
+        file.write_all(b"not valid json {").unwrap();
+
+        let result: Result<TestStruct, _> = parse_json_file(&file_path);
+        assert!(matches!(result, Err(ParseError::JsonError(_))));
+    }
+
+    #[test]
+    fn test_parse_json_file_empty() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("empty.json");
+
+        File::create(&file_path).unwrap();
+
+        let result: Result<TestStruct, _> = parse_json_file(&file_path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_jsonl_file_basic() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("test.jsonl");
+
+        let mut file = File::create(&file_path).unwrap();
+        writeln!(file, r#"{{"name": "first", "value": 1}}"#).unwrap();
+        writeln!(file, r#"{{"name": "second", "value": 2}}"#).unwrap();
+        writeln!(file, r#"{{"name": "third", "value": 3}}"#).unwrap();
+
+        let mut results: Vec<TestStruct> = Vec::new();
+        parse_jsonl_file(&file_path, |item: TestStruct| {
+            results.push(item);
+        })
+        .unwrap();
+
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0].name, "first");
+        assert_eq!(results[1].value, 2);
+        assert_eq!(results[2].name, "third");
+    }
+
+    #[test]
+    fn test_parse_jsonl_file_with_empty_lines() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("with_empty.jsonl");
+
+        let mut file = File::create(&file_path).unwrap();
+        writeln!(file, r#"{{"name": "a", "value": 1}}"#).unwrap();
+        writeln!(file, "").unwrap(); // Empty line
+        writeln!(file, "   ").unwrap(); // Whitespace only
+        writeln!(file, r#"{{"name": "b", "value": 2}}"#).unwrap();
+
+        let mut results: Vec<TestStruct> = Vec::new();
+        parse_jsonl_file(&file_path, |item: TestStruct| {
+            results.push(item);
+        })
+        .unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].name, "a");
+        assert_eq!(results[1].name, "b");
+    }
+
+    #[test]
+    fn test_parse_jsonl_file_with_malformed_lines() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("malformed.jsonl");
+
+        let mut file = File::create(&file_path).unwrap();
+        writeln!(file, r#"{{"name": "good", "value": 1}}"#).unwrap();
+        writeln!(file, "not valid json").unwrap(); // Should be skipped
+        writeln!(file, r#"{{"incomplete"#).unwrap(); // Should be skipped
+        writeln!(file, r#"{{"name": "also good", "value": 2}}"#).unwrap();
+
+        let mut results: Vec<TestStruct> = Vec::new();
+        parse_jsonl_file(&file_path, |item: TestStruct| {
+            results.push(item);
+        })
+        .unwrap();
+
+        // Only valid lines should be parsed
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].name, "good");
+        assert_eq!(results[1].name, "also good");
+    }
+
+    #[test]
+    fn test_parse_jsonl_file_empty() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("empty.jsonl");
+
+        File::create(&file_path).unwrap();
+
+        let mut count = 0;
+        parse_jsonl_file(&file_path, |_: TestStruct| {
+            count += 1;
+        })
+        .unwrap();
+
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_parse_jsonl_file_not_found() {
+        let result = parse_jsonl_file(Path::new("/nonexistent/file.jsonl"), |_: TestStruct| {});
+        assert!(matches!(result, Err(ParseError::IoError(_))));
+    }
+
+    #[test]
+    fn test_parse_jsonl_large_file() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("large.jsonl");
+
+        let mut file = File::create(&file_path).unwrap();
+        for i in 0..1000 {
+            writeln!(file, r#"{{"name": "item-{}", "value": {}}}"#, i, i).unwrap();
+        }
+
+        let mut count = 0;
+        parse_jsonl_file(&file_path, |_: TestStruct| {
+            count += 1;
+        })
+        .unwrap();
+
+        assert_eq!(count, 1000);
+    }
+
+    #[test]
+    fn test_parse_error_display() {
+        let io_error = ParseError::IoError("file not found".to_string());
+        assert!(io_error.to_string().contains("IO error"));
+
+        let json_error = ParseError::JsonError("unexpected token".to_string());
+        assert!(json_error.to_string().contains("JSON parse error"));
+    }
+}

--- a/vendor/tokscale-core/src/pricing/aliases.rs
+++ b/vendor/tokscale-core/src/pricing/aliases.rs
@@ -1,0 +1,22 @@
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+
+static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    m.insert("big-pickle", "glm-4.7");
+    m.insert("big pickle", "glm-4.7");
+    m.insert("bigpickle", "glm-4.7");
+    m.insert("k2p5", "kimi-k2-thinking");
+    m.insert("k2-p5", "kimi-k2-thinking");
+    m.insert("kimi-k2.5-thinking", "kimi-k2-thinking");
+    m.insert("kimi-for-coding", "kimi-k2.5");
+
+    // Synthetic model variants (only where resolver needs help)
+    m.insert("kimi-k2.5-nvfp4", "kimi-k2.5"); // Quantization variant → base model pricing
+    m.insert("kimi-k2-instruct-0905", "kimi-k2.5"); // Specific version → base (avoids reseller)
+    m
+});
+
+pub fn resolve_alias(model_id: &str) -> Option<&'static str> {
+    MODEL_ALIASES.get(model_id.to_lowercase().as_str()).copied()
+}

--- a/vendor/tokscale-core/src/pricing/cache.rs
+++ b/vendor/tokscale-core/src/pricing/cache.rs
@@ -1,0 +1,97 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+const CACHE_TTL_SECS: u64 = 3600;
+
+pub fn get_cache_dir() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("tokscale")
+}
+
+pub fn get_cache_path(filename: &str) -> PathBuf {
+    get_cache_dir().join(filename)
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CachedData<T> {
+    pub timestamp: u64,
+    pub data: T,
+}
+
+fn load_cache_with_policy<T: for<'de> Deserialize<'de>>(
+    filename: &str,
+    allow_stale: bool,
+) -> Option<T> {
+    let path = get_cache_path(filename);
+    let content = fs::read_to_string(&path).ok()?;
+    let cached: CachedData<T> = serde_json::from_str(&content).ok()?;
+
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .ok()?
+        .as_secs();
+
+    if cached.timestamp > now {
+        return None;
+    }
+
+    if !allow_stale && now.saturating_sub(cached.timestamp) > CACHE_TTL_SECS {
+        return None;
+    }
+
+    Some(cached.data)
+}
+
+pub fn load_cache<T: for<'de> Deserialize<'de>>(filename: &str) -> Option<T> {
+    load_cache_with_policy(filename, false)
+}
+
+pub fn load_cache_any_age<T: for<'de> Deserialize<'de>>(filename: &str) -> Option<T> {
+    load_cache_with_policy(filename, true)
+}
+
+pub fn save_cache<T: Serialize>(filename: &str, data: &T) -> Result<(), std::io::Error> {
+    let dir = get_cache_dir();
+    fs::create_dir_all(&dir)?;
+
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or(std::time::Duration::ZERO)
+        .as_secs();
+
+    let cached = CachedData {
+        timestamp: now,
+        data,
+    };
+    let content = serde_json::to_string(&cached)?;
+
+    let final_path = get_cache_path(filename);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    let tmp_filename = format!(".{}.{}.{:x}.tmp", filename, std::process::id(), nanos);
+    let tmp_path = dir.join(&tmp_filename);
+
+    use std::io::Write;
+    let write_result = (|| {
+        let mut file = fs::File::create(&tmp_path)?;
+        file.write_all(content.as_bytes())?;
+        file.sync_all()?;
+        if fs::rename(&tmp_path, &final_path).is_err() {
+            // Windows: rename can't overwrite; copy then cleanup so destination is never removed first.
+            fs::copy(&tmp_path, &final_path)?;
+            let _ = fs::remove_file(&tmp_path);
+        }
+        Ok(())
+    })();
+
+    if write_result.is_err() {
+        let _ = fs::remove_file(&tmp_path);
+    }
+
+    write_result
+}

--- a/vendor/tokscale-core/src/pricing/litellm.rs
+++ b/vendor/tokscale-core/src/pricing/litellm.rs
@@ -1,0 +1,176 @@
+use super::cache;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+const CACHE_FILENAME: &str = "pricing-litellm.json";
+const PRICING_URL: &str =
+    "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+const MAX_RETRIES: u32 = 3;
+const INITIAL_BACKOFF_MS: u64 = 200;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ModelPricing {
+    pub input_cost_per_token: Option<f64>,
+    pub input_cost_per_token_above_200k_tokens: Option<f64>,
+    pub output_cost_per_token: Option<f64>,
+    pub output_cost_per_token_above_200k_tokens: Option<f64>,
+    pub cache_creation_input_token_cost: Option<f64>,
+    pub cache_creation_input_token_cost_above_200k_tokens: Option<f64>,
+    pub cache_read_input_token_cost: Option<f64>,
+    pub cache_read_input_token_cost_above_200k_tokens: Option<f64>,
+}
+
+pub type PricingDataset = HashMap<String, ModelPricing>;
+
+pub fn load_cached() -> Option<PricingDataset> {
+    cache::load_cache(CACHE_FILENAME)
+}
+
+pub fn load_cached_any_age() -> Option<PricingDataset> {
+    cache::load_cache_any_age(CACHE_FILENAME)
+}
+
+pub async fn fetch() -> Result<PricingDataset, reqwest::Error> {
+    if let Some(cached) = load_cached() {
+        return Ok(cached);
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .build()?;
+
+    let mut last_error: Option<reqwest::Error> = None;
+
+    for attempt in 0..MAX_RETRIES {
+        match client.get(PRICING_URL).send().await {
+            Ok(response) => {
+                let status = response.status();
+
+                if status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                    eprintln!(
+                        "[tokscale] LiteLLM HTTP {} (attempt {}/{})",
+                        status,
+                        attempt + 1,
+                        MAX_RETRIES
+                    );
+                    let _ = response.bytes().await;
+                    if attempt < MAX_RETRIES - 1 {
+                        tokio::time::sleep(std::time::Duration::from_millis(
+                            INITIAL_BACKOFF_MS * (1 << attempt),
+                        ))
+                        .await;
+                    }
+                    continue;
+                }
+
+                if !status.is_success() {
+                    eprintln!("[tokscale] LiteLLM HTTP {}", status);
+                    return Err(response.error_for_status().unwrap_err());
+                }
+
+                match response.json::<PricingDataset>().await {
+                    Ok(data) => {
+                        if let Err(e) = cache::save_cache(CACHE_FILENAME, &data) {
+                            eprintln!(
+                                "[tokscale] Warning: Failed to cache LiteLLM pricing at {}: {}",
+                                cache::get_cache_path(CACHE_FILENAME).display(),
+                                e
+                            );
+                        }
+                        return Ok(data);
+                    }
+                    Err(e) => {
+                        eprintln!("[tokscale] LiteLLM JSON parse failed: {}", e);
+                        return Err(e);
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!(
+                    "[tokscale] LiteLLM network error (attempt {}/{}): {}",
+                    attempt + 1,
+                    MAX_RETRIES,
+                    e
+                );
+                last_error = Some(e);
+                if attempt < MAX_RETRIES - 1 {
+                    tokio::time::sleep(std::time::Duration::from_millis(
+                        INITIAL_BACKOFF_MS * (1 << attempt),
+                    ))
+                    .await;
+                }
+            }
+        }
+    }
+
+    Err(last_error.expect("should have error after retries"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_model_pricing_with_above_200k_fields() {
+        let pricing: ModelPricing = serde_json::from_str(
+            r#"{
+                "input_cost_per_token": 0.0000015,
+                "input_cost_per_token_above_200k_tokens": 0.000003,
+                "output_cost_per_token": 0.0000075,
+                "output_cost_per_token_above_200k_tokens": 0.000015,
+                "cache_creation_input_token_cost": 0.000001875,
+                "cache_creation_input_token_cost_above_200k_tokens": 0.00000375,
+                "cache_read_input_token_cost": 0.00000015,
+                "cache_read_input_token_cost_above_200k_tokens": 0.0000003
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(pricing.input_cost_per_token, Some(0.0000015));
+        assert_eq!(
+            pricing.input_cost_per_token_above_200k_tokens,
+            Some(0.000003)
+        );
+        assert_eq!(pricing.output_cost_per_token, Some(0.0000075));
+        assert_eq!(
+            pricing.output_cost_per_token_above_200k_tokens,
+            Some(0.000015)
+        );
+        assert_eq!(pricing.cache_creation_input_token_cost, Some(0.000001875));
+        assert_eq!(
+            pricing.cache_creation_input_token_cost_above_200k_tokens,
+            Some(0.00000375)
+        );
+        assert_eq!(pricing.cache_read_input_token_cost, Some(0.00000015));
+        assert_eq!(
+            pricing.cache_read_input_token_cost_above_200k_tokens,
+            Some(0.0000003)
+        );
+    }
+
+    #[test]
+    fn test_deserialize_model_pricing_without_above_200k_fields() {
+        let pricing: ModelPricing = serde_json::from_str(
+            r#"{
+                "input_cost_per_token": 0.00000125,
+                "output_cost_per_token": 0.00001,
+                "cache_creation_input_token_cost": 0.00000125,
+                "cache_read_input_token_cost": 0.000000125
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(pricing.input_cost_per_token, Some(0.00000125));
+        assert_eq!(pricing.input_cost_per_token_above_200k_tokens, None);
+        assert_eq!(pricing.output_cost_per_token, Some(0.00001));
+        assert_eq!(pricing.output_cost_per_token_above_200k_tokens, None);
+        assert_eq!(pricing.cache_creation_input_token_cost, Some(0.00000125));
+        assert_eq!(
+            pricing.cache_creation_input_token_cost_above_200k_tokens,
+            None
+        );
+        assert_eq!(pricing.cache_read_input_token_cost, Some(0.000000125));
+        assert_eq!(pricing.cache_read_input_token_cost_above_200k_tokens, None);
+    }
+}

--- a/vendor/tokscale-core/src/pricing/lookup.rs
+++ b/vendor/tokscale-core/src/pricing/lookup.rs
@@ -1,0 +1,2678 @@
+use super::{aliases, litellm::ModelPricing};
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+const PROVIDER_PREFIXES: &[&str] = &[
+    "openai/",
+    "anthropic/",
+    "google/",
+    "meta-llama/",
+    "mistralai/",
+    "deepseek/",
+    "qwen/",
+    "cohere/",
+    "perplexity/",
+    "x-ai/",
+];
+
+const ORIGINAL_PROVIDER_PREFIXES: &[&str] = &[
+    "x-ai/",
+    "xai/",
+    "anthropic/",
+    "openai/",
+    "google/",
+    "meta-llama/",
+    "mistralai/",
+    "deepseek/",
+    "z-ai/",
+    "qwen/",
+    "cohere/",
+    "perplexity/",
+    "moonshotai/",
+];
+
+const RESELLER_PROVIDER_PREFIXES: &[&str] = &[
+    "azure/",
+    "azure_ai/",
+    "bedrock/",
+    "vertex_ai/",
+    "together/",
+    "together_ai/",
+    "fireworks_ai/",
+    "groq/",
+    "openrouter/",
+];
+
+const FUZZY_BLOCKLIST: &[&str] = &["auto", "mini", "chat", "base"];
+
+const MAX_LOOKUP_CACHE_ENTRIES: usize = 512;
+const TIERED_PRICING_THRESHOLD_TOKENS: f64 = 200_000.0;
+
+const MIN_FUZZY_MATCH_LEN: usize = 5;
+
+/// Minimum length for a model name candidate after prefix/suffix stripping.
+/// Prevents false positives like "pro" or "flash" being matched alone.
+const MIN_MODEL_NAME_LEN: usize = 2;
+
+/// Maximum number of leading segments that can be treated as a routing prefix.
+/// Limits how aggressively we strip (e.g., "a-b-claude-3" strips at most "a-b-").
+const MAX_PREFIX_STRIP_SEGMENTS: usize = 2;
+
+/// Maximum number of trailing segments that can be treated as a routing suffix.
+/// Handles tier suffixes (-high, -low) and variant suffixes (-thinking, -codex, -codex-max-xhigh).
+const MAX_SUFFIX_STRIP_SEGMENTS: usize = 4;
+
+#[derive(Clone)]
+struct CachedResult {
+    pricing: ModelPricing,
+    source: String,
+    matched_key: String,
+}
+
+pub struct PricingLookup {
+    litellm: HashMap<String, ModelPricing>,
+    openrouter: HashMap<String, ModelPricing>,
+    cursor: HashMap<String, ModelPricing>,
+    litellm_keys: Vec<String>,
+    openrouter_keys: Vec<String>,
+    litellm_lower: HashMap<String, String>,
+    openrouter_lower: HashMap<String, String>,
+    openrouter_model_part: HashMap<String, String>,
+    cursor_lower: HashMap<String, String>,
+    lookup_cache: RwLock<HashMap<String, Option<CachedResult>>>,
+}
+
+pub struct LookupResult {
+    pub pricing: ModelPricing,
+    pub source: String,
+    pub matched_key: String,
+}
+
+impl PricingLookup {
+    pub fn new(
+        litellm: HashMap<String, ModelPricing>,
+        openrouter: HashMap<String, ModelPricing>,
+        cursor: HashMap<String, ModelPricing>,
+    ) -> Self {
+        let mut litellm_keys: Vec<String> = litellm.keys().cloned().collect();
+        litellm_keys.sort_by_key(|k| std::cmp::Reverse(k.len()));
+
+        let mut openrouter_keys: Vec<String> = openrouter.keys().cloned().collect();
+        openrouter_keys.sort_by_key(|k| std::cmp::Reverse(k.len()));
+
+        let mut litellm_lower = HashMap::with_capacity(litellm.len());
+        for key in &litellm_keys {
+            litellm_lower.insert(key.to_lowercase(), key.clone());
+        }
+
+        let mut openrouter_lower = HashMap::with_capacity(openrouter.len());
+        let mut openrouter_model_part = HashMap::with_capacity(openrouter.len());
+        for key in &openrouter_keys {
+            let lower = key.to_lowercase();
+            openrouter_lower.insert(lower.clone(), key.clone());
+            if let Some(model_part) = lower.split('/').next_back() {
+                if model_part != lower {
+                    openrouter_model_part.insert(model_part.to_string(), key.clone());
+                }
+            }
+        }
+
+        let mut cursor_lower = HashMap::with_capacity(cursor.len());
+        for key in cursor.keys() {
+            cursor_lower.insert(key.to_lowercase(), key.clone());
+        }
+
+        Self {
+            litellm,
+            openrouter,
+            cursor,
+            litellm_keys,
+            openrouter_keys,
+            litellm_lower,
+            openrouter_lower,
+            openrouter_model_part,
+            cursor_lower,
+            lookup_cache: RwLock::new(HashMap::with_capacity(64)),
+        }
+    }
+
+    pub fn lookup(&self, model_id: &str) -> Option<LookupResult> {
+        if let Some(cached) = self
+            .lookup_cache
+            .read()
+            .ok()
+            .and_then(|c| c.get(model_id).cloned())
+        {
+            return cached.map(|c| LookupResult {
+                pricing: c.pricing,
+                source: c.source,
+                matched_key: c.matched_key,
+            });
+        }
+
+        let result = self.lookup_with_source(model_id, None);
+
+        if let Ok(mut cache) = self.lookup_cache.write() {
+            if cache.len() >= MAX_LOOKUP_CACHE_ENTRIES {
+                // Evict ~25% of entries instead of clearing everything.
+                // This avoids a thundering-herd cache miss storm that happens
+                // when clear() wipes all entries at once.
+                let evict_count = cache.len() / 4;
+                let keys_to_remove: Vec<String> = cache.keys().take(evict_count).cloned().collect();
+                for key in keys_to_remove {
+                    cache.remove(&key);
+                }
+            }
+            cache.insert(
+                model_id.to_string(),
+                result.as_ref().map(|r| CachedResult {
+                    pricing: r.pricing.clone(),
+                    source: r.source.clone(),
+                    matched_key: r.matched_key.clone(),
+                }),
+            );
+        }
+
+        result
+    }
+
+    pub fn lookup_with_source(
+        &self,
+        model_id: &str,
+        force_source: Option<&str>,
+    ) -> Option<LookupResult> {
+        let canonical = aliases::resolve_alias(model_id).unwrap_or(model_id);
+        let lower = canonical.to_lowercase();
+
+        // Helper to perform lookup with the given source constraint
+        let do_lookup = |id: &str| match force_source {
+            Some("litellm") => self.lookup_litellm_only(id),
+            Some("openrouter") => self.lookup_openrouter_only(id),
+            _ => self.lookup_auto(id),
+        };
+
+        // 1. Try direct lookup
+        if let Some(result) = do_lookup(&lower) {
+            return Some(result);
+        }
+
+        // 2. Try stripping unknown suffixes (e.g., -thinking, -high, -codex)
+        if let Some(result) = try_strip_unknown_suffix(&lower, do_lookup) {
+            return Some(result);
+        }
+
+        // 3. Try stripping unknown prefixes (e.g., antigravity-, myplugin-)
+        //    For each prefix candidate, also try suffix stripping
+        if let Some(result) = try_strip_unknown_prefix(&lower, do_lookup) {
+            return Some(result);
+        }
+
+        None
+    }
+
+    fn lookup_auto(&self, model_id: &str) -> Option<LookupResult> {
+        if let Some(result) = self.exact_match_litellm(model_id) {
+            return Some(result);
+        }
+
+        let exact_openrouter = self.exact_match_openrouter(model_id);
+        if let Some(stripped) = strip_known_provider_prefix(model_id) {
+            let stripped_litellm = self.exact_or_normalized_litellm(stripped);
+
+            if let (Some(litellm), Some(openrouter)) = (&stripped_litellm, &exact_openrouter) {
+                if has_meaningful_tier_support(&litellm.pricing)
+                    && !has_any_valid_above_tier_value(&openrouter.pricing)
+                {
+                    return stripped_litellm;
+                }
+            }
+
+            if let Some(result) = exact_openrouter {
+                return Some(result);
+            }
+            if let Some(result) = stripped_litellm {
+                return Some(result);
+            }
+        } else if let Some(result) = exact_openrouter {
+            return Some(result);
+        }
+
+        if let Some(version_normalized) = normalize_version_separator(model_id) {
+            if let Some(result) = self.exact_match_litellm(&version_normalized) {
+                return Some(result);
+            }
+            if let Some(result) = self.exact_match_openrouter(&version_normalized) {
+                return Some(result);
+            }
+        }
+
+        if let Some(normalized) = normalize_model_name(model_id) {
+            if let Some(result) = self.exact_match_litellm(&normalized) {
+                return Some(result);
+            }
+            if let Some(result) = self.exact_match_openrouter(&normalized) {
+                return Some(result);
+            }
+        }
+
+        if let Some(result) = self.prefix_match_litellm(model_id) {
+            return Some(result);
+        }
+        if let Some(result) = self.prefix_match_openrouter(model_id) {
+            return Some(result);
+        }
+
+        if let Some(version_normalized) = normalize_version_separator(model_id) {
+            if let Some(result) = self.prefix_match_litellm(&version_normalized) {
+                return Some(result);
+            }
+            if let Some(result) = self.prefix_match_openrouter(&version_normalized) {
+                return Some(result);
+            }
+        }
+
+        if let Some(result) = self.exact_match_cursor(model_id) {
+            return Some(result);
+        }
+        if let Some(version_normalized) = normalize_version_separator(model_id) {
+            if let Some(result) = self.exact_match_cursor(&version_normalized) {
+                return Some(result);
+            }
+        }
+
+        if !is_fuzzy_eligible(model_id) {
+            return None;
+        }
+
+        let litellm_result = self.fuzzy_match_litellm(model_id);
+        let openrouter_result = self.fuzzy_match_openrouter(model_id);
+
+        match (&litellm_result, &openrouter_result) {
+            (Some(l), Some(o)) => {
+                let l_is_original = is_original_provider(&l.matched_key);
+                let o_is_original = is_original_provider(&o.matched_key);
+                let l_is_reseller = is_reseller_provider(&l.matched_key);
+                let o_is_reseller = is_reseller_provider(&o.matched_key);
+
+                if o_is_original && !l_is_original {
+                    return openrouter_result;
+                }
+                if l_is_original && !o_is_original {
+                    return litellm_result;
+                }
+                if !l_is_reseller && o_is_reseller {
+                    return litellm_result;
+                }
+                if !o_is_reseller && l_is_reseller {
+                    return openrouter_result;
+                }
+                litellm_result
+            }
+            (Some(_), None) => litellm_result,
+            (None, Some(_)) => openrouter_result,
+            (None, None) => None,
+        }
+    }
+
+    fn exact_or_normalized_litellm(&self, model_id: &str) -> Option<LookupResult> {
+        if let Some(result) = self.exact_match_litellm(model_id) {
+            return Some(result);
+        }
+        if let Some(version_normalized) = normalize_version_separator(model_id) {
+            if let Some(result) = self.exact_match_litellm(&version_normalized) {
+                return Some(result);
+            }
+        }
+        if let Some(normalized) = normalize_model_name(model_id) {
+            if let Some(result) = self.exact_match_litellm(&normalized) {
+                return Some(result);
+            }
+        }
+        None
+    }
+
+    fn lookup_litellm_only(&self, model_id: &str) -> Option<LookupResult> {
+        if let Some(result) = self.exact_or_normalized_litellm(model_id) {
+            return Some(result);
+        }
+        if let Some(stripped) = strip_known_provider_prefix(model_id) {
+            if let Some(result) = self.exact_or_normalized_litellm(stripped) {
+                return Some(result);
+            }
+        }
+        if let Some(result) = self.prefix_match_litellm(model_id) {
+            return Some(result);
+        }
+        if let Some(version_normalized) = normalize_version_separator(model_id) {
+            if let Some(result) = self.prefix_match_litellm(&version_normalized) {
+                return Some(result);
+            }
+        }
+        if is_fuzzy_eligible(model_id) {
+            if let Some(result) = self.fuzzy_match_litellm(model_id) {
+                return Some(result);
+            }
+        }
+        None
+    }
+
+    fn lookup_openrouter_only(&self, model_id: &str) -> Option<LookupResult> {
+        if let Some(result) = self.exact_match_openrouter(model_id) {
+            return Some(result);
+        }
+        if let Some(version_normalized) = normalize_version_separator(model_id) {
+            if let Some(result) = self.exact_match_openrouter(&version_normalized) {
+                return Some(result);
+            }
+        }
+        if let Some(normalized) = normalize_model_name(model_id) {
+            if let Some(result) = self.exact_match_openrouter(&normalized) {
+                return Some(result);
+            }
+        }
+        if let Some(result) = self.prefix_match_openrouter(model_id) {
+            return Some(result);
+        }
+        if let Some(version_normalized) = normalize_version_separator(model_id) {
+            if let Some(result) = self.prefix_match_openrouter(&version_normalized) {
+                return Some(result);
+            }
+        }
+        if is_fuzzy_eligible(model_id) {
+            if let Some(result) = self.fuzzy_match_openrouter(model_id) {
+                return Some(result);
+            }
+        }
+        None
+    }
+
+    fn exact_match_litellm(&self, model_id: &str) -> Option<LookupResult> {
+        let key = self.litellm_lower.get(model_id)?;
+        let pricing = self.litellm.get(key)?;
+        Some(LookupResult {
+            pricing: pricing.clone(),
+            source: "LiteLLM".into(),
+            matched_key: key.clone(),
+        })
+    }
+
+    fn exact_match_openrouter(&self, model_id: &str) -> Option<LookupResult> {
+        if let Some(key) = self.openrouter_lower.get(model_id) {
+            if let Some(pricing) = self.openrouter.get(key) {
+                return Some(LookupResult {
+                    pricing: pricing.clone(),
+                    source: "OpenRouter".into(),
+                    matched_key: key.clone(),
+                });
+            }
+        }
+        if let Some(key) = self.openrouter_model_part.get(model_id) {
+            if let Some(pricing) = self.openrouter.get(key) {
+                return Some(LookupResult {
+                    pricing: pricing.clone(),
+                    source: "OpenRouter".into(),
+                    matched_key: key.clone(),
+                });
+            }
+        }
+        None
+    }
+
+    fn exact_match_cursor(&self, model_id: &str) -> Option<LookupResult> {
+        if let Some(key) = self.cursor_lower.get(model_id) {
+            return Some(LookupResult {
+                pricing: self.cursor.get(key).unwrap().clone(),
+                source: "Cursor".into(),
+                matched_key: key.clone(),
+            });
+        }
+        if let Some(model_part) = model_id.split('/').next_back() {
+            if model_part != model_id {
+                if let Some(key) = self.cursor_lower.get(model_part) {
+                    return Some(LookupResult {
+                        pricing: self.cursor.get(key).unwrap().clone(),
+                        source: "Cursor".into(),
+                        matched_key: key.clone(),
+                    });
+                }
+            }
+        }
+        None
+    }
+
+    fn prefix_match_litellm(&self, model_id: &str) -> Option<LookupResult> {
+        for prefix in PROVIDER_PREFIXES {
+            let key = format!("{}{}", prefix, model_id);
+            if let Some(litellm_key) = self.litellm_lower.get(&key) {
+                if let Some(pricing) = self.litellm.get(litellm_key) {
+                    return Some(LookupResult {
+                        pricing: pricing.clone(),
+                        source: "LiteLLM".into(),
+                        matched_key: litellm_key.clone(),
+                    });
+                }
+            }
+        }
+        None
+    }
+
+    fn prefix_match_openrouter(&self, model_id: &str) -> Option<LookupResult> {
+        for prefix in PROVIDER_PREFIXES {
+            let key = format!("{}{}", prefix, model_id);
+            if let Some(or_key) = self.openrouter_lower.get(&key) {
+                if let Some(pricing) = self.openrouter.get(or_key) {
+                    return Some(LookupResult {
+                        pricing: pricing.clone(),
+                        source: "OpenRouter".into(),
+                        matched_key: or_key.clone(),
+                    });
+                }
+            }
+        }
+        None
+    }
+
+    fn fuzzy_match_litellm(&self, model_id: &str) -> Option<LookupResult> {
+        let family = extract_model_family(model_id);
+        let mut family_matches_list: Vec<&String> = Vec::new();
+
+        for key in &self.litellm_keys {
+            let lower_key = key.to_lowercase();
+            if family_matches(&lower_key, &family) && contains_model_id(&lower_key, model_id) {
+                family_matches_list.push(key);
+            }
+        }
+
+        if let Some(result) = select_best_match(&family_matches_list, &self.litellm, "LiteLLM") {
+            return Some(result);
+        }
+
+        let mut all_matches: Vec<&String> = Vec::new();
+        for key in &self.litellm_keys {
+            let lower_key = key.to_lowercase();
+            if contains_model_id(&lower_key, model_id) {
+                all_matches.push(key);
+            }
+        }
+
+        select_best_match(&all_matches, &self.litellm, "LiteLLM")
+    }
+
+    fn fuzzy_match_openrouter(&self, model_id: &str) -> Option<LookupResult> {
+        let family = extract_model_family(model_id);
+        let mut family_matches_list: Vec<&String> = Vec::new();
+
+        for key in &self.openrouter_keys {
+            let lower_key = key.to_lowercase();
+            let model_part = lower_key.split('/').next_back().unwrap_or(&lower_key);
+            if family_matches(model_part, &family) && contains_model_id(model_part, model_id) {
+                family_matches_list.push(key);
+            }
+        }
+
+        if let Some(result) =
+            select_best_match(&family_matches_list, &self.openrouter, "OpenRouter")
+        {
+            return Some(result);
+        }
+
+        let mut all_matches: Vec<&String> = Vec::new();
+        for key in &self.openrouter_keys {
+            let lower_key = key.to_lowercase();
+            let model_part = lower_key.split('/').next_back().unwrap_or(&lower_key);
+            if contains_model_id(model_part, model_id) {
+                all_matches.push(key);
+            }
+        }
+
+        select_best_match(&all_matches, &self.openrouter, "OpenRouter")
+    }
+
+    pub fn calculate_cost(
+        &self,
+        model_id: &str,
+        input: i64,
+        output: i64,
+        cache_read: i64,
+        cache_write: i64,
+        reasoning: i64,
+    ) -> f64 {
+        let result = match self.lookup(model_id) {
+            Some(r) => r,
+            None => return 0.0,
+        };
+
+        compute_cost(
+            &result.pricing,
+            input,
+            output,
+            cache_read,
+            cache_write,
+            reasoning,
+        )
+    }
+}
+
+pub fn compute_cost(
+    pricing: &ModelPricing,
+    input: i64,
+    output: i64,
+    cache_read: i64,
+    cache_write: i64,
+    reasoning: i64,
+) -> f64 {
+    let safe_price = |opt: Option<f64>| opt.filter(|v| is_valid_price_value(*v)).unwrap_or(0.0);
+    let tiered_cost = |tokens: f64, base: Option<f64>, above_200k: Option<f64>| {
+        let base_price = safe_price(base);
+        let above_price = above_200k.filter(|v| is_valid_price_value(*v));
+        if tokens > TIERED_PRICING_THRESHOLD_TOKENS {
+            if let Some(above_price) = above_price {
+                return TIERED_PRICING_THRESHOLD_TOKENS * base_price
+                    + (tokens - TIERED_PRICING_THRESHOLD_TOKENS) * above_price;
+            }
+        }
+        tokens * base_price
+    };
+
+    let input_clamped = input.max(0) as f64;
+    let output_clamped = output.max(0).saturating_add(reasoning.max(0)) as f64;
+    let cache_read_clamped = cache_read.max(0) as f64;
+    let cache_write_clamped = cache_write.max(0) as f64;
+
+    let input_cost = tiered_cost(
+        input_clamped,
+        pricing.input_cost_per_token,
+        pricing.input_cost_per_token_above_200k_tokens,
+    );
+    let output_cost = tiered_cost(
+        output_clamped,
+        pricing.output_cost_per_token,
+        pricing.output_cost_per_token_above_200k_tokens,
+    );
+    let cache_read_cost = tiered_cost(
+        cache_read_clamped,
+        pricing.cache_read_input_token_cost,
+        pricing.cache_read_input_token_cost_above_200k_tokens,
+    );
+    let cache_write_cost = tiered_cost(
+        cache_write_clamped,
+        pricing.cache_creation_input_token_cost,
+        pricing.cache_creation_input_token_cost_above_200k_tokens,
+    );
+
+    input_cost + output_cost + cache_read_cost + cache_write_cost
+}
+
+fn extract_model_family(model_id: &str) -> String {
+    let lower = model_id.to_lowercase();
+
+    if lower.contains("gpt-5") {
+        return "gpt-5".into();
+    }
+    if lower.contains("gpt-4.1") {
+        return "gpt-4.1".into();
+    }
+    if lower.contains("gpt-4o") {
+        return "gpt-4o".into();
+    }
+    if lower.contains("gpt-4") {
+        return "gpt-4".into();
+    }
+    if lower.contains("o3") {
+        return "o3".into();
+    }
+    if lower.contains("o4") {
+        return "o4".into();
+    }
+
+    if lower.contains("opus") {
+        return "opus".into();
+    }
+    if lower.contains("sonnet") {
+        return "sonnet".into();
+    }
+    if lower.contains("haiku") {
+        return "haiku".into();
+    }
+    if lower.contains("claude") {
+        return "claude".into();
+    }
+
+    if lower.contains("gemini-3") {
+        return "gemini-3".into();
+    }
+    if lower.contains("gemini-2.5") {
+        return "gemini-2.5".into();
+    }
+    if lower.contains("gemini-2") {
+        return "gemini-2".into();
+    }
+    if lower.contains("gemini") {
+        return "gemini".into();
+    }
+
+    if lower.contains("llama") {
+        return "llama".into();
+    }
+    if lower.contains("mistral") {
+        return "mistral".into();
+    }
+    if lower.contains("deepseek") {
+        return "deepseek".into();
+    }
+    if lower.contains("qwen") {
+        return "qwen".into();
+    }
+
+    lower
+        .split(['-', '_', '.'])
+        .next()
+        .unwrap_or(&lower)
+        .to_string()
+}
+
+fn family_matches(key: &str, family: &str) -> bool {
+    if family.is_empty() {
+        return true;
+    }
+    key.contains(family)
+}
+
+fn contains_model_id(key: &str, model_id: &str) -> bool {
+    if let Some(pos) = key.find(model_id) {
+        let before_ok = pos == 0 || !key[..pos].chars().last().unwrap().is_alphanumeric();
+        let after_pos = pos + model_id.len();
+        let after_ok =
+            after_pos == key.len() || !key[after_pos..].chars().next().unwrap().is_alphanumeric();
+        before_ok && after_ok
+    } else {
+        false
+    }
+}
+
+fn normalize_model_name(model_id: &str) -> Option<String> {
+    let lower = model_id.to_lowercase();
+
+    if lower.contains("opus") {
+        if contains_delimited_fragment(&lower, "4.6") || contains_delimited_fragment(&lower, "4-6")
+        {
+            return Some("claude-opus-4-6".into());
+        } else if contains_delimited_fragment(&lower, "4.5")
+            || contains_delimited_fragment(&lower, "4-5")
+        {
+            return Some("claude-opus-4-5".into());
+        } else if contains_delimited_fragment(&lower, "4") {
+            return Some("claude-opus-4".into());
+        }
+    }
+    if lower.contains("sonnet") {
+        if contains_delimited_fragment(&lower, "4.5") || contains_delimited_fragment(&lower, "4-5")
+        {
+            return Some("claude-sonnet-4-5".into());
+        } else if contains_delimited_fragment(&lower, "4") {
+            return Some("claude-sonnet-4".into());
+        } else if contains_delimited_fragment(&lower, "3.7")
+            || contains_delimited_fragment(&lower, "3-7")
+        {
+            return Some("claude-3-7-sonnet".into());
+        } else if contains_delimited_fragment(&lower, "3.5")
+            || contains_delimited_fragment(&lower, "3-5")
+        {
+            return Some("claude-3.5-sonnet".into());
+        }
+    }
+    if lower.contains("haiku") {
+        if contains_delimited_fragment(&lower, "4.5") || contains_delimited_fragment(&lower, "4-5")
+        {
+            return Some("claude-haiku-4-5".into());
+        } else if contains_delimited_fragment(&lower, "3.5")
+            || contains_delimited_fragment(&lower, "3-5")
+        {
+            return Some("claude-3.5-haiku".into());
+        }
+    }
+
+    None
+}
+
+fn normalize_version_separator(model_id: &str) -> Option<String> {
+    let mut result = String::with_capacity(model_id.len());
+    let chars: Vec<char> = model_id.chars().collect();
+    let mut changed = false;
+
+    for i in 0..chars.len() {
+        if chars[i] == '-'
+            && i > 0
+            && i < chars.len() - 1
+            && chars[i - 1].is_ascii_digit()
+            && chars[i + 1].is_ascii_digit()
+        {
+            let is_multi_digit_before = i >= 2 && chars[i - 2].is_ascii_digit();
+            let is_multi_digit_after = i + 2 < chars.len() && chars[i + 2].is_ascii_digit();
+            let looks_like_date = is_multi_digit_before || is_multi_digit_after;
+
+            if looks_like_date {
+                result.push(chars[i]);
+            } else {
+                result.push('.');
+                changed = true;
+            }
+        } else {
+            result.push(chars[i]);
+        }
+    }
+
+    if changed {
+        Some(result)
+    } else {
+        None
+    }
+}
+
+fn strip_known_provider_prefix(model_id: &str) -> Option<&str> {
+    for prefix in PROVIDER_PREFIXES {
+        if let Some(stripped) = model_id.strip_prefix(prefix) {
+            if !stripped.is_empty() {
+                return Some(stripped);
+            }
+        }
+    }
+    None
+}
+
+fn is_valid_price_value(value: f64) -> bool {
+    value.is_finite() && value >= 0.0
+}
+
+fn has_any_valid_above_tier_value(pricing: &ModelPricing) -> bool {
+    [
+        pricing.input_cost_per_token_above_200k_tokens,
+        pricing.output_cost_per_token_above_200k_tokens,
+        pricing.cache_read_input_token_cost_above_200k_tokens,
+        pricing.cache_creation_input_token_cost_above_200k_tokens,
+    ]
+    .into_iter()
+    .flatten()
+    .any(is_valid_price_value)
+}
+
+fn has_meaningful_tier_support(pricing: &ModelPricing) -> bool {
+    [
+        (
+            pricing.input_cost_per_token,
+            pricing.input_cost_per_token_above_200k_tokens,
+        ),
+        (
+            pricing.output_cost_per_token,
+            pricing.output_cost_per_token_above_200k_tokens,
+        ),
+    ]
+    .into_iter()
+    .any(|(base, above)| match (base, above) {
+        (Some(base), Some(above)) => base.is_finite() && base >= 0.0 && is_valid_price_value(above),
+        _ => false,
+    })
+}
+
+fn contains_delimited_fragment(haystack: &str, fragment: &str) -> bool {
+    if fragment.is_empty() {
+        return false;
+    }
+
+    for (pos, _) in haystack.match_indices(fragment) {
+        let before_ok = pos == 0 || !haystack[..pos].chars().last().unwrap().is_alphanumeric();
+        let after_pos = pos + fragment.len();
+        let after_ok = after_pos == haystack.len()
+            || !haystack[after_pos..]
+                .chars()
+                .next()
+                .unwrap()
+                .is_alphanumeric();
+
+        if before_ok && after_ok {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn is_fuzzy_eligible(model_id: &str) -> bool {
+    if model_id.len() < MIN_FUZZY_MATCH_LEN {
+        return false;
+    }
+    !FUZZY_BLOCKLIST.contains(&model_id)
+}
+
+/// Attempts to find a model by progressively stripping trailing segments.
+/// Handles arbitrary suffixes (e.g., "claude-sonnet-4-5-thinking" → "claude-sonnet-4-5").
+/// This replaces the hardcoded TIER_SUFFIXES and FALLBACK_SUFFIXES approach.
+fn try_strip_unknown_suffix<F>(model_id: &str, do_lookup: F) -> Option<LookupResult>
+where
+    F: Fn(&str) -> Option<LookupResult>,
+{
+    let parts: Vec<&str> = model_id.split('-').collect();
+
+    if parts.len() < 2 {
+        return None;
+    }
+
+    let max_strip = std::cmp::min(parts.len() - 1, MAX_SUFFIX_STRIP_SEGMENTS);
+
+    for strip in 1..=max_strip {
+        let candidate: String = parts[..parts.len() - strip].join("-");
+
+        if candidate.len() >= MIN_MODEL_NAME_LEN {
+            if let Some(result) = do_lookup(&candidate) {
+                return Some(result);
+            }
+        }
+    }
+
+    None
+}
+
+/// Attempts to find a model by progressively stripping leading segments.
+/// Handles arbitrary routing prefixes (e.g., "myplugin-claude-3.5-sonnet" → "claude-3.5-sonnet").
+/// This replaces the hardcoded STRIPPED_PREFIXES approach.
+fn try_strip_unknown_prefix<F>(model_id: &str, do_lookup: F) -> Option<LookupResult>
+where
+    F: Fn(&str) -> Option<LookupResult>,
+{
+    let parts: Vec<&str> = model_id.split('-').collect();
+
+    if parts.len() < 2 {
+        return None;
+    }
+
+    let max_skip = std::cmp::min(parts.len() - 1, MAX_PREFIX_STRIP_SEGMENTS);
+
+    for skip in 1..=max_skip {
+        let candidate: String = parts[skip..].join("-");
+
+        if candidate.len() >= MIN_MODEL_NAME_LEN {
+            // Try candidate directly
+            if let Some(result) = do_lookup(&candidate) {
+                return Some(result);
+            }
+
+            // Try candidate with suffix stripping
+            if let Some(result) = try_strip_unknown_suffix(&candidate, &do_lookup) {
+                return Some(result);
+            }
+        }
+    }
+
+    None
+}
+
+fn is_original_provider(key: &str) -> bool {
+    let lower = key.to_lowercase();
+    ORIGINAL_PROVIDER_PREFIXES
+        .iter()
+        .any(|prefix| lower.starts_with(prefix))
+}
+
+fn is_reseller_provider(key: &str) -> bool {
+    let lower = key.to_lowercase();
+    RESELLER_PROVIDER_PREFIXES
+        .iter()
+        .any(|prefix| lower.starts_with(prefix))
+}
+
+fn select_best_match(
+    matches: &[&String],
+    dataset: &HashMap<String, ModelPricing>,
+    source: &str,
+) -> Option<LookupResult> {
+    if matches.is_empty() {
+        return None;
+    }
+
+    if let Some(key) = matches.iter().find(|k| is_original_provider(k)) {
+        if let Some(pricing) = dataset.get(*key) {
+            return Some(LookupResult {
+                pricing: pricing.clone(),
+                source: source.into(),
+                matched_key: (*key).clone(),
+            });
+        }
+    }
+
+    if let Some(key) = matches.iter().find(|k| !is_reseller_provider(k)) {
+        if let Some(pricing) = dataset.get(*key) {
+            return Some(LookupResult {
+                pricing: pricing.clone(),
+                source: source.into(),
+                matched_key: (*key).clone(),
+            });
+        }
+    }
+
+    let key = matches[0];
+    dataset.get(key).map(|pricing| LookupResult {
+        pricing: pricing.clone(),
+        source: source.into(),
+        matched_key: key.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mock LiteLLM data matching real API responses for OpenCode Zen models
+    fn mock_litellm() -> HashMap<String, ModelPricing> {
+        let mut m = HashMap::new();
+
+        // === GPT-4 models (baseline) ===
+        m.insert(
+            "gpt-4o".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000025),
+                output_cost_per_token: Some(0.00001),
+                cache_read_input_token_cost: Some(0.00000125),
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "gpt-4o-mini".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00000015),
+                output_cost_per_token: Some(0.0000006),
+                cache_read_input_token_cost: Some(0.000000075),
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "gpt-4-turbo".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00001),
+                output_cost_per_token: Some(0.00003),
+                cache_read_input_token_cost: None,
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+
+        // === OpenCode Zen: GPT-5 family ===
+        m.insert(
+            "gpt-5.2".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00000175),
+                output_cost_per_token: Some(0.000014),
+                cache_read_input_token_cost: Some(1.75e-7),
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "gpt-5.1".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00000125),
+                output_cost_per_token: Some(0.00001),
+                cache_read_input_token_cost: Some(1.25e-7),
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "gpt-5.1-codex".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00000125),
+                output_cost_per_token: Some(0.00001),
+                cache_read_input_token_cost: Some(1.25e-7),
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "gpt-5.1-codex-max".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00000125),
+                output_cost_per_token: Some(0.00001),
+                cache_read_input_token_cost: Some(1.25e-7),
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "gpt-5".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00000125),
+                output_cost_per_token: Some(0.00001),
+                cache_read_input_token_cost: Some(1.25e-7),
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "gpt-5-codex".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00000125),
+                output_cost_per_token: Some(0.00001),
+                cache_read_input_token_cost: Some(1.25e-7),
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "gpt-5-nano".into(),
+            ModelPricing {
+                input_cost_per_token: Some(5e-8),
+                output_cost_per_token: Some(4e-7),
+                cache_read_input_token_cost: Some(5e-9),
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+
+        // === OpenCode Zen: Claude family (LiteLLM entries) ===
+        m.insert(
+            "claude-3-5-sonnet-20241022".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000003),
+                output_cost_per_token: Some(0.000015),
+                cache_read_input_token_cost: Some(0.0000003),
+                cache_creation_input_token_cost: Some(0.00000375),
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "claude-sonnet-4-5".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000003),
+                output_cost_per_token: Some(0.000015),
+                cache_read_input_token_cost: Some(3e-7),
+                cache_creation_input_token_cost: Some(0.00000375),
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "claude-haiku-4-5".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000001),
+                output_cost_per_token: Some(0.000005),
+                cache_read_input_token_cost: Some(1e-7),
+                cache_creation_input_token_cost: Some(0.00000125),
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "bedrock/us.anthropic.claude-3-5-haiku-20241022-v1:0".into(),
+            ModelPricing {
+                input_cost_per_token: Some(8e-7),
+                output_cost_per_token: Some(0.000004),
+                cache_read_input_token_cost: Some(8e-8),
+                cache_creation_input_token_cost: Some(0.000001),
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "claude-opus-4-5".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000005),
+                output_cost_per_token: Some(0.000025),
+                cache_read_input_token_cost: Some(5e-7),
+                cache_creation_input_token_cost: Some(0.00000625),
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "claude-opus-4-1".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000015),
+                output_cost_per_token: Some(0.000075),
+                cache_read_input_token_cost: Some(0.0000015),
+                cache_creation_input_token_cost: Some(0.00001875),
+                ..Default::default()
+            },
+        );
+
+        // === OpenCode Zen: Gemini family (LiteLLM entries) ===
+        m.insert(
+            "openrouter/google/gemini-3-pro-preview".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000002),
+                output_cost_per_token: Some(0.000012),
+                cache_read_input_token_cost: Some(2e-7),
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "vertex_ai/gemini-3-flash-preview".into(),
+            ModelPricing {
+                input_cost_per_token: Some(5e-7),
+                output_cost_per_token: Some(0.000003),
+                cache_read_input_token_cost: Some(5e-8),
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+
+        // === OpenCode Zen: Grok (LiteLLM entry) ===
+        m.insert(
+            "xai/grok-code-fast-1-0825".into(),
+            ModelPricing {
+                input_cost_per_token: Some(2e-7),
+                output_cost_per_token: Some(0.0000015),
+                cache_read_input_token_cost: Some(2e-8),
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+
+        m.insert(
+            "azure_ai/grok-code-fast-1".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000035),
+                output_cost_per_token: Some(0.0000175),
+                cache_read_input_token_cost: None,
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "bedrock/anthropic.claude-sonnet-4".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000003),
+                output_cost_per_token: Some(0.000015),
+                cache_read_input_token_cost: Some(3e-7),
+                cache_creation_input_token_cost: Some(0.00000375),
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "vertex_ai/gemini-2.5-pro".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00000125),
+                output_cost_per_token: Some(0.000005),
+                cache_read_input_token_cost: None,
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "google/gemini-2.5-pro".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00000125),
+                output_cost_per_token: Some(0.000005),
+                cache_read_input_token_cost: None,
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+
+        m
+    }
+
+    /// Mock OpenRouter data matching real API responses for OpenCode Zen models
+    fn mock_openrouter() -> HashMap<String, ModelPricing> {
+        let mut m = HashMap::new();
+
+        // === Baseline models ===
+        m.insert(
+            "openai/gpt-4o".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000025),
+                output_cost_per_token: Some(0.00001),
+                cache_read_input_token_cost: Some(0.00000125),
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+
+        // === OpenCode Zen: Claude (OpenRouter entries) ===
+        m.insert(
+            "anthropic/claude-sonnet-4".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000003),
+                output_cost_per_token: Some(0.000015),
+                cache_read_input_token_cost: Some(3e-7),
+                cache_creation_input_token_cost: Some(0.00000375),
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "anthropic/claude-opus-4-5".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000005),
+                output_cost_per_token: Some(0.000025),
+                cache_read_input_token_cost: Some(0.0000005),
+                cache_creation_input_token_cost: Some(0.00000625),
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "anthropic/claude-3.5-haiku".into(),
+            ModelPricing {
+                input_cost_per_token: Some(8e-7),
+                output_cost_per_token: Some(0.000004),
+                cache_read_input_token_cost: Some(8e-8),
+                cache_creation_input_token_cost: Some(0.000001),
+                ..Default::default()
+            },
+        );
+
+        // === OpenCode Zen: GLM family ===
+        m.insert(
+            "z-ai/glm-4.7".into(),
+            ModelPricing {
+                input_cost_per_token: Some(4e-7),
+                output_cost_per_token: Some(0.0000015),
+                cache_read_input_token_cost: None,
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "z-ai/glm-4.6".into(),
+            ModelPricing {
+                input_cost_per_token: Some(3.9e-7),
+                output_cost_per_token: Some(0.0000019),
+                cache_read_input_token_cost: None,
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+
+        m.insert(
+            "moonshotai/kimi-k2".into(),
+            ModelPricing {
+                input_cost_per_token: Some(4.56e-7),
+                output_cost_per_token: Some(0.00000184),
+                cache_read_input_token_cost: None,
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "moonshotai/kimi-k2.5".into(),
+            ModelPricing {
+                input_cost_per_token: Some(4.5e-7),
+                output_cost_per_token: Some(0.0000025),
+                cache_read_input_token_cost: None,
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "moonshotai/kimi-k2-thinking".into(),
+            ModelPricing {
+                input_cost_per_token: Some(4e-7),
+                output_cost_per_token: Some(0.00000175),
+                cache_read_input_token_cost: None,
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+
+        // === OpenCode Zen: Qwen family ===
+        m.insert(
+            "qwen/qwen3-coder".into(),
+            ModelPricing {
+                input_cost_per_token: Some(2.2e-7),
+                output_cost_per_token: Some(9.5e-7),
+                cache_read_input_token_cost: None,
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+
+        m
+    }
+
+    fn create_lookup() -> PricingLookup {
+        PricingLookup::new(mock_litellm(), mock_openrouter(), HashMap::new())
+    }
+
+    // =========================================================================
+    // OPENCODE ZEN MODELS - GPT-5 FAMILY
+    // All models from https://opencode.ai/docs/zen/
+    // =========================================================================
+
+    #[test]
+    fn test_opencode_zen_gpt_5_2() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gpt-5.2").unwrap();
+        assert_eq!(result.matched_key, "gpt-5.2");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_opencode_zen_gpt_5_1() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gpt-5.1").unwrap();
+        assert_eq!(result.matched_key, "gpt-5.1");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_opencode_zen_gpt_5_1_codex() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gpt-5.1-codex").unwrap();
+        assert_eq!(result.matched_key, "gpt-5.1-codex");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_opencode_zen_gpt_5_1_codex_max() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gpt-5.1-codex-max").unwrap();
+        assert_eq!(result.matched_key, "gpt-5.1-codex-max");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_opencode_zen_gpt_5() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gpt-5").unwrap();
+        assert_eq!(result.matched_key, "gpt-5");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_opencode_zen_gpt_5_codex() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gpt-5-codex").unwrap();
+        assert_eq!(result.matched_key, "gpt-5-codex");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_opencode_zen_gpt_5_nano() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gpt-5-nano").unwrap();
+        assert_eq!(result.matched_key, "gpt-5-nano");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    // =========================================================================
+    // OPENCODE ZEN MODELS - CLAUDE FAMILY
+    // =========================================================================
+
+    #[test]
+    fn test_opencode_zen_claude_sonnet_4_5() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("claude-sonnet-4-5").unwrap();
+        assert_eq!(result.matched_key, "claude-sonnet-4-5");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_opencode_zen_claude_sonnet_4() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("claude-sonnet-4").unwrap();
+        assert_eq!(result.matched_key, "anthropic/claude-sonnet-4");
+        assert_eq!(result.source, "OpenRouter");
+    }
+
+    #[test]
+    fn test_opencode_zen_claude_haiku_4_5() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("claude-haiku-4-5").unwrap();
+        assert_eq!(result.matched_key, "claude-haiku-4-5");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_opencode_zen_claude_3_5_haiku() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("claude-3-5-haiku").unwrap();
+        assert_eq!(result.matched_key, "anthropic/claude-3.5-haiku");
+        assert_eq!(result.source, "OpenRouter");
+    }
+
+    #[test]
+    fn test_opencode_zen_claude_3_5_haiku_with_dot() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("claude-3.5-haiku").unwrap();
+        assert_eq!(result.matched_key, "anthropic/claude-3.5-haiku");
+        assert_eq!(result.source, "OpenRouter");
+    }
+
+    #[test]
+    fn test_opencode_zen_claude_opus_4_5() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("claude-opus-4-5").unwrap();
+        assert_eq!(result.matched_key, "claude-opus-4-5");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_opencode_zen_claude_opus_4_1() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("claude-opus-4-1").unwrap();
+        assert_eq!(result.matched_key, "claude-opus-4-1");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    // =========================================================================
+    // OPENCODE ZEN MODELS - GLM FAMILY
+    // =========================================================================
+
+    #[test]
+    fn test_opencode_zen_glm_4_7_free() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("glm-4.7-free").unwrap();
+        assert_eq!(result.matched_key, "z-ai/glm-4.7");
+        assert_eq!(result.source, "OpenRouter");
+    }
+
+    #[test]
+    fn test_opencode_zen_glm_4_6() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("glm-4.6").unwrap();
+        assert_eq!(result.matched_key, "z-ai/glm-4.6");
+        assert_eq!(result.source, "OpenRouter");
+    }
+
+    #[test]
+    fn test_opencode_zen_glm_4_7_with_hyphen() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("glm-4-7").unwrap();
+        assert_eq!(result.matched_key, "z-ai/glm-4.7");
+        assert_eq!(result.source, "OpenRouter");
+    }
+
+    #[test]
+    fn test_opencode_zen_glm_4_6_with_hyphen() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("glm-4-6").unwrap();
+        assert_eq!(result.matched_key, "z-ai/glm-4.6");
+        assert_eq!(result.source, "OpenRouter");
+    }
+
+    #[test]
+    fn test_opencode_zen_big_pickle() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("big-pickle").unwrap();
+        assert_eq!(result.matched_key, "z-ai/glm-4.7");
+        assert_eq!(result.source, "OpenRouter");
+    }
+
+    // =========================================================================
+    // OPENCODE ZEN MODELS - GEMINI FAMILY
+    // =========================================================================
+
+    #[test]
+    fn test_opencode_zen_gemini_3_pro() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gemini-3-pro").unwrap();
+        assert_eq!(result.matched_key, "openrouter/google/gemini-3-pro-preview");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_opencode_zen_gemini_3_flash() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gemini-3-flash").unwrap();
+        assert_eq!(result.matched_key, "vertex_ai/gemini-3-flash-preview");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    // =========================================================================
+    // OPENCODE ZEN MODELS - KIMI FAMILY
+    // =========================================================================
+
+    #[test]
+    fn test_opencode_zen_kimi_k2() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("kimi-k2").unwrap();
+        assert_eq!(result.matched_key, "moonshotai/kimi-k2");
+        assert_eq!(result.source, "OpenRouter");
+    }
+
+    #[test]
+    fn test_opencode_zen_kimi_k2_thinking() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("kimi-k2-thinking").unwrap();
+        assert_eq!(result.matched_key, "moonshotai/kimi-k2-thinking");
+        assert_eq!(result.source, "OpenRouter");
+    }
+
+    #[test]
+    fn test_opencode_zen_kimi_k2_5() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("kimi-k2.5").unwrap();
+        assert_eq!(result.matched_key, "moonshotai/kimi-k2.5");
+        assert_eq!(result.source, "OpenRouter");
+    }
+
+    #[test]
+    fn test_opencode_zen_kimi_k2_5_free() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("kimi-k2.5-free").unwrap();
+        assert_eq!(result.matched_key, "moonshotai/kimi-k2.5");
+        assert_eq!(result.source, "OpenRouter");
+    }
+
+    // =========================================================================
+    // OPENCODE ZEN MODELS - QWEN FAMILY
+    // =========================================================================
+
+    #[test]
+    fn test_opencode_zen_qwen3_coder() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("qwen3-coder").unwrap();
+        assert_eq!(result.matched_key, "qwen/qwen3-coder");
+        assert_eq!(result.source, "OpenRouter");
+    }
+
+    // =========================================================================
+    // OPENCODE ZEN MODELS - GROK FAMILY
+    // =========================================================================
+
+    #[test]
+    fn test_opencode_zen_grok_code() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("grok-code").unwrap();
+        assert_eq!(result.matched_key, "xai/grok-code-fast-1-0825");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    // =========================================================================
+    // BASELINE / LEGACY TESTS
+    // =========================================================================
+
+    #[test]
+    fn test_exact_match_litellm() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gpt-4o").unwrap();
+        assert_eq!(result.matched_key, "gpt-4o");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_exact_match_openrouter() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("z-ai/glm-4.7").unwrap();
+        assert_eq!(result.matched_key, "z-ai/glm-4.7");
+        assert_eq!(result.source, "OpenRouter");
+    }
+
+    #[test]
+    fn test_openrouter_model_part_match() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("glm-4.7").unwrap();
+        assert_eq!(result.matched_key, "z-ai/glm-4.7");
+        assert_eq!(result.source, "OpenRouter");
+    }
+
+    #[test]
+    fn test_tier_suffix_low() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gpt-5.1-codex-low").unwrap();
+        assert_eq!(result.matched_key, "gpt-5.1-codex");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_tier_suffix_high() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gpt-4o-high").unwrap();
+        assert_eq!(result.matched_key, "gpt-4o");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_tier_suffix_free() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("glm-4.7-free").unwrap();
+        assert_eq!(result.matched_key, "z-ai/glm-4.7");
+        assert_eq!(result.source, "OpenRouter");
+    }
+
+    #[test]
+    fn test_tier_suffix_xhigh() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gpt-5.2-xhigh").unwrap();
+        assert_eq!(result.matched_key, "gpt-5.2");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_tier_suffix_xhigh_codex_max() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gpt-5.1-codex-max-xhigh").unwrap();
+        assert_eq!(result.matched_key, "gpt-5.1-codex-max");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_normalize_opus_4_5() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("opus-4-5").unwrap();
+        assert_eq!(result.matched_key, "claude-opus-4-5");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_normalize_opus_4_6_prefers_4_6_over_4() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-opus-4".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00002),
+                output_cost_per_token: Some(0.0001),
+                ..Default::default()
+            },
+        );
+        litellm.insert(
+            "claude-opus-4-6".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00001),
+                output_cost_per_token: Some(0.00005),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+        let result = lookup.lookup("opus-4-6").unwrap();
+        assert_eq!(result.matched_key, "claude-opus-4-6");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_normalize_opus_4_6_dot_prefers_4_6_over_4() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-opus-4".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00002),
+                output_cost_per_token: Some(0.0001),
+                ..Default::default()
+            },
+        );
+        litellm.insert(
+            "claude-opus-4-6".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00001),
+                output_cost_per_token: Some(0.00005),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+        let result = lookup.lookup("opus-4.6").unwrap();
+        assert_eq!(result.matched_key, "claude-opus-4-6");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_normalize_opus_4_60_does_not_map_to_4_6() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-opus-4".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00002),
+                output_cost_per_token: Some(0.0001),
+                ..Default::default()
+            },
+        );
+        litellm.insert(
+            "claude-opus-4-6".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00001),
+                output_cost_per_token: Some(0.00005),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+        let result = lookup.lookup("opus-4-60").unwrap();
+        assert_eq!(result.matched_key, "claude-opus-4");
+        assert_ne!(result.matched_key, "claude-opus-4-6");
+    }
+
+    #[test]
+    fn test_normalize_opus_14_6_does_not_map_to_4_6() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-opus-4-6".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00001),
+                output_cost_per_token: Some(0.00005),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+        assert!(lookup.lookup("opus-14-6").is_none());
+    }
+
+    #[test]
+    fn test_normalize_sonnet_14_5_does_not_map_to_4_5() {
+        assert_eq!(normalize_model_name("sonnet-14-5"), None);
+    }
+
+    #[test]
+    fn test_normalize_haiku_14_5_does_not_map_to_4_5() {
+        assert_eq!(normalize_model_name("haiku-14-5"), None);
+    }
+
+    #[test]
+    fn test_blocklist_auto() {
+        let lookup = create_lookup();
+        assert!(lookup.lookup("auto").is_none());
+    }
+
+    #[test]
+    fn test_blocklist_mini() {
+        let lookup = create_lookup();
+        assert!(lookup.lookup("mini").is_none());
+    }
+
+    #[test]
+    fn test_force_source_litellm() {
+        let lookup = create_lookup();
+        let result = lookup
+            .lookup_with_source("gpt-4o", Some("litellm"))
+            .unwrap();
+        assert_eq!(result.source, "LiteLLM");
+        assert_eq!(result.matched_key, "gpt-4o");
+    }
+
+    #[test]
+    fn test_force_source_openrouter() {
+        let lookup = create_lookup();
+        let result = lookup
+            .lookup_with_source("gpt-4o", Some("openrouter"))
+            .unwrap();
+        assert_eq!(result.source, "OpenRouter");
+        assert_eq!(result.matched_key, "openai/gpt-4o");
+    }
+
+    #[test]
+    fn test_case_insensitive() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("GPT-4O").unwrap();
+        assert_eq!(result.matched_key, "gpt-4o");
+    }
+
+    #[test]
+    fn test_fuzzy_match_gemini() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gemini-3-pro").unwrap();
+        assert_eq!(result.matched_key, "openrouter/google/gemini-3-pro-preview");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_tier_suffix_with_fuzzy() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gemini-3-pro-high").unwrap();
+        assert_eq!(result.matched_key, "openrouter/google/gemini-3-pro-preview");
+    }
+
+    #[test]
+    fn test_nonexistent_model() {
+        let lookup = create_lookup();
+        assert!(lookup.lookup("nonexistent-model-xyz").is_none());
+    }
+
+    #[test]
+    fn test_fallback_suffix_lookup() {
+        // Create a lookup with only the base model (no -codex variant)
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "gpt-5".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00000125),
+                output_cost_per_token: Some(0.00001),
+                cache_read_input_token_cost: Some(1.25e-7),
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+        // Note: gpt-5-codex is NOT in the pricing data
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        // Looking up gpt-5-codex should fall back to gpt-5
+        let result = lookup.lookup("gpt-5-codex").unwrap();
+        assert_eq!(result.matched_key, "gpt-5");
+        assert_eq!(result.source, "LiteLLM");
+
+        // Looking up gpt-5-codex-max should also fall back to gpt-5
+        let result = lookup.lookup("gpt-5-codex-max").unwrap();
+        assert_eq!(result.matched_key, "gpt-5");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_fallback_suffix_with_tier_suffix() {
+        // Test that tier suffix + fallback suffix both work together
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "gpt-5".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00000125),
+                output_cost_per_token: Some(0.00001),
+                cache_read_input_token_cost: Some(1.25e-7),
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        // gpt-5-codex-high should strip -high first, then fall back from gpt-5-codex to gpt-5
+        let result = lookup.lookup("gpt-5-codex-high").unwrap();
+        assert_eq!(result.matched_key, "gpt-5");
+        assert_eq!(result.source, "LiteLLM");
+
+        // gpt-5-codex-max-xhigh should strip -xhigh first, then fall back from gpt-5-codex-max to gpt-5
+        let result = lookup.lookup("gpt-5-codex-max-xhigh").unwrap();
+        assert_eq!(result.matched_key, "gpt-5");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_fallback_suffix_prefers_exact_match() {
+        // If the exact model exists, it should be used (no fallback)
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "gpt-5".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00000125),
+                output_cost_per_token: Some(0.00001),
+                cache_read_input_token_cost: None,
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+        litellm.insert(
+            "gpt-5-codex".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000002), // Different price to verify which one is used
+                output_cost_per_token: Some(0.000015),
+                cache_read_input_token_cost: None,
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        // Should use the exact match, not fall back
+        let result = lookup.lookup("gpt-5-codex").unwrap();
+        assert_eq!(result.matched_key, "gpt-5-codex");
+        assert_eq!(result.pricing.input_cost_per_token, Some(0.000002));
+    }
+
+    #[test]
+    fn test_normalize_version_separator() {
+        assert_eq!(
+            normalize_version_separator("glm-4-7"),
+            Some("glm-4.7".into())
+        );
+        assert_eq!(
+            normalize_version_separator("glm-4-6"),
+            Some("glm-4.6".into())
+        );
+        assert_eq!(
+            normalize_version_separator("claude-3-5-haiku"),
+            Some("claude-3.5-haiku".into())
+        );
+        assert_eq!(
+            normalize_version_separator("gpt-5-1-codex"),
+            Some("gpt-5.1-codex".into())
+        );
+        assert_eq!(normalize_version_separator("gpt-4o"), None);
+        assert_eq!(normalize_version_separator("claude-sonnet"), None);
+        assert_eq!(normalize_version_separator("big-pickle"), None);
+    }
+
+    #[test]
+    fn test_normalize_version_separator_preserves_dates() {
+        assert_eq!(normalize_version_separator("2024-11-20"), None);
+        assert_eq!(normalize_version_separator("model-2024-11-20"), None);
+        assert_eq!(
+            normalize_version_separator("claude-3-5-sonnet-20241022"),
+            Some("claude-3.5-sonnet-20241022".into())
+        );
+        assert_eq!(normalize_version_separator("sonnet-20241022"), None);
+        assert_eq!(normalize_version_separator("model-20241022-v1"), None);
+    }
+
+    #[test]
+    fn test_is_fuzzy_eligible() {
+        assert!(!is_fuzzy_eligible("auto"));
+        assert!(!is_fuzzy_eligible("mini"));
+        assert!(!is_fuzzy_eligible("chat"));
+        assert!(!is_fuzzy_eligible("base"));
+        assert!(!is_fuzzy_eligible("abc"));
+        assert!(is_fuzzy_eligible("gpt-4o"));
+        assert!(is_fuzzy_eligible("claude"));
+    }
+
+    // =========================================================================
+    // PROVIDER PREFERENCE TESTS
+    // =========================================================================
+
+    #[test]
+    fn test_provider_preference_grok_prefers_xai_over_azure() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("grok-code").unwrap();
+        assert_eq!(result.matched_key, "xai/grok-code-fast-1-0825");
+        assert_eq!(result.source, "LiteLLM");
+        assert!(!result.matched_key.starts_with("azure"));
+    }
+
+    /// Test that documents the exact before/after behavior for grok-code provider preference.
+    /// This test explicitly verifies that the original provider (xai/) is preferred over resellers (azure_ai/).
+    #[test]
+    fn test_grok_code_prefers_xai_over_azure() {
+        // =========================================================================
+        // BEFORE FIX: grok-code → azure_ai/grok-code-fast-1 ($3.50/$17.50) ❌ reseller
+        // AFTER FIX:  grok-code → xai/grok-code-fast-1-0825 ($0.20/$1.50) ✅ original provider
+        //
+        // The azure_ai/ prefix indicates a reseller (Azure AI marketplace), which typically
+        // has higher prices. The xai/ prefix indicates the original provider (X.AI/Grok),
+        // which offers lower direct pricing. Our lookup should prefer the original provider.
+        // =========================================================================
+
+        let mut litellm = HashMap::new();
+
+        // Reseller entry: azure_ai/ prefix with higher prices ($3.50/$17.50 per 1M tokens)
+        litellm.insert(
+            "azure_ai/grok-code-fast-1".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000035),  // $3.50/1M tokens
+                output_cost_per_token: Some(0.0000175), // $17.50/1M tokens
+                cache_read_input_token_cost: None,
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+
+        // Original provider entry: xai/ prefix with lower prices ($0.20/$1.50 per 1M tokens)
+        litellm.insert(
+            "xai/grok-code-fast-1-0825".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000002),  // $0.20/1M tokens
+                output_cost_per_token: Some(0.0000015), // $1.50/1M tokens
+                cache_read_input_token_cost: Some(0.00000002),
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+        let result = lookup.lookup("grok-code").unwrap();
+
+        // Must prefer xai (original provider) over azure_ai (reseller)
+        assert!(
+            result.matched_key.starts_with("xai/"),
+            "Expected xai/ prefix (original provider) but got: {}. \
+             The lookup should prefer original providers over resellers.",
+            result.matched_key
+        );
+        assert_eq!(
+            result.matched_key, "xai/grok-code-fast-1-0825",
+            "Should match the xai/grok-code-fast-1-0825 entry, not azure_ai/grok-code-fast-1"
+        );
+
+        // Verify we got the lower price (original provider)
+        let pricing = &result.pricing;
+        assert!(
+            pricing.input_cost_per_token.unwrap() < 0.000001,
+            "Input cost should be ~$0.20/1M (0.0000002), not ~$3.50/1M (reseller price)"
+        );
+        assert!(
+            pricing.output_cost_per_token.unwrap() < 0.000005,
+            "Output cost should be ~$1.50/1M (0.0000015), not ~$17.50/1M (reseller price)"
+        );
+    }
+
+    #[test]
+    fn test_provider_preference_gemini_prefers_google_over_vertex() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gemini-2.5-pro").unwrap();
+        assert_eq!(result.matched_key, "google/gemini-2.5-pro");
+        assert_eq!(result.source, "LiteLLM");
+        assert!(!result.matched_key.starts_with("vertex_ai"));
+    }
+
+    #[test]
+    fn test_is_original_provider() {
+        assert!(is_original_provider("xai/grok-code"));
+        assert!(is_original_provider("anthropic/claude-3"));
+        assert!(is_original_provider("openai/gpt-4"));
+        assert!(is_original_provider("google/gemini"));
+        assert!(is_original_provider("x-ai/grok"));
+        assert!(!is_original_provider("azure_ai/grok"));
+        assert!(!is_original_provider("bedrock/anthropic"));
+        assert!(!is_original_provider("vertex_ai/gemini"));
+        assert!(!is_original_provider("unknown-provider/model"));
+    }
+
+    #[test]
+    fn test_is_reseller_provider() {
+        assert!(is_reseller_provider("azure_ai/grok-code"));
+        assert!(is_reseller_provider("azure/openai/gpt-4"));
+        assert!(is_reseller_provider("bedrock/anthropic.claude"));
+        assert!(is_reseller_provider("vertex_ai/gemini"));
+        assert!(is_reseller_provider("together_ai/llama"));
+        assert!(is_reseller_provider("groq/llama"));
+        assert!(!is_reseller_provider("xai/grok"));
+        assert!(!is_reseller_provider("anthropic/claude"));
+        assert!(!is_reseller_provider("openai/gpt-4"));
+    }
+
+    // =========================================================================
+    // COST CALCULATION TESTS
+    // =========================================================================
+
+    #[test]
+    fn test_calculate_cost_gpt_5_2() {
+        let lookup = create_lookup();
+        // 1M input, 500K output tokens
+        let cost = lookup.calculate_cost("gpt-5.2", 1_000_000, 500_000, 0, 0, 0);
+        // input: 1M * 0.00000175 = 1.75, output: 500K * 0.000014 = 7.0
+        assert!((cost - 8.75).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_calculate_cost_claude_sonnet_4_5() {
+        let lookup = create_lookup();
+        // 100K input, 50K output, 200K cache read
+        let cost = lookup.calculate_cost("claude-sonnet-4-5", 100_000, 50_000, 200_000, 0, 0);
+        // input: 100K * 0.000003 = 0.30, output: 50K * 0.000015 = 0.75, cache: 200K * 3e-7 = 0.06
+        assert!((cost - 1.11).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_compute_cost_tiered_boundary_at_200k_uses_base_rates() {
+        let pricing: ModelPricing = serde_json::from_str(
+            r#"{
+                "input_cost_per_token": 0.000001,
+                "input_cost_per_token_above_200k_tokens": 0.000002,
+                "output_cost_per_token": 0.000003,
+                "output_cost_per_token_above_200k_tokens": 0.000004
+            }"#,
+        )
+        .unwrap();
+
+        let cost = compute_cost(&pricing, 200_000, 200_000, 0, 0, 0);
+        let expected = 200_000.0 * 0.000001 + 200_000.0 * 0.000003;
+
+        assert!((cost - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_compute_cost_tiered_above_200k_splits_input_and_output() {
+        let pricing: ModelPricing = serde_json::from_str(
+            r#"{
+                "input_cost_per_token": 0.000001,
+                "input_cost_per_token_above_200k_tokens": 0.000002,
+                "output_cost_per_token": 0.000003,
+                "output_cost_per_token_above_200k_tokens": 0.000004
+            }"#,
+        )
+        .unwrap();
+
+        let cost = compute_cost(&pricing, 200_001, 200_001, 0, 0, 0);
+        let expected =
+            (200_000.0 * 0.000001 + 1.0 * 0.000002) + (200_000.0 * 0.000003 + 1.0 * 0.000004);
+
+        assert!((cost - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_compute_cost_tiered_is_applied_per_bucket() {
+        let pricing: ModelPricing = serde_json::from_str(
+            r#"{
+                "input_cost_per_token": 0.000001,
+                "input_cost_per_token_above_200k_tokens": 0.000002,
+                "output_cost_per_token": 0.000003,
+                "output_cost_per_token_above_200k_tokens": 0.000004
+            }"#,
+        )
+        .unwrap();
+
+        let cost = compute_cost(&pricing, 200_001, 200_000, 0, 0, 0);
+        let expected = (200_000.0 * 0.000001 + 1.0 * 0.000002) + (200_000.0 * 0.000003);
+
+        assert!((cost - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_compute_cost_tiered_missing_base_input_only_charges_above_threshold() {
+        let pricing: ModelPricing = serde_json::from_str(
+            r#"{
+                "input_cost_per_token_above_200k_tokens": 0.000002
+            }"#,
+        )
+        .unwrap();
+
+        let at_threshold = compute_cost(&pricing, 200_000, 0, 0, 0, 0);
+        let above_threshold = compute_cost(&pricing, 200_001, 0, 0, 0, 0);
+
+        assert_eq!(at_threshold, 0.0);
+        assert!((above_threshold - 0.000002).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_compute_cost_tiered_cache_read_applies_split() {
+        let pricing: ModelPricing = serde_json::from_str(
+            r#"{
+                "cache_read_input_token_cost": 0.0000001,
+                "cache_read_input_token_cost_above_200k_tokens": 0.0000002
+            }"#,
+        )
+        .unwrap();
+
+        let at_threshold = compute_cost(&pricing, 0, 0, 200_000, 0, 0);
+        let above_threshold = compute_cost(&pricing, 0, 0, 200_001, 0, 0);
+
+        assert!((at_threshold - (200_000.0 * 0.0000001)).abs() < 1e-12);
+        assert!((above_threshold - (200_000.0 * 0.0000001 + 0.0000002)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_compute_cost_tiered_cache_write_applies_split() {
+        let pricing: ModelPricing = serde_json::from_str(
+            r#"{
+                "cache_creation_input_token_cost": 0.0000003,
+                "cache_creation_input_token_cost_above_200k_tokens": 0.0000004
+            }"#,
+        )
+        .unwrap();
+
+        let at_threshold = compute_cost(&pricing, 0, 0, 0, 200_000, 0);
+        let above_threshold = compute_cost(&pricing, 0, 0, 0, 200_001, 0);
+
+        assert!((at_threshold - (200_000.0 * 0.0000003)).abs() < 1e-12);
+        assert!((above_threshold - (200_000.0 * 0.0000003 + 0.0000004)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_compute_cost_tiered_without_above_rate_uses_base_for_all_tokens() {
+        let pricing = ModelPricing {
+            input_cost_per_token: Some(0.000001),
+            ..Default::default()
+        };
+
+        let cost = compute_cost(&pricing, 250_000, 0, 0, 0, 0);
+
+        assert!((cost - (250_000.0 * 0.000001)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_compute_cost_tiered_invalid_above_rate_falls_back_to_base() {
+        let pricing_negative = ModelPricing {
+            input_cost_per_token: Some(0.000001),
+            input_cost_per_token_above_200k_tokens: Some(-0.000002),
+            ..Default::default()
+        };
+        let pricing_infinite = ModelPricing {
+            input_cost_per_token: Some(0.000001),
+            input_cost_per_token_above_200k_tokens: Some(f64::INFINITY),
+            ..Default::default()
+        };
+        let pricing_nan = ModelPricing {
+            input_cost_per_token: Some(0.000001),
+            input_cost_per_token_above_200k_tokens: Some(f64::NAN),
+            ..Default::default()
+        };
+
+        let expected = 200_001.0 * 0.000001;
+        assert!((compute_cost(&pricing_negative, 200_001, 0, 0, 0, 0) - expected).abs() < 1e-12);
+        assert!((compute_cost(&pricing_infinite, 200_001, 0, 0, 0, 0) - expected).abs() < 1e-12);
+        assert!((compute_cost(&pricing_nan, 200_001, 0, 0, 0, 0) - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_compute_cost_tiered_reasoning_boundary_at_200k_uses_base_output_rate() {
+        let pricing = ModelPricing {
+            output_cost_per_token: Some(0.000003),
+            output_cost_per_token_above_200k_tokens: Some(0.000004),
+            ..Default::default()
+        };
+
+        let cost = compute_cost(&pricing, 0, 199_999, 0, 0, 1);
+        let expected = 200_000.0 * 0.000003;
+
+        assert!((cost - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_compute_cost_tiered_invalid_above_rate_falls_back_to_base_output_reasoning() {
+        let pricing_negative = ModelPricing {
+            output_cost_per_token: Some(0.000003),
+            output_cost_per_token_above_200k_tokens: Some(-0.000004),
+            ..Default::default()
+        };
+        let pricing_infinite = ModelPricing {
+            output_cost_per_token: Some(0.000003),
+            output_cost_per_token_above_200k_tokens: Some(f64::INFINITY),
+            ..Default::default()
+        };
+        let pricing_nan = ModelPricing {
+            output_cost_per_token: Some(0.000003),
+            output_cost_per_token_above_200k_tokens: Some(f64::NAN),
+            ..Default::default()
+        };
+
+        let expected = 200_001.0 * 0.000003;
+        assert!((compute_cost(&pricing_negative, 0, 199_999, 0, 0, 2) - expected).abs() < 1e-12);
+        assert!((compute_cost(&pricing_infinite, 0, 199_999, 0, 0, 2) - expected).abs() < 1e-12);
+        assert!((compute_cost(&pricing_nan, 0, 199_999, 0, 0, 2) - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_compute_cost_tiered_invalid_above_rate_falls_back_to_base_cache_read() {
+        let pricing_negative = ModelPricing {
+            cache_read_input_token_cost: Some(0.0000001),
+            cache_read_input_token_cost_above_200k_tokens: Some(-0.0000002),
+            ..Default::default()
+        };
+        let pricing_infinite = ModelPricing {
+            cache_read_input_token_cost: Some(0.0000001),
+            cache_read_input_token_cost_above_200k_tokens: Some(f64::INFINITY),
+            ..Default::default()
+        };
+        let pricing_nan = ModelPricing {
+            cache_read_input_token_cost: Some(0.0000001),
+            cache_read_input_token_cost_above_200k_tokens: Some(f64::NAN),
+            ..Default::default()
+        };
+
+        let expected = 200_001.0 * 0.0000001;
+        assert!((compute_cost(&pricing_negative, 0, 0, 200_001, 0, 0) - expected).abs() < 1e-12);
+        assert!((compute_cost(&pricing_infinite, 0, 0, 200_001, 0, 0) - expected).abs() < 1e-12);
+        assert!((compute_cost(&pricing_nan, 0, 0, 200_001, 0, 0) - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_compute_cost_tiered_invalid_above_rate_falls_back_to_base_cache_write() {
+        let pricing_negative = ModelPricing {
+            cache_creation_input_token_cost: Some(0.0000003),
+            cache_creation_input_token_cost_above_200k_tokens: Some(-0.0000004),
+            ..Default::default()
+        };
+        let pricing_infinite = ModelPricing {
+            cache_creation_input_token_cost: Some(0.0000003),
+            cache_creation_input_token_cost_above_200k_tokens: Some(f64::INFINITY),
+            ..Default::default()
+        };
+        let pricing_nan = ModelPricing {
+            cache_creation_input_token_cost: Some(0.0000003),
+            cache_creation_input_token_cost_above_200k_tokens: Some(f64::NAN),
+            ..Default::default()
+        };
+
+        let expected = 200_001.0 * 0.0000003;
+        assert!((compute_cost(&pricing_negative, 0, 0, 0, 200_001, 0) - expected).abs() < 1e-12);
+        assert!((compute_cost(&pricing_infinite, 0, 0, 0, 200_001, 0) - expected).abs() < 1e-12);
+        assert!((compute_cost(&pricing_nan, 0, 0, 0, 200_001, 0) - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_provider_prefixed_non_opus_prefers_exact_openrouter_without_tier_advantage() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-sonnet-4".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000003),
+                output_cost_per_token: Some(0.000015),
+                ..Default::default()
+            },
+        );
+
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "anthropic/claude-sonnet-4".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000123),
+                output_cost_per_token: Some(0.0000456),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, openrouter, HashMap::new());
+        let resolved = lookup.lookup("anthropic/claude-sonnet-4").unwrap();
+        assert_eq!(resolved.source, "OpenRouter");
+        assert_eq!(resolved.matched_key, "anthropic/claude-sonnet-4");
+    }
+
+    #[test]
+    fn test_provider_prefixed_override_requires_valid_base_and_above_pair() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-sonnet-4".into(),
+            ModelPricing {
+                // Above tier exists, but corresponding base is missing.
+                // This must not qualify for provider-prefixed override.
+                input_cost_per_token: None,
+                input_cost_per_token_above_200k_tokens: Some(0.00002),
+                ..Default::default()
+            },
+        );
+
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "anthropic/claude-sonnet-4".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000123),
+                output_cost_per_token: Some(0.0000456),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, openrouter, HashMap::new());
+        let resolved = lookup.lookup("anthropic/claude-sonnet-4").unwrap();
+        assert_eq!(resolved.source, "OpenRouter");
+        assert_eq!(resolved.matched_key, "anthropic/claude-sonnet-4");
+    }
+
+    #[test]
+    fn test_provider_prefixed_override_rejects_invalid_base_even_with_above() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-sonnet-4".into(),
+            ModelPricing {
+                input_cost_per_token: Some(f64::NAN),
+                input_cost_per_token_above_200k_tokens: Some(0.00002),
+                ..Default::default()
+            },
+        );
+
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "anthropic/claude-sonnet-4".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000123),
+                output_cost_per_token: Some(0.0000456),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, openrouter, HashMap::new());
+        let resolved = lookup.lookup("anthropic/claude-sonnet-4").unwrap();
+        assert_eq!(resolved.source, "OpenRouter");
+        assert_eq!(resolved.matched_key, "anthropic/claude-sonnet-4");
+    }
+
+    #[test]
+    fn test_provider_prefixed_override_allows_zero_base_with_valid_above() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-sonnet-4".into(),
+            ModelPricing {
+                // Policy: base=0 with valid above is a valid tier pair.
+                input_cost_per_token: Some(0.0),
+                input_cost_per_token_above_200k_tokens: Some(0.00002),
+                ..Default::default()
+            },
+        );
+
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "anthropic/claude-sonnet-4".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000123),
+                output_cost_per_token: Some(0.0000456),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, openrouter, HashMap::new());
+        let resolved = lookup.lookup("anthropic/claude-sonnet-4").unwrap();
+        assert_eq!(resolved.source, "LiteLLM");
+        assert_eq!(resolved.matched_key, "claude-sonnet-4");
+    }
+
+    #[test]
+    fn test_provider_prefixed_cache_only_tier_keeps_exact_openrouter() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-sonnet-4".into(),
+            ModelPricing {
+                cache_read_input_token_cost: Some(0.0000001),
+                cache_read_input_token_cost_above_200k_tokens: Some(0.0000002),
+                cache_creation_input_token_cost: Some(0.0000003),
+                cache_creation_input_token_cost_above_200k_tokens: Some(0.0000004),
+                ..Default::default()
+            },
+        );
+
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "anthropic/claude-sonnet-4".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000123),
+                output_cost_per_token: Some(0.0000456),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, openrouter, HashMap::new());
+        let resolved = lookup.lookup("anthropic/claude-sonnet-4").unwrap();
+        assert_eq!(resolved.source, "OpenRouter");
+        assert_eq!(resolved.matched_key, "anthropic/claude-sonnet-4");
+    }
+
+    #[test]
+    fn test_provider_prefixed_opus_4_6_prefers_litellm_tiered_pricing() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-opus-4-6".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00001),
+                input_cost_per_token_above_200k_tokens: Some(0.00002),
+                output_cost_per_token: Some(0.00005),
+                output_cost_per_token_above_200k_tokens: Some(0.00006),
+                cache_read_input_token_cost: Some(0.000001),
+                cache_read_input_token_cost_above_200k_tokens: Some(0.000002),
+                cache_creation_input_token_cost: Some(0.000003),
+                cache_creation_input_token_cost_above_200k_tokens: Some(0.000004),
+            },
+        );
+
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "anthropic/claude-opus-4-6".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.123),
+                output_cost_per_token: Some(0.456),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, openrouter, HashMap::new());
+        let resolved = lookup.lookup("anthropic/claude-opus-4-6").unwrap();
+        assert_eq!(resolved.source, "LiteLLM");
+        assert_eq!(resolved.matched_key, "claude-opus-4-6");
+
+        let cost = lookup.calculate_cost("anthropic/claude-opus-4-6", 200_001, 0, 0, 0, 0);
+        let expected = 200_000.0 * 0.00001 + 0.00002;
+        assert!((cost - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_calculate_cost_tiered_all_buckets_with_reasoning_threshold_crossing() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-opus-4-6".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000001),
+                input_cost_per_token_above_200k_tokens: Some(0.000002),
+                output_cost_per_token: Some(0.000003),
+                output_cost_per_token_above_200k_tokens: Some(0.000004),
+                cache_read_input_token_cost: Some(0.0000001),
+                cache_read_input_token_cost_above_200k_tokens: Some(0.0000002),
+                cache_creation_input_token_cost: Some(0.0000003),
+                cache_creation_input_token_cost_above_200k_tokens: Some(0.0000004),
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+        let cost = lookup.calculate_cost("claude-opus-4-6", 200_001, 199_999, 200_001, 200_001, 2);
+
+        let expected_input = 200_000.0 * 0.000001 + 0.000002;
+        let expected_output = 200_000.0 * 0.000003 + 0.000004; // output + reasoning = 200_001
+        let expected_cache_read = 200_000.0 * 0.0000001 + 0.0000002;
+        let expected_cache_write = 200_000.0 * 0.0000003 + 0.0000004;
+        let expected =
+            expected_input + expected_output + expected_cache_read + expected_cache_write;
+
+        assert!((cost - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_calculate_cost_unknown_model() {
+        let lookup = create_lookup();
+        let cost = lookup.calculate_cost("nonexistent-model", 1_000_000, 500_000, 0, 0, 0);
+        assert_eq!(cost, 0.0);
+    }
+
+    // =========================================================================
+    // INTELLIGENT PREFIX/SUFFIX STRIPPING TESTS
+    // =========================================================================
+
+    #[test]
+    fn test_antigravity_prefix_gemini_3_flash() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("antigravity-gemini-3-flash").unwrap();
+        assert_eq!(result.matched_key, "vertex_ai/gemini-3-flash-preview");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_antigravity_prefix_gemini_3_pro() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("antigravity-gemini-3-pro").unwrap();
+        assert_eq!(result.matched_key, "openrouter/google/gemini-3-pro-preview");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_antigravity_prefix_with_tier_suffix() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("antigravity-gemini-3-pro-high").unwrap();
+        assert_eq!(result.matched_key, "openrouter/google/gemini-3-pro-preview");
+    }
+
+    #[test]
+    fn test_antigravity_prefix_claude() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("antigravity-claude-sonnet-4-5").unwrap();
+        assert_eq!(result.matched_key, "claude-sonnet-4-5");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_antigravity_prefix_gpt() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("antigravity-gpt-4o").unwrap();
+        assert_eq!(result.matched_key, "gpt-4o");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_antigravity_prefix_case_insensitive() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("Antigravity-gpt-4o").unwrap();
+        assert_eq!(result.matched_key, "gpt-4o");
+    }
+
+    #[test]
+    fn test_antigravity_cost_calculation() {
+        let lookup = create_lookup();
+        let cost_with_prefix =
+            lookup.calculate_cost("antigravity-gpt-5.2", 1_000_000, 500_000, 0, 0, 0);
+        let cost_without_prefix = lookup.calculate_cost("gpt-5.2", 1_000_000, 500_000, 0, 0, 0);
+        assert!((cost_with_prefix - cost_without_prefix).abs() < 0.001);
+        assert!(cost_with_prefix > 0.0);
+    }
+
+    // New tests for intelligent detection
+
+    #[test]
+    fn test_unknown_prefix_generic() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("myplugin-gpt-4o").unwrap();
+        assert_eq!(result.matched_key, "gpt-4o");
+    }
+
+    #[test]
+    fn test_unknown_prefix_two_segments() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("router-v2-claude-sonnet-4-5").unwrap();
+        assert_eq!(result.matched_key, "claude-sonnet-4-5");
+    }
+
+    #[test]
+    fn test_unknown_suffix_thinking() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("claude-sonnet-4-5-thinking").unwrap();
+        assert_eq!(result.matched_key, "claude-sonnet-4-5");
+    }
+
+    #[test]
+    fn test_unknown_suffix_two_segments() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("claude-opus-4-5-thinking-pro").unwrap();
+        assert_eq!(result.matched_key, "claude-opus-4-5");
+    }
+
+    #[test]
+    fn test_prefix_and_suffix_combined() {
+        let lookup = create_lookup();
+        let result = lookup
+            .lookup("antigravity-claude-opus-4-5-thinking")
+            .unwrap();
+        assert_eq!(result.matched_key, "claude-opus-4-5");
+    }
+
+    #[test]
+    fn test_prefix_and_suffix_with_tier() {
+        let lookup = create_lookup();
+        let result = lookup
+            .lookup("antigravity-claude-opus-4-5-thinking-high")
+            .unwrap();
+        assert_eq!(result.matched_key, "claude-opus-4-5");
+    }
+
+    #[test]
+    fn test_no_false_positive_valid_model() {
+        let lookup = create_lookup();
+        // gpt-4o-mini is a valid model, should NOT strip "gpt"
+        let result = lookup.lookup("gpt-4o-mini").unwrap();
+        assert_eq!(result.matched_key, "gpt-4o-mini");
+    }
+
+    #[test]
+    fn test_suffix_strip_high() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("claude-sonnet-4-5-high").unwrap();
+        assert_eq!(result.matched_key, "claude-sonnet-4-5");
+    }
+
+    #[test]
+    fn test_suffix_strip_xhigh() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("claude-sonnet-4-5-xhigh").unwrap();
+        assert_eq!(result.matched_key, "claude-sonnet-4-5");
+    }
+
+    #[test]
+    fn test_suffix_strip_low() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gpt-4o-low").unwrap();
+        assert_eq!(result.matched_key, "gpt-4o");
+    }
+
+    #[test]
+    fn test_suffix_strip_codex() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gpt-5.2-codex").unwrap();
+        assert_eq!(result.matched_key, "gpt-5.2");
+    }
+}

--- a/vendor/tokscale-core/src/pricing/mod.rs
+++ b/vendor/tokscale-core/src/pricing/mod.rs
@@ -1,0 +1,347 @@
+pub mod aliases;
+pub mod cache;
+pub mod litellm;
+pub mod lookup;
+pub mod openrouter;
+
+use lookup::{LookupResult, PricingLookup};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::OnceCell;
+
+pub use litellm::ModelPricing;
+
+static PRICING_SERVICE: OnceCell<Arc<PricingService>> = OnceCell::const_new();
+
+// @keep: documents non-obvious filtering behavior — without this, the next person
+// will wonder why github_copilot entries disappear from the pricing data.
+/// Provider prefixes in LiteLLM data that use subscription-based pricing ($0.00)
+/// and should be excluded from pay-per-token cost estimation.
+const EXCLUDED_LITELLM_PREFIXES: &[&str] = &["github_copilot/"];
+
+pub struct PricingService {
+    lookup: PricingLookup,
+}
+
+impl PricingService {
+    pub fn new(
+        litellm_data: HashMap<String, ModelPricing>,
+        openrouter_data: HashMap<String, ModelPricing>,
+    ) -> Self {
+        Self {
+            lookup: PricingLookup::new(
+                litellm_data,
+                openrouter_data,
+                Self::build_cursor_overrides(),
+            ),
+        }
+    }
+
+    // @keep: the retain logic is non-trivial (lowercase + prefix match); this doc
+    // explains *why* these entries are dropped, not just *what* the code does.
+    /// Filter out LiteLLM entries from subscription-based providers (e.g. github_copilot/)
+    /// whose $0.00 pricing is meaningless for per-token cost estimation.
+    fn filter_litellm_data(
+        mut data: HashMap<String, ModelPricing>,
+    ) -> HashMap<String, ModelPricing> {
+        data.retain(|key, _| {
+            let lower = key.to_lowercase();
+            !EXCLUDED_LITELLM_PREFIXES
+                .iter()
+                .any(|prefix| lower.starts_with(prefix))
+        });
+        data
+    }
+
+    // @keep: Cursor-sourced pricing for models not yet in LiteLLM/OpenRouter.
+    // Checked after exact/prefix matches but before fuzzy matching in PricingLookup,
+    // so real upstream entries (including provider-prefixed like openai/gpt-5.3-codex)
+    // always win. Source citations are required for audit trail.
+    fn build_cursor_overrides() -> HashMap<String, ModelPricing> {
+        let entries: &[(&str, f64, f64, Option<f64>)] = &[
+            // GPT-5.3 family: $1.75/$14.00 per 1M tokens, $0.175 cache read
+            // Source: Cursor docs (cursor.com/en-US/docs/models), llm-stats.com
+            ("gpt-5.3", 0.00000175, 0.000014, Some(1.75e-7)),
+            ("gpt-5.3-codex", 0.00000175, 0.000014, Some(1.75e-7)),
+            ("gpt-5.3-codex-spark", 0.00000175, 0.000014, Some(1.75e-7)),
+            // Composer 1.5: $3.50/$17.50 per 1M tokens, $0.35 cache read
+            // Source: Cursor docs (cursor.com/docs/models#model-pricing), issue #276
+            ("composer 1.5", 0.0000035, 0.0000175, Some(3.5e-7)),
+            ("composer-1.5", 0.0000035, 0.0000175, Some(3.5e-7)),
+        ];
+
+        let mut overrides = HashMap::with_capacity(entries.len());
+        for (model_id, input, output, cache_read) in entries {
+            overrides.insert(
+                model_id.to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(*input),
+                    output_cost_per_token: Some(*output),
+                    cache_read_input_token_cost: *cache_read,
+                    cache_creation_input_token_cost: None,
+                    ..Default::default()
+                },
+            );
+        }
+        overrides
+    }
+
+    async fn fetch_inner() -> Result<Self, String> {
+        let (litellm_result, openrouter_data) =
+            tokio::join!(litellm::fetch(), openrouter::fetch_all_mapped());
+
+        let litellm_data = litellm_result.map_err(|e| e.to_string())?;
+        let litellm_data = Self::filter_litellm_data(litellm_data);
+
+        Ok(Self::new(litellm_data, openrouter_data))
+    }
+
+    fn from_cached_datasets(
+        litellm_data: Option<HashMap<String, ModelPricing>>,
+        openrouter_data: Option<HashMap<String, ModelPricing>>,
+    ) -> Option<Self> {
+        if litellm_data.is_none() && openrouter_data.is_none() {
+            return None;
+        }
+
+        Some(Self::new(
+            Self::filter_litellm_data(litellm_data.unwrap_or_default()),
+            openrouter_data.unwrap_or_default(),
+        ))
+    }
+
+    pub fn load_cached_any_age() -> Option<Self> {
+        Self::from_cached_datasets(
+            litellm::load_cached_any_age(),
+            openrouter::load_cached_any_age(),
+        )
+    }
+
+    pub async fn get_or_init() -> Result<Arc<PricingService>, String> {
+        PRICING_SERVICE
+            .get_or_try_init(|| async { Self::fetch_inner().await.map(Arc::new) })
+            .await
+            .map(Arc::clone)
+    }
+
+    pub fn lookup_with_source(
+        &self,
+        model_id: &str,
+        force_source: Option<&str>,
+    ) -> Option<LookupResult> {
+        self.lookup.lookup_with_source(model_id, force_source)
+    }
+
+    pub fn calculate_cost(
+        &self,
+        model_id: &str,
+        input: i64,
+        output: i64,
+        cache_read: i64,
+        cache_write: i64,
+        reasoning: i64,
+    ) -> f64 {
+        self.lookup
+            .calculate_cost(model_id, input, output, cache_read, cache_write, reasoning)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_excludes_github_copilot() {
+        let mut data = HashMap::new();
+        data.insert(
+            "github_copilot/gpt-5.3-codex".into(),
+            ModelPricing::default(),
+        );
+        data.insert("github_copilot/gpt-4o".into(), ModelPricing::default());
+        data.insert(
+            "gpt-5.2".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00000175),
+                ..Default::default()
+            },
+        );
+        data.insert("openai/gpt-5.2".into(), ModelPricing::default());
+
+        let filtered = PricingService::filter_litellm_data(data);
+        assert!(!filtered.contains_key("github_copilot/gpt-5.3-codex"));
+        assert!(!filtered.contains_key("github_copilot/gpt-4o"));
+        assert!(filtered.contains_key("gpt-5.2"));
+        assert!(filtered.contains_key("openai/gpt-5.2"));
+    }
+
+    #[test]
+    fn test_cursor_returns_pricing_when_not_in_upstream() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let result = service.lookup_with_source("gpt-5.3-codex", None).unwrap();
+        assert_eq!(result.source, "Cursor");
+        assert_eq!(result.pricing.input_cost_per_token, Some(0.00000175));
+        assert_eq!(result.pricing.output_cost_per_token, Some(0.000014));
+        assert_eq!(result.pricing.cache_read_input_token_cost, Some(1.75e-7));
+    }
+
+    #[test]
+    fn test_cursor_yields_to_litellm_exact() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "gpt-5.3-codex".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.002),
+                output_cost_per_token: Some(0.016),
+                ..Default::default()
+            },
+        );
+        let service = PricingService::new(litellm, HashMap::new());
+        let result = service.lookup_with_source("gpt-5.3-codex", None).unwrap();
+        assert_eq!(result.source, "LiteLLM");
+        assert_eq!(result.pricing.input_cost_per_token, Some(0.002));
+    }
+
+    #[test]
+    fn test_cursor_yields_to_openrouter_prefix() {
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "openai/gpt-5.3-codex".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.003),
+                output_cost_per_token: Some(0.012),
+                ..Default::default()
+            },
+        );
+        let service = PricingService::new(HashMap::new(), openrouter);
+        let result = service.lookup_with_source("gpt-5.3-codex", None).unwrap();
+        assert_eq!(result.source, "OpenRouter");
+        assert_eq!(result.pricing.input_cost_per_token, Some(0.003));
+    }
+
+    #[test]
+    fn test_cursor_skipped_when_force_source_set() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        assert!(service
+            .lookup_with_source("gpt-5.3-codex", Some("litellm"))
+            .is_none());
+        assert!(service
+            .lookup_with_source("gpt-5.3-codex", Some("openrouter"))
+            .is_none());
+    }
+
+    #[test]
+    fn test_cursor_matches_after_version_normalization() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let result = service.lookup_with_source("gpt-5-3-codex", None).unwrap();
+        assert_eq!(result.source, "Cursor");
+        assert_eq!(result.matched_key, "gpt-5.3-codex");
+        assert_eq!(result.pricing.input_cost_per_token, Some(0.00000175));
+    }
+
+    #[test]
+    fn test_cursor_matches_provider_prefixed_input() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let result = service
+            .lookup_with_source("openai/gpt-5.3-codex", None)
+            .unwrap();
+        assert_eq!(result.source, "Cursor");
+        assert_eq!(result.matched_key, "gpt-5.3-codex");
+    }
+
+    #[test]
+    fn test_cursor_provider_prefix_yields_to_upstream() {
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "openai/gpt-5.3-codex".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.003),
+                output_cost_per_token: Some(0.012),
+                ..Default::default()
+            },
+        );
+        let service = PricingService::new(HashMap::new(), openrouter);
+        let result = service
+            .lookup_with_source("openai/gpt-5.3-codex", None)
+            .unwrap();
+        assert_eq!(result.source, "OpenRouter");
+        assert_eq!(result.pricing.input_cost_per_token, Some(0.003));
+    }
+
+    #[test]
+    fn test_cursor_matches_via_suffix_stripping() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let result = service
+            .lookup_with_source("gpt-5.3-codex-high", None)
+            .unwrap();
+        assert_eq!(result.source, "Cursor");
+        assert_eq!(result.matched_key, "gpt-5.3-codex");
+    }
+
+    #[test]
+    fn test_cursor_calculate_cost() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let cost = service.calculate_cost("gpt-5.3-codex", 1_000_000, 100_000, 0, 0, 0);
+        let expected = 1_000_000.0 * 0.00000175 + 100_000.0 * 0.000014;
+        assert!((cost - expected).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_cursor_returns_pricing_for_composer_1_5() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let result = service.lookup_with_source("Composer 1.5", None).unwrap();
+        assert_eq!(result.source, "Cursor");
+        assert_eq!(result.matched_key, "composer 1.5");
+        assert_eq!(result.pricing.input_cost_per_token, Some(0.0000035));
+        assert_eq!(result.pricing.output_cost_per_token, Some(0.0000175));
+        assert_eq!(result.pricing.cache_read_input_token_cost, Some(3.5e-7));
+    }
+
+    #[test]
+    fn test_cursor_calculate_cost_for_composer_1_5() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let cost = service.calculate_cost("Composer 1.5", 1_000_000, 100_000, 50_000, 0, 0);
+        let expected = 1_000_000.0 * 0.0000035 + 100_000.0 * 0.0000175 + 50_000.0 * 3.5e-7;
+        assert!((cost - expected).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_cursor_returns_pricing_for_hyphenated_composer_1_5() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let result = service.lookup_with_source("composer-1.5", None).unwrap();
+        assert_eq!(result.source, "Cursor");
+        assert_eq!(result.matched_key, "composer-1.5");
+    }
+
+    #[test]
+    fn test_from_cached_datasets_returns_none_when_both_sources_missing() {
+        assert!(PricingService::from_cached_datasets(None, None).is_none());
+    }
+
+    #[test]
+    fn test_from_cached_datasets_filters_subscription_only_litellm_entries() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "github_copilot/gpt-5.3-codex".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0),
+                ..Default::default()
+            },
+        );
+        litellm.insert(
+            "gpt-5.2".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00000175),
+                ..Default::default()
+            },
+        );
+
+        let service = PricingService::from_cached_datasets(Some(litellm), None).unwrap();
+
+        assert!(service
+            .lookup_with_source("github_copilot/gpt-5.3-codex", Some("litellm"))
+            .is_none());
+        assert!(service
+            .lookup_with_source("gpt-5.2", Some("litellm"))
+            .is_some());
+    }
+}

--- a/vendor/tokscale-core/src/pricing/openrouter.rs
+++ b/vendor/tokscale-core/src/pricing/openrouter.rs
@@ -1,0 +1,320 @@
+use super::cache;
+use super::litellm::ModelPricing;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+
+const CACHE_FILENAME: &str = "pricing-openrouter.json";
+const MODELS_URL: &str = "https://openrouter.ai/api/v1/models";
+const MAX_RETRIES: u32 = 3;
+const INITIAL_BACKOFF_MS: u64 = 200;
+const MAX_CONCURRENT_REQUESTS: usize = 10;
+
+/// Structs for `/api/v1/models` endpoint (list all models).
+
+#[derive(Deserialize)]
+struct ModelListPricing {
+    prompt: String,
+    completion: String,
+}
+
+#[derive(Deserialize)]
+struct ModelListItem {
+    id: String,
+    pricing: Option<ModelListPricing>,
+}
+
+#[derive(Deserialize)]
+struct ModelsListResponse {
+    data: Vec<ModelListItem>,
+}
+
+/// Structs for `/api/v1/models/{id}/endpoints` endpoint (author pricing).
+
+#[derive(Deserialize)]
+struct EndpointPricing {
+    prompt: String,
+    completion: String,
+    #[serde(default)]
+    input_cache_read: Option<String>,
+    #[serde(default)]
+    input_cache_write: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct Endpoint {
+    provider_name: String,
+    pricing: EndpointPricing,
+}
+
+#[derive(Deserialize)]
+struct EndpointData {
+    #[allow(dead_code)]
+    id: String,
+    endpoints: Vec<Endpoint>,
+}
+
+#[derive(Deserialize)]
+struct EndpointsResponse {
+    data: EndpointData,
+}
+
+/// Model ID prefix to provider name mapping.
+///
+/// Translates model ID prefixes like `z-ai` to their corresponding
+/// provider names in the endpoints API, such as `Z.AI`.
+fn get_author_provider_name(model_id: &str) -> Option<&'static str> {
+    let prefix = model_id.split('/').next()?;
+
+    match prefix.to_lowercase().as_str() {
+        "z-ai" => Some("Z.AI"),
+        "x-ai" => Some("xAI"),
+        "anthropic" => Some("Anthropic"),
+        "openai" => Some("OpenAI"),
+        "google" => Some("Google"),
+        "meta-llama" => Some("Meta"),
+        "mistralai" => Some("Mistral"),
+        "deepseek" => Some("DeepSeek"),
+        "qwen" => Some("Alibaba"),
+        "cohere" => Some("Cohere"),
+        "perplexity" => Some("Perplexity"),
+        "moonshotai" => Some("Moonshot AI"),
+        _ => None,
+    }
+}
+
+pub fn load_cached() -> Option<HashMap<String, ModelPricing>> {
+    cache::load_cache(CACHE_FILENAME)
+}
+
+pub fn load_cached_any_age() -> Option<HashMap<String, ModelPricing>> {
+    cache::load_cache_any_age(CACHE_FILENAME)
+}
+
+fn parse_price(s: &str) -> Option<f64> {
+    s.trim()
+        .parse::<f64>()
+        .ok()
+        .filter(|v| v.is_finite() && *v >= 0.0)
+}
+
+async fn fetch_author_pricing(
+    client: Arc<reqwest::Client>,
+    model_id: String,
+    semaphore: Arc<Semaphore>,
+    fallback_pricing: Option<ModelPricing>,
+) -> Option<(String, ModelPricing)> {
+    let _permit = semaphore.acquire().await.ok()?;
+
+    let author_name = match get_author_provider_name(&model_id) {
+        Some(name) => name,
+        None => return fallback_pricing.map(|p| (model_id, p)),
+    };
+
+    let url = format!("https://openrouter.ai/api/v1/models/{}/endpoints", model_id);
+
+    let response = match client
+        .get(&url)
+        .header("Content-Type", "application/json")
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(_) => {
+            return fallback_pricing.map(|p| (model_id, p));
+        }
+    };
+
+    if !response.status().is_success() {
+        return fallback_pricing.map(|p| (model_id, p));
+    }
+
+    let data: EndpointsResponse = match response.json().await {
+        Ok(d) => d,
+        Err(_) => {
+            return fallback_pricing.map(|p| (model_id, p));
+        }
+    };
+
+    // Find the endpoint from the author provider
+    let author_endpoint = match data
+        .data
+        .endpoints
+        .iter()
+        .find(|e| e.provider_name == author_name)
+    {
+        Some(ep) => ep,
+        None => {
+            return fallback_pricing.map(|p| (model_id, p));
+        }
+    };
+
+    let input_cost = parse_price(&author_endpoint.pricing.prompt);
+    let output_cost = parse_price(&author_endpoint.pricing.completion);
+
+    if input_cost.is_none() || output_cost.is_none() {
+        return fallback_pricing.map(|p| (model_id, p));
+    }
+
+    let pricing = ModelPricing {
+        input_cost_per_token: input_cost,
+        output_cost_per_token: output_cost,
+        cache_read_input_token_cost: author_endpoint
+            .pricing
+            .input_cache_read
+            .as_ref()
+            .and_then(|s| parse_price(s)),
+        cache_creation_input_token_cost: author_endpoint
+            .pricing
+            .input_cache_write
+            .as_ref()
+            .and_then(|s| parse_price(s)),
+        ..Default::default()
+    };
+
+    Some((model_id, pricing))
+}
+
+/// Fetch all models and get author pricing for each
+pub async fn fetch_all_models() -> HashMap<String, ModelPricing> {
+    if let Some(cached) = load_cached() {
+        return cached;
+    }
+
+    let client = Arc::new(
+        reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .build()
+            .unwrap_or_default(),
+    );
+
+    let mut last_error: Option<String> = None;
+
+    let models_with_fallback: Vec<(String, Option<ModelPricing>)> = 'retry: {
+        for attempt in 0..MAX_RETRIES {
+            let response = match client
+                .get(MODELS_URL)
+                .header("Content-Type", "application/json")
+                .send()
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    last_error = Some(format!("network error: {}", e));
+                    if attempt < MAX_RETRIES - 1 {
+                        tokio::time::sleep(std::time::Duration::from_millis(
+                            INITIAL_BACKOFF_MS * (1 << attempt),
+                        ))
+                        .await;
+                    }
+                    continue;
+                }
+            };
+
+            let status = response.status();
+            if status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                last_error = Some(format!("HTTP {}", status));
+                let _ = response.bytes().await;
+                if attempt < MAX_RETRIES - 1 {
+                    tokio::time::sleep(std::time::Duration::from_millis(
+                        INITIAL_BACKOFF_MS * (1 << attempt),
+                    ))
+                    .await;
+                }
+                continue;
+            }
+
+            if !status.is_success() {
+                eprintln!("[tokscale] OpenRouter models API returned {}", status);
+                break 'retry Vec::new();
+            }
+
+            let data: ModelsListResponse = match response.json().await {
+                Ok(d) => d,
+                Err(e) => {
+                    eprintln!("[tokscale] OpenRouter models JSON parse failed: {}", e);
+                    break 'retry Vec::new();
+                }
+            };
+
+            break 'retry data
+                .data
+                .into_iter()
+                .map(|m| {
+                    let fallback = m.pricing.and_then(|p| {
+                        let input = parse_price(&p.prompt)?;
+                        let output = parse_price(&p.completion)?;
+                        Some(ModelPricing {
+                            input_cost_per_token: Some(input),
+                            output_cost_per_token: Some(output),
+                            cache_read_input_token_cost: None,
+                            cache_creation_input_token_cost: None,
+                            ..Default::default()
+                        })
+                    });
+                    (m.id, fallback)
+                })
+                .collect();
+        }
+
+        if let Some(err) = &last_error {
+            eprintln!(
+                "[tokscale] OpenRouter fetch failed after {} retries: {}",
+                MAX_RETRIES, err
+            );
+        }
+        Vec::new()
+    };
+
+    if models_with_fallback.is_empty() {
+        return HashMap::new();
+    }
+
+    let models_with_authors: Vec<(String, Option<ModelPricing>)> = models_with_fallback
+        .into_iter()
+        .filter(|(id, _)| get_author_provider_name(id).is_some())
+        .collect();
+
+    let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_REQUESTS));
+
+    let mut handles = Vec::with_capacity(models_with_authors.len());
+
+    for (model_id, fallback) in models_with_authors {
+        let client = Arc::clone(&client);
+        let sem = Arc::clone(&semaphore);
+
+        let handle =
+            tokio::spawn(
+                async move { fetch_author_pricing(client, model_id, sem, fallback).await },
+            );
+
+        handles.push(handle);
+    }
+
+    // Collect results
+    let mut result = HashMap::new();
+
+    for handle in handles {
+        if let Ok(Some((model_id, pricing))) = handle.await {
+            result.insert(model_id, pricing);
+        }
+    }
+
+    if !result.is_empty() {
+        if let Err(e) = cache::save_cache(CACHE_FILENAME, &result) {
+            eprintln!(
+                "[tokscale] Warning: Failed to cache OpenRouter pricing at {}: {}",
+                cache::get_cache_path(CACHE_FILENAME).display(),
+                e
+            );
+        }
+    }
+
+    result
+}
+
+pub async fn fetch_all_mapped() -> HashMap<String, ModelPricing> {
+    fetch_all_models().await
+}

--- a/vendor/tokscale-core/src/scanner.rs
+++ b/vendor/tokscale-core/src/scanner.rs
@@ -1,0 +1,852 @@
+//! Parallel file scanner for session directories
+//!
+//! Uses walkdir with rayon for parallel directory traversal.
+
+use rayon::prelude::*;
+use std::collections::HashSet;
+use std::path::PathBuf;
+use walkdir::WalkDir;
+
+use crate::clients::ClientId;
+
+/// Result of scanning all session directories
+#[derive(Debug)]
+pub struct ScanResult {
+    pub files: [Vec<PathBuf>; ClientId::COUNT],
+    pub opencode_db: Option<PathBuf>,
+    pub synthetic_db: Option<PathBuf>,
+    /// Path to the OpenCode legacy JSON directory (for migration cache stat checks)
+    pub opencode_json_dir: Option<PathBuf>,
+}
+
+impl Default for ScanResult {
+    fn default() -> Self {
+        Self {
+            files: std::array::from_fn(|_| Vec::new()),
+            opencode_db: None,
+            synthetic_db: None,
+            opencode_json_dir: None,
+        }
+    }
+}
+
+impl ScanResult {
+    pub fn get(&self, client: ClientId) -> &Vec<PathBuf> {
+        &self.files[client as usize]
+    }
+
+    pub fn get_mut(&mut self, client: ClientId) -> &mut Vec<PathBuf> {
+        &mut self.files[client as usize]
+    }
+
+    /// Get total number of files found
+    pub fn total_files(&self) -> usize {
+        self.files.iter().map(|v| v.len()).sum()
+    }
+
+    /// Get all files as a single vector
+    pub fn all_files(&self) -> Vec<(ClientId, PathBuf)> {
+        let mut result = Vec::with_capacity(self.total_files());
+
+        for client in ClientId::iter() {
+            for path in self.get(client) {
+                result.push((client, path.clone()));
+            }
+        }
+
+        result
+    }
+}
+
+pub fn headless_roots(home_dir: &str) -> Vec<PathBuf> {
+    if let Ok(path) = std::env::var("TOKSCALE_HEADLESS_DIR") {
+        return vec![PathBuf::from(path)];
+    }
+
+    let mut roots = Vec::new();
+    roots.push(PathBuf::from(format!(
+        "{}/.config/tokscale/headless",
+        home_dir
+    )));
+
+    let mac_root = PathBuf::from(format!(
+        "{}/Library/Application Support/tokscale/headless",
+        home_dir
+    ));
+    roots.push(mac_root);
+
+    roots
+}
+
+/// Scan a single directory for session files
+pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
+    if !std::path::Path::new(root).exists() {
+        return Vec::new();
+    }
+
+    WalkDir::new(root)
+        .into_iter()
+        .par_bridge()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let path = e.path();
+            if !path.is_file() {
+                return false;
+            }
+
+            let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+
+            let is_in_archive_dir = path.components().any(|c| {
+                c.as_os_str()
+                    .to_string_lossy()
+                    .eq_ignore_ascii_case("archive")
+            });
+
+            match pattern {
+                "*.json" => file_name.ends_with(".json"),
+                "*.jsonl" => file_name.ends_with(".jsonl"),
+                "*.csv" => file_name.ends_with(".csv"),
+                "usage*.csv" => {
+                    if is_in_archive_dir {
+                        return false;
+                    }
+
+                    if file_name == "usage.csv" {
+                        return true;
+                    }
+
+                    // Accept only per-account files: usage.<account>.csv
+                    if !file_name.starts_with("usage.") || !file_name.ends_with(".csv") {
+                        return false;
+                    }
+
+                    // Exclude legacy backups like usage.backup-<ts>.csv
+                    if file_name.starts_with("usage.backup") {
+                        return false;
+                    }
+
+                    true
+                }
+                "session-*.json" => {
+                    file_name.starts_with("session-") && file_name.ends_with(".json")
+                }
+                "T-*.json" => file_name.starts_with("T-") && file_name.ends_with(".json"),
+                "*.settings.json" => file_name.ends_with(".settings.json"),
+                "sessions.json" => file_name == "sessions.json",
+                "wire.jsonl" => file_name == "wire.jsonl",
+                "ui_messages.json" => file_name == "ui_messages.json",
+                "session-usage.json" => file_name == "session-usage.json",
+                _ => false,
+            }
+        })
+        .map(|e| e.path().to_path_buf())
+        .collect()
+}
+
+/// Scan all session client directories in parallel
+pub fn scan_all_clients(home_dir: &str, clients: &[String]) -> ScanResult {
+    let mut result = ScanResult::default();
+
+    let include_all = clients.is_empty();
+    let include_synthetic = include_all || clients.iter().any(|s| s == "synthetic");
+
+    let enabled: HashSet<ClientId> = if include_all || include_synthetic {
+        ClientId::iter().collect()
+    } else {
+        clients
+            .iter()
+            .filter_map(|s| ClientId::from_str(s))
+            .collect()
+    };
+
+    let headless_roots = headless_roots(home_dir);
+
+    // Define scan tasks
+    let mut tasks: Vec<(ClientId, String, &str)> = Vec::new();
+
+    for client_id in &enabled {
+        if matches!(
+            client_id,
+            ClientId::OpenCode
+                | ClientId::Codex
+                | ClientId::OpenClaw
+                | ClientId::RooCode
+                | ClientId::KiloCode
+        ) {
+            continue;
+        }
+
+        let def = client_id.data();
+        let path = def.resolve_path(home_dir);
+        tasks.push((*client_id, path, def.pattern));
+    }
+
+    if enabled.contains(&ClientId::OpenCode) {
+        let xdg_data =
+            std::env::var("XDG_DATA_HOME").unwrap_or_else(|_| format!("{}/.local/share", home_dir));
+
+        // OpenCode 1.2+: SQLite database at ~/.local/share/opencode/opencode.db
+        let opencode_db_path = PathBuf::from(format!("{}/opencode/opencode.db", xdg_data));
+        if opencode_db_path.exists() {
+            result.opencode_db = Some(opencode_db_path);
+        }
+
+        // OpenCode legacy: JSON files at ~/.local/share/opencode/storage/message/*/*.json
+        let opencode_path = ClientId::OpenCode.data().resolve_path(home_dir);
+        result.opencode_json_dir = Some(PathBuf::from(&opencode_path));
+        tasks.push((
+            ClientId::OpenCode,
+            opencode_path,
+            ClientId::OpenCode.data().pattern,
+        ));
+    }
+
+    if enabled.contains(&ClientId::Codex) {
+        // Codex: ~/.codex/sessions/**/*.jsonl
+        let codex_home =
+            std::env::var("CODEX_HOME").unwrap_or_else(|_| format!("{}/.codex", home_dir));
+        let codex_path = ClientId::Codex.data().resolve_path(home_dir);
+        tasks.push((ClientId::Codex, codex_path, ClientId::Codex.data().pattern));
+
+        // Codex archived sessions: ~/.codex/archived_sessions/**/*.jsonl
+        let codex_archived_path = format!("{}/archived_sessions", codex_home);
+        tasks.push((
+            ClientId::Codex,
+            codex_archived_path,
+            ClientId::Codex.data().pattern,
+        ));
+
+        // Codex headless: <headless_root>/codex/*.jsonl
+        for root in &headless_roots {
+            let codex_headless_path = root.join("codex");
+            let path = codex_headless_path.to_string_lossy().to_string();
+            tasks.push((ClientId::Codex, path, ClientId::Codex.data().pattern));
+        }
+    }
+
+    if enabled.contains(&ClientId::OpenClaw) {
+        // OpenClaw transcripts: ~/.openclaw/agents/**/*.jsonl
+        let openclaw_path = ClientId::OpenClaw.data().resolve_path(home_dir);
+        tasks.push((
+            ClientId::OpenClaw,
+            openclaw_path,
+            ClientId::OpenClaw.data().pattern,
+        ));
+
+        // Legacy paths (Clawd -> Moltbot -> OpenClaw rebrand history)
+        let clawdbot_path = format!("{}/.clawdbot/agents", home_dir);
+        tasks.push((
+            ClientId::OpenClaw,
+            clawdbot_path,
+            ClientId::OpenClaw.data().pattern,
+        ));
+
+        let moltbot_path = format!("{}/.moltbot/agents", home_dir);
+        tasks.push((
+            ClientId::OpenClaw,
+            moltbot_path,
+            ClientId::OpenClaw.data().pattern,
+        ));
+
+        let moldbot_path = format!("{}/.moldbot/agents", home_dir);
+        tasks.push((
+            ClientId::OpenClaw,
+            moldbot_path,
+            ClientId::OpenClaw.data().pattern,
+        ));
+    }
+
+    if include_synthetic {
+        let xdg_data =
+            std::env::var("XDG_DATA_HOME").unwrap_or_else(|_| format!("{}/.local/share", home_dir));
+        let octofriend_db_path = PathBuf::from(format!("{}/octofriend/sqlite.db", xdg_data));
+        if octofriend_db_path.exists() {
+            result.synthetic_db = Some(octofriend_db_path);
+        }
+    }
+
+    if enabled.contains(&ClientId::RooCode) {
+        let local_path = ClientId::RooCode.data().resolve_path(home_dir);
+        tasks.push((
+            ClientId::RooCode,
+            local_path,
+            ClientId::RooCode.data().pattern,
+        ));
+
+        let server_path = format!(
+            "{}/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/tasks",
+            home_dir
+        );
+        tasks.push((
+            ClientId::RooCode,
+            server_path,
+            ClientId::RooCode.data().pattern,
+        ));
+    }
+
+    if enabled.contains(&ClientId::KiloCode) {
+        let local_path = ClientId::KiloCode.data().resolve_path(home_dir);
+        tasks.push((
+            ClientId::KiloCode,
+            local_path,
+            ClientId::KiloCode.data().pattern,
+        ));
+
+        let server_path = format!(
+            "{}/.vscode-server/data/User/globalStorage/kilocode.kilo-code/tasks",
+            home_dir
+        );
+        tasks.push((
+            ClientId::KiloCode,
+            server_path,
+            ClientId::KiloCode.data().pattern,
+        ));
+    }
+
+    // Execute scans in parallel
+    let scan_results: Vec<(ClientId, Vec<PathBuf>)> = tasks
+        .into_par_iter()
+        .map(|(client_id, path, pattern)| {
+            let files = scan_directory(&path, pattern);
+            (client_id, files)
+        })
+        .collect();
+
+    // Aggregate results
+    for (client_id, files) in scan_results {
+        result.get_mut(client_id).extend(files);
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::fs::{self, File};
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn restore_env(var: &str, previous: Option<String>) {
+        match previous {
+            Some(value) => unsafe { std::env::set_var(var, value) },
+            None => unsafe { std::env::remove_var(var) },
+        }
+    }
+
+    #[test]
+    fn test_scan_result_total_files() {
+        let mut result = ScanResult::default();
+        result
+            .get_mut(ClientId::OpenCode)
+            .push(PathBuf::from("a.json"));
+        result
+            .get_mut(ClientId::OpenCode)
+            .push(PathBuf::from("b.json"));
+        result
+            .get_mut(ClientId::Claude)
+            .push(PathBuf::from("c.jsonl"));
+        result
+            .get_mut(ClientId::Gemini)
+            .push(PathBuf::from("d.json"));
+        result.get_mut(ClientId::Pi).push(PathBuf::from("e.jsonl"));
+        assert_eq!(result.total_files(), 5);
+    }
+
+    #[test]
+    fn test_scan_result_all_files() {
+        let mut result = ScanResult::default();
+        result
+            .get_mut(ClientId::OpenCode)
+            .push(PathBuf::from("a.json"));
+        result
+            .get_mut(ClientId::Claude)
+            .push(PathBuf::from("b.jsonl"));
+        result
+            .get_mut(ClientId::Codex)
+            .push(PathBuf::from("c.jsonl"));
+        result
+            .get_mut(ClientId::Gemini)
+            .push(PathBuf::from("d.json"));
+        result
+            .get_mut(ClientId::Cursor)
+            .push(PathBuf::from("e.csv"));
+        result.get_mut(ClientId::Pi).push(PathBuf::from("f.jsonl"));
+
+        let all = result.all_files();
+        assert_eq!(all.len(), 6);
+        assert_eq!(all[0], (ClientId::OpenCode, PathBuf::from("a.json")));
+        assert_eq!(all[1], (ClientId::Claude, PathBuf::from("b.jsonl")));
+        assert_eq!(all[2], (ClientId::Codex, PathBuf::from("c.jsonl")));
+        assert_eq!(all[3], (ClientId::Cursor, PathBuf::from("e.csv")));
+        assert_eq!(all[4], (ClientId::Gemini, PathBuf::from("d.json")));
+        assert_eq!(all[5], (ClientId::Pi, PathBuf::from("f.jsonl")));
+    }
+
+    #[test]
+    fn test_scan_result_empty() {
+        let result = ScanResult::default();
+        assert_eq!(result.total_files(), 0);
+        assert!(result.all_files().is_empty());
+    }
+
+    #[test]
+    fn test_client_id_equality() {
+        assert_eq!(ClientId::OpenCode, ClientId::OpenCode);
+        assert_ne!(ClientId::OpenCode, ClientId::Claude);
+    }
+
+    #[test]
+    fn test_scan_directory_json_pattern() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+
+        // Create test files
+        File::create(path.join("test1.json")).unwrap();
+        File::create(path.join("test2.json")).unwrap();
+        File::create(path.join("data.txt")).unwrap();
+        File::create(path.join("other.jsonl")).unwrap();
+
+        let json_files = scan_directory(path.to_str().unwrap(), "*.json");
+        assert_eq!(json_files.len(), 2);
+        assert!(json_files.iter().all(|p| p.extension().unwrap() == "json"));
+    }
+
+    #[test]
+    fn test_scan_directory_jsonl_pattern() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+
+        File::create(path.join("session.jsonl")).unwrap();
+        File::create(path.join("log.jsonl")).unwrap();
+        File::create(path.join("data.json")).unwrap();
+
+        let jsonl_files = scan_directory(path.to_str().unwrap(), "*.jsonl");
+        assert_eq!(jsonl_files.len(), 2);
+        assert!(jsonl_files
+            .iter()
+            .all(|p| p.extension().unwrap() == "jsonl"));
+    }
+
+    #[test]
+    fn test_scan_directory_session_pattern() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+
+        File::create(path.join("session-001.json")).unwrap();
+        File::create(path.join("session-abc.json")).unwrap();
+        File::create(path.join("other.json")).unwrap();
+        File::create(path.join("session.json")).unwrap(); // Shouldn't match
+
+        let session_files = scan_directory(path.to_str().unwrap(), "session-*.json");
+        assert_eq!(session_files.len(), 2);
+        assert!(session_files.iter().all(|p| {
+            let name = p.file_name().unwrap().to_str().unwrap();
+            name.starts_with("session-") && name.ends_with(".json")
+        }));
+    }
+
+    #[test]
+    fn test_scan_directory_ui_messages_pattern() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+
+        let tasks = path.join("tasks");
+        fs::create_dir_all(tasks.join("task-a")).unwrap();
+        fs::create_dir_all(tasks.join("task-b")).unwrap();
+        fs::create_dir_all(tasks.join("task-c")).unwrap();
+
+        File::create(tasks.join("task-a").join("ui_messages.json")).unwrap();
+        File::create(tasks.join("task-b").join("ui_messages.json")).unwrap();
+        File::create(tasks.join("task-c").join("api_conversation_history.json")).unwrap();
+
+        let files = scan_directory(path.to_str().unwrap(), "ui_messages.json");
+        assert_eq!(files.len(), 2);
+        assert!(files.iter().all(|p| {
+            p.file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default()
+                == "ui_messages.json"
+        }));
+    }
+
+    #[test]
+    fn test_scan_directory_nested() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+
+        // Create nested structure
+        let sub1 = path.join("project1");
+        let sub2 = path.join("project2");
+        fs::create_dir_all(&sub1).unwrap();
+        fs::create_dir_all(&sub2).unwrap();
+
+        File::create(sub1.join("session.json")).unwrap();
+        File::create(sub2.join("session.json")).unwrap();
+        File::create(path.join("root.json")).unwrap();
+
+        let files = scan_directory(path.to_str().unwrap(), "*.json");
+        assert_eq!(files.len(), 3);
+    }
+
+    #[test]
+    fn test_scan_directory_csv_pattern() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+
+        File::create(path.join("usage.csv")).unwrap();
+        File::create(path.join("data.csv")).unwrap();
+        File::create(path.join("other.json")).unwrap();
+
+        let csv_files = scan_directory(path.to_str().unwrap(), "*.csv");
+        assert_eq!(csv_files.len(), 2);
+        assert!(csv_files.iter().all(|p| p.extension().unwrap() == "csv"));
+    }
+
+    #[test]
+    fn test_scan_directory_nonexistent() {
+        let files = scan_directory("/nonexistent/path/that/does/not/exist", "*.json");
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn test_scan_directory_empty() {
+        let dir = TempDir::new().unwrap();
+        let files = scan_directory(dir.path().to_str().unwrap(), "*.json");
+        assert!(files.is_empty());
+    }
+
+    fn setup_mock_opencode_dir(base: &std::path::Path) {
+        let opencode_path = base.join(".local/share/opencode/storage/message/proj1");
+        fs::create_dir_all(&opencode_path).unwrap();
+        let mut file = File::create(opencode_path.join("msg_001.json")).unwrap();
+        file.write_all(b"{}").unwrap();
+    }
+
+    fn setup_mock_claude_dir(base: &std::path::Path) {
+        let claude_path = base.join(".claude/projects/myproject");
+        fs::create_dir_all(&claude_path).unwrap();
+        let mut file = File::create(claude_path.join("conversation.jsonl")).unwrap();
+        file.write_all(b"").unwrap();
+    }
+
+    fn setup_mock_codex_dir(base: &std::path::Path) {
+        let codex_path = base.join(".codex/sessions");
+        fs::create_dir_all(&codex_path).unwrap();
+        let mut file = File::create(codex_path.join("session.jsonl")).unwrap();
+        file.write_all(b"").unwrap();
+    }
+
+    fn setup_mock_codex_archived_dir(base: &std::path::Path) {
+        let archived_path = base.join(".codex/archived_sessions");
+        fs::create_dir_all(&archived_path).unwrap();
+        let mut file = File::create(archived_path.join("archived.jsonl")).unwrap();
+        file.write_all(b"").unwrap();
+    }
+
+    fn setup_mock_gemini_dir(base: &std::path::Path) {
+        let gemini_path = base.join(".gemini/tmp/123/chats");
+        fs::create_dir_all(&gemini_path).unwrap();
+        let mut file = File::create(gemini_path.join("session-abc.json")).unwrap();
+        file.write_all(b"{}").unwrap();
+    }
+
+    fn setup_mock_pi_dir(base: &std::path::Path) {
+        let pi_path = base.join(".pi/agent/sessions/--test--");
+        fs::create_dir_all(&pi_path).unwrap();
+        let mut file = File::create(pi_path.join("1733011200000_pi_ses_001.jsonl")).unwrap();
+        file.write_all(b"{}").unwrap();
+    }
+
+    fn setup_mock_kimi_dir(base: &std::path::Path) {
+        let kimi_session = base.join(".kimi/sessions/group1/session-uuid-1");
+        fs::create_dir_all(&kimi_session).unwrap();
+        let mut file = File::create(kimi_session.join("wire.jsonl")).unwrap();
+        file.write_all(b"{\"type\": \"metadata\", \"protocol_version\": \"1.3\"}\n")
+            .unwrap();
+    }
+
+    fn setup_mock_openclaw_dir(base: &std::path::Path) {
+        // Mirror real OpenClaw layout: ~/.openclaw/agents/<agentId>/sessions/*.jsonl
+        let openclaw_sessions = base.join(".openclaw/agents/main/sessions");
+        fs::create_dir_all(&openclaw_sessions).unwrap();
+
+        let mut transcript = File::create(openclaw_sessions.join("session-abc.jsonl")).unwrap();
+        transcript.write_all(b"{}").unwrap();
+
+        // Even if an index exists, we should count JSONL transcripts (not sessions.json only)
+        let mut index = File::create(openclaw_sessions.join("sessions.json")).unwrap();
+        index.write_all(b"{}").unwrap();
+    }
+
+    fn setup_mock_roocode_dir(base: &std::path::Path) {
+        let local = base
+            .join(".config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/task-local");
+        let server = base.join(
+            ".vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/tasks/task-server",
+        );
+        fs::create_dir_all(&local).unwrap();
+        fs::create_dir_all(&server).unwrap();
+        File::create(local.join("ui_messages.json")).unwrap();
+        File::create(server.join("ui_messages.json")).unwrap();
+    }
+
+    fn setup_mock_kilocode_dir(base: &std::path::Path) {
+        let local =
+            base.join(".config/Code/User/globalStorage/kilocode.kilo-code/tasks/task-local");
+        let server = base
+            .join(".vscode-server/data/User/globalStorage/kilocode.kilo-code/tasks/task-server");
+        fs::create_dir_all(&local).unwrap();
+        fs::create_dir_all(&server).unwrap();
+        File::create(local.join("ui_messages.json")).unwrap();
+        File::create(server.join("ui_messages.json")).unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn test_headless_roots_default() {
+        let previous = std::env::var("TOKSCALE_HEADLESS_DIR").ok();
+        unsafe { std::env::remove_var("TOKSCALE_HEADLESS_DIR") };
+
+        let home = "/tmp/tokscale-test-home";
+        let roots = headless_roots(home);
+        let config_root = PathBuf::from(format!("{}/.config/tokscale/headless", home));
+        let mac_root = PathBuf::from(format!(
+            "{}/Library/Application Support/tokscale/headless",
+            home
+        ));
+
+        assert_eq!(roots.len(), 2);
+        assert!(roots.contains(&config_root));
+        assert!(roots.contains(&mac_root));
+
+        restore_env("TOKSCALE_HEADLESS_DIR", previous);
+    }
+
+    #[test]
+    #[serial]
+    fn test_headless_roots_override() {
+        let previous = std::env::var("TOKSCALE_HEADLESS_DIR").ok();
+        unsafe { std::env::set_var("TOKSCALE_HEADLESS_DIR", "/custom/headless") };
+
+        let roots = headless_roots("/tmp/home");
+        assert_eq!(roots, vec![PathBuf::from("/custom/headless")]);
+
+        restore_env("TOKSCALE_HEADLESS_DIR", previous);
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_opencode() {
+        let previous_xdg = std::env::var("XDG_DATA_HOME").ok();
+
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_opencode_dir(home);
+
+        // Set XDG_DATA_HOME for the test
+        unsafe { std::env::set_var("XDG_DATA_HOME", home.join(".local/share")) };
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["opencode".to_string()]);
+        assert_eq!(result.get(ClientId::OpenCode).len(), 1);
+        assert!(result.get(ClientId::Claude).is_empty());
+        assert!(result.get(ClientId::Codex).is_empty());
+        assert!(result.get(ClientId::Gemini).is_empty());
+
+        restore_env("XDG_DATA_HOME", previous_xdg);
+    }
+
+    #[test]
+    fn test_scan_all_clients_pi() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_pi_dir(home);
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["pi".to_string()]);
+        assert_eq!(result.get(ClientId::Pi).len(), 1);
+        assert!(result.get(ClientId::OpenCode).is_empty());
+        assert!(result.get(ClientId::Claude).is_empty());
+    }
+
+    #[test]
+    fn test_scan_all_clients_claude() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_claude_dir(home);
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["claude".to_string()]);
+        assert_eq!(result.get(ClientId::Claude).len(), 1);
+        assert!(result.get(ClientId::OpenCode).is_empty());
+    }
+
+    #[test]
+    fn test_scan_all_clients_gemini() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_gemini_dir(home);
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["gemini".to_string()]);
+        assert_eq!(result.get(ClientId::Gemini).len(), 1);
+        assert!(result.get(ClientId::OpenCode).is_empty());
+    }
+
+    #[test]
+    fn test_scan_all_clients_openclaw_jsonl_only() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_openclaw_dir(home);
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["openclaw".to_string()]);
+        assert_eq!(result.get(ClientId::OpenClaw).len(), 1);
+        assert!(result.get(ClientId::OpenClaw)[0].ends_with("session-abc.jsonl"));
+    }
+
+    #[test]
+    fn test_scan_all_clients_multiple() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        setup_mock_claude_dir(home);
+        setup_mock_gemini_dir(home);
+
+        let result = scan_all_clients(
+            home.to_str().unwrap(),
+            &["claude".to_string(), "gemini".to_string()],
+        );
+
+        assert_eq!(result.get(ClientId::Claude).len(), 1);
+        assert_eq!(result.get(ClientId::Gemini).len(), 1);
+        assert!(result.get(ClientId::OpenCode).is_empty());
+        assert!(result.get(ClientId::Codex).is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_headless_paths() {
+        let previous_headless = std::env::var("TOKSCALE_HEADLESS_DIR").ok();
+        unsafe { std::env::remove_var("TOKSCALE_HEADLESS_DIR") };
+
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        let mac_root = home
+            .join("Library")
+            .join("Application Support")
+            .join("tokscale")
+            .join("headless");
+
+        fs::create_dir_all(mac_root.join("codex")).unwrap();
+        File::create(mac_root.join("codex").join("codex.jsonl")).unwrap();
+
+        let result = scan_all_clients(
+            home.to_str().unwrap(),
+            &[
+                "claude".to_string(),
+                "codex".to_string(),
+                "gemini".to_string(),
+            ],
+        );
+
+        assert!(result.get(ClientId::Claude).is_empty());
+        assert_eq!(result.get(ClientId::Codex).len(), 1);
+        assert!(result.get(ClientId::Gemini).is_empty());
+
+        restore_env("TOKSCALE_HEADLESS_DIR", previous_headless);
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_codex_with_env() {
+        let previous_codex = std::env::var("CODEX_HOME").ok();
+
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_codex_dir(home);
+
+        // Set CODEX_HOME environment variable
+        unsafe { std::env::set_var("CODEX_HOME", home.join(".codex")) };
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["codex".to_string()]);
+        assert_eq!(result.get(ClientId::Codex).len(), 1);
+
+        restore_env("CODEX_HOME", previous_codex);
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_codex_archived_sessions() {
+        let previous_codex = std::env::var("CODEX_HOME").ok();
+
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_codex_archived_dir(home);
+
+        unsafe { std::env::set_var("CODEX_HOME", home.join(".codex")) };
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["codex".to_string()]);
+        assert_eq!(result.get(ClientId::Codex).len(), 1);
+        assert!(result.get(ClientId::Codex)[0].ends_with("archived.jsonl"));
+
+        restore_env("CODEX_HOME", previous_codex);
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_codex_sessions_and_archived() {
+        let previous_codex = std::env::var("CODEX_HOME").ok();
+
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_codex_dir(home);
+        setup_mock_codex_archived_dir(home);
+
+        unsafe { std::env::set_var("CODEX_HOME", home.join(".codex")) };
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["codex".to_string()]);
+        assert_eq!(result.get(ClientId::Codex).len(), 2);
+
+        restore_env("CODEX_HOME", previous_codex);
+    }
+
+    #[test]
+    fn test_scan_all_clients_kimi() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_kimi_dir(home);
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["kimi".to_string()]);
+        assert_eq!(result.get(ClientId::Kimi).len(), 1);
+        assert!(result.get(ClientId::Kimi)[0].ends_with("wire.jsonl"));
+        assert!(result.get(ClientId::OpenCode).is_empty());
+        assert!(result.get(ClientId::Claude).is_empty());
+    }
+
+    #[test]
+    fn test_scan_all_clients_roocode() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_roocode_dir(home);
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["roocode".to_string()]);
+        assert_eq!(result.get(ClientId::RooCode).len(), 2);
+        assert!(result
+            .get(ClientId::RooCode)
+            .iter()
+            .all(|p| p.ends_with("ui_messages.json")));
+    }
+
+    #[test]
+    fn test_scan_all_clients_kilocode() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_kilocode_dir(home);
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["kilocode".to_string()]);
+        assert_eq!(result.get(ClientId::KiloCode).len(), 2);
+        assert!(result
+            .get(ClientId::KiloCode)
+            .iter()
+            .all(|p| p.ends_with("ui_messages.json")));
+    }
+}

--- a/vendor/tokscale-core/src/sessions/amp.rs
+++ b/vendor/tokscale-core/src/sessions/amp.rs
@@ -1,0 +1,218 @@
+//! Amp (Sourcegraph) session parser
+//!
+//! Parses JSON files from ~/.local/share/amp/threads/
+
+use super::UnifiedMessage;
+use crate::TokenBreakdown;
+use serde::Deserialize;
+use std::path::Path;
+
+/// Amp usage event from usageLedger
+#[derive(Debug, Deserialize)]
+pub struct AmpUsageEvent {
+    pub timestamp: Option<String>,
+    pub model: Option<String>,
+    pub credits: Option<f64>,
+    pub tokens: Option<AmpTokens>,
+    #[serde(rename = "operationType")]
+    pub _operation_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AmpTokens {
+    pub input: Option<i64>,
+    pub output: Option<i64>,
+    #[serde(rename = "cacheReadInputTokens")]
+    pub cache_read_input_tokens: Option<i64>,
+    #[serde(rename = "cacheCreationInputTokens")]
+    pub cache_creation_input_tokens: Option<i64>,
+}
+
+/// Amp message usage (per-message, more detailed)
+#[derive(Debug, Deserialize)]
+pub struct AmpMessageUsage {
+    pub model: Option<String>,
+    #[serde(rename = "inputTokens")]
+    pub input_tokens: Option<i64>,
+    #[serde(rename = "outputTokens")]
+    pub output_tokens: Option<i64>,
+    #[serde(rename = "cacheReadInputTokens")]
+    pub cache_read_input_tokens: Option<i64>,
+    #[serde(rename = "cacheCreationInputTokens")]
+    pub cache_creation_input_tokens: Option<i64>,
+    pub credits: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AmpMessage {
+    pub role: Option<String>,
+    #[serde(rename = "messageId")]
+    pub message_id: Option<i64>,
+    pub usage: Option<AmpMessageUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AmpUsageLedger {
+    pub events: Option<Vec<AmpUsageEvent>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AmpThread {
+    pub id: Option<String>,
+    pub created: Option<i64>,
+    pub messages: Option<Vec<AmpMessage>>,
+    #[serde(rename = "usageLedger")]
+    pub usage_ledger: Option<AmpUsageLedger>,
+}
+
+/// Get provider from model name
+fn get_provider_from_model(model: &str) -> &'static str {
+    let model_lower = model.to_lowercase();
+    if model_lower.contains("claude")
+        || model_lower.contains("opus")
+        || model_lower.contains("sonnet")
+        || model_lower.contains("haiku")
+    {
+        return "anthropic";
+    }
+    if model_lower.contains("gpt") || model_lower.contains("o1") || model_lower.contains("o3") {
+        return "openai";
+    }
+    if model_lower.contains("gemini") {
+        return "google";
+    }
+    if model_lower.contains("grok") {
+        return "xai";
+    }
+    "anthropic" // Default for Amp
+}
+
+/// Parse an Amp thread JSON file
+pub fn parse_amp_file(path: &Path) -> Vec<UnifiedMessage> {
+    let content = match std::fs::read(path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+
+    // Get file mtime as last-resort timestamp fallback
+    let file_mtime_ms = std::fs::metadata(path)
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+
+    let mut bytes = content;
+    let thread: AmpThread = match simd_json::from_slice(&mut bytes) {
+        Ok(t) => t,
+        Err(_) => return Vec::new(),
+    };
+
+    let thread_id = thread.id.clone().unwrap_or_else(|| {
+        path.file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string()
+    });
+
+    // Extract thread created time before consuming usage_ledger, for use as timestamp fallback
+    let thread_created_ms = thread.created.unwrap_or(0);
+
+    let mut messages = Vec::new();
+
+    // Prefer usageLedger.events (cleaner aggregated data)
+    if let Some(ledger) = thread.usage_ledger {
+        if let Some(events) = ledger.events {
+            for event in events {
+                let model = match event.model {
+                    Some(m) => m,
+                    None => continue,
+                };
+
+                let timestamp = event
+                    .timestamp
+                    .and_then(|ts| chrono::DateTime::parse_from_rfc3339(&ts).ok())
+                    .map(|dt| dt.timestamp_millis())
+                    .unwrap_or(0);
+
+                // Use fallbacks when timestamp is missing: thread created time, then file mtime.
+                // Never skip events solely because of a missing timestamp.
+                let timestamp = if timestamp != 0 {
+                    timestamp
+                } else if thread_created_ms != 0 {
+                    thread_created_ms
+                } else {
+                    file_mtime_ms
+                };
+
+                let tokens = event.tokens.unwrap_or(AmpTokens {
+                    input: Some(0),
+                    output: Some(0),
+                    cache_read_input_tokens: Some(0),
+                    cache_creation_input_tokens: Some(0),
+                });
+
+                messages.push(UnifiedMessage::new(
+                    "amp",
+                    &model,
+                    get_provider_from_model(&model),
+                    thread_id.clone(),
+                    timestamp,
+                    TokenBreakdown {
+                        input: tokens.input.unwrap_or(0).max(0),
+                        output: tokens.output.unwrap_or(0).max(0),
+                        cache_read: tokens.cache_read_input_tokens.unwrap_or(0).max(0),
+                        cache_write: tokens.cache_creation_input_tokens.unwrap_or(0).max(0),
+                        reasoning: 0,
+                    },
+                    event.credits.unwrap_or(0.0).max(0.0),
+                ));
+            }
+            if !messages.is_empty() {
+                return messages;
+            }
+        }
+    }
+
+    // Fallback: parse from individual message usage
+    let created = thread_created_ms;
+    if let Some(thread_messages) = thread.messages {
+        for msg in thread_messages {
+            if msg.role.as_deref() != Some("assistant") {
+                continue;
+            }
+
+            let usage = match msg.usage {
+                Some(u) => u,
+                None => continue,
+            };
+
+            let model = match usage.model {
+                Some(m) => m,
+                None => continue,
+            };
+
+            // Approximate timestamp from created + messageId offset
+            let message_id = msg.message_id.unwrap_or(0);
+            let timestamp = created + (message_id * 1000);
+
+            messages.push(UnifiedMessage::new(
+                "amp",
+                &model,
+                get_provider_from_model(&model),
+                thread_id.clone(),
+                timestamp,
+                TokenBreakdown {
+                    input: usage.input_tokens.unwrap_or(0).max(0),
+                    output: usage.output_tokens.unwrap_or(0).max(0),
+                    cache_read: usage.cache_read_input_tokens.unwrap_or(0).max(0),
+                    cache_write: usage.cache_creation_input_tokens.unwrap_or(0).max(0),
+                    reasoning: 0,
+                },
+                usage.credits.unwrap_or(0.0).max(0.0),
+            ));
+        }
+    }
+
+    messages
+}

--- a/vendor/tokscale-core/src/sessions/claudecode.rs
+++ b/vendor/tokscale-core/src/sessions/claudecode.rs
@@ -1,0 +1,461 @@
+//! Claude Code session parser
+//!
+//! Parses JSONL files from ~/.claude/projects/
+
+use super::utils::{
+    extract_i64, extract_string, file_modified_timestamp_ms, parse_timestamp_value,
+};
+use super::UnifiedMessage;
+use crate::TokenBreakdown;
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashSet;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+/// Claude Code entry structure (from JSONL files)
+#[derive(Debug, Deserialize)]
+pub struct ClaudeEntry {
+    #[serde(rename = "type")]
+    pub entry_type: String,
+    pub timestamp: Option<String>,
+    pub message: Option<ClaudeMessage>,
+    /// Request ID for deduplication (used with message.id)
+    #[serde(rename = "requestId")]
+    pub request_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ClaudeMessage {
+    pub model: Option<String>,
+    pub usage: Option<ClaudeUsage>,
+    /// Message ID for deduplication (used with requestId)
+    pub id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ClaudeUsage {
+    pub input_tokens: Option<i64>,
+    pub output_tokens: Option<i64>,
+    pub cache_read_input_tokens: Option<i64>,
+    pub cache_creation_input_tokens: Option<i64>,
+}
+
+/// Parse a Claude Code JSONL file
+pub fn parse_claude_file(path: &Path) -> Vec<UnifiedMessage> {
+    let session_id = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let fallback_timestamp = file_modified_timestamp_ms(path);
+
+    if path.extension().and_then(|s| s.to_str()) == Some("json") {
+        let json_messages = parse_claude_headless_json(path, &session_id, fallback_timestamp);
+        if !json_messages.is_empty() {
+            return json_messages;
+        }
+    }
+
+    let file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return Vec::new(),
+    };
+
+    let reader = BufReader::new(file);
+    let mut messages = Vec::with_capacity(64);
+    let mut processed_hashes: HashSet<String> = HashSet::new();
+    let mut headless_state = ClaudeHeadlessState::default();
+    let mut buffer = Vec::with_capacity(4096);
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let mut handled = false;
+        buffer.clear();
+        buffer.extend_from_slice(trimmed.as_bytes());
+        if let Ok(entry) = simd_json::from_slice::<ClaudeEntry>(&mut buffer) {
+            // Only process assistant messages with usage data
+            if entry.entry_type == "assistant" {
+                let message = match entry.message {
+                    Some(m) => m,
+                    None => continue,
+                };
+
+                // Build dedup key for global deduplication (messageId:requestId composite)
+                let dedup_key = match (&message.id, &entry.request_id) {
+                    (Some(msg_id), Some(req_id)) => {
+                        let hash = format!("{}:{}", msg_id, req_id);
+                        if !processed_hashes.insert(hash.clone()) {
+                            continue;
+                        }
+                        Some(hash)
+                    }
+                    _ => None,
+                };
+
+                let usage = match message.usage {
+                    Some(u) => u,
+                    None => continue,
+                };
+
+                let model = match message.model {
+                    Some(m) => m,
+                    None => continue,
+                };
+
+                let timestamp = entry
+                    .timestamp
+                    .and_then(|ts| chrono::DateTime::parse_from_rfc3339(&ts).ok())
+                    .map(|dt| dt.timestamp_millis())
+                    .unwrap_or(fallback_timestamp);
+
+                messages.push(UnifiedMessage::new_with_dedup(
+                    "claude",
+                    model,
+                    "anthropic",
+                    session_id.clone(),
+                    timestamp,
+                    TokenBreakdown {
+                        input: usage.input_tokens.unwrap_or(0).max(0),
+                        output: usage.output_tokens.unwrap_or(0).max(0),
+                        cache_read: usage.cache_read_input_tokens.unwrap_or(0).max(0),
+                        cache_write: usage.cache_creation_input_tokens.unwrap_or(0).max(0),
+                        reasoning: 0,
+                    },
+                    0.0,
+                    dedup_key,
+                ));
+                handled = true;
+            }
+        }
+
+        if handled {
+            continue;
+        }
+
+        if let Some(message) = process_claude_headless_line(
+            trimmed,
+            &session_id,
+            &mut headless_state,
+            fallback_timestamp,
+        ) {
+            messages.push(message);
+        }
+    }
+
+    if let Some(message) =
+        finalize_headless_state(&mut headless_state, &session_id, fallback_timestamp)
+    {
+        messages.push(message);
+    }
+
+    messages
+}
+
+#[derive(Default)]
+struct ClaudeHeadlessState {
+    model: Option<String>,
+    input: i64,
+    output: i64,
+    cache_read: i64,
+    cache_write: i64,
+    timestamp_ms: Option<i64>,
+}
+
+fn parse_claude_headless_json(
+    path: &Path,
+    session_id: &str,
+    fallback_timestamp: i64,
+) -> Vec<UnifiedMessage> {
+    let data = match std::fs::read(path) {
+        Ok(d) => d,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut bytes = data;
+    let value: Value = match simd_json::from_slice(&mut bytes) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut messages = Vec::with_capacity(1);
+    if let Some(message) = extract_claude_headless_message(&value, session_id, fallback_timestamp) {
+        messages.push(message);
+    }
+
+    messages
+}
+
+fn process_claude_headless_line(
+    line: &str,
+    session_id: &str,
+    state: &mut ClaudeHeadlessState,
+    fallback_timestamp: i64,
+) -> Option<UnifiedMessage> {
+    let mut bytes = line.as_bytes().to_vec();
+    let value: Value = simd_json::from_slice(&mut bytes).ok()?;
+
+    let event_type = value.get("type").and_then(|val| val.as_str()).unwrap_or("");
+    let mut completed_message: Option<UnifiedMessage> = None;
+
+    match event_type {
+        "message_start" => {
+            completed_message = finalize_headless_state(state, session_id, fallback_timestamp);
+
+            state.model = extract_claude_model(&value);
+            state.timestamp_ms = extract_claude_timestamp(&value).or(state.timestamp_ms);
+            if let Some(usage) = value
+                .get("message")
+                .and_then(|msg| msg.get("usage"))
+                .or_else(|| value.get("usage"))
+            {
+                update_claude_usage(state, usage);
+            }
+        }
+        "message_delta" => {
+            if let Some(usage) = value
+                .get("usage")
+                .or_else(|| value.get("delta").and_then(|delta| delta.get("usage")))
+            {
+                update_claude_usage(state, usage);
+            }
+        }
+        "message_stop" => {
+            completed_message = finalize_headless_state(state, session_id, fallback_timestamp);
+        }
+        _ => {
+            if let Some(message) =
+                extract_claude_headless_message(&value, session_id, fallback_timestamp)
+            {
+                completed_message = Some(message);
+            }
+        }
+    }
+
+    completed_message
+}
+
+fn extract_claude_headless_message(
+    value: &Value,
+    session_id: &str,
+    fallback_timestamp: i64,
+) -> Option<UnifiedMessage> {
+    let usage = value
+        .get("usage")
+        .or_else(|| value.get("message").and_then(|msg| msg.get("usage")))?;
+    let model = extract_claude_model(value)?;
+    let timestamp = extract_claude_timestamp(value).unwrap_or(fallback_timestamp);
+
+    Some(UnifiedMessage::new(
+        "claude",
+        model,
+        "anthropic",
+        session_id.to_string(),
+        timestamp,
+        TokenBreakdown {
+            input: extract_i64(usage.get("input_tokens")).unwrap_or(0).max(0),
+            output: extract_i64(usage.get("output_tokens")).unwrap_or(0).max(0),
+            cache_read: extract_i64(usage.get("cache_read_input_tokens"))
+                .unwrap_or(0)
+                .max(0),
+            cache_write: extract_i64(usage.get("cache_creation_input_tokens"))
+                .unwrap_or(0)
+                .max(0),
+            reasoning: 0,
+        },
+        0.0,
+    ))
+}
+
+fn extract_claude_model(value: &Value) -> Option<String> {
+    extract_string(value.get("model")).or_else(|| {
+        value
+            .get("message")
+            .and_then(|msg| extract_string(msg.get("model")))
+    })
+}
+
+fn extract_claude_timestamp(value: &Value) -> Option<i64> {
+    value
+        .get("timestamp")
+        .or_else(|| value.get("created_at"))
+        .or_else(|| value.get("message").and_then(|msg| msg.get("created_at")))
+        .and_then(parse_timestamp_value)
+}
+
+fn update_claude_usage(state: &mut ClaudeHeadlessState, usage: &Value) {
+    if let Some(input) = extract_i64(usage.get("input_tokens")) {
+        state.input = state.input.max(input);
+    }
+    if let Some(output) = extract_i64(usage.get("output_tokens")) {
+        state.output = state.output.max(output);
+    }
+    if let Some(cache_read) = extract_i64(usage.get("cache_read_input_tokens")) {
+        state.cache_read = state.cache_read.max(cache_read);
+    }
+    if let Some(cache_write) = extract_i64(usage.get("cache_creation_input_tokens")) {
+        state.cache_write = state.cache_write.max(cache_write);
+    }
+}
+
+fn finalize_headless_state(
+    state: &mut ClaudeHeadlessState,
+    session_id: &str,
+    fallback_timestamp: i64,
+) -> Option<UnifiedMessage> {
+    let model = state.model.clone()?;
+    let timestamp = state.timestamp_ms.unwrap_or(fallback_timestamp);
+    if state.input == 0 && state.output == 0 && state.cache_read == 0 && state.cache_write == 0 {
+        *state = ClaudeHeadlessState::default();
+        return None;
+    }
+
+    let message = UnifiedMessage::new(
+        "claude",
+        model,
+        "anthropic",
+        session_id.to_string(),
+        timestamp,
+        TokenBreakdown {
+            input: state.input.max(0),
+            output: state.output.max(0),
+            cache_read: state.cache_read.max(0),
+            cache_write: state.cache_write.max(0),
+            reasoning: 0,
+        },
+        0.0,
+    );
+
+    *state = ClaudeHeadlessState::default();
+    Some(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn create_test_file(content: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file.flush().unwrap();
+        file
+    }
+
+    #[test]
+    fn test_deduplication_skips_duplicate_entries() {
+        let content = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}
+{"type":"assistant","timestamp":"2024-12-01T10:00:01.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}
+{"type":"assistant","timestamp":"2024-12-01T10:00:02.000Z","requestId":"req_002","message":{"id":"msg_002","model":"claude-3-5-sonnet","usage":{"input_tokens":200,"output_tokens":100}}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(
+            messages.len(),
+            2,
+            "Should deduplicate to 2 messages (first duplicate skipped)"
+        );
+        assert_eq!(messages[0].tokens.input, 100);
+        assert_eq!(messages[1].tokens.input, 200);
+    }
+
+    #[test]
+    fn test_deduplication_allows_same_message_different_request() {
+        let content = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}
+{"type":"assistant","timestamp":"2024-12-01T10:00:01.000Z","requestId":"req_002","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":150,"output_tokens":75}}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(
+            messages.len(),
+            2,
+            "Different requestId should not be deduplicated"
+        );
+    }
+
+    #[test]
+    fn test_entries_without_dedup_fields_still_processed() {
+        let content = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","message":{"model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}
+{"type":"assistant","timestamp":"2024-12-01T10:00:01.000Z","message":{"model":"claude-3-5-sonnet","usage":{"input_tokens":200,"output_tokens":100}}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(
+            messages.len(),
+            2,
+            "Entries without messageId/requestId should still be processed"
+        );
+    }
+
+    #[test]
+    fn test_user_messages_ignored() {
+        let content = r#"{"type":"user","timestamp":"2024-12-01T10:00:00.000Z","message":{"content":"Hello"}}
+{"type":"assistant","timestamp":"2024-12-01T10:00:01.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1, "User messages should be ignored");
+        assert_eq!(messages[0].tokens.input, 100);
+    }
+
+    #[test]
+    fn test_token_breakdown_parsing() {
+        let content = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":1000,"output_tokens":500,"cache_read_input_tokens":200,"cache_creation_input_tokens":100}}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 1000);
+        assert_eq!(messages[0].tokens.output, 500);
+        assert_eq!(messages[0].tokens.cache_read, 200);
+        assert_eq!(messages[0].tokens.cache_write, 100);
+        assert_eq!(messages[0].tokens.reasoning, 0);
+    }
+
+    #[test]
+    fn test_headless_json_output() {
+        let content = r#"{"type":"message","message":{"model":"claude-3-5-sonnet","usage":{"input_tokens":120,"output_tokens":60,"cache_read_input_tokens":10}}}"#;
+        let file = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+        std::fs::write(file.path(), content).unwrap();
+
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "claude-3-5-sonnet");
+        assert_eq!(messages[0].tokens.input, 120);
+        assert_eq!(messages[0].tokens.output, 60);
+        assert_eq!(messages[0].tokens.cache_read, 10);
+    }
+
+    #[test]
+    fn test_headless_stream_output() {
+        let content = r#"{"type":"message_start","timestamp":"2025-01-01T00:00:00Z","message":{"id":"msg_1","model":"claude-3-5-sonnet","usage":{"input_tokens":200,"cache_read_input_tokens":20,"cache_creation_input_tokens":5}}}
+{"type":"message_delta","usage":{"output_tokens":80}}
+{"type":"message_stop"}"#;
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "claude-3-5-sonnet");
+        assert_eq!(messages[0].tokens.input, 200);
+        assert_eq!(messages[0].tokens.output, 80);
+        assert_eq!(messages[0].tokens.cache_read, 20);
+        assert_eq!(messages[0].tokens.cache_write, 5);
+    }
+}

--- a/vendor/tokscale-core/src/sessions/codex.rs
+++ b/vendor/tokscale-core/src/sessions/codex.rs
@@ -1,0 +1,901 @@
+//! Codex CLI session parser
+//!
+//! Parses JSONL files from ~/.codex/sessions/
+//! Note: This parser has stateful logic to track model and delta calculations.
+
+use super::utils::{
+    extract_i64, extract_string, file_modified_timestamp_ms, parse_timestamp_value,
+};
+use super::UnifiedMessage;
+use crate::TokenBreakdown;
+use serde::Deserialize;
+use serde_json::Value;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+/// Codex entry structure (from JSONL files)
+#[derive(Debug, Deserialize)]
+pub struct CodexEntry {
+    #[serde(rename = "type")]
+    pub entry_type: String,
+    pub timestamp: Option<String>,
+    pub payload: Option<CodexPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CodexPayload {
+    #[serde(rename = "type")]
+    pub payload_type: Option<String>,
+    pub model: Option<String>,
+    pub model_name: Option<String>,
+    pub model_info: Option<CodexModelInfo>,
+    pub info: Option<CodexInfo>,
+    pub source: Option<String>,
+    /// Provider identity from session_meta (e.g. "openai", "azure")
+    pub model_provider: Option<String>,
+    /// Agent name from session_meta
+    pub agent_nickname: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CodexModelInfo {
+    pub slug: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CodexInfo {
+    pub model: Option<String>,
+    pub model_name: Option<String>,
+    pub last_token_usage: Option<CodexTokenUsage>,
+    pub total_token_usage: Option<CodexTokenUsage>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct CodexTokenUsage {
+    pub input_tokens: Option<i64>,
+    pub output_tokens: Option<i64>,
+    pub cached_input_tokens: Option<i64>,
+    pub cache_read_input_tokens: Option<i64>,
+    pub reasoning_output_tokens: Option<i64>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct CodexTotals {
+    input: i64,
+    output: i64,
+    cached: i64,
+    reasoning: i64,
+}
+
+impl CodexTotals {
+    fn from_usage(usage: &CodexTokenUsage) -> Self {
+        Self {
+            input: usage.input_tokens.unwrap_or(0).max(0),
+            output: usage.output_tokens.unwrap_or(0).max(0),
+            cached: usage
+                .cached_input_tokens
+                .unwrap_or(0)
+                .max(usage.cache_read_input_tokens.unwrap_or(0))
+                .max(0),
+            reasoning: usage.reasoning_output_tokens.unwrap_or(0).max(0),
+        }
+    }
+
+    fn delta_from(self, previous: Self) -> Option<Self> {
+        if self.input < previous.input
+            || self.output < previous.output
+            || self.cached < previous.cached
+            || self.reasoning < previous.reasoning
+        {
+            return None;
+        }
+
+        Some(Self {
+            input: self.input - previous.input,
+            output: self.output - previous.output,
+            cached: self.cached - previous.cached,
+            reasoning: self.reasoning - previous.reasoning,
+        })
+    }
+
+    fn saturating_add(self, other: Self) -> Self {
+        Self {
+            input: self.input.saturating_add(other.input),
+            output: self.output.saturating_add(other.output),
+            cached: self.cached.saturating_add(other.cached),
+            reasoning: self.reasoning.saturating_add(other.reasoning),
+        }
+    }
+
+    fn total(self) -> i64 {
+        self.input
+            .saturating_add(self.output)
+            .saturating_add(self.cached)
+            .saturating_add(self.reasoning)
+    }
+
+    fn looks_like_stale_regression(self, previous: Self, last: Self) -> bool {
+        let previous_total = previous.total();
+        let current_total = self.total();
+        let last_total = last.total();
+
+        if previous_total <= 0 || current_total <= 0 || last_total <= 0 {
+            return false;
+        }
+
+        // Some Codex token_count snapshots arrive slightly out of order: the cumulative
+        // total regresses by roughly one recent increment, then resumes from the true
+        // higher watermark on the next row. Treat those as stale snapshots rather than
+        // hard resets so we do not count `last_token_usage` twice.
+        current_total.saturating_mul(100) >= previous_total.saturating_mul(98)
+            || current_total.saturating_add(last_total.saturating_mul(2)) >= previous_total
+    }
+
+    fn into_tokens(self) -> TokenBreakdown {
+        // Clamp cached to not exceed input to prevent inflated totals when
+        // malformed data reports more cached tokens than input tokens.
+        let clamped_cached = self.cached.min(self.input).max(0);
+        TokenBreakdown {
+            input: (self.input - clamped_cached).max(0),
+            output: self.output.max(0),
+            cache_read: clamped_cached,
+            cache_write: 0,
+            reasoning: self.reasoning.max(0),
+        }
+    }
+}
+
+/// Parse a Codex JSONL file with stateful tracking
+pub fn parse_codex_file(path: &Path) -> Vec<UnifiedMessage> {
+    let file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return Vec::new(),
+    };
+
+    let session_id = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let fallback_timestamp = file_modified_timestamp_ms(path);
+
+    let reader = BufReader::new(file);
+    let mut messages = Vec::with_capacity(64);
+    let mut buffer = Vec::with_capacity(4096);
+
+    let mut current_model: Option<String> = None;
+    let mut previous_totals: Option<CodexTotals> = None;
+    let mut session_is_headless = false;
+    let mut session_provider: Option<String> = None;
+    let mut session_agent: Option<String> = None;
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let mut handled = false;
+        buffer.clear();
+        buffer.extend_from_slice(trimmed.as_bytes());
+        if let Ok(entry) = simd_json::from_slice::<CodexEntry>(&mut buffer) {
+            if let Some(payload) = entry.payload {
+                if entry.entry_type == "session_meta" {
+                    if payload.source.as_deref() == Some("exec") {
+                        session_is_headless = true;
+                    }
+                    if let Some(ref provider) = payload.model_provider {
+                        session_provider = Some(provider.clone());
+                    }
+                    if let Some(ref nickname) = payload.agent_nickname {
+                        session_agent = Some(nickname.clone());
+                    }
+                }
+                // Extract model from turn_context
+                if entry.entry_type == "turn_context" {
+                    current_model = extract_model(&payload);
+                    handled = true;
+                }
+
+                // Process token_count events
+                if entry.entry_type == "event_msg"
+                    && payload.payload_type.as_deref() == Some("token_count")
+                {
+                    // Try to extract model from payload
+                    if let Some(model) = extract_model(&payload) {
+                        current_model = Some(model);
+                    }
+
+                    let info = match payload.info {
+                        Some(i) => i,
+                        None => continue,
+                    };
+
+                    // Try to extract model from info
+                    if let Some(model) = info.model.clone().or(info.model_name.clone()) {
+                        current_model = Some(model);
+                    }
+
+                    let model = current_model
+                        .clone()
+                        .unwrap_or_else(|| "unknown".to_string());
+
+                    // Use last_token_usage as the primary increment source.
+                    // Upstream totals are mutable snapshots (compaction, context-window
+                    // capping can rewrite them), so we only use total_token_usage for
+                    // dedup and monotonicity checks — never as a direct delta source.
+                    let total_usage = info.total_token_usage.as_ref().map(CodexTotals::from_usage);
+                    let last_usage = info.last_token_usage.as_ref().map(CodexTotals::from_usage);
+
+                    let (tokens, next_totals) = match (total_usage, last_usage, previous_totals) {
+                        // Both present with previous baseline (standard path)
+                        (Some(total), Some(last), Some(previous)) => {
+                            if total == previous {
+                                continue;
+                            }
+                            if total.delta_from(previous).is_none()
+                                && total.looks_like_stale_regression(previous, last)
+                            {
+                                continue;
+                            }
+                            (last.into_tokens(), Some(total))
+                        }
+                        // Both present, first event — use last (NOT full total) to
+                        // avoid overcounting tokens carried from a resumed session.
+                        (Some(total), Some(last), None) => (last.into_tokens(), Some(total)),
+                        // Only total, have previous (defensive — upstream schema
+                        // requires both when info is present)
+                        (Some(total), None, Some(previous)) => {
+                            if total == previous {
+                                continue;
+                            }
+                            if let Some(delta) = total.delta_from(previous) {
+                                (delta.into_tokens(), Some(total))
+                            } else {
+                                previous_totals = Some(total);
+                                continue;
+                            }
+                        }
+                        // Only total, first event, no last — legacy/degraded path
+                        (Some(total), None, None) => (total.into_tokens(), Some(total)),
+                        // Only last, have previous
+                        (None, Some(last), Some(previous)) => {
+                            (last.into_tokens(), Some(previous.saturating_add(last)))
+                        }
+                        // Only last, no previous
+                        (None, Some(last), None) => (last.into_tokens(), None),
+                        // Neither
+                        (None, None, _) => continue,
+                    };
+
+                    // Skip zero-token snapshots without advancing the baseline so
+                    // that post-compaction zero totals don't inflate later deltas.
+                    if tokens.input == 0
+                        && tokens.output == 0
+                        && tokens.cache_read == 0
+                        && tokens.reasoning == 0
+                    {
+                        continue;
+                    }
+
+                    previous_totals = next_totals;
+
+                    let timestamp = entry
+                        .timestamp
+                        .and_then(|ts| chrono::DateTime::parse_from_rfc3339(&ts).ok())
+                        .map(|dt| dt.timestamp_millis())
+                        .unwrap_or(fallback_timestamp);
+
+                    let agent = if session_is_headless {
+                        Some("headless".to_string())
+                    } else {
+                        session_agent.clone()
+                    };
+
+                    let provider = session_provider.as_deref().unwrap_or("openai");
+
+                    messages.push(UnifiedMessage::new_with_agent(
+                        "codex",
+                        model,
+                        provider,
+                        session_id.clone(),
+                        timestamp,
+                        tokens,
+                        0.0,
+                        agent,
+                    ));
+                    handled = true;
+                }
+            }
+
+            // Mark session_meta as handled (even if payload was processed above)
+            if entry.entry_type == "session_meta" {
+                handled = true;
+            }
+        }
+
+        if handled {
+            continue;
+        }
+
+        if let Some(msg) = parse_codex_headless_line(
+            trimmed,
+            &session_id,
+            &mut current_model,
+            fallback_timestamp,
+            session_provider.as_deref(),
+            &session_agent,
+            session_is_headless,
+        ) {
+            messages.push(msg);
+        }
+    }
+
+    messages
+}
+
+fn extract_model(payload: &CodexPayload) -> Option<String> {
+    payload
+        .model_info
+        .as_ref()
+        .and_then(|mi| mi.slug.clone())
+        .filter(|s| !s.is_empty())
+        .or(payload.model.clone().filter(|s| !s.is_empty()))
+        .or(payload.model_name.clone().filter(|s| !s.is_empty()))
+        .or(payload
+            .info
+            .as_ref()
+            .and_then(|i| i.model.clone())
+            .filter(|s| !s.is_empty()))
+        .or(payload
+            .info
+            .as_ref()
+            .and_then(|i| i.model_name.clone())
+            .filter(|s| !s.is_empty()))
+}
+
+struct CodexHeadlessUsage {
+    input: i64,
+    output: i64,
+    cached: i64,
+    model: Option<String>,
+    timestamp_ms: Option<i64>,
+}
+
+fn parse_codex_headless_line(
+    line: &str,
+    session_id: &str,
+    current_model: &mut Option<String>,
+    fallback_timestamp: i64,
+    session_provider: Option<&str>,
+    session_agent: &Option<String>,
+    session_is_headless: bool,
+) -> Option<UnifiedMessage> {
+    let mut bytes = line.as_bytes().to_vec();
+    let value: Value = simd_json::from_slice(&mut bytes).ok()?;
+
+    if let Some(model) = extract_model_from_value(&value) {
+        *current_model = Some(model);
+    }
+
+    let usage = extract_headless_usage(&value)?;
+    let model = usage
+        .model
+        .or_else(|| current_model.clone())
+        .unwrap_or_else(|| "unknown".to_string());
+    let timestamp = usage.timestamp_ms.unwrap_or(fallback_timestamp);
+
+    if usage.input == 0 && usage.output == 0 && usage.cached == 0 {
+        return None;
+    }
+
+    let provider = session_provider.unwrap_or("openai");
+    let agent = if session_is_headless {
+        Some("headless".to_string())
+    } else {
+        session_agent.clone()
+    };
+
+    Some(UnifiedMessage::new_with_agent(
+        "codex",
+        model,
+        provider,
+        session_id.to_string(),
+        timestamp,
+        TokenBreakdown {
+            input: usage.input.max(0),
+            output: usage.output.max(0),
+            cache_read: usage.cached.max(0),
+            cache_write: 0,
+            reasoning: 0,
+        },
+        0.0,
+        agent,
+    ))
+}
+
+fn extract_headless_usage(value: &Value) -> Option<CodexHeadlessUsage> {
+    let usage = value
+        .get("usage")
+        .or_else(|| value.get("data").and_then(|data| data.get("usage")))
+        .or_else(|| value.get("result").and_then(|data| data.get("usage")))
+        .or_else(|| value.get("response").and_then(|data| data.get("usage")))?;
+
+    let input_tokens = extract_i64(usage.get("input_tokens"))
+        .or_else(|| extract_i64(usage.get("prompt_tokens")))
+        .or_else(|| extract_i64(usage.get("input")))
+        .unwrap_or(0);
+    let output_tokens = extract_i64(usage.get("output_tokens"))
+        .or_else(|| extract_i64(usage.get("completion_tokens")))
+        .or_else(|| extract_i64(usage.get("output")))
+        .unwrap_or(0);
+    let cached_tokens = extract_i64(usage.get("cached_input_tokens"))
+        .or_else(|| extract_i64(usage.get("cache_read_input_tokens")))
+        .or_else(|| extract_i64(usage.get("cached_tokens")))
+        .unwrap_or(0);
+
+    let model = extract_model_from_value(value)
+        .or_else(|| value.get("data").and_then(extract_model_from_value));
+    let timestamp_ms = extract_timestamp_from_value(value);
+
+    Some(CodexHeadlessUsage {
+        input: input_tokens.saturating_sub(cached_tokens),
+        output: output_tokens,
+        cached: cached_tokens,
+        model,
+        timestamp_ms,
+    })
+}
+
+fn extract_model_from_value(value: &Value) -> Option<String> {
+    extract_string(value.get("model"))
+        .or_else(|| extract_string(value.get("model_name")))
+        .or_else(|| {
+            value
+                .get("data")
+                .and_then(|data| extract_string(data.get("model")))
+        })
+        .or_else(|| {
+            value
+                .get("data")
+                .and_then(|data| extract_string(data.get("model_name")))
+        })
+        .or_else(|| {
+            value
+                .get("response")
+                .and_then(|data| extract_string(data.get("model")))
+        })
+}
+
+fn extract_timestamp_from_value(value: &Value) -> Option<i64> {
+    value
+        .get("timestamp")
+        .or_else(|| value.get("time"))
+        .or_else(|| value.get("created_at"))
+        .or_else(|| value.get("data").and_then(|data| data.get("timestamp")))
+        .and_then(parse_timestamp_value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn create_test_file(content: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file.flush().unwrap();
+        file
+    }
+
+    #[test]
+    fn test_headless_usage_line() {
+        let content = r#"{"type":"turn.completed","model":"gpt-4o-mini","usage":{"input_tokens":120,"cached_input_tokens":20,"output_tokens":30}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gpt-4o-mini");
+        assert_eq!(messages[0].tokens.input, 100);
+        assert_eq!(messages[0].tokens.output, 30);
+        assert_eq!(messages[0].tokens.cache_read, 20);
+    }
+
+    #[test]
+    fn test_headless_usage_nested_data() {
+        let content = r#"{"type":"result","data":{"model_name":"gpt-4o","usage":{"input_tokens":50,"cached_input_tokens":5,"output_tokens":12}}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gpt-4o");
+        assert_eq!(messages[0].tokens.input, 45);
+        assert_eq!(messages[0].tokens.output, 12);
+        assert_eq!(messages[0].tokens.cache_read, 5);
+    }
+
+    #[test]
+    fn test_session_meta_exec_marks_headless() {
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta","payload":{"originator":"codex_exec","source":"exec"}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3}}}}"#;
+        let content = format!("{}\n{}", line1, line2);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].agent.as_deref(), Some("headless"));
+    }
+
+    #[test]
+    fn test_token_count_uses_total_deltas_when_totals_repeat() {
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":5},"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":5}}}}"#;
+        let line3 = r#"{"timestamp":"2026-01-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":5},"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":5}}}}"#;
+        let content = format!("{}\n{}\n{}", line1, line2, line3);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 80);
+        assert_eq!(messages[0].tokens.output, 30);
+        assert_eq!(messages[0].tokens.cache_read, 20);
+        assert_eq!(messages[0].tokens.reasoning, 5);
+    }
+
+    #[test]
+    fn test_token_count_falls_back_to_last_usage_when_totals_reset() {
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":5},"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":5}}}}"#;
+        let line3 = r#"{"timestamp":"2026-01-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#;
+        let content = format!("{}\n{}\n{}", line1, line2, line3);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].tokens.input, 80);
+        assert_eq!(messages[0].tokens.output, 30);
+        assert_eq!(messages[0].tokens.cache_read, 20);
+        assert_eq!(messages[0].tokens.reasoning, 5);
+        assert_eq!(messages[1].tokens.input, 8);
+        assert_eq!(messages[1].tokens.output, 3);
+        assert_eq!(messages[1].tokens.cache_read, 2);
+        assert_eq!(messages[1].tokens.reasoning, 1);
+    }
+
+    #[test]
+    fn test_token_count_advances_baseline_after_missing_total_fallback() {
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":5},"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":5}}}}"#;
+        let line3 = r#"{"timestamp":"2026-01-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#;
+        let line4 = r#"{"timestamp":"2026-01-01T00:00:03Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":110,"cached_input_tokens":22,"output_tokens":33,"reasoning_output_tokens":6},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#;
+        let content = format!("{}\n{}\n{}\n{}", line1, line2, line3, line4);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].tokens.input, 80);
+        assert_eq!(messages[0].tokens.output, 30);
+        assert_eq!(messages[0].tokens.cache_read, 20);
+        assert_eq!(messages[0].tokens.reasoning, 5);
+        assert_eq!(messages[1].tokens.input, 8);
+        assert_eq!(messages[1].tokens.output, 3);
+        assert_eq!(messages[1].tokens.cache_read, 2);
+        assert_eq!(messages[1].tokens.reasoning, 1);
+    }
+
+    #[test]
+    fn test_token_count_skips_regressed_totals_without_last_usage() {
+        // When totals regress and last_usage is absent, the row should be
+        // skipped entirely to avoid double-counting the full cumulative total.
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":5}}}}"#;
+        // Totals regress (lower values) and no last_token_usage — should skip
+        let line3 = r#"{"timestamp":"2026-01-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":50,"cached_input_tokens":10,"output_tokens":15,"reasoning_output_tokens":2}}}}"#;
+        // Normal continuation after reset
+        let line4 = r#"{"timestamp":"2026-01-01T00:00:03Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":80,"cached_input_tokens":15,"output_tokens":25,"reasoning_output_tokens":4}}}}"#;
+        let content = format!("{}\n{}\n{}\n{}", line1, line2, line3, line4);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        // Should produce 2 messages: first from line2 (full total),
+        // then delta from line4 relative to line3 (baseline reset).
+        assert_eq!(messages.len(), 2);
+        // First message: full total
+        assert_eq!(messages[0].tokens.input, 80);
+        assert_eq!(messages[0].tokens.output, 30);
+        assert_eq!(messages[0].tokens.cache_read, 20);
+        assert_eq!(messages[0].tokens.reasoning, 5);
+        // Second message: delta from 50→80
+        assert_eq!(messages[1].tokens.input, 25);
+        assert_eq!(messages[1].tokens.output, 10);
+        assert_eq!(messages[1].tokens.cache_read, 5);
+        assert_eq!(messages[1].tokens.reasoning, 2);
+    }
+
+    #[test]
+    fn test_into_tokens_clamps_cached_to_input() {
+        // When cached > input (malformed data), cached should be clamped to input
+        // so that input + cache_read never exceeds the raw input value.
+        let totals = CodexTotals {
+            input: 50,
+            output: 30,
+            cached: 100, // More than input — malformed
+            reasoning: 5,
+        };
+        let tokens = totals.into_tokens();
+        assert_eq!(tokens.cache_read, 50); // Clamped to input
+        assert_eq!(tokens.input, 0); // input - clamped_cached = 0
+        assert_eq!(tokens.output, 30);
+        assert_eq!(tokens.reasoning, 5);
+    }
+
+    #[test]
+    fn test_token_count_ignores_negative_fallback_usage_in_baseline() {
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":5},"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":5}}}}"#;
+        let line3 = r#"{"timestamp":"2026-01-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":-10,"cached_input_tokens":-2,"output_tokens":-3,"reasoning_output_tokens":-1}}}}"#;
+        let line4 = r#"{"timestamp":"2026-01-01T00:00:03Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":110,"cached_input_tokens":22,"output_tokens":33,"reasoning_output_tokens":6},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#;
+        let content = format!("{}\n{}\n{}\n{}", line1, line2, line3, line4);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].tokens.input, 80);
+        assert_eq!(messages[0].tokens.output, 30);
+        assert_eq!(messages[0].tokens.cache_read, 20);
+        assert_eq!(messages[0].tokens.reasoning, 5);
+        assert_eq!(messages[1].tokens.input, 8);
+        assert_eq!(messages[1].tokens.output, 3);
+        assert_eq!(messages[1].tokens.cache_read, 2);
+        assert_eq!(messages[1].tokens.reasoning, 1);
+    }
+
+    #[test]
+    fn test_token_count_avoids_double_counting_stale_cumulative_regressions() {
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":5},"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":5}}}}"#;
+        let line3 = r#"{"timestamp":"2026-01-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":110,"cached_input_tokens":22,"output_tokens":33,"reasoning_output_tokens":6},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#;
+        let line4 = r#"{"timestamp":"2026-01-01T00:00:03Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":109,"cached_input_tokens":21,"output_tokens":32,"reasoning_output_tokens":6},"last_token_usage":{"input_tokens":9,"cached_input_tokens":1,"output_tokens":2,"reasoning_output_tokens":0}}}}"#;
+        let line5 = r#"{"timestamp":"2026-01-01T00:00:04Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":119,"cached_input_tokens":23,"output_tokens":35,"reasoning_output_tokens":6},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":0}}}}"#;
+        let content = format!("{}\n{}\n{}\n{}\n{}", line1, line2, line3, line4, line5);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0].tokens.input, 80);
+        assert_eq!(messages[0].tokens.output, 30);
+        assert_eq!(messages[0].tokens.cache_read, 20);
+        assert_eq!(messages[0].tokens.reasoning, 5);
+
+        assert_eq!(messages[1].tokens.input, 8);
+        assert_eq!(messages[1].tokens.output, 3);
+        assert_eq!(messages[1].tokens.cache_read, 2);
+        assert_eq!(messages[1].tokens.reasoning, 1);
+
+        // Stale snapshot (line4) is now skipped entirely; messages[2]
+        // comes from line5's last_token_usage instead.
+        assert_eq!(messages[2].tokens.input, 8);
+        assert_eq!(messages[2].tokens.output, 3);
+        assert_eq!(messages[2].tokens.cache_read, 2);
+        assert_eq!(messages[2].tokens.reasoning, 0);
+    }
+
+    #[test]
+    fn test_token_count_handles_multiple_stale_regressions_before_recovery() {
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":5},"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":5}}}}"#;
+        let line3 = r#"{"timestamp":"2026-01-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":110,"cached_input_tokens":22,"output_tokens":33,"reasoning_output_tokens":6},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#;
+        let line4 = r#"{"timestamp":"2026-01-01T00:00:03Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":109,"cached_input_tokens":21,"output_tokens":32,"reasoning_output_tokens":6},"last_token_usage":{"input_tokens":9,"cached_input_tokens":1,"output_tokens":2,"reasoning_output_tokens":0}}}}"#;
+        let line5 = r#"{"timestamp":"2026-01-01T00:00:04Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":118,"cached_input_tokens":22,"output_tokens":34,"reasoning_output_tokens":6},"last_token_usage":{"input_tokens":9,"cached_input_tokens":1,"output_tokens":2,"reasoning_output_tokens":0}}}}"#;
+        let line6 = r#"{"timestamp":"2026-01-01T00:00:05Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":128,"cached_input_tokens":24,"output_tokens":37,"reasoning_output_tokens":6},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":0}}}}"#;
+        let content = format!(
+            "{}\n{}\n{}\n{}\n{}\n{}",
+            line1, line2, line3, line4, line5, line6
+        );
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        // Stale line4 is skipped; messages come from lines 2, 3, 5, 6.
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[0].tokens.input, 80);
+        assert_eq!(messages[1].tokens.input, 8);
+        assert_eq!(messages[2].tokens.input, 8);
+        assert_eq!(messages[2].tokens.output, 2);
+        assert_eq!(messages[2].tokens.cache_read, 1);
+        assert_eq!(messages[2].tokens.reasoning, 0);
+        assert_eq!(messages[3].tokens.input, 8);
+        assert_eq!(messages[3].tokens.output, 3);
+        assert_eq!(messages[3].tokens.cache_read, 2);
+        assert_eq!(messages[3].tokens.reasoning, 0);
+    }
+
+    #[test]
+    fn test_token_count_treats_large_regressions_as_real_resets() {
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10000,"cached_input_tokens":1000,"output_tokens":400,"reasoning_output_tokens":50},"last_token_usage":{"input_tokens":10000,"cached_input_tokens":1000,"output_tokens":400,"reasoning_output_tokens":50}}}}"#;
+        let line3 = r#"{"timestamp":"2026-01-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":7600,"cached_input_tokens":800,"output_tokens":280,"reasoning_output_tokens":35},"last_token_usage":{"input_tokens":25,"cached_input_tokens":5,"output_tokens":4,"reasoning_output_tokens":1}}}}"#;
+        let line4 = r#"{"timestamp":"2026-01-01T00:00:03Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":7625,"cached_input_tokens":805,"output_tokens":284,"reasoning_output_tokens":36},"last_token_usage":{"input_tokens":25,"cached_input_tokens":5,"output_tokens":4,"reasoning_output_tokens":1}}}}"#;
+        let content = format!("{}\n{}\n{}\n{}", line1, line2, line3, line4);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0].tokens.input, 9000);
+        assert_eq!(messages[0].tokens.output, 400);
+        assert_eq!(messages[0].tokens.cache_read, 1000);
+        assert_eq!(messages[0].tokens.reasoning, 50);
+
+        assert_eq!(messages[1].tokens.input, 20);
+        assert_eq!(messages[1].tokens.output, 4);
+        assert_eq!(messages[1].tokens.cache_read, 5);
+        assert_eq!(messages[1].tokens.reasoning, 1);
+
+        assert_eq!(messages[2].tokens.input, 20);
+        assert_eq!(messages[2].tokens.output, 4);
+        assert_eq!(messages[2].tokens.cache_read, 5);
+        assert_eq!(messages[2].tokens.reasoning, 1);
+    }
+
+    #[test]
+    fn test_first_event_uses_last_not_total_for_resumed_sessions() {
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":5000,"cached_input_tokens":500,"output_tokens":800,"reasoning_output_tokens":100},"last_token_usage":{"input_tokens":12,"cached_input_tokens":2,"output_tokens":5,"reasoning_output_tokens":1}}}}"#;
+        let line3 = r#"{"timestamp":"2026-01-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":5012,"cached_input_tokens":502,"output_tokens":805,"reasoning_output_tokens":101},"last_token_usage":{"input_tokens":12,"cached_input_tokens":2,"output_tokens":5,"reasoning_output_tokens":1}}}}"#;
+        let content = format!("{}\n{}\n{}", line1, line2, line3);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].tokens.input, 10);
+        assert_eq!(messages[0].tokens.output, 5);
+        assert_eq!(messages[0].tokens.cache_read, 2);
+        assert_eq!(messages[0].tokens.reasoning, 1);
+        assert_eq!(messages[1].tokens.input, 10);
+        assert_eq!(messages[1].tokens.output, 5);
+        assert_eq!(messages[1].tokens.cache_read, 2);
+        assert_eq!(messages[1].tokens.reasoning, 1);
+    }
+
+    #[test]
+    fn test_zero_token_snapshot_does_not_inflate_later_deltas() {
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":500,"cached_input_tokens":50,"output_tokens":80,"reasoning_output_tokens":10},"last_token_usage":{"input_tokens":500,"cached_input_tokens":50,"output_tokens":80,"reasoning_output_tokens":10}}}}"#;
+        let line3 = r#"{"timestamp":"2026-01-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":0,"cached_input_tokens":0,"output_tokens":0,"reasoning_output_tokens":0},"last_token_usage":{"input_tokens":0,"cached_input_tokens":0,"output_tokens":0,"reasoning_output_tokens":0}}}}"#;
+        let line4 = r#"{"timestamp":"2026-01-01T00:00:03Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":510,"cached_input_tokens":52,"output_tokens":83,"reasoning_output_tokens":11},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#;
+        let content = format!("{}\n{}\n{}\n{}", line1, line2, line3, line4);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].tokens.input, 450);
+        assert_eq!(messages[0].tokens.output, 80);
+        assert_eq!(messages[0].tokens.cache_read, 50);
+        assert_eq!(messages[0].tokens.reasoning, 10);
+        assert_eq!(messages[1].tokens.input, 8);
+        assert_eq!(messages[1].tokens.output, 3);
+        assert_eq!(messages[1].tokens.cache_read, 2);
+        assert_eq!(messages[1].tokens.reasoning, 1);
+    }
+
+    #[test]
+    fn test_model_info_slug_from_turn_context() {
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context","payload":{"model_info":{"slug":"o3-pro"}}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#;
+        let content = format!("{}\n{}", line1, line2);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "o3-pro");
+    }
+
+    #[test]
+    fn test_session_meta_provider_and_agent() {
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta","payload":{"source":"interactive","model_provider":"azure","agent_nickname":"my-agent"}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
+        let line3 = r#"{"timestamp":"2026-01-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#;
+        let content = format!("{}\n{}\n{}", line1, line2, line3);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].provider_id, "azure");
+        assert_eq!(messages[0].agent.as_deref(), Some("my-agent"));
+    }
+
+    #[test]
+    fn test_cached_tokens_takes_max_of_both_fields() {
+        let usage = CodexTokenUsage {
+            input_tokens: Some(100),
+            output_tokens: Some(30),
+            cached_input_tokens: Some(10),
+            cache_read_input_tokens: Some(20),
+            reasoning_output_tokens: Some(5),
+        };
+        let totals = CodexTotals::from_usage(&usage);
+        assert_eq!(totals.cached, 20);
+    }
+
+    #[test]
+    fn test_compaction_total_drop_uses_last_as_increment() {
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":150000,"cached_input_tokens":10000,"output_tokens":20000,"reasoning_output_tokens":5000},"last_token_usage":{"input_tokens":150000,"cached_input_tokens":10000,"output_tokens":20000,"reasoning_output_tokens":5000}}}}"#;
+        let line3 = r#"{"timestamp":"2026-01-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":200000,"cached_input_tokens":15000,"output_tokens":25000,"reasoning_output_tokens":6000},"last_token_usage":{"input_tokens":50,"cached_input_tokens":5,"output_tokens":10,"reasoning_output_tokens":2}}}}"#;
+        let content = format!("{}\n{}\n{}", line1, line2, line3);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[1].tokens.input, 45);
+        assert_eq!(messages[1].tokens.output, 10);
+        assert_eq!(messages[1].tokens.cache_read, 5);
+        assert_eq!(messages[1].tokens.reasoning, 2);
+    }
+
+    #[test]
+    fn test_headless_fallback_uses_session_provider_and_agent() {
+        // session_meta sets provider to "azure" and agent to "my-bot",
+        // then a line falls through to headless parsing (no structured entry_type)
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta","payload":{"model_provider":"azure","agent_nickname":"my-bot"}}"#;
+        let line2 = r#"{"type":"turn.completed","model":"gpt-4o","usage":{"input_tokens":100,"output_tokens":50}}"#;
+        let content = format!("{}\n{}", line1, line2);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].provider_id, "azure");
+        assert_eq!(messages[0].agent.as_deref(), Some("my-bot"));
+    }
+
+    #[test]
+    fn test_headless_fallback_defaults_to_openai_without_session_meta() {
+        // No session_meta — headless fallback should default to "openai"
+        let content = r#"{"type":"turn.completed","model":"gpt-4o-mini","usage":{"input_tokens":120,"cached_input_tokens":20,"output_tokens":30}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].provider_id, "openai");
+        assert!(messages[0].agent.is_none());
+    }
+
+    #[test]
+    fn test_extract_model_skips_empty_slug_falls_through_to_model() {
+        // model_info.slug is empty string, but payload.model has a valid value.
+        // extract_model should skip the empty slug and return payload.model.
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context","payload":{"model_info":{"slug":""},"model":"gpt-4o"}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":10,"output_tokens":5}}}}"#;
+        let content = format!("{}\n{}", line1, line2);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gpt-4o");
+    }
+}

--- a/vendor/tokscale-core/src/sessions/cursor.rs
+++ b/vendor/tokscale-core/src/sessions/cursor.rs
@@ -1,0 +1,376 @@
+//! Cursor IDE session parser
+//!
+//! Parses CSV files from the Cursor usage export API.
+//! CSV files are cached locally at ~/.config/tokscale/cursor-cache/*.csv
+//! (legacy single-account cache uses usage.csv; additional accounts may use usage.<account>.csv)
+//!
+//! CSV Format (actual from API):
+//! Date,Kind,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Total Tokens,Cost
+
+use super::UnifiedMessage;
+use crate::TokenBreakdown;
+use std::path::Path;
+
+fn account_id_from_cursor_cache_path(path: &Path) -> String {
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("usage.csv");
+
+    if file_name == "usage.csv" {
+        return "active".to_string();
+    }
+
+    if let Some(stem) = file_name
+        .strip_prefix("usage.")
+        .and_then(|s| s.strip_suffix(".csv"))
+    {
+        // Keep it simple/ASCII. The CLI already sanitizes file names.
+        let cleaned = stem
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                    c
+                } else {
+                    '-'
+                }
+            })
+            .collect::<String>();
+        if cleaned.is_empty() {
+            return "unknown".to_string();
+        }
+        return cleaned;
+    }
+
+    "unknown".to_string()
+}
+
+/// Provider inference from model name
+fn infer_provider(model: &str) -> &'static str {
+    let lower = model.to_lowercase();
+
+    if lower.contains("claude")
+        || lower.contains("sonnet")
+        || lower.contains("opus")
+        || lower.contains("haiku")
+    {
+        "anthropic"
+    } else if lower.contains("gpt") || lower.contains("o1") || lower.contains("o3") {
+        "openai"
+    } else if lower.contains("gemini") {
+        "google"
+    } else if lower.contains("deepseek") {
+        "deepseek"
+    } else if lower.contains("llama") || lower.contains("mixtral") {
+        "meta"
+    } else {
+        "cursor"
+    }
+}
+
+/// Parse a cost string like "$0.50" or "0.50" to f64
+/// Returns 0.0 for empty strings, NaN values, or invalid formats
+fn parse_cost(cost_str: &str) -> f64 {
+    let cleaned = cost_str.replace(['$', ','], "");
+    let trimmed = cleaned.trim();
+
+    // Handle empty or NaN values
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("nan") {
+        return 0.0;
+    }
+
+    trimmed.parse().unwrap_or(0.0)
+}
+
+/// Parse a Cursor usage CSV file
+///
+/// Handles both formats:
+/// - New: Date,Kind,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Total Tokens,Cost
+/// - Old: Date,Model,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Total Tokens,Cost,Cost to you
+pub fn parse_cursor_file(path: &Path) -> Vec<UnifiedMessage> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return vec![],
+    };
+
+    let mut messages = Vec::with_capacity(128);
+    let mut lines = content.lines();
+
+    // Parse header line to determine column indices
+    let header = match lines.next() {
+        Some(h) => h,
+        None => return vec![],
+    };
+
+    // Verify this is a valid Cursor CSV
+    if !header.contains("Date") || !header.contains("Model") {
+        return vec![];
+    }
+
+    // Detect format by checking for "Kind" column
+    let header_fields: Vec<&str> = parse_csv_line(header);
+    let has_kind_column = header_fields.iter().any(|f| f.trim() == "Kind");
+
+    // Column indices based on format
+    let (
+        model_idx,
+        input_cache_write_idx,
+        input_no_cache_idx,
+        cache_read_idx,
+        output_idx,
+        cost_idx,
+    ) = if has_kind_column {
+        // New format: Date,Kind,Model,Max Mode,Input (w/ Cache Write),...
+        (2, 4, 5, 6, 7, 9)
+    } else {
+        // Old format: Date,Model,Input (w/ Cache Write),...
+        (1, 2, 3, 4, 5, 7)
+    };
+
+    let account_id = account_id_from_cursor_cache_path(path);
+
+    for line in lines {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        // Parse CSV line (simple parsing, handles quoted fields)
+        let fields: Vec<&str> = parse_csv_line(line);
+
+        // Need at least enough columns for the format
+        let min_fields = cost_idx + 1;
+        if fields.len() < min_fields {
+            continue;
+        }
+
+        let date_str = fields[0].trim().trim_matches('"');
+        let model = fields[model_idx].trim().trim_matches('"');
+        let input_with_cache_write: i64 = fields[input_cache_write_idx]
+            .trim()
+            .trim_matches('"')
+            .parse()
+            .unwrap_or(0);
+        let input_without_cache_write: i64 = fields[input_no_cache_idx]
+            .trim()
+            .trim_matches('"')
+            .parse()
+            .unwrap_or(0);
+        let cache_read: i64 = fields[cache_read_idx]
+            .trim()
+            .trim_matches('"')
+            .parse()
+            .unwrap_or(0);
+        let output_tokens: i64 = fields[output_idx]
+            .trim()
+            .trim_matches('"')
+            .parse()
+            .unwrap_or(0);
+        let cost_str = fields[cost_idx].trim().trim_matches('"');
+        let cost = parse_cost(cost_str);
+
+        // Skip empty or errored entries
+        if model.is_empty() {
+            continue;
+        }
+
+        // Parse timestamp from date string
+        let timestamp = parse_date_to_timestamp(date_str);
+        if timestamp == 0 {
+            continue;
+        }
+
+        // Cache write = input_with_cache_write - input_without_cache_write
+        let cache_write = (input_with_cache_write - input_without_cache_write).max(0);
+        // Input tokens = input_without_cache_write
+        let input = input_without_cache_write;
+
+        messages.push(UnifiedMessage::new(
+            "cursor",
+            model,
+            infer_provider(model),
+            format!("cursor-{}-{}", account_id, date_str),
+            timestamp,
+            TokenBreakdown {
+                input: input.max(0),
+                output: output_tokens.max(0),
+                cache_read: cache_read.max(0),
+                cache_write, // Already clamped above with .max(0)
+                reasoning: 0,
+            },
+            cost.max(0.0),
+        ));
+    }
+
+    messages
+}
+
+/// Simple CSV line parser that handles quoted fields
+fn parse_csv_line(line: &str) -> Vec<&str> {
+    let mut fields = Vec::new();
+    let mut start = 0;
+    let mut in_quotes = false;
+    let bytes = line.as_bytes();
+
+    for (i, &byte) in bytes.iter().enumerate() {
+        match byte {
+            b'"' => in_quotes = !in_quotes,
+            b',' if !in_quotes => {
+                fields.push(&line[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+
+    // Add the last field
+    if start <= line.len() {
+        fields.push(&line[start..]);
+    }
+
+    fields
+}
+
+/// Parse a date string to Unix milliseconds timestamp
+fn parse_date_to_timestamp(date_str: &str) -> i64 {
+    use chrono::{NaiveDate, NaiveDateTime, TimeZone, Utc};
+
+    // Try ISO 8601 format with milliseconds: "2025-02-05T12:00:00.123Z"
+    if let Ok(dt) = NaiveDateTime::parse_from_str(date_str, "%Y-%m-%dT%H:%M:%S%.3fZ") {
+        return Utc.from_utc_datetime(&dt).timestamp_millis();
+    }
+
+    // Try ISO 8601 format with time: "2025-02-05T12:00:00Z"
+    if let Ok(dt) = NaiveDateTime::parse_from_str(date_str, "%Y-%m-%dT%H:%M:%SZ") {
+        return Utc.from_utc_datetime(&dt).timestamp_millis();
+    }
+
+    // Try ISO 8601 format with milliseconds without Z: "2025-02-05T12:00:00.123"
+    if let Ok(dt) = NaiveDateTime::parse_from_str(date_str, "%Y-%m-%dT%H:%M:%S%.3f") {
+        return Utc.from_utc_datetime(&dt).timestamp_millis();
+    }
+
+    // Try ISO 8601 format with time without Z: "2025-02-05T12:00:00"
+    if let Ok(dt) = NaiveDateTime::parse_from_str(date_str, "%Y-%m-%dT%H:%M:%S") {
+        return Utc.from_utc_datetime(&dt).timestamp_millis();
+    }
+
+    // Date-only format: "2025-02-05" - use noon UTC (12:00:00Z)
+    // Noon keeps the local date stable for all timezones from UTC-12 to UTC+14,
+    // so filtering by local day boundaries won't shift the record to an adjacent day.
+    if let Ok(date) = NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
+        let dt = date.and_hms_opt(12, 0, 0).unwrap();
+        return Utc.from_utc_datetime(&dt).timestamp_millis();
+    }
+
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_infer_provider() {
+        assert_eq!(infer_provider("claude-3-sonnet"), "anthropic");
+        assert_eq!(infer_provider("gpt-4o"), "openai");
+        assert_eq!(infer_provider("gemini-pro"), "google");
+        assert_eq!(infer_provider("deepseek-coder"), "deepseek");
+        assert_eq!(infer_provider("llama-3"), "meta");
+        assert_eq!(infer_provider("unknown-model"), "cursor");
+    }
+
+    #[test]
+    fn test_parse_cost() {
+        assert_eq!(parse_cost("$0.50"), 0.50);
+        assert_eq!(parse_cost("0.50"), 0.50);
+        assert_eq!(parse_cost("$1,234.56"), 1234.56);
+        assert_eq!(parse_cost(""), 0.0);
+        assert_eq!(parse_cost("NaN"), 0.0);
+        assert_eq!(parse_cost("nan"), 0.0);
+        assert_eq!(parse_cost("  "), 0.0);
+    }
+
+    #[test]
+    fn test_parse_csv_line() {
+        let line = "2025-02-01,gpt-4o,10,5,0,15,30,$0.10,$0.10";
+        let fields = parse_csv_line(line);
+        assert_eq!(fields.len(), 9);
+        assert_eq!(fields[0], "2025-02-01");
+        assert_eq!(fields[1], "gpt-4o");
+        assert_eq!(fields[8], "$0.10");
+    }
+
+    #[test]
+    fn test_parse_date_to_timestamp() {
+        // ISO with milliseconds and Z (new Cursor format)
+        let ts = parse_date_to_timestamp("2025-11-13T18:36:05.846Z");
+        assert!(ts > 0);
+
+        // ISO with Z
+        let ts = parse_date_to_timestamp("2025-02-05T12:00:00Z");
+        assert!(ts > 0);
+
+        // Date only
+        let ts = parse_date_to_timestamp("2025-02-05");
+        assert!(ts > 0);
+
+        // Invalid
+        let ts = parse_date_to_timestamp("invalid");
+        assert_eq!(ts, 0);
+    }
+
+    #[test]
+    fn test_parse_cursor_csv_sample_old_format() {
+        let csv = "Date,Model,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Total Tokens,Cost,Cost to you
+2025-02-01,gpt-4o,10,5,0,15,30,$0.10,$0.10
+2025-02-02,gpt-4o-mini,0,0,0,5,5,$0.05,$0.05";
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("usage.csv");
+        std::fs::write(&file_path, csv).unwrap();
+
+        let messages = parse_cursor_file(&file_path);
+        assert_eq!(messages.len(), 2);
+
+        assert_eq!(messages[0].client, "cursor");
+        assert_eq!(messages[0].model_id, "gpt-4o");
+        assert_eq!(messages[0].provider_id, "openai");
+        assert_eq!(messages[0].tokens.input, 5);
+        assert_eq!(messages[0].tokens.output, 15);
+        assert_eq!(messages[0].tokens.cache_write, 5); // 10 - 5
+        assert!((messages[0].cost - 0.10).abs() < 0.001);
+
+        assert_eq!(messages[1].model_id, "gpt-4o-mini");
+    }
+
+    #[test]
+    fn test_parse_cursor_csv_sample_new_format() {
+        // Real format from Cursor API
+        let csv = r#"Date,Kind,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Total Tokens,Cost
+"2025-11-13T18:36:05.846Z","Included","auto","No","28342","775","105891","21282","156290","0.19"
+"2025-11-13T13:35:04.658Z","On-Demand","gpt-5-codex","No","0","8263","66964","1612","76839","0.03""#;
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("usage.csv");
+        std::fs::write(&file_path, csv).unwrap();
+
+        let messages = parse_cursor_file(&file_path);
+        assert_eq!(messages.len(), 2);
+
+        // First message: auto model
+        assert_eq!(messages[0].client, "cursor");
+        assert_eq!(messages[0].model_id, "auto");
+        assert_eq!(messages[0].provider_id, "cursor"); // unknown model -> cursor
+        assert_eq!(messages[0].tokens.input, 775);
+        assert_eq!(messages[0].tokens.output, 21282);
+        assert_eq!(messages[0].tokens.cache_read, 105891);
+        assert_eq!(messages[0].tokens.cache_write, 28342 - 775); // 27567
+        assert!((messages[0].cost - 0.19).abs() < 0.001);
+
+        // Second message: gpt-5-codex
+        assert_eq!(messages[1].model_id, "gpt-5-codex");
+        assert_eq!(messages[1].provider_id, "openai"); // gpt -> openai
+        assert_eq!(messages[1].tokens.input, 8263);
+        assert_eq!(messages[1].tokens.cache_read, 66964);
+    }
+}

--- a/vendor/tokscale-core/src/sessions/droid.rs
+++ b/vendor/tokscale-core/src/sessions/droid.rs
@@ -1,0 +1,339 @@
+//! Droid (Factory.ai) session parser
+//!
+//! Parses JSON files from ~/.factory/sessions/
+
+use super::UnifiedMessage;
+use crate::TokenBreakdown;
+use serde::Deserialize;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+/// Droid settings.json structure
+#[derive(Debug, Deserialize)]
+pub struct DroidSettingsJson {
+    pub model: Option<String>,
+    #[serde(rename = "providerLock")]
+    pub provider_lock: Option<String>,
+    #[serde(rename = "providerLockTimestamp")]
+    pub provider_lock_timestamp: Option<String>,
+    #[serde(rename = "tokenUsage")]
+    pub token_usage: Option<DroidTokenUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DroidTokenUsage {
+    #[serde(rename = "inputTokens")]
+    pub input_tokens: Option<i64>,
+    #[serde(rename = "outputTokens")]
+    pub output_tokens: Option<i64>,
+    #[serde(rename = "cacheCreationTokens")]
+    pub cache_creation_tokens: Option<i64>,
+    #[serde(rename = "cacheReadTokens")]
+    pub cache_read_tokens: Option<i64>,
+    #[serde(rename = "thinkingTokens")]
+    pub thinking_tokens: Option<i64>,
+}
+
+/// Normalize model name from Droid's custom format
+/// e.g., "custom:Claude-Opus-4.5-Thinking-[Anthropic]-0" -> "claude-opus-4-5-thinking-0"
+/// e.g., "gemini-2.5-pro" -> "gemini-2-5-pro"
+/// e.g., "Claude-Sonnet-4-[Anthropic]" -> "claude-sonnet-4"
+fn normalize_model_name(model: &str) -> String {
+    // Remove "custom:" prefix if present
+    let mut normalized = model.strip_prefix("custom:").unwrap_or(model).to_string();
+
+    // Handle bracket notation like "Claude-Opus-4.5-Thinking-[Anthropic]-0"
+    // Remove [anything] patterns (like TypeScript's .replace(/\[.*?\]/g, ""))
+    let mut result = String::new();
+    let mut in_bracket = false;
+
+    for ch in normalized.chars() {
+        match ch {
+            '[' => in_bracket = true,
+            ']' => in_bracket = false,
+            _ if !in_bracket => result.push(ch),
+            _ => {}
+        }
+    }
+
+    normalized = result;
+
+    // Remove trailing hyphens only (like TypeScript's .replace(/-+$/, ""))
+    // NOTE: Do NOT remove trailing digits - TypeScript keeps them
+    normalized = normalized.trim_end_matches('-').to_string();
+
+    // Convert to lowercase (like TypeScript's .toLowerCase())
+    normalized = normalized.to_lowercase();
+
+    // Replace dots with hyphens (like TypeScript's .replace(/\./g, "-"))
+    normalized = normalized.replace('.', "-");
+
+    // Collapse multiple consecutive hyphens into one (like TypeScript's .replace(/-+/g, "-"))
+    let mut collapsed = String::new();
+    let mut last_was_hyphen = false;
+    for ch in normalized.chars() {
+        if ch == '-' {
+            if !last_was_hyphen {
+                collapsed.push(ch);
+            }
+            last_was_hyphen = true;
+        } else {
+            collapsed.push(ch);
+            last_was_hyphen = false;
+        }
+    }
+
+    collapsed
+}
+
+fn get_provider_from_model(model: &str) -> &'static str {
+    let lower = model.to_lowercase();
+
+    if lower.contains("claude")
+        || lower.contains("anthropic")
+        || lower.contains("opus")
+        || lower.contains("sonnet")
+        || lower.contains("haiku")
+    {
+        return "anthropic";
+    }
+    if lower.contains("gpt")
+        || lower.contains("openai")
+        || lower.contains("o1")
+        || lower.contains("o3")
+    {
+        return "openai";
+    }
+    if lower.contains("gemini") || lower.contains("google") {
+        return "google";
+    }
+    if lower.contains("grok") {
+        return "xai";
+    }
+
+    "unknown"
+}
+
+/// Get default model name based on provider when model field is missing
+fn get_default_model_from_provider(provider: &str) -> String {
+    match provider.to_lowercase().as_str() {
+        "anthropic" => "claude-unknown".to_string(),
+        "openai" => "gpt-unknown".to_string(),
+        "google" => "gemini-unknown".to_string(),
+        "xai" => "grok-unknown".to_string(),
+        _ => format!("{}-unknown", provider),
+    }
+}
+
+/// Try to extract model name from JSONL file's system-reminder
+/// Looks for pattern: "Model: Claude Opus 4.5 Thinking [Anthropic]"
+fn extract_model_from_jsonl(jsonl_path: &Path) -> Option<String> {
+    let file = std::fs::File::open(jsonl_path).ok()?;
+    let reader = BufReader::new(file);
+
+    // Scan more lines for parity with TypeScript which reads entire file
+    // Cap at 500 lines to avoid performance issues with very large files
+    for line in reader.lines().take(500) {
+        let line = line.ok()?;
+        // Look for Model: pattern in system-reminder
+        if let Some(pos) = line.find("Model:") {
+            let after_model = &line[pos + 6..];
+            // Extract until [ or end of string/newline
+            let model_part: String = after_model
+                .chars()
+                .take_while(|&c| c != '[' && c != '\\' && c != '"')
+                .collect();
+            let model_name = model_part.trim();
+            if !model_name.is_empty() {
+                return Some(normalize_model_name(model_name));
+            }
+        }
+    }
+
+    None
+}
+
+/// Parse a Droid settings.json file
+pub fn parse_droid_file(path: &Path) -> Vec<UnifiedMessage> {
+    let data = match std::fs::read(path) {
+        Ok(d) => d,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut bytes = data;
+    let settings: DroidSettingsJson = match simd_json::from_slice(&mut bytes) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+
+    // Skip if no token usage data
+    let usage = match settings.token_usage {
+        Some(u) => u,
+        None => return Vec::new(),
+    };
+
+    // Calculate total tokens to check if any were used
+    let total_tokens = usage.input_tokens.unwrap_or(0)
+        + usage.output_tokens.unwrap_or(0)
+        + usage.cache_creation_tokens.unwrap_or(0)
+        + usage.cache_read_tokens.unwrap_or(0)
+        + usage.thinking_tokens.unwrap_or(0);
+
+    if total_tokens == 0 {
+        return Vec::new();
+    }
+
+    // Extract session ID from filename (e.g., "uuid.settings.json" -> "uuid")
+    let session_id = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+        .replace(".settings", "");
+
+    // Get model and provider
+    let provider = settings.provider_lock.clone().unwrap_or_else(|| {
+        get_provider_from_model(settings.model.as_deref().unwrap_or("")).to_string()
+    });
+
+    let model = if let Some(m) = settings.model {
+        normalize_model_name(&m)
+    } else {
+        // Try to extract from JSONL file
+        let jsonl_path = path
+            .to_str()
+            .map(|s| s.replace(".settings.json", ".jsonl"))
+            .map(std::path::PathBuf::from);
+
+        if let Some(ref jsonl) = jsonl_path {
+            extract_model_from_jsonl(jsonl)
+                .unwrap_or_else(|| get_default_model_from_provider(&provider))
+        } else {
+            get_default_model_from_provider(&provider)
+        }
+    };
+
+    // Get timestamp from providerLockTimestamp or file mtime
+    let timestamp = settings
+        .provider_lock_timestamp
+        .and_then(|ts| chrono::DateTime::parse_from_rfc3339(&ts).ok())
+        .map(|dt| dt.timestamp_millis())
+        .or_else(|| {
+            std::fs::metadata(path)
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .map(|t| {
+                    t.duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_millis() as i64)
+                        .unwrap_or(0)
+                })
+        })
+        .unwrap_or(0);
+
+    if timestamp == 0 {
+        return Vec::new();
+    }
+
+    vec![UnifiedMessage::new(
+        "droid",
+        model,
+        provider,
+        session_id,
+        timestamp,
+        TokenBreakdown {
+            input: usage.input_tokens.unwrap_or(0).max(0),
+            output: usage.output_tokens.unwrap_or(0).max(0),
+            cache_read: usage.cache_read_tokens.unwrap_or(0).max(0),
+            cache_write: usage.cache_creation_tokens.unwrap_or(0).max(0),
+            reasoning: usage.thinking_tokens.unwrap_or(0).max(0),
+        },
+        0.0,
+    )]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_model_name_custom_prefix() {
+        // TypeScript keeps trailing digits: "claude-opus-4-5-thinking-0"
+        assert_eq!(
+            normalize_model_name("custom:Claude-Opus-4.5-Thinking-[Anthropic]-0"),
+            "claude-opus-4-5-thinking-0"
+        );
+    }
+
+    #[test]
+    fn test_normalize_model_name_simple() {
+        // Dots become hyphens: "gemini-2.5-pro" -> "gemini-2-5-pro"
+        assert_eq!(normalize_model_name("gemini-2.5-pro"), "gemini-2-5-pro");
+    }
+
+    #[test]
+    fn test_normalize_model_name_brackets() {
+        // TypeScript keeps trailing digits: "claude-sonnet-4"
+        assert_eq!(
+            normalize_model_name("Claude-Sonnet-4-[Anthropic]"),
+            "claude-sonnet-4"
+        );
+    }
+
+    #[test]
+    fn test_get_provider_from_model() {
+        assert_eq!(get_provider_from_model("claude-3-sonnet"), "anthropic");
+        assert_eq!(get_provider_from_model("opus-4"), "anthropic");
+        assert_eq!(get_provider_from_model("sonnet-4"), "anthropic");
+        assert_eq!(get_provider_from_model("haiku-3"), "anthropic");
+        assert_eq!(get_provider_from_model("gpt-4o"), "openai");
+        assert_eq!(get_provider_from_model("o1-preview"), "openai");
+        assert_eq!(get_provider_from_model("o3-mini"), "openai");
+        assert_eq!(get_provider_from_model("gemini-pro"), "google");
+        assert_eq!(get_provider_from_model("grok-2"), "xai");
+        assert_eq!(get_provider_from_model("unknown-model"), "unknown");
+    }
+
+    #[test]
+    fn test_get_default_model_from_provider() {
+        assert_eq!(
+            get_default_model_from_provider("anthropic"),
+            "claude-unknown"
+        );
+        assert_eq!(get_default_model_from_provider("openai"), "gpt-unknown");
+        assert_eq!(get_default_model_from_provider("google"), "gemini-unknown");
+        assert_eq!(get_default_model_from_provider("xai"), "grok-unknown");
+        assert_eq!(get_default_model_from_provider("custom"), "custom-unknown");
+    }
+
+    #[test]
+    fn test_parse_droid_settings_structure() {
+        let json = r#"{
+            "model": "custom:Claude-Opus-4.5-Thinking-[Anthropic]-0",
+            "providerLock": "anthropic",
+            "providerLockTimestamp": "2024-12-26T12:00:00Z",
+            "tokenUsage": {
+                "inputTokens": 1234,
+                "outputTokens": 567,
+                "cacheCreationTokens": 89,
+                "cacheReadTokens": 12,
+                "thinkingTokens": 34
+            }
+        }"#;
+
+        let mut bytes = json.as_bytes().to_vec();
+        let settings: DroidSettingsJson = simd_json::from_slice(&mut bytes).unwrap();
+
+        assert_eq!(
+            settings.model,
+            Some("custom:Claude-Opus-4.5-Thinking-[Anthropic]-0".to_string())
+        );
+        assert_eq!(settings.provider_lock, Some("anthropic".to_string()));
+
+        let usage = settings.token_usage.unwrap();
+        assert_eq!(usage.input_tokens, Some(1234));
+        assert_eq!(usage.output_tokens, Some(567));
+        assert_eq!(usage.cache_creation_tokens, Some(89));
+        assert_eq!(usage.cache_read_tokens, Some(12));
+        assert_eq!(usage.thinking_tokens, Some(34));
+    }
+}

--- a/vendor/tokscale-core/src/sessions/gemini.rs
+++ b/vendor/tokscale-core/src/sessions/gemini.rs
@@ -1,0 +1,561 @@
+//! Gemini CLI session parser
+//!
+//! Parses JSON session files from ~/.gemini/tmp/* supporting both legacy
+//! `session-*.json` files and new UUID-named files in `chats/` directories.
+
+use super::utils::{
+    extract_i64, extract_string, file_modified_timestamp_ms, parse_timestamp_value,
+};
+use super::UnifiedMessage;
+use crate::TokenBreakdown;
+use serde::Deserialize;
+use serde_json::Value;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+/// Gemini session structure
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct GeminiSession {
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    #[serde(rename = "projectHash")]
+    pub project_hash: String,
+    #[serde(rename = "startTime")]
+    pub start_time: String,
+    #[serde(rename = "lastUpdated")]
+    pub last_updated: String,
+    pub messages: Vec<GeminiMessage>,
+}
+
+/// Gemini message structure
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct GeminiMessage {
+    pub id: String,
+    pub timestamp: Option<String>,
+    #[serde(rename = "type")]
+    pub message_type: String,
+    pub tokens: Option<GeminiTokens>,
+    pub model: Option<String>,
+}
+
+/// Gemini token structure
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct GeminiTokens {
+    pub input: Option<i64>,
+    pub output: Option<i64>,
+    pub cached: Option<i64>,
+    pub thoughts: Option<i64>,
+    pub tool: Option<i64>,
+    pub total: Option<i64>,
+}
+
+/// Parse a Gemini session file
+pub fn parse_gemini_file(path: &Path) -> Vec<UnifiedMessage> {
+    let fallback_timestamp = file_modified_timestamp_ms(path);
+
+    if path.extension().and_then(|s| s.to_str()) == Some("jsonl") {
+        return parse_gemini_headless_jsonl(path, fallback_timestamp);
+    }
+
+    // Filter to expected Gemini layouts only:
+    // - Legacy: files starting with "session-"
+    // - Modern: path structure .../.gemini/tmp/<some_id>/chats/<file>.json
+    let file_name_os = path.file_name().unwrap_or_default();
+
+    // Fast path: legacy files are always accepted
+    if !file_name_os
+        .to_str()
+        .map(|s| s.starts_with("session-"))
+        .unwrap_or(false)
+    {
+        use std::ffi::OsStr;
+        // All scanned paths live under ~/.gemini/tmp (scanner root). Enforce the expected subdirectory pattern.
+        let comps: Vec<&OsStr> = path.components().map(|c| c.as_os_str()).collect();
+        let mut ok = false;
+        // Look for ".gemini" immediately followed by "tmp" to avoid matching /tmp paths.
+        'outer: for i in 0..comps.len().saturating_sub(2) {
+            if comps[i] == ".gemini" && comps[i + 1] == "tmp" {
+                // After "tmp", expect exactly 3 components: <some_id>, "chats", and the filename.
+                let after_tmp = &comps[i + 2..];
+                if after_tmp.len() == 3 {
+                    let chats_dir = after_tmp[1];
+                    let last = after_tmp[2];
+                    if chats_dir == OsStr::new("chats") && last == file_name_os {
+                        ok = true;
+                        break 'outer;
+                    }
+                }
+            }
+        }
+        if !ok {
+            return Vec::new();
+        }
+    }
+
+    let data = match std::fs::read(path) {
+        Ok(d) => d,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut bytes = data.clone();
+    if let Ok(session) = simd_json::from_slice::<GeminiSession>(&mut bytes) {
+        return parse_gemini_session(session, fallback_timestamp);
+    }
+
+    let mut bytes = data;
+    if let Ok(value) = simd_json::from_slice::<Value>(&mut bytes) {
+        let session_id = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+        let messages = parse_gemini_headless_value(&value, &session_id, fallback_timestamp);
+        if !messages.is_empty() {
+            return messages;
+        }
+    }
+
+    parse_gemini_headless_jsonl(path, fallback_timestamp)
+}
+
+fn parse_gemini_session(session: GeminiSession, fallback_timestamp: i64) -> Vec<UnifiedMessage> {
+    let mut messages = Vec::with_capacity(session.messages.len());
+    let session_id = session.session_id.clone();
+
+    for msg in session.messages {
+        // Only process gemini messages with token data
+        if msg.message_type != "gemini" {
+            continue;
+        }
+
+        let tokens = match msg.tokens {
+            Some(t) => t,
+            None => continue,
+        };
+
+        let model = match msg.model {
+            Some(m) => m,
+            None => continue,
+        };
+
+        let timestamp = msg
+            .timestamp
+            .and_then(|ts| chrono::DateTime::parse_from_rfc3339(&ts).ok())
+            .map(|dt| dt.timestamp_millis())
+            .unwrap_or(fallback_timestamp);
+
+        messages.push(UnifiedMessage::new(
+            "gemini",
+            model,
+            "google",
+            session_id.clone(),
+            timestamp,
+            TokenBreakdown {
+                input: tokens.input.unwrap_or(0).max(0),
+                output: tokens.output.unwrap_or(0).max(0),
+                cache_read: tokens.cached.unwrap_or(0).max(0),
+                cache_write: 0,
+                reasoning: tokens.thoughts.unwrap_or(0).max(0),
+            },
+            0.0,
+        ));
+    }
+
+    messages
+}
+
+fn parse_gemini_headless_jsonl(path: &Path, fallback_timestamp: i64) -> Vec<UnifiedMessage> {
+    let file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut session_id = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let mut current_model: Option<String> = None;
+    let reader = BufReader::new(file);
+    let mut messages = Vec::with_capacity(64);
+    let mut buffer = Vec::with_capacity(4096);
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        buffer.clear();
+        buffer.extend_from_slice(trimmed.as_bytes());
+        let value: Value = match simd_json::from_slice(&mut buffer) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        let event_type = value.get("type").and_then(|val| val.as_str()).unwrap_or("");
+        if event_type == "init" {
+            if let Some(model) = extract_string(value.get("model")) {
+                current_model = Some(model);
+            }
+            if let Some(id) =
+                extract_string(value.get("session_id").or_else(|| value.get("sessionId")))
+            {
+                session_id = id;
+            }
+            continue;
+        }
+
+        let stats = value
+            .get("stats")
+            .or_else(|| value.get("result").and_then(|result| result.get("stats")));
+        if let Some(stats) = stats {
+            let timestamp = extract_timestamp_from_value(&value).unwrap_or(fallback_timestamp);
+            messages.extend(build_messages_from_stats(
+                stats,
+                current_model.clone(),
+                &session_id,
+                timestamp,
+            ));
+        }
+    }
+
+    messages
+}
+
+fn parse_gemini_headless_value(
+    value: &Value,
+    session_id: &str,
+    fallback_timestamp: i64,
+) -> Vec<UnifiedMessage> {
+    let stats = match value
+        .get("stats")
+        .or_else(|| value.get("result").and_then(|result| result.get("stats")))
+    {
+        Some(s) => s,
+        None => return Vec::new(),
+    };
+
+    let model_hint = extract_string(value.get("model"));
+    let timestamp = extract_timestamp_from_value(value).unwrap_or(fallback_timestamp);
+
+    build_messages_from_stats(stats, model_hint, session_id, timestamp)
+}
+
+fn build_messages_from_stats(
+    stats: &Value,
+    model_hint: Option<String>,
+    session_id: &str,
+    timestamp: i64,
+) -> Vec<UnifiedMessage> {
+    let usages = extract_gemini_usages(stats, model_hint);
+    usages
+        .into_iter()
+        .map(|usage| {
+            UnifiedMessage::new(
+                "gemini",
+                usage.model,
+                "google",
+                session_id.to_string(),
+                timestamp,
+                TokenBreakdown {
+                    input: usage.input.max(0),
+                    output: usage.output.max(0),
+                    cache_read: usage.cached.max(0),
+                    cache_write: 0,
+                    reasoning: usage.reasoning.max(0),
+                },
+                0.0,
+            )
+        })
+        .collect()
+}
+
+struct GeminiHeadlessUsage {
+    model: String,
+    input: i64,
+    output: i64,
+    cached: i64,
+    reasoning: i64,
+}
+
+fn extract_gemini_usages(stats: &Value, model_hint: Option<String>) -> Vec<GeminiHeadlessUsage> {
+    if let Some(models) = stats.get("models").and_then(|val| val.as_object()) {
+        let mut usages = Vec::new();
+        for (model, data) in models {
+            let tokens = match data.get("tokens") {
+                Some(t) => t,
+                None => continue,
+            };
+            let input = extract_i64(tokens.get("prompt"))
+                .or_else(|| extract_i64(tokens.get("input")))
+                .or_else(|| extract_i64(tokens.get("input_tokens")))
+                .unwrap_or(0);
+            let output = extract_i64(tokens.get("candidates"))
+                .or_else(|| extract_i64(tokens.get("output")))
+                .or_else(|| extract_i64(tokens.get("output_tokens")))
+                .unwrap_or(0);
+            let cached = extract_i64(tokens.get("cached"))
+                .or_else(|| extract_i64(tokens.get("cached_tokens")))
+                .unwrap_or(0);
+            let reasoning = extract_i64(tokens.get("thoughts"))
+                .or_else(|| extract_i64(tokens.get("reasoning")))
+                .unwrap_or(0);
+
+            if input == 0 && output == 0 && cached == 0 && reasoning == 0 {
+                continue;
+            }
+
+            usages.push(GeminiHeadlessUsage {
+                model: model.clone(),
+                input,
+                output,
+                cached,
+                reasoning,
+            });
+        }
+
+        if !usages.is_empty() {
+            return usages;
+        }
+    }
+
+    let input = extract_i64(stats.get("input_tokens"))
+        .or_else(|| extract_i64(stats.get("prompt_tokens")))
+        .unwrap_or(0);
+    let output = extract_i64(stats.get("output_tokens"))
+        .or_else(|| extract_i64(stats.get("candidates_tokens")))
+        .unwrap_or(0);
+    let cached = extract_i64(stats.get("cached_tokens")).unwrap_or(0);
+    let reasoning = extract_i64(stats.get("thoughts_tokens"))
+        .or_else(|| extract_i64(stats.get("reasoning_tokens")))
+        .unwrap_or(0);
+
+    if input == 0 && output == 0 && cached == 0 && reasoning == 0 {
+        return Vec::new();
+    }
+
+    vec![GeminiHeadlessUsage {
+        model: model_hint.unwrap_or_else(|| "unknown".to_string()),
+        input,
+        output,
+        cached,
+        reasoning,
+    }]
+}
+
+fn extract_timestamp_from_value(value: &Value) -> Option<i64> {
+    value
+        .get("timestamp")
+        .or_else(|| value.get("created_at"))
+        .and_then(parse_timestamp_value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_parse_gemini_structure() {
+        let json = r#"{
+            "sessionId": "ses_123",
+            "projectHash": "abc123",
+            "startTime": "2025-06-15T12:00:00Z",
+            "lastUpdated": "2025-06-15T12:30:00Z",
+            "messages": [
+                {
+                    "id": "msg_1",
+                    "timestamp": "2025-06-15T12:00:00Z",
+                    "type": "user"
+                },
+                {
+                    "id": "msg_2",
+                    "timestamp": "2025-06-15T12:01:00Z",
+                    "type": "gemini",
+                    "model": "gemini-2.0-flash",
+                    "tokens": {
+                        "input": 10,
+                        "output": 20,
+                        "cached": 5,
+                        "thoughts": 0,
+                        "tool": 0,
+                        "total": 35
+                    }
+                }
+            ]
+        }"#;
+
+        let mut bytes = json.as_bytes().to_vec();
+        let session: GeminiSession = simd_json::from_slice(&mut bytes).unwrap();
+
+        assert_eq!(session.messages.len(), 2);
+        assert_eq!(
+            session.messages[1].model,
+            Some("gemini-2.0-flash".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_gemini_with_array_content() {
+        let json = r#"{
+            "sessionId": "ses_123",
+            "projectHash": "abc123",
+            "startTime": "2025-06-15T12:00:00Z",
+            "lastUpdated": "2025-06-15T12:30:00Z",
+            "messages": [
+                {
+                    "id": "msg_1",
+                    "timestamp": "2025-06-15T12:00:00Z",
+                    "type": "user",
+                    "content": [{"text": "Hello"}]
+                },
+                {
+                    "id": "msg_2",
+                    "timestamp": "2025-06-15T12:01:00Z",
+                    "type": "gemini",
+                    "content": "Hi there!",
+                    "model": "gemini-2.0-flash",
+                    "tokens": {
+                        "input": 10,
+                        "output": 20
+                    }
+                }
+            ]
+        }"#;
+
+        // Create a path that matches the legacy prefix so it passes the 'is_in_chats' filter
+        let file = tempfile::Builder::new()
+            .prefix("session-")
+            .suffix(".json")
+            .tempfile()
+            .unwrap();
+        std::fs::write(file.path(), json).unwrap();
+
+        let messages = parse_gemini_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gemini-2.0-flash");
+        assert_eq!(messages[0].tokens.input, 10);
+        assert_eq!(messages[0].tokens.output, 20);
+    }
+
+    #[test]
+    fn test_parse_headless_json() {
+        let json = r#"{"response":"Hi","stats":{"models":{"gemini-2.5-pro":{"tokens":{"prompt":12,"candidates":34,"cached":5,"thoughts":2}}}}}"#;
+        // Use a legacy prefix to satisfy the path check
+        let file = tempfile::Builder::new()
+            .prefix("session-")
+            .suffix(".json")
+            .tempfile()
+            .unwrap();
+        std::fs::write(file.path(), json).unwrap();
+
+        let messages = parse_gemini_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gemini-2.5-pro");
+        assert_eq!(messages[0].tokens.input, 12);
+        assert_eq!(messages[0].tokens.output, 34);
+        assert_eq!(messages[0].tokens.cache_read, 5);
+        assert_eq!(messages[0].tokens.reasoning, 2);
+    }
+
+    #[test]
+    fn test_parse_headless_stream_jsonl() {
+        let content = r#"{"type":"init","model":"gemini-2.5-pro","session_id":"session-1"}
+{"type":"result","stats":{"input_tokens":10,"output_tokens":20}}"#;
+        let mut file = tempfile::Builder::new()
+            .suffix(".jsonl")
+            .tempfile()
+            .unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_gemini_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gemini-2.5-pro");
+        assert_eq!(messages[0].tokens.input, 10);
+        assert_eq!(messages[0].tokens.output, 20);
+    }
+
+    #[test]
+    fn test_parse_gemini_valid_uuid_path() {
+        let json = r#"{
+            "sessionId": "ses_123",
+            "projectHash": "abc123",
+            "startTime": "2025-06-15T12:00:00Z",
+            "lastUpdated": "2025-06-15T12:30:00Z",
+            "messages": [
+                {
+                    "id": "msg_2",
+                    "timestamp": "2025-06-15T12:01:00Z",
+                    "type": "gemini",
+                    "model": "gemini-2.0-flash",
+                    "tokens": {
+                        "input": 10,
+                        "output": 20
+                    }
+                }
+            ]
+        }"#;
+
+        let dir = TempDir::new().unwrap();
+        let base = dir.path();
+        let chats_dir = base.join(".gemini/tmp/abc123/chats");
+        std::fs::create_dir_all(&chats_dir).unwrap();
+        let file_path = chats_dir.join("uuid-file.json");
+        std::fs::write(&file_path, json).unwrap();
+
+        let messages = parse_gemini_file(&file_path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gemini-2.0-flash");
+        assert_eq!(messages[0].tokens.input, 10);
+        assert_eq!(messages[0].tokens.output, 20);
+    }
+
+    #[test]
+    fn test_parse_gemini_reject_nested_chats() {
+        let json = r#"{
+            "sessionId": "ses_123",
+            "projectHash": "abc123",
+            "startTime": "2025-06-15T12:00:00Z",
+            "lastUpdated": "2025-06-15T12:30:00Z",
+            "messages": [
+                {
+                    "id": "msg_2",
+                    "timestamp": "2025-06-15T12:01:00Z",
+                    "type": "gemini",
+                    "content": [{"text": "test"}],
+                    "model": "gemini-2.0-flash",
+                    "tokens": {
+                        "input": 10,
+                        "output": 20
+                    }
+                }
+            ]
+        }"#;
+
+        let dir = TempDir::new().unwrap();
+        let base = dir.path();
+        let nested_dir = base.join(".gemini/tmp/abc123/backup/chats");
+        std::fs::create_dir_all(&nested_dir).unwrap();
+        let file_path = nested_dir.join("nested.json");
+        std::fs::write(&file_path, json).unwrap();
+
+        let messages = parse_gemini_file(&file_path);
+
+        assert_eq!(messages.len(), 0);
+    }
+}

--- a/vendor/tokscale-core/src/sessions/kilocode.rs
+++ b/vendor/tokscale-core/src/sessions/kilocode.rs
@@ -1,0 +1,82 @@
+//! KiloCode task parser
+//!
+//! Shares the same task-log format as Roo Code and reuses the same parser helper.
+
+use super::roocode::parse_roo_kilo_file;
+use super::UnifiedMessage;
+use std::path::Path;
+
+pub fn parse_kilocode_file(path: &Path) -> Vec<UnifiedMessage> {
+    parse_roo_kilo_file(path, "kilocode")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_parse_kilocode_valid_api_req_started() {
+        let dir = TempDir::new().unwrap();
+        let task_dir = dir.path().join("tasks").join("kilo-task-1");
+        fs::create_dir_all(&task_dir).unwrap();
+        fs::write(
+            task_dir.join("ui_messages.json"),
+            r#"[
+  {
+    "type": "say",
+    "say": "api_req_started",
+    "ts": "2026-02-18T12:00:00Z",
+    "text": "{\"cost\":0.05,\"tokensIn\":40,\"tokensOut\":15,\"cacheReads\":7,\"cacheWrites\":3,\"apiProtocol\":\"openai\"}"
+  }
+]"#,
+        )
+        .unwrap();
+        fs::write(
+            task_dir.join("api_conversation_history.json"),
+            r#"
+<environment_details>
+<model>gpt-5</model>
+<name>KiloAgent</name>
+</environment_details>
+"#,
+        )
+        .unwrap();
+
+        let messages = parse_kilocode_file(&task_dir.join("ui_messages.json"));
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, "kilocode");
+        assert_eq!(messages[0].provider_id, "openai");
+        assert_eq!(messages[0].model_id, "gpt-5");
+        assert_eq!(messages[0].session_id, "kilo-task-1");
+        assert_eq!(messages[0].agent.as_deref(), Some("KiloAgent"));
+        assert_eq!(messages[0].tokens.input, 40);
+        assert_eq!(messages[0].tokens.output, 15);
+        assert_eq!(messages[0].tokens.cache_read, 7);
+        assert_eq!(messages[0].tokens.cache_write, 3);
+        assert_eq!(messages[0].cost, 0.05);
+    }
+
+    #[test]
+    fn test_parse_kilocode_ignores_non_api_req_started_events() {
+        let dir = TempDir::new().unwrap();
+        let task_dir = dir.path().join("tasks").join("kilo-task-2");
+        fs::create_dir_all(&task_dir).unwrap();
+        fs::write(
+            task_dir.join("ui_messages.json"),
+            r#"[
+  {
+    "type": "say",
+    "say": "assistant_message",
+    "ts": "2026-02-18T12:00:00Z",
+    "text": "{\"cost\":0.2,\"tokensIn\":10,\"tokensOut\":1,\"cacheReads\":0,\"cacheWrites\":0,\"apiProtocol\":\"openai\"}"
+  }
+]"#,
+        )
+        .unwrap();
+
+        let messages = parse_kilocode_file(&task_dir.join("ui_messages.json"));
+        assert!(messages.is_empty());
+    }
+}

--- a/vendor/tokscale-core/src/sessions/kimi.rs
+++ b/vendor/tokscale-core/src/sessions/kimi.rs
@@ -1,0 +1,317 @@
+//! Kimi CLI session parser
+//!
+//! Parses wire.jsonl files from ~/.kimi/sessions/[GROUP_ID]/[SESSION_UUID]/wire.jsonl
+//! Token data comes from StatusUpdate messages in the wire protocol.
+
+use super::utils::file_modified_timestamp_ms;
+use super::UnifiedMessage;
+use crate::TokenBreakdown;
+use serde::Deserialize;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+/// Top-level wire.jsonl line: either metadata or a timestamped message
+#[derive(Debug, Deserialize)]
+struct WireLine {
+    timestamp: Option<f64>,
+    message: Option<WireMessage>,
+    #[serde(rename = "type")]
+    line_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WireMessage {
+    #[serde(rename = "type")]
+    msg_type: String,
+    payload: Option<StatusPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StatusPayload {
+    token_usage: Option<TokenUsage>,
+    #[allow(dead_code)]
+    message_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenUsage {
+    input_other: Option<i64>,
+    output: Option<i64>,
+    input_cache_read: Option<i64>,
+    input_cache_creation: Option<i64>,
+}
+
+/// Default model name when config.json is not available
+const DEFAULT_MODEL: &str = "kimi-for-coding";
+const DEFAULT_PROVIDER: &str = "moonshot";
+
+/// Read model name from ~/.kimi/config.json if available
+fn read_model_from_config(wire_path: &Path) -> String {
+    // Navigate from wire.jsonl up to ~/.kimi/config.json
+    // wire.jsonl is at ~/.kimi/sessions/GROUP/UUID/wire.jsonl
+    if let Some(sessions_dir) = wire_path
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+    {
+        if let Some(kimi_dir) = sessions_dir.parent() {
+            let config_path = kimi_dir.join("config.json");
+            if let Ok(content) = std::fs::read_to_string(&config_path) {
+                if let Ok(bytes) = serde_json::from_str::<serde_json::Value>(&content) {
+                    if let Some(model) = bytes.get("model").and_then(|v| v.as_str()) {
+                        if !model.is_empty() {
+                            return model.to_string();
+                        }
+                    }
+                }
+            }
+        }
+    }
+    DEFAULT_MODEL.to_string()
+}
+
+/// Extract session ID from the wire.jsonl path
+/// Path format: ~/.kimi/sessions/GROUP_ID/SESSION_UUID/wire.jsonl
+fn extract_session_id(path: &Path) -> String {
+    path.parent()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+/// Parse a Kimi CLI wire.jsonl file
+pub fn parse_kimi_file(path: &Path) -> Vec<UnifiedMessage> {
+    let file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return Vec::new(),
+    };
+
+    let model = read_model_from_config(path);
+    let session_id = extract_session_id(path);
+
+    let reader = BufReader::new(file);
+    let mut messages: Vec<UnifiedMessage> = Vec::new();
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let mut bytes = trimmed.as_bytes().to_vec();
+        let wire_line = match simd_json::from_slice::<WireLine>(&mut bytes) {
+            Ok(wl) => wl,
+            Err(_) => continue,
+        };
+
+        // Skip metadata lines (first line: {"type": "metadata", ...})
+        if wire_line.line_type.as_deref() == Some("metadata") {
+            continue;
+        }
+
+        let message = match wire_line.message {
+            Some(m) => m,
+            None => continue,
+        };
+
+        // Only process StatusUpdate messages
+        if message.msg_type != "StatusUpdate" {
+            continue;
+        }
+
+        let payload = match message.payload {
+            Some(p) => p,
+            None => continue,
+        };
+
+        let token_usage = match payload.token_usage {
+            Some(u) => u,
+            None => continue,
+        };
+
+        // Convert Unix seconds (float) to milliseconds, fallback to file mtime
+        let timestamp_ms = wire_line
+            .timestamp
+            .map(|ts| (ts * 1000.0) as i64)
+            .unwrap_or_else(|| file_modified_timestamp_ms(path));
+
+        let input = token_usage.input_other.unwrap_or(0).max(0);
+        let output = token_usage.output.unwrap_or(0).max(0);
+        let cache_read = token_usage.input_cache_read.unwrap_or(0).max(0);
+        let cache_write = token_usage.input_cache_creation.unwrap_or(0).max(0);
+
+        // Skip entries with zero tokens
+        if input + output + cache_read + cache_write == 0 {
+            continue;
+        }
+
+        let dedup_key = payload.message_id;
+
+        messages.push(UnifiedMessage::new_with_dedup(
+            "kimi",
+            model.clone(),
+            DEFAULT_PROVIDER,
+            session_id.clone(),
+            timestamp_ms,
+            TokenBreakdown {
+                input,
+                output,
+                cache_read,
+                cache_write,
+                // Kimi wire protocol does not expose reasoning tokens; all reasoning included in output
+                reasoning: 0,
+            },
+            0.0,
+            dedup_key,
+        ));
+    }
+
+    messages
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn create_test_file(content: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file.flush().unwrap();
+        file
+    }
+
+    #[test]
+    fn test_parse_kimi_valid_status_update() {
+        let content = r#"{"type": "metadata", "protocol_version": "1.3"}
+{"timestamp": 1770983426.420942, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 1562, "output": 2463, "input_cache_read": 0, "input_cache_creation": 0}, "message_id": "chatcmpl-xxx"}}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_kimi_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, "kimi");
+        assert_eq!(messages[0].model_id, "kimi-for-coding");
+        assert_eq!(messages[0].provider_id, "moonshot");
+        assert_eq!(messages[0].tokens.input, 1562);
+        assert_eq!(messages[0].tokens.output, 2463);
+        assert_eq!(messages[0].tokens.cache_read, 0);
+        assert_eq!(messages[0].tokens.cache_write, 0);
+        // Timestamp: 1770983426.420942 * 1000 = 1770983426420
+        assert_eq!(messages[0].timestamp, 1770983426420);
+    }
+
+    #[test]
+    fn test_parse_kimi_multi_turn() {
+        let content = r#"{"type": "metadata", "protocol_version": "1.3"}
+{"timestamp": 1770983400.0, "message": {"type": "TurnBegin", "payload": {"user_input": "hello"}}}
+{"timestamp": 1770983410.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 100, "output": 200, "input_cache_read": 0, "input_cache_creation": 0}, "message_id": "msg-1"}}}
+{"timestamp": 1770983420.0, "message": {"type": "TurnBegin", "payload": {"user_input": "world"}}}
+{"timestamp": 1770983430.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 300, "output": 400, "input_cache_read": 50, "input_cache_creation": 0}, "message_id": "msg-2"}}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_kimi_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].tokens.input, 100);
+        assert_eq!(messages[0].tokens.output, 200);
+        assert_eq!(messages[1].tokens.input, 300);
+        assert_eq!(messages[1].tokens.output, 400);
+        assert_eq!(messages[1].tokens.cache_read, 50);
+    }
+
+    #[test]
+    fn test_parse_kimi_skip_non_status_update() {
+        let content = r#"{"type": "metadata", "protocol_version": "1.3"}
+{"timestamp": 1770983400.0, "message": {"type": "TurnBegin", "payload": {"user_input": "hello"}}}
+{"timestamp": 1770983410.0, "message": {"type": "ContentPart", "payload": {"type": "text", "text": "response"}}}
+{"timestamp": 1770983420.0, "message": {"type": "ToolCall", "payload": {"type": "function", "id": "tool_1", "function": {"name": "ReadFile", "arguments": "{}"}}}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_kimi_file(file.path());
+
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_parse_kimi_empty_file() {
+        let file = create_test_file("");
+
+        let messages = parse_kimi_file(file.path());
+
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_parse_kimi_tool_call_multi_step() {
+        // Simulates a tool-call scenario with multiple StatusUpdate messages in one turn
+        let content = r#"{"type": "metadata", "protocol_version": "1.3"}
+{"timestamp": 1770983400.0, "message": {"type": "TurnBegin", "payload": {"user_input": "read file"}}}
+{"timestamp": 1770983405.0, "message": {"type": "StepBegin", "payload": {"n": 1}}}
+{"timestamp": 1770983410.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 500, "output": 100, "input_cache_read": 200, "input_cache_creation": 0}, "message_id": "msg-step1"}}}
+{"timestamp": 1770983415.0, "message": {"type": "ToolCall", "payload": {"type": "function", "id": "tool_1", "function": {"name": "ReadFile", "arguments": "{}"}}}}
+{"timestamp": 1770983420.0, "message": {"type": "StepBegin", "payload": {"n": 2}}}
+{"timestamp": 1770983425.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 800, "output": 300, "input_cache_read": 400, "input_cache_creation": 100}, "message_id": "msg-step2"}}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_kimi_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        // Step 1
+        assert_eq!(messages[0].tokens.input, 500);
+        assert_eq!(messages[0].tokens.output, 100);
+        assert_eq!(messages[0].tokens.cache_read, 200);
+        assert_eq!(messages[0].tokens.cache_write, 0);
+        // Step 2
+        assert_eq!(messages[1].tokens.input, 800);
+        assert_eq!(messages[1].tokens.output, 300);
+        assert_eq!(messages[1].tokens.cache_read, 400);
+        assert_eq!(messages[1].tokens.cache_write, 100);
+    }
+
+    #[test]
+    fn test_parse_kimi_with_cache_tokens() {
+        let content = r#"{"type": "metadata", "protocol_version": "1.3"}
+{"timestamp": 1771123711.615454, "message": {"type": "StatusUpdate", "payload": {"context_usage": 0.024, "token_usage": {"input_other": 1508, "output": 205, "input_cache_read": 4864, "input_cache_creation": 0}, "message_id": "chatcmpl-2tNw2mhUNfdPMP0Jyie7gDhD"}}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_kimi_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 1508);
+        assert_eq!(messages[0].tokens.output, 205);
+        assert_eq!(messages[0].tokens.cache_read, 4864);
+        assert_eq!(messages[0].tokens.cache_write, 0);
+    }
+
+    #[test]
+    fn test_parse_kimi_skips_zero_token_entries() {
+        let content = r#"{"type": "metadata", "protocol_version": "1.3"}
+{"timestamp": 1770983410.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 0, "output": 0, "input_cache_read": 0, "input_cache_creation": 0}, "message_id": "msg-empty"}}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_kimi_file(file.path());
+
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_parse_kimi_malformed_lines() {
+        let content = r#"{"type": "metadata", "protocol_version": "1.3"}
+not valid json at all
+{"timestamp": 1770983410.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 100, "output": 200, "input_cache_read": 0, "input_cache_creation": 0}, "message_id": "msg-1"}}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_kimi_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 100);
+    }
+}

--- a/vendor/tokscale-core/src/sessions/mod.rs
+++ b/vendor/tokscale-core/src/sessions/mod.rs
@@ -1,0 +1,240 @@
+//! Session parsers for different AI coding assistant formats
+//!
+//! Each client has its own parser that converts to a unified message format.
+
+pub mod amp;
+pub mod claudecode;
+pub mod codex;
+pub mod cursor;
+pub mod droid;
+pub mod gemini;
+pub mod kilocode;
+pub mod kimi;
+pub mod mux;
+pub mod openclaw;
+pub mod opencode;
+pub mod pi;
+pub mod qwen;
+pub mod roocode;
+pub mod synthetic;
+pub(crate) mod utils;
+
+use crate::TokenBreakdown;
+
+#[derive(Debug, Clone)]
+pub struct UnifiedMessage {
+    pub client: String,
+    pub model_id: String,
+    pub provider_id: String,
+    pub session_id: String,
+    pub timestamp: i64,
+    pub date: String,
+    pub tokens: TokenBreakdown,
+    pub cost: f64,
+    pub agent: Option<String>,
+    pub dedup_key: Option<String>,
+}
+
+pub fn normalize_agent_name(agent: &str) -> String {
+    let agent_lower = agent.to_lowercase();
+
+    if agent_lower.contains("plan") {
+        if agent_lower.contains("omo") || agent_lower.contains("sisyphus") {
+            return "Planner-Sisyphus".to_string();
+        }
+        return agent.to_string();
+    }
+
+    if agent_lower == "omo" || agent_lower == "sisyphus" {
+        return "Sisyphus".to_string();
+    }
+
+    agent.to_string()
+}
+
+impl UnifiedMessage {
+    pub fn new(
+        client: impl Into<String>,
+        model_id: impl Into<String>,
+        provider_id: impl Into<String>,
+        session_id: impl Into<String>,
+        timestamp: i64,
+        tokens: TokenBreakdown,
+        cost: f64,
+    ) -> Self {
+        Self::new_full(
+            client,
+            model_id,
+            provider_id,
+            session_id,
+            timestamp,
+            tokens,
+            cost,
+            None,
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_agent(
+        client: impl Into<String>,
+        model_id: impl Into<String>,
+        provider_id: impl Into<String>,
+        session_id: impl Into<String>,
+        timestamp: i64,
+        tokens: TokenBreakdown,
+        cost: f64,
+        agent: Option<String>,
+    ) -> Self {
+        Self::new_full(
+            client,
+            model_id,
+            provider_id,
+            session_id,
+            timestamp,
+            tokens,
+            cost,
+            agent,
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_dedup(
+        client: impl Into<String>,
+        model_id: impl Into<String>,
+        provider_id: impl Into<String>,
+        session_id: impl Into<String>,
+        timestamp: i64,
+        tokens: TokenBreakdown,
+        cost: f64,
+        dedup_key: Option<String>,
+    ) -> Self {
+        Self::new_full(
+            client,
+            model_id,
+            provider_id,
+            session_id,
+            timestamp,
+            tokens,
+            cost,
+            None,
+            dedup_key,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_full(
+        client: impl Into<String>,
+        model_id: impl Into<String>,
+        provider_id: impl Into<String>,
+        session_id: impl Into<String>,
+        timestamp: i64,
+        tokens: TokenBreakdown,
+        cost: f64,
+        agent: Option<String>,
+        dedup_key: Option<String>,
+    ) -> Self {
+        let date = timestamp_to_date(timestamp);
+        Self {
+            client: client.into(),
+            model_id: model_id.into(),
+            provider_id: provider_id.into(),
+            session_id: session_id.into(),
+            timestamp,
+            date,
+            tokens,
+            cost,
+            agent,
+            dedup_key,
+        }
+    }
+}
+
+/// Convert Unix milliseconds to a local YYYY-MM-DD date string.
+fn timestamp_to_date(timestamp_ms: i64) -> String {
+    timestamp_to_date_with_timezone(timestamp_ms, &chrono::Local)
+}
+
+fn timestamp_to_date_with_timezone<Tz>(timestamp_ms: i64, timezone: &Tz) -> String
+where
+    Tz: chrono::TimeZone,
+    Tz::Offset: std::fmt::Display,
+{
+    match timezone.timestamp_millis_opt(timestamp_ms) {
+        chrono::LocalResult::Single(dt) => dt.format("%Y-%m-%d").to_string(),
+        _ => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::FixedOffset;
+
+    #[test]
+    fn test_timestamp_to_date_with_positive_offset() {
+        let kst = FixedOffset::east_opt(9 * 60 * 60).unwrap();
+        let ts = 1772512200000_i64; // 2026-03-03T04:30:00Z
+        let date = timestamp_to_date_with_timezone(ts, &kst);
+        assert_eq!(date, "2026-03-03");
+    }
+
+    #[test]
+    fn test_timestamp_to_date_with_negative_offset() {
+        let pst = FixedOffset::west_opt(8 * 60 * 60).unwrap();
+        let ts = 1772512200000_i64; // 2026-03-03T04:30:00Z
+        let date = timestamp_to_date_with_timezone(ts, &pst);
+        assert_eq!(date, "2026-03-02");
+    }
+
+    #[test]
+    fn test_timestamp_to_date_invalid_timestamp() {
+        let utc = FixedOffset::east_opt(0).unwrap();
+        let date = timestamp_to_date_with_timezone(i64::MAX, &utc);
+        assert_eq!(date, "");
+    }
+
+    #[test]
+    fn test_unified_message_creation() {
+        let tokens = TokenBreakdown {
+            input: 100,
+            output: 50,
+            cache_read: 0,
+            cache_write: 0,
+            reasoning: 0,
+        };
+
+        let msg = UnifiedMessage::new(
+            "opencode",
+            "claude-3-5-sonnet",
+            "anthropic",
+            "test-session-id",
+            1733011200000,
+            tokens,
+            0.05,
+        );
+
+        assert_eq!(msg.client, "opencode");
+        assert_eq!(msg.model_id, "claude-3-5-sonnet");
+        assert_eq!(msg.session_id, "test-session-id");
+        assert_eq!(msg.date, timestamp_to_date(1733011200000));
+        assert_eq!(msg.cost, 0.05);
+        assert_eq!(msg.agent, None);
+    }
+
+    #[test]
+    fn test_normalize_agent_name() {
+        assert_eq!(normalize_agent_name("OmO"), "Sisyphus");
+        assert_eq!(normalize_agent_name("Sisyphus"), "Sisyphus");
+        assert_eq!(normalize_agent_name("omo"), "Sisyphus");
+        assert_eq!(normalize_agent_name("sisyphus"), "Sisyphus");
+
+        assert_eq!(normalize_agent_name("OmO-Plan"), "Planner-Sisyphus");
+        assert_eq!(normalize_agent_name("Planner-Sisyphus"), "Planner-Sisyphus");
+        assert_eq!(normalize_agent_name("omo-plan"), "Planner-Sisyphus");
+
+        assert_eq!(normalize_agent_name("explore"), "explore");
+        assert_eq!(normalize_agent_name("CustomAgent"), "CustomAgent");
+    }
+}

--- a/vendor/tokscale-core/src/sessions/mux.rs
+++ b/vendor/tokscale-core/src/sessions/mux.rs
@@ -1,0 +1,315 @@
+//! Mux (coder/mux) session parser
+//!
+//! Parses session-usage.json files from ~/.mux/sessions/<workspaceId>/session-usage.json
+
+use super::utils::file_modified_timestamp_ms;
+use super::UnifiedMessage;
+use crate::TokenBreakdown;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::Path;
+
+#[derive(Debug, Deserialize)]
+pub struct MuxSessionUsage {
+    #[allow(dead_code)]
+    pub version: Option<u32>,
+    #[serde(rename = "byModel")]
+    pub by_model: Option<HashMap<String, MuxModelUsage>>,
+    #[serde(rename = "lastRequest")]
+    pub last_request: Option<MuxLastRequest>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MuxModelUsage {
+    pub input: Option<MuxTokenBucket>,
+    pub cached: Option<MuxTokenBucket>,
+    #[serde(rename = "cacheCreate")]
+    pub cache_create: Option<MuxTokenBucket>,
+    pub output: Option<MuxTokenBucket>,
+    pub reasoning: Option<MuxTokenBucket>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MuxTokenBucket {
+    pub tokens: Option<i64>,
+    pub cost_usd: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MuxLastRequest {
+    #[allow(dead_code)]
+    pub model: Option<String>,
+    pub timestamp: Option<i64>,
+}
+
+/// Parse a mux session-usage.json file.
+/// Returns one UnifiedMessage per model entry in byModel.
+pub fn parse_mux_file(path: &Path) -> Vec<UnifiedMessage> {
+    let data = match std::fs::read(path) {
+        Ok(d) => d,
+        Err(_) => return vec![],
+    };
+
+    let usage: MuxSessionUsage = match serde_json::from_slice(&data) {
+        Ok(u) => u,
+        Err(_) => return vec![],
+    };
+
+    let timestamp = usage
+        .last_request
+        .as_ref()
+        .and_then(|lr| lr.timestamp)
+        .unwrap_or_else(|| file_modified_timestamp_ms(path));
+
+    let session_id = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    let by_model = match usage.by_model {
+        Some(m) => m,
+        None => return vec![],
+    };
+
+    by_model
+        .into_iter()
+        .filter_map(|(model_key, model_usage)| {
+            let tokens =
+                |b: &Option<MuxTokenBucket>| b.as_ref().and_then(|b| b.tokens).unwrap_or(0).max(0);
+            let cost =
+                |b: &Option<MuxTokenBucket>| b.as_ref().and_then(|b| b.cost_usd).unwrap_or(0.0);
+            let input = tokens(&model_usage.input);
+            let cached = tokens(&model_usage.cached);
+            let cache_create = tokens(&model_usage.cache_create);
+            let output = tokens(&model_usage.output);
+            let reasoning = tokens(&model_usage.reasoning);
+            let source_cost = cost(&model_usage.input)
+                + cost(&model_usage.cached)
+                + cost(&model_usage.cache_create)
+                + cost(&model_usage.output)
+                + cost(&model_usage.reasoning);
+
+            if input == 0 && cached == 0 && cache_create == 0 && output == 0 && reasoning == 0 {
+                return None;
+            }
+
+            // Strip "provider:" prefix for model ID (e.g., "anthropic:claude-opus-4-6" -> "claude-opus-4-6")
+            let (provider, model_id) = if model_key.contains(':') {
+                let mut parts = model_key.splitn(2, ':');
+                let p = parts.next().unwrap_or("").to_string();
+                let m = parts.next().unwrap_or(&model_key).to_string();
+                (p, m)
+            } else {
+                (String::new(), model_key)
+            };
+
+            Some(UnifiedMessage::new(
+                "mux",
+                model_id,
+                provider,
+                session_id.clone(),
+                timestamp,
+                TokenBreakdown {
+                    input,
+                    output,
+                    cache_read: cached,
+                    cache_write: cache_create,
+                    reasoning,
+                },
+                source_cost,
+            ))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp_json(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn test_parse_valid_session_usage() {
+        let json = r#"{
+            "version": 1,
+            "byModel": {
+                "anthropic:claude-opus-4-6": {
+                    "input": { "tokens": 100, "cost_usd": 0.01 },
+                    "cached": { "tokens": 5000, "cost_usd": 0.05 },
+                    "cacheCreate": { "tokens": 200, "cost_usd": 0.02 },
+                    "output": { "tokens": 300, "cost_usd": 0.03 },
+                    "reasoning": { "tokens": 0, "cost_usd": 0 }
+                },
+                "openai:gpt-4o": {
+                    "input": { "tokens": 50, "cost_usd": 0.005 },
+                    "cached": { "tokens": 0, "cost_usd": 0 },
+                    "cacheCreate": { "tokens": 0, "cost_usd": 0 },
+                    "output": { "tokens": 150, "cost_usd": 0.015 },
+                    "reasoning": { "tokens": 0, "cost_usd": 0 }
+                }
+            },
+            "lastRequest": {
+                "model": "anthropic:claude-opus-4-6",
+                "timestamp": 1700000000000
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let msgs = parse_mux_file(f.path());
+        assert_eq!(msgs.len(), 2);
+
+        // Find the claude message
+        let claude = msgs
+            .iter()
+            .find(|m| m.model_id == "claude-opus-4-6")
+            .unwrap();
+        assert_eq!(claude.client, "mux");
+        assert_eq!(claude.provider_id, "anthropic");
+        assert_eq!(claude.tokens.input, 100);
+        assert_eq!(claude.tokens.cache_read, 5000);
+        assert_eq!(claude.tokens.cache_write, 200);
+        assert_eq!(claude.tokens.output, 300);
+        assert_eq!(claude.tokens.reasoning, 0);
+        assert_eq!(claude.timestamp, 1700000000000);
+
+        let gpt = msgs.iter().find(|m| m.model_id == "gpt-4o").unwrap();
+        assert_eq!(gpt.provider_id, "openai");
+        assert_eq!(gpt.tokens.input, 50);
+        assert_eq!(gpt.tokens.output, 150);
+    }
+
+    #[test]
+    fn test_parse_empty_by_model() {
+        let json = r#"{ "version": 1, "byModel": {} }"#;
+        let f = write_temp_json(json);
+        let msgs = parse_mux_file(f.path());
+        assert!(msgs.is_empty());
+    }
+
+    #[test]
+    fn test_parse_missing_by_model() {
+        let json = r#"{ "version": 1 }"#;
+        let f = write_temp_json(json);
+        let msgs = parse_mux_file(f.path());
+        assert!(msgs.is_empty());
+    }
+
+    #[test]
+    fn test_zero_token_entries_filtered() {
+        let json = r#"{
+            "version": 1,
+            "byModel": {
+                "anthropic:claude-opus-4-6": {
+                    "input": { "tokens": 0, "cost_usd": 0 },
+                    "cached": { "tokens": 0, "cost_usd": 0 },
+                    "cacheCreate": { "tokens": 0, "cost_usd": 0 },
+                    "output": { "tokens": 0, "cost_usd": 0 },
+                    "reasoning": { "tokens": 0, "cost_usd": 0 }
+                }
+            },
+            "lastRequest": { "model": "anthropic:claude-opus-4-6", "timestamp": 1700000000000 }
+        }"#;
+        let f = write_temp_json(json);
+        let msgs = parse_mux_file(f.path());
+        assert!(msgs.is_empty());
+    }
+
+    #[test]
+    fn test_model_without_provider_prefix() {
+        let json = r#"{
+            "version": 1,
+            "byModel": {
+                "claude-opus-4-6": {
+                    "input": { "tokens": 100 },
+                    "output": { "tokens": 200 }
+                }
+            },
+            "lastRequest": { "timestamp": 1700000000000 }
+        }"#;
+        let f = write_temp_json(json);
+        let msgs = parse_mux_file(f.path());
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].model_id, "claude-opus-4-6");
+        assert_eq!(msgs[0].provider_id, "");
+    }
+
+    #[test]
+    fn test_invalid_json() {
+        let f = write_temp_json("not json at all");
+        let msgs = parse_mux_file(f.path());
+        assert!(msgs.is_empty());
+    }
+
+    #[test]
+    fn test_nonexistent_file() {
+        let msgs = parse_mux_file(Path::new("/nonexistent/path/session-usage.json"));
+        assert!(msgs.is_empty());
+    }
+
+    #[test]
+    fn test_negative_tokens_clamped() {
+        let json = r#"{
+            "version": 1,
+            "byModel": {
+                "anthropic:claude-opus-4-6": {
+                    "input": { "tokens": -50, "cost_usd": 0.01 },
+                    "output": { "tokens": 100, "cost_usd": 0.02 }
+                }
+            },
+            "lastRequest": { "timestamp": 1700000000000 }
+        }"#;
+        let f = write_temp_json(json);
+        let msgs = parse_mux_file(f.path());
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].tokens.input, 0);
+        assert_eq!(msgs[0].tokens.output, 100);
+    }
+
+    #[test]
+    fn test_source_cost_summed() {
+        let json = r#"{
+            "version": 1,
+            "byModel": {
+                "anthropic:claude-opus-4-6": {
+                    "input": { "tokens": 100, "cost_usd": 0.01 },
+                    "cached": { "tokens": 200, "cost_usd": 0.02 },
+                    "cacheCreate": { "tokens": 50, "cost_usd": 0.005 },
+                    "output": { "tokens": 300, "cost_usd": 0.03 },
+                    "reasoning": { "tokens": 0, "cost_usd": 0 }
+                }
+            },
+            "lastRequest": { "timestamp": 1700000000000 }
+        }"#;
+        let f = write_temp_json(json);
+        let msgs = parse_mux_file(f.path());
+        assert_eq!(msgs.len(), 1);
+        let expected_cost = 0.01 + 0.02 + 0.005 + 0.03;
+        assert!((msgs[0].cost - expected_cost).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_multi_colon_model_key() {
+        let json = r#"{
+            "version": 1,
+            "byModel": {
+                "provider:sub:model-name": {
+                    "input": { "tokens": 100 },
+                    "output": { "tokens": 200 }
+                }
+            },
+            "lastRequest": { "timestamp": 1700000000000 }
+        }"#;
+        let f = write_temp_json(json);
+        let msgs = parse_mux_file(f.path());
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].provider_id, "provider");
+        assert_eq!(msgs[0].model_id, "sub:model-name");
+    }
+}

--- a/vendor/tokscale-core/src/sessions/openclaw.rs
+++ b/vendor/tokscale-core/src/sessions/openclaw.rs
@@ -1,0 +1,362 @@
+//! OpenClaw session parser
+//!
+//! Parses OpenClaw transcript JSONL files from agent directories.
+//! Supports legacy sessions.json index parsing for compatibility.
+
+use super::UnifiedMessage;
+use crate::TokenBreakdown;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Deserialize)]
+struct SessionIndex {
+    #[serde(flatten)]
+    sessions: HashMap<String, SessionEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionEntry {
+    #[serde(rename = "sessionId")]
+    session_id: String,
+    #[serde(rename = "sessionFile")]
+    session_file: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenClawEntry {
+    #[serde(rename = "type")]
+    entry_type: String,
+    message: Option<OpenClawMessage>,
+    #[serde(rename = "modelId")]
+    model_id: Option<String>,
+    provider: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenClawMessage {
+    role: Option<String>,
+    usage: Option<OpenClawUsage>,
+    timestamp: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenClawUsage {
+    input: Option<i64>,
+    output: Option<i64>,
+    #[serde(rename = "cacheRead")]
+    cache_read: Option<i64>,
+    #[serde(rename = "cacheWrite")]
+    cache_write: Option<i64>,
+    #[serde(rename = "totalTokens")]
+    #[allow(dead_code)]
+    total_tokens: Option<i64>,
+    cost: Option<OpenClawCost>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenClawCost {
+    total: Option<f64>,
+}
+
+pub fn parse_openclaw_index(index_path: &Path) -> Vec<UnifiedMessage> {
+    let data = match std::fs::read(index_path) {
+        Ok(d) => d,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut bytes = data;
+    let index: SessionIndex = match simd_json::from_slice(&mut bytes) {
+        Ok(i) => i,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut all_messages = Vec::new();
+    let index_dir = index_path.parent().unwrap_or_else(|| Path::new("."));
+
+    for (_key, entry) in index.sessions {
+        let session_path = resolve_session_path(index_dir, &entry);
+        if session_path.exists() {
+            let messages = parse_openclaw_session(&session_path, &entry.session_id);
+            all_messages.extend(messages);
+        }
+    }
+
+    all_messages
+}
+
+pub fn parse_openclaw_transcript(transcript_path: &Path) -> Vec<UnifiedMessage> {
+    let session_id = match transcript_path
+        .file_stem()
+        .map(|stem| stem.to_string_lossy().to_string())
+        .filter(|stem| !stem.is_empty())
+    {
+        Some(id) => id,
+        None => return Vec::new(),
+    };
+
+    parse_openclaw_session(transcript_path, &session_id)
+}
+
+fn resolve_session_path(index_dir: &Path, entry: &SessionEntry) -> PathBuf {
+    match entry
+        .session_file
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        Some(session_file) => {
+            let path = Path::new(session_file);
+            if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                index_dir.join(path)
+            }
+        }
+        None => index_dir.join(format!("{}.jsonl", entry.session_id)),
+    }
+}
+
+fn parse_openclaw_session(session_path: &Path, session_id: &str) -> Vec<UnifiedMessage> {
+    let file = match std::fs::File::open(session_path) {
+        Ok(f) => f,
+        Err(_) => return Vec::new(),
+    };
+
+    // Get file modification time as fallback for missing timestamps
+    let file_mtime_ms = std::fs::metadata(session_path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+
+    let reader = BufReader::new(file);
+    let mut messages = Vec::with_capacity(64);
+    let mut current_model: Option<String> = None;
+    let mut current_provider: Option<String> = None;
+    let mut buffer = Vec::with_capacity(4096);
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        buffer.clear();
+        buffer.extend_from_slice(trimmed.as_bytes());
+        let entry: OpenClawEntry = match simd_json::from_slice(&mut buffer) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        match entry.entry_type.as_str() {
+            "model_change" => {
+                if let Some(model) = entry.model_id {
+                    current_model = Some(model);
+                }
+                if let Some(provider) = entry.provider {
+                    current_provider = Some(provider);
+                }
+            }
+            "message" => {
+                if let Some(msg) = entry.message {
+                    if msg.role.as_deref() != Some("assistant") {
+                        continue;
+                    }
+
+                    let usage = match msg.usage {
+                        Some(u) => u,
+                        None => continue,
+                    };
+
+                    let model = match &current_model {
+                        Some(m) => m.clone(),
+                        None => continue,
+                    };
+
+                    let provider = current_provider
+                        .clone()
+                        .unwrap_or_else(|| "unknown".to_string());
+                    let timestamp = msg.timestamp.unwrap_or(file_mtime_ms);
+                    let cost = usage.cost.and_then(|c| c.total).unwrap_or(0.0);
+
+                    messages.push(UnifiedMessage::new(
+                        "openclaw",
+                        model,
+                        provider,
+                        session_id.to_string(),
+                        timestamp,
+                        TokenBreakdown {
+                            input: usage.input.unwrap_or(0).max(0),
+                            output: usage.output.unwrap_or(0).max(0),
+                            cache_read: usage.cache_read.unwrap_or(0).max(0),
+                            cache_write: usage.cache_write.unwrap_or(0).max(0),
+                            reasoning: 0,
+                        },
+                        cost.max(0.0),
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    messages
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn create_test_session(dir: &TempDir, filename: &str, content: &str) -> String {
+        let path = dir.path().join(filename);
+        let mut file = File::create(&path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        path.to_string_lossy().to_string()
+    }
+
+    #[test]
+    fn test_parse_openclaw_session_with_model_change() {
+        let dir = TempDir::new().unwrap();
+        let content = r#"{"type":"model_change","id":"abc","provider":"openai-codex","modelId":"gpt-5.2"}
+{"type":"message","id":"msg1","message":{"role":"assistant","content":[],"usage":{"input":100,"output":50,"cacheRead":200,"totalTokens":350,"cost":{"total":0.05}},"timestamp":1700000000000}}"#;
+
+        let session_path = create_test_session(&dir, "session.jsonl", content);
+        let messages = parse_openclaw_session(Path::new(&session_path), "test-session");
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gpt-5.2");
+        assert_eq!(messages[0].provider_id, "openai-codex");
+        assert_eq!(messages[0].tokens.input, 100);
+        assert_eq!(messages[0].tokens.output, 50);
+        assert_eq!(messages[0].tokens.cache_read, 200);
+        assert_eq!(messages[0].cost, 0.05);
+    }
+
+    #[test]
+    fn test_parse_openclaw_session_user_messages_ignored() {
+        let dir = TempDir::new().unwrap();
+        let content = r#"{"type":"model_change","provider":"anthropic","modelId":"claude-3.5-sonnet"}
+{"type":"message","id":"msg1","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}
+{"type":"message","id":"msg2","message":{"role":"assistant","content":[],"usage":{"input":50,"output":25},"timestamp":1700000000000}}"#;
+
+        let session_path = create_test_session(&dir, "session.jsonl", content);
+        let messages = parse_openclaw_session(Path::new(&session_path), "test-session");
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 50);
+    }
+
+    #[test]
+    fn test_parse_openclaw_session_no_model_change() {
+        let dir = TempDir::new().unwrap();
+        let content = r#"{"type":"message","id":"msg1","message":{"role":"assistant","content":[],"usage":{"input":100,"output":50},"timestamp":1700000000000}}"#;
+
+        let session_path = create_test_session(&dir, "session.jsonl", content);
+        let messages = parse_openclaw_session(Path::new(&session_path), "test-session");
+
+        assert_eq!(messages.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_openclaw_transcript_derives_session_id_from_filename() {
+        let dir = TempDir::new().unwrap();
+        let content = r#"{"type":"model_change","provider":"openai-codex","modelId":"gpt-5.2"}
+{"type":"message","id":"msg1","message":{"role":"assistant","content":[],"usage":{"input":10,"output":5,"cacheRead":0,"cacheWrite":0},"timestamp":1700000000000}}"#;
+
+        let session_path = create_test_session(&dir, "my-session-123.jsonl", content);
+        let messages = parse_openclaw_transcript(Path::new(&session_path));
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].session_id, "my-session-123");
+        assert_eq!(messages[0].model_id, "gpt-5.2");
+        assert_eq!(messages[0].provider_id, "openai-codex");
+        assert_eq!(messages[0].tokens.input, 10);
+        assert_eq!(messages[0].tokens.output, 5);
+    }
+
+    fn create_test_index(dir: &TempDir, content: &str) -> PathBuf {
+        let index_path = dir.path().join("sessions.json");
+        let mut file = File::create(&index_path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        index_path
+    }
+
+    #[test]
+    fn test_parse_openclaw_index_absolute_session_file() {
+        let dir = TempDir::new().unwrap();
+
+        let session_content = r#"{"type":"model_change","provider":"anthropic","modelId":"claude-3.5-sonnet"}
+{"type":"message","id":"msg1","message":{"role":"assistant","content":[],"usage":{"input":100,"output":50,"cacheRead":0,"cacheWrite":0},"timestamp":1700000000000}}"#;
+        let session_path = create_test_session(&dir, "session-abc.jsonl", session_content);
+
+        let index_content = format!(
+            r#"{{
+            "agent:main:main": {{
+                "sessionId": "abc-123",
+                "sessionFile": "{}"
+            }}
+        }}"#,
+            session_path.replace('\\', "\\\\")
+        );
+        let index_path = create_test_index(&dir, &index_content);
+
+        let messages = parse_openclaw_index(&index_path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "claude-3.5-sonnet");
+        assert_eq!(messages[0].session_id, "abc-123");
+    }
+
+    #[test]
+    fn test_parse_openclaw_index_relative_session_file() {
+        let dir = TempDir::new().unwrap();
+
+        let session_content = r#"{"type":"model_change","provider":"anthropic","modelId":"claude-3.5-sonnet"}
+{"type":"message","id":"msg1","message":{"role":"assistant","content":[],"usage":{"input":100,"output":50,"cacheRead":0,"cacheWrite":0},"timestamp":1700000000000}}"#;
+        create_test_session(&dir, "session-relative.jsonl", session_content);
+
+        let index_content = r#"{
+            "agent:main:main": {
+                "sessionId": "relative-123",
+                "sessionFile": "session-relative.jsonl"
+            }
+        }"#;
+        let index_path = create_test_index(&dir, index_content);
+
+        let messages = parse_openclaw_index(&index_path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "claude-3.5-sonnet");
+        assert_eq!(messages[0].session_id, "relative-123");
+    }
+
+    #[test]
+    fn test_parse_openclaw_index_missing_session_file_fallback() {
+        let dir = TempDir::new().unwrap();
+
+        let session_content = r#"{"type":"model_change","provider":"anthropic","modelId":"claude-3.5-sonnet"}
+{"type":"message","id":"msg1","message":{"role":"assistant","content":[],"usage":{"input":100,"output":50,"cacheRead":0,"cacheWrite":0},"timestamp":1700000000000}}"#;
+        create_test_session(&dir, "fallback-123.jsonl", session_content);
+
+        let index_content = r#"{
+            "agent:main:main": {
+                "sessionId": "fallback-123"
+            }
+        }"#;
+        let index_path = create_test_index(&dir, index_content);
+
+        let messages = parse_openclaw_index(&index_path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "claude-3.5-sonnet");
+        assert_eq!(messages[0].session_id, "fallback-123");
+    }
+}

--- a/vendor/tokscale-core/src/sessions/opencode.rs
+++ b/vendor/tokscale-core/src/sessions/opencode.rs
@@ -1,0 +1,886 @@
+//! OpenCode session parser
+//!
+//! Parses messages from:
+//! - SQLite database (OpenCode 1.2+): ~/.local/share/opencode/opencode.db
+//! - Legacy JSON files: ~/.local/share/opencode/storage/message/
+
+use super::{normalize_agent_name, UnifiedMessage};
+use crate::TokenBreakdown;
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// OpenCode message structure (from JSON files and SQLite data column)
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct OpenCodeMessage {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(rename = "sessionID", default)]
+    pub session_id: Option<String>,
+    pub role: String,
+    #[serde(rename = "modelID")]
+    pub model_id: Option<String>,
+    #[serde(rename = "providerID")]
+    pub provider_id: Option<String>,
+    pub cost: Option<f64>,
+    pub tokens: Option<OpenCodeTokens>,
+    pub time: OpenCodeTime,
+    pub agent: Option<String>,
+    pub mode: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OpenCodeTokens {
+    pub input: i64,
+    pub output: i64,
+    pub reasoning: Option<i64>,
+    pub cache: OpenCodeCache,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OpenCodeCache {
+    pub read: i64,
+    pub write: i64,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct OpenCodeTime {
+    pub created: f64, // Unix timestamp in milliseconds (as float)
+    pub completed: Option<f64>,
+}
+
+pub fn parse_opencode_file(path: &Path) -> Option<UnifiedMessage> {
+    let data = std::fs::read(path).ok()?;
+    let mut bytes = data;
+
+    let msg: OpenCodeMessage = simd_json::from_slice(&mut bytes).ok()?;
+
+    if msg.role != "assistant" {
+        return None;
+    }
+
+    let tokens = msg.tokens?;
+    let model_id = msg.model_id?;
+    let agent_or_mode = msg.mode.or(msg.agent);
+    let agent = agent_or_mode.map(|a| normalize_agent_name(&a));
+
+    let session_id = msg.session_id.unwrap_or_else(|| "unknown".to_string());
+
+    // Use message ID from JSON or derive from filename for deduplication
+    let dedup_key = msg.id.or_else(|| {
+        path.file_stem()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_string())
+    });
+
+    let mut unified = UnifiedMessage::new_with_agent(
+        "opencode",
+        model_id,
+        msg.provider_id.unwrap_or_else(|| "unknown".to_string()),
+        session_id,
+        msg.time.created as i64,
+        TokenBreakdown {
+            input: tokens.input.max(0),
+            output: tokens.output.max(0),
+            cache_read: tokens.cache.read.max(0),
+            cache_write: tokens.cache.write.max(0),
+            reasoning: tokens.reasoning.unwrap_or(0).max(0),
+        },
+        msg.cost.unwrap_or(0.0).max(0.0),
+        agent,
+    );
+    unified.dedup_key = dedup_key;
+    Some(unified)
+}
+
+pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
+    let conn = match Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    ) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+
+    let query = r#"
+        SELECT m.id, m.session_id, m.data
+        FROM message m
+        WHERE json_extract(m.data, '$.role') = 'assistant'
+          AND json_extract(m.data, '$.tokens') IS NOT NULL
+    "#;
+
+    let mut stmt = match conn.prepare(query) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+
+    let rows = match stmt.query_map([], |row| {
+        let id: String = row.get(0)?;
+        let session_id: String = row.get(1)?;
+        let data_json: String = row.get(2)?;
+        Ok((id, session_id, data_json))
+    }) {
+        Ok(r) => r,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut messages = Vec::new();
+
+    for row_result in rows {
+        let (id, session_id, data_json) = match row_result {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+
+        let mut bytes = data_json.into_bytes();
+        let msg: OpenCodeMessage = match simd_json::from_slice(&mut bytes) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+
+        if msg.role != "assistant" {
+            continue;
+        }
+
+        let tokens = match msg.tokens {
+            Some(t) => t,
+            None => continue,
+        };
+
+        let model_id = match msg.model_id {
+            Some(m) => m,
+            None => continue,
+        };
+
+        let agent_or_mode = msg.mode.or(msg.agent);
+        let agent = agent_or_mode.map(|a| normalize_agent_name(&a));
+
+        let mut unified = UnifiedMessage::new_with_agent(
+            "opencode",
+            model_id,
+            msg.provider_id.unwrap_or_else(|| "unknown".to_string()),
+            session_id,
+            msg.time.created as i64,
+            TokenBreakdown {
+                input: tokens.input.max(0),
+                output: tokens.output.max(0),
+                cache_read: tokens.cache.read.max(0),
+                cache_write: tokens.cache.write.max(0),
+                reasoning: tokens.reasoning.unwrap_or(0).max(0),
+            },
+            msg.cost.unwrap_or(0.0).max(0.0),
+            agent,
+        );
+        unified.dedup_key = Some(id);
+        messages.push(unified);
+    }
+
+    messages
+}
+
+// =============================================================================
+// Migration cache: skip redundant legacy JSON scanning after full migration
+// =============================================================================
+
+const MIGRATION_CACHE_FILENAME: &str = "opencode-migration.json";
+
+/// Persisted migration status for OpenCode JSON → SQLite migration.
+/// Stored at ~/.cache/tokscale/opencode-migration.json.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OpenCodeMigrationCache {
+    /// True when every legacy JSON message was already present in SQLite.
+    pub migration_complete: bool,
+    /// Number of JSON files in the message directory at detection time.
+    pub json_file_count: u64,
+    /// Modification time of the JSON directory (Unix seconds) at detection time.
+    pub json_dir_mtime_secs: u64,
+    /// When this entry was written (Unix seconds).
+    pub checked_at_secs: u64,
+}
+
+fn migration_cache_dir() -> std::path::PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+        .join("tokscale")
+}
+
+fn migration_cache_path() -> std::path::PathBuf {
+    migration_cache_dir().join(MIGRATION_CACHE_FILENAME)
+}
+
+/// Load the migration cache from disk. Returns `None` if the file is missing or
+/// unparseable.
+pub fn load_opencode_migration_cache() -> Option<OpenCodeMigrationCache> {
+    let content = std::fs::read_to_string(migration_cache_path()).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// Persist the migration cache atomically (write to temp file, then rename).
+pub fn save_opencode_migration_cache(cache: &OpenCodeMigrationCache) {
+    use std::io::Write as _;
+
+    let dir = migration_cache_dir();
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+
+    let content = match serde_json::to_string(cache) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    let final_path = migration_cache_path();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    let tmp_name = format!(".opencode-migration.{}.{:x}.tmp", std::process::id(), nanos);
+    let tmp_path = dir.join(tmp_name);
+
+    let result = (|| -> std::io::Result<()> {
+        let mut file = std::fs::File::create(&tmp_path)?;
+        file.write_all(content.as_bytes())?;
+        file.sync_all()?;
+        if std::fs::rename(&tmp_path, &final_path).is_err() {
+            std::fs::copy(&tmp_path, &final_path)?;
+            std::fs::remove_file(&tmp_path)?;
+        }
+        Ok(())
+    })();
+
+    if result.is_err() {
+        let _ = std::fs::remove_file(&tmp_path);
+    }
+}
+
+/// Return the modification time of `json_dir` as Unix seconds, or `None` on
+/// error (directory absent, permissions, etc.).
+pub fn get_json_dir_mtime(json_dir: &Path) -> Option<u64> {
+    std::fs::metadata(json_dir)
+        .ok()?
+        .modified()
+        .ok()?
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs())
+}
+
+/// Current Unix timestamp in seconds.
+pub fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_opencode_structure() {
+        let json = r#"{
+            "id": "msg_123",
+            "sessionID": "ses_456",
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "cost": 0.05,
+            "tokens": {
+                "input": 1000,
+                "output": 500,
+                "reasoning": 100,
+                "cache": { "read": 200, "write": 50 }
+            },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        let mut bytes = json.as_bytes().to_vec();
+        let msg: OpenCodeMessage = simd_json::from_slice(&mut bytes).unwrap();
+
+        assert_eq!(msg.model_id, Some("claude-sonnet-4".to_string()));
+        assert_eq!(msg.tokens.unwrap().input, 1000);
+        assert_eq!(msg.agent, None);
+    }
+
+    #[test]
+    fn test_parse_opencode_with_agent() {
+        let json = r#"{
+            "id": "msg_123",
+            "sessionID": "ses_456",
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "agent": "OmO",
+            "cost": 0.05,
+            "tokens": {
+                "input": 1000,
+                "output": 500,
+                "reasoning": 100,
+                "cache": { "read": 200, "write": 50 }
+            },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        let mut bytes = json.as_bytes().to_vec();
+        let msg: OpenCodeMessage = simd_json::from_slice(&mut bytes).unwrap();
+
+        assert_eq!(msg.agent, Some("OmO".to_string()));
+    }
+
+    /// Verify negative token values are clamped to 0 (defense-in-depth for PR #147)
+    #[test]
+    fn test_negative_values_clamped_to_zero() {
+        use std::io::Write;
+
+        let json = r#"{
+            "id": "msg_negative",
+            "sessionID": "ses_negative",
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "cost": -0.05,
+            "tokens": {
+                "input": -100,
+                "output": -50,
+                "reasoning": -25,
+                "cache": { "read": -200, "write": -10 }
+            },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        let mut temp_file = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+        temp_file.write_all(json.as_bytes()).unwrap();
+
+        let result = parse_opencode_file(temp_file.path());
+        assert!(result.is_some(), "Should parse file with negative values");
+
+        let msg = result.unwrap();
+        assert_eq!(msg.tokens.input, 0, "Negative input should be clamped to 0");
+        assert_eq!(
+            msg.tokens.output, 0,
+            "Negative output should be clamped to 0"
+        );
+        assert_eq!(
+            msg.tokens.cache_read, 0,
+            "Negative cache_read should be clamped to 0"
+        );
+        assert_eq!(
+            msg.tokens.cache_write, 0,
+            "Negative cache_write should be clamped to 0"
+        );
+        assert_eq!(
+            msg.tokens.reasoning, 0,
+            "Negative reasoning should be clamped to 0"
+        );
+        assert!(
+            msg.cost >= 0.0,
+            "Negative cost should be clamped to 0.0, got {}",
+            msg.cost
+        );
+    }
+
+    /// JSON dedup_key uses msg.id when present
+    #[test]
+    fn test_dedup_key_from_json_message_id() {
+        use std::io::Write;
+
+        let json = r#"{
+            "id": "msg_dedup_001",
+            "sessionID": "ses_001",
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "cost": 0.01,
+            "tokens": {
+                "input": 100,
+                "output": 50,
+                "reasoning": 0,
+                "cache": { "read": 0, "write": 0 }
+            },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        let mut temp_file = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+        temp_file.write_all(json.as_bytes()).unwrap();
+
+        let msg = parse_opencode_file(temp_file.path()).expect("Should parse");
+        assert_eq!(
+            msg.dedup_key,
+            Some("msg_dedup_001".to_string()),
+            "dedup_key should use msg.id from JSON"
+        );
+    }
+
+    /// JSON dedup_key falls back to file stem when msg.id is absent
+    #[test]
+    fn test_dedup_key_falls_back_to_file_stem() {
+        let json = r#"{
+            "sessionID": "ses_001",
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "cost": 0.01,
+            "tokens": {
+                "input": 100,
+                "output": 50,
+                "reasoning": 0,
+                "cache": { "read": 0, "write": 0 }
+            },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("msg_fallback_999.json");
+        std::fs::write(&file_path, json).unwrap();
+
+        let msg = parse_opencode_file(&file_path).expect("Should parse");
+        assert_eq!(
+            msg.dedup_key,
+            Some("msg_fallback_999".to_string()),
+            "dedup_key should fall back to file stem when id is missing"
+        );
+    }
+
+    /// Non-assistant messages are skipped (no dedup_key produced)
+    #[test]
+    fn test_dedup_key_skips_non_assistant() {
+        let json = r#"{
+            "id": "msg_user_001",
+            "sessionID": "ses_001",
+            "role": "user",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "tokens": {
+                "input": 100,
+                "output": 50,
+                "reasoning": 0,
+                "cache": { "read": 0, "write": 0 }
+            },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("msg_user_001.json");
+        std::fs::write(&file_path, json).unwrap();
+
+        let result = parse_opencode_file(&file_path);
+        assert!(result.is_none(), "User messages should be skipped");
+    }
+
+    /// SQLite dedup_key uses m.id from the database row
+    #[test]
+    fn test_sqlite_dedup_key_from_row_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_opencode.db");
+
+        // Create a minimal SQLite DB matching OpenCode's schema
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                data TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+
+        let data_json = r#"{
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "cost": 0.05,
+            "tokens": {
+                "input": 1000,
+                "output": 500,
+                "reasoning": 0,
+                "cache": { "read": 200, "write": 50 }
+            },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["msg_sqlite_001", "ses_001", data_json],
+        )
+        .unwrap();
+        drop(conn);
+
+        let messages = parse_opencode_sqlite(&db_path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].dedup_key,
+            Some("msg_sqlite_001".to_string()),
+            "SQLite dedup_key should come from m.id column"
+        );
+        assert_eq!(messages[0].model_id, "claude-sonnet-4");
+        assert_eq!(messages[0].tokens.input, 1000);
+    }
+
+    /// SQLite skips rows without tokens or with non-assistant role
+    #[test]
+    fn test_sqlite_skips_invalid_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_opencode.db");
+
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                data TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+
+        // Valid assistant message
+        let valid = r#"{
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "tokens": { "input": 100, "output": 50, "reasoning": 0, "cache": { "read": 0, "write": 0 } },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        // User message (should be filtered by SQL WHERE clause)
+        let user_msg = r#"{
+            "role": "user",
+            "modelID": "claude-sonnet-4",
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        // Assistant without tokens (should be filtered by SQL WHERE clause)
+        let no_tokens = r#"{
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["msg_valid", "ses_001", valid],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["msg_user", "ses_001", user_msg],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["msg_no_tokens", "ses_001", no_tokens],
+        )
+        .unwrap();
+        drop(conn);
+
+        let messages = parse_opencode_sqlite(&db_path);
+        assert_eq!(
+            messages.len(),
+            1,
+            "Should only parse valid assistant message"
+        );
+        assert_eq!(messages[0].dedup_key, Some("msg_valid".to_string()));
+    }
+
+    /// Cross-source dedup: matching IDs between SQLite and JSON should deduplicate
+    #[test]
+    fn test_cross_source_dedup_by_message_id() {
+        use std::collections::HashSet;
+
+        let dir = tempfile::tempdir().unwrap();
+
+        // --- SQLite source ---
+        let db_path = dir.path().join("opencode.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                data TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+
+        let data_json = r#"{
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "tokens": { "input": 500, "output": 200, "reasoning": 0, "cache": { "read": 0, "write": 0 } },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        // Insert two messages into SQLite
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["msg_shared_001", "ses_001", data_json],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["msg_sqlite_only", "ses_001", data_json],
+        )
+        .unwrap();
+        drop(conn);
+
+        // --- JSON source ---
+        let json_dir = dir.path().join("json");
+        std::fs::create_dir_all(&json_dir).unwrap();
+
+        // Duplicate of SQLite msg_shared_001
+        let json_shared = r#"{
+            "id": "msg_shared_001",
+            "sessionID": "ses_001",
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "tokens": { "input": 500, "output": 200, "reasoning": 0, "cache": { "read": 0, "write": 0 } },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+        std::fs::write(json_dir.join("msg_shared_001.json"), json_shared).unwrap();
+
+        // JSON-only message (not in SQLite)
+        let json_only = r#"{
+            "id": "msg_json_only",
+            "sessionID": "ses_001",
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "tokens": { "input": 100, "output": 50, "reasoning": 0, "cache": { "read": 0, "write": 0 } },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+        std::fs::write(json_dir.join("msg_json_only.json"), json_only).unwrap();
+
+        // --- Simulate the dedup logic from lib.rs ---
+        let sqlite_messages = parse_opencode_sqlite(&db_path);
+        assert_eq!(sqlite_messages.len(), 2);
+
+        // Build seen set from SQLite (same as lib.rs)
+        let mut seen: HashSet<String> = HashSet::new();
+        for msg in &sqlite_messages {
+            if let Some(ref key) = msg.dedup_key {
+                seen.insert(key.clone());
+            }
+        }
+        assert_eq!(seen.len(), 2);
+
+        // Parse JSON files
+        let json_msg_shared = parse_opencode_file(&json_dir.join("msg_shared_001.json")).unwrap();
+        let json_msg_only = parse_opencode_file(&json_dir.join("msg_json_only.json")).unwrap();
+
+        // Filter JSON through seen set (same logic as lib.rs)
+        let json_messages = vec![json_msg_shared, json_msg_only];
+        let deduped: Vec<UnifiedMessage> = json_messages
+            .into_iter()
+            .filter(|msg| {
+                msg.dedup_key
+                    .as_ref()
+                    .map_or(true, |key| seen.insert(key.clone()))
+            })
+            .collect();
+
+        // msg_shared_001 should be filtered (duplicate), msg_json_only should survive
+        assert_eq!(
+            deduped.len(),
+            1,
+            "Only the JSON-only message should survive dedup"
+        );
+        assert_eq!(
+            deduped[0].dedup_key,
+            Some("msg_json_only".to_string()),
+            "Surviving message should be the JSON-only one"
+        );
+
+        // Total unique messages = 2 from SQLite + 1 from JSON
+        let total = sqlite_messages.len() + deduped.len();
+        assert_eq!(total, 3, "Should have 3 unique messages total");
+    }
+
+    // -------------------------------------------------------------------------
+    // Migration cache tests
+    // -------------------------------------------------------------------------
+
+    /// Round-trip: save then load returns identical data.
+    #[test]
+    fn test_migration_cache_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        // Point the cache at a temp dir by overriding via a temporary env var is
+        // impractical here; instead we test the structs and serde directly.
+        let cache = OpenCodeMigrationCache {
+            migration_complete: true,
+            json_file_count: 42,
+            json_dir_mtime_secs: 1_700_000_000,
+            checked_at_secs: 1_700_100_000,
+        };
+
+        let json = serde_json::to_string(&cache).unwrap();
+        let loaded: OpenCodeMigrationCache = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded, cache);
+
+        // Ensure the JSON contains all expected keys
+        assert!(json.contains("migration_complete"));
+        assert!(json.contains("json_file_count"));
+        assert!(json.contains("json_dir_mtime_secs"));
+        assert!(json.contains("checked_at_secs"));
+
+        drop(dir);
+    }
+
+    /// Cache is valid when file count and mtime are unchanged.
+    #[test]
+    fn test_migration_cache_valid_when_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let json_dir = dir.path().join("message");
+        std::fs::create_dir_all(&json_dir).unwrap();
+
+        // Write a dummy file so the directory exists and has a stable mtime
+        std::fs::write(json_dir.join("msg.json"), b"{}").unwrap();
+
+        let current_mtime = get_json_dir_mtime(&json_dir).expect("should stat dir");
+        let current_file_count = 1u64;
+
+        let cache = OpenCodeMigrationCache {
+            migration_complete: true,
+            json_file_count: current_file_count,
+            json_dir_mtime_secs: current_mtime, // same mtime
+            checked_at_secs: now_secs(),
+        };
+
+        // Simulate the validity check from lib.rs
+        let is_valid = cache.migration_complete
+            && current_file_count == cache.json_file_count
+            && get_json_dir_mtime(&json_dir).map_or(false, |m| m <= cache.json_dir_mtime_secs);
+
+        assert!(is_valid, "Cache should be valid when count and mtime match");
+    }
+
+    /// Cache is invalid when file count has changed.
+    #[test]
+    fn test_migration_cache_invalid_when_file_count_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let json_dir = dir.path().join("message");
+        std::fs::create_dir_all(&json_dir).unwrap();
+        std::fs::write(json_dir.join("msg1.json"), b"{}").unwrap();
+
+        let current_mtime = get_json_dir_mtime(&json_dir).unwrap();
+
+        let cache = OpenCodeMigrationCache {
+            migration_complete: true,
+            json_file_count: 1,
+            json_dir_mtime_secs: current_mtime,
+            checked_at_secs: now_secs(),
+        };
+
+        // Simulate: a new file was added → current_file_count = 2
+        let current_file_count = 2u64; // changed
+        let is_valid = cache.migration_complete
+            && current_file_count == cache.json_file_count
+            && get_json_dir_mtime(&json_dir).map_or(false, |m| m <= cache.json_dir_mtime_secs);
+
+        assert!(!is_valid, "Cache should be invalid when file count changes");
+    }
+
+    /// Cache is invalid when directory mtime is newer than cached value.
+    #[test]
+    fn test_migration_cache_invalid_when_mtime_newer() {
+        let dir = tempfile::tempdir().unwrap();
+        let json_dir = dir.path().join("message");
+        std::fs::create_dir_all(&json_dir).unwrap();
+        std::fs::write(json_dir.join("msg.json"), b"{}").unwrap();
+
+        let current_mtime = get_json_dir_mtime(&json_dir).unwrap();
+
+        // Simulate: cache recorded an older mtime → directory is now newer
+        let stale_mtime = current_mtime.saturating_sub(1);
+        let cache = OpenCodeMigrationCache {
+            migration_complete: true,
+            json_file_count: 1,
+            json_dir_mtime_secs: stale_mtime, // older than current
+            checked_at_secs: now_secs(),
+        };
+
+        let is_valid = cache.migration_complete
+            && 1u64 == cache.json_file_count
+            && get_json_dir_mtime(&json_dir).map_or(false, |m| m <= cache.json_dir_mtime_secs);
+
+        assert!(
+            !is_valid,
+            "Cache should be invalid when directory mtime is newer than cached value"
+        );
+    }
+
+    /// Cache is not loaded when the file is missing (load returns None).
+    #[test]
+    fn test_migration_cache_missing_returns_none() {
+        // load_opencode_migration_cache reads from ~/.cache/tokscale/opencode-migration.json
+        // We can't easily override the path in a unit test, but we can verify that
+        // serde_json::from_str returns None for invalid input (simulating missing file).
+        let result: Option<OpenCodeMigrationCache> = serde_json::from_str("").ok();
+        assert!(
+            result.is_none(),
+            "Empty/missing content should produce None"
+        );
+    }
+
+    /// migration_complete=false disables the cache even if count/mtime match.
+    #[test]
+    fn test_migration_cache_not_skipped_when_incomplete() {
+        let dir = tempfile::tempdir().unwrap();
+        let json_dir = dir.path().join("message");
+        std::fs::create_dir_all(&json_dir).unwrap();
+        std::fs::write(json_dir.join("msg.json"), b"{}").unwrap();
+
+        let current_mtime = get_json_dir_mtime(&json_dir).unwrap();
+
+        let cache = OpenCodeMigrationCache {
+            migration_complete: false, // migration not complete
+            json_file_count: 1,
+            json_dir_mtime_secs: current_mtime,
+            checked_at_secs: now_secs(),
+        };
+
+        let is_valid = cache.migration_complete
+            && 1u64 == cache.json_file_count
+            && get_json_dir_mtime(&json_dir).map_or(false, |m| m <= cache.json_dir_mtime_secs);
+
+        assert!(
+            !is_valid,
+            "Cache should not allow skipping when migration_complete=false"
+        );
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    #[ignore] // Run manually with: cargo test integration -- --ignored
+    fn test_parse_real_sqlite_db() {
+        let home = std::env::var("HOME").unwrap();
+        let db_path = PathBuf::from(format!("{}/.local/share/opencode/opencode.db", home));
+
+        if !db_path.exists() {
+            println!("Skipping: OpenCode database not found at {:?}", db_path);
+            return;
+        }
+
+        let messages = parse_opencode_sqlite(&db_path);
+        println!("Parsed {} messages from SQLite", messages.len());
+
+        if !messages.is_empty() {
+            let first = &messages[0];
+            println!(
+                "First message: model={}, provider={}, tokens={:?}",
+                first.model_id, first.provider_id, first.tokens
+            );
+        }
+
+        assert!(
+            !messages.is_empty(),
+            "Expected to parse some messages from SQLite"
+        );
+    }
+}

--- a/vendor/tokscale-core/src/sessions/pi.rs
+++ b/vendor/tokscale-core/src/sessions/pi.rs
@@ -1,0 +1,237 @@
+//! Pi (badlogic/pi-mono) session parser
+//!
+//! Parses JSONL files from ~/.pi/agent/sessions/<encoded-cwd>/*.jsonl
+
+use super::utils::file_modified_timestamp_ms;
+use super::UnifiedMessage;
+use crate::TokenBreakdown;
+use serde::Deserialize;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+/// Pi session header (first line of JSONL)
+#[derive(Debug, Deserialize)]
+pub struct PiSessionHeader {
+    #[serde(rename = "type")]
+    pub entry_type: String,
+    pub id: String,
+    #[allow(dead_code)]
+    pub timestamp: Option<String>,
+    #[allow(dead_code)]
+    pub cwd: Option<String>,
+}
+
+/// Pi session entry (subsequent lines of JSONL)
+#[derive(Debug, Deserialize)]
+pub struct PiSessionEntry {
+    #[serde(rename = "type")]
+    pub entry_type: String,
+    #[allow(dead_code)]
+    pub id: Option<String>,
+    #[serde(rename = "parentId")]
+    #[allow(dead_code)]
+    pub parent_id: Option<String>,
+    pub timestamp: Option<String>,
+    pub message: Option<PiMessage>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PiMessage {
+    pub role: Option<String>,
+    pub usage: Option<PiUsage>,
+    pub model: Option<String>,
+    pub provider: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PiUsage {
+    pub input: Option<i64>,
+    pub output: Option<i64>,
+    pub cache_read: Option<i64>,
+    pub cache_write: Option<i64>,
+    #[allow(dead_code)]
+    pub total_tokens: Option<i64>,
+}
+
+/// Parse a Pi JSONL session file
+pub fn parse_pi_file(path: &Path) -> Vec<UnifiedMessage> {
+    let file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return Vec::new(),
+    };
+
+    let fallback_timestamp = file_modified_timestamp_ms(path);
+
+    let reader = BufReader::new(file);
+    let mut messages: Vec<UnifiedMessage> = Vec::with_capacity(64);
+    let mut buffer = Vec::with_capacity(4096);
+
+    let mut session_id: Option<String> = None;
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if session_id.is_none() {
+            buffer.clear();
+            buffer.extend_from_slice(trimmed.as_bytes());
+            let header = match simd_json::from_slice::<PiSessionHeader>(&mut buffer) {
+                Ok(h) => h,
+                Err(_) => return Vec::new(),
+            };
+
+            if header.entry_type != "session" {
+                return Vec::new();
+            }
+            session_id = Some(header.id);
+            continue;
+        }
+
+        buffer.clear();
+        buffer.extend_from_slice(trimmed.as_bytes());
+        let entry = match simd_json::from_slice::<PiSessionEntry>(&mut buffer) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        if entry.entry_type != "message" {
+            continue;
+        }
+
+        let message = match entry.message {
+            Some(m) => m,
+            None => continue,
+        };
+
+        if message.role.as_deref() != Some("assistant") {
+            continue;
+        }
+
+        let usage = match message.usage {
+            Some(u) => u,
+            None => continue,
+        };
+
+        let model = match message.model {
+            Some(m) => m,
+            None => continue,
+        };
+
+        let provider = match message.provider {
+            Some(p) => p,
+            None => continue,
+        };
+
+        let timestamp = entry
+            .timestamp
+            .and_then(|ts| chrono::DateTime::parse_from_rfc3339(&ts).ok())
+            .map(|dt| dt.timestamp_millis())
+            .unwrap_or(fallback_timestamp);
+
+        messages.push(UnifiedMessage::new(
+            "pi",
+            model,
+            provider,
+            session_id.clone().unwrap_or_else(|| "unknown".to_string()),
+            timestamp,
+            TokenBreakdown {
+                input: usage.input.unwrap_or(0).max(0),
+                output: usage.output.unwrap_or(0).max(0),
+                cache_read: usage.cache_read.unwrap_or(0).max(0),
+                cache_write: usage.cache_write.unwrap_or(0).max(0),
+                reasoning: 0,
+            },
+            0.0,
+        ));
+    }
+
+    messages
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn create_test_file(content: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file.flush().unwrap();
+        file
+    }
+
+    #[test]
+    fn test_parse_pi_jsonl_valid_assistant_message() {
+        // given
+        let content = r#"{"type":"session","id":"pi_ses_001","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/tmp"}
+{"type":"message","id":"msg_001","parentId":null,"timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","model":"claude-3-5-sonnet","provider":"anthropic","usage":{"input":100,"output":50,"cacheRead":10,"cacheWrite":5,"totalTokens":165}}}"#;
+        let file = create_test_file(content);
+
+        // when
+        let messages = parse_pi_file(file.path());
+
+        // then
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, "pi");
+        assert_eq!(messages[0].session_id, "pi_ses_001");
+        assert_eq!(messages[0].model_id, "claude-3-5-sonnet");
+        assert_eq!(messages[0].provider_id, "anthropic");
+        assert_eq!(messages[0].tokens.input, 100);
+        assert_eq!(messages[0].tokens.output, 50);
+        assert_eq!(messages[0].tokens.cache_read, 10);
+        assert_eq!(messages[0].tokens.cache_write, 5);
+    }
+
+    #[test]
+    fn test_parse_pi_skips_non_assistant_messages() {
+        // given
+        let content = r#"{"type":"session","id":"pi_ses_002","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/tmp"}
+{"type":"message","timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"user","model":"claude-3-5-sonnet","provider":"anthropic","usage":{"input":100,"output":50,"cacheRead":0,"cacheWrite":0,"totalTokens":150}}}"#;
+        let file = create_test_file(content);
+
+        // when
+        let messages = parse_pi_file(file.path());
+
+        // then
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_parse_pi_skips_missing_usage() {
+        // given
+        let content = r#"{"type":"session","id":"pi_ses_003","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/tmp"}
+{"type":"message","timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","model":"claude-3-5-sonnet","provider":"anthropic"}}"#;
+        let file = create_test_file(content);
+
+        // when
+        let messages = parse_pi_file(file.path());
+
+        // then
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_parse_pi_skips_malformed_json_lines() {
+        // given
+        let content = r#"{"type":"session","id":"pi_ses_004","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/tmp"}
+not valid json
+{"type":"message","timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","model":"gpt-4o-mini","provider":"openai","usage":{"input":10,"output":5,"cacheRead":0,"cacheWrite":0,"totalTokens":15}}}"#;
+        let file = create_test_file(content);
+
+        // when
+        let messages = parse_pi_file(file.path());
+
+        // then
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gpt-4o-mini");
+        assert_eq!(messages[0].provider_id, "openai");
+    }
+}

--- a/vendor/tokscale-core/src/sessions/qwen.rs
+++ b/vendor/tokscale-core/src/sessions/qwen.rs
@@ -1,0 +1,458 @@
+//! Qwen CLI session parser
+//!
+//! Parses JSONL files from ~/.qwen/projects/{projectPath}/chats/*.jsonl
+//! Token data comes from assistant messages with usageMetadata field.
+
+use super::utils::{file_modified_timestamp_ms, parse_timestamp_str};
+use super::UnifiedMessage;
+use crate::TokenBreakdown;
+use serde::Deserialize;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+/// Qwen CLI JSONL line structure
+#[derive(Debug, Deserialize)]
+struct QwenLine {
+    #[serde(rename = "type")]
+    msg_type: Option<String>,
+    model: Option<String>,
+    timestamp: Option<String>,
+    #[serde(rename = "sessionId")]
+    session_id: Option<String>,
+
+    #[serde(rename = "usageMetadata")]
+    usage_metadata: Option<UsageMetadata>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UsageMetadata {
+    #[serde(rename = "promptTokenCount")]
+    prompt_token_count: Option<i64>,
+    #[serde(rename = "candidatesTokenCount")]
+    candidates_token_count: Option<i64>,
+    #[serde(rename = "thoughtsTokenCount")]
+    thoughts_token_count: Option<i64>,
+    #[serde(rename = "cachedContentTokenCount")]
+    cached_content_token_count: Option<i64>,
+}
+
+/// Default model name when not specified
+const DEFAULT_MODEL: &str = "unknown";
+const DEFAULT_PROVIDER: &str = "qwen";
+
+/// Extract session ID with fallback logic:
+/// 1. Use JSON session_id if present and non-empty
+/// 2. Otherwise derive from path including project name to avoid collisions
+///
+/// Path format: ~/.qwen/projects/{project}/chats/{filename}.jsonl
+pub fn extract_session_id_with_fallback(path: &Path, json_session_id: Option<&str>) -> String {
+    // Priority 1: Use JSON sessionId if present and non-empty
+    if let Some(id) = json_session_id {
+        if !id.is_empty() {
+            return id.to_string();
+        }
+    }
+
+    // Priority 2: Derive from path with project context
+    // Extract project name from path structure: .../projects/{project}/chats/{file}.jsonl
+    let filename = path
+        .file_stem()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown");
+
+    // Try to extract project name from the path
+    let project_name = path
+        .parent() // .../chats
+        .and_then(|p| p.parent()) // .../projects/{project}
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown");
+
+    // Combine project and filename for unique session ID
+    format!("{}-{}", project_name, filename)
+}
+
+/// Parse a Qwen CLI JSONL file
+pub fn parse_qwen_file(path: &Path) -> Vec<UnifiedMessage> {
+    let file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return Vec::new(),
+    };
+
+    let file_mtime = file_modified_timestamp_ms(path);
+
+    let reader = BufReader::new(file);
+    let mut messages: Vec<UnifiedMessage> = Vec::new();
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let mut bytes = trimmed.as_bytes().to_vec();
+        let qwen_line = match simd_json::from_slice::<QwenLine>(&mut bytes) {
+            Ok(q) => q,
+            Err(_) => continue,
+        };
+
+        // Only process assistant type messages with usageMetadata
+        if qwen_line.msg_type.as_deref() != Some("assistant") {
+            continue;
+        }
+
+        let usage = match qwen_line.usage_metadata {
+            Some(u) => u,
+            None => continue,
+        };
+
+        // Parse timestamp, fallback to file mtime
+        let timestamp_ms = qwen_line
+            .timestamp
+            .and_then(|ts| parse_timestamp_str(&ts))
+            .unwrap_or(file_mtime);
+
+        // Extract token counts with defaults
+        let input = usage.prompt_token_count.unwrap_or(0).max(0);
+        let output = usage.candidates_token_count.unwrap_or(0).max(0);
+        let reasoning = usage.thoughts_token_count.unwrap_or(0).max(0);
+        let cache_read = usage.cached_content_token_count.unwrap_or(0).max(0);
+        let cache_write = 0; // Qwen CLI doesn't report cache write tokens
+
+        // Skip entries with zero tokens
+        if input + output + cache_read + reasoning == 0 {
+            continue;
+        }
+
+        // Use model from line or fallback to "unknown"
+        let model = qwen_line.model.unwrap_or_else(|| DEFAULT_MODEL.to_string());
+
+        // Resolve session ID: prefer JSON sessionId, fallback to path-derived
+        let line_session_id =
+            extract_session_id_with_fallback(path, qwen_line.session_id.as_deref());
+
+        messages.push(UnifiedMessage::new(
+            "qwen",
+            model,
+            DEFAULT_PROVIDER,
+            line_session_id,
+            timestamp_ms,
+            TokenBreakdown {
+                input,
+                output,
+                cache_read,
+                cache_write,
+                reasoning,
+            },
+            0.0, // Cost calculated later by pricing resolver
+        ));
+    }
+
+    messages
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::path::Path;
+    use tempfile::{NamedTempFile, TempDir};
+
+    fn create_test_file(content: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file.flush().unwrap();
+        file
+    }
+
+    fn create_test_file_with_name(content: &str, filename: &str) -> (TempDir, std::path::PathBuf) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir
+            .path()
+            .join(format!("test_project/chats/{}.jsonl", filename));
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        (temp_dir, path)
+    }
+
+    #[test]
+    fn test_parse_qwen_valid_assistant_message() {
+        let content = r#"{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:24:56.857Z", "sessionId": "d96bf338", "usageMetadata": {"promptTokenCount": 12414, "candidatesTokenCount": 76, "thoughtsTokenCount": 39, "cachedContentTokenCount": 0}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_qwen_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, "qwen");
+        assert_eq!(messages[0].model_id, "qwen3.5-plus");
+        assert_eq!(messages[0].provider_id, "qwen");
+        // Session ID comes from filename, not JSON content (temp file has random name)
+        assert!(!messages[0].session_id.is_empty());
+        assert_eq!(messages[0].tokens.input, 12414);
+        assert_eq!(messages[0].tokens.output, 76);
+        assert_eq!(messages[0].tokens.reasoning, 39);
+        assert_eq!(messages[0].tokens.cache_read, 0);
+        assert_eq!(messages[0].tokens.cache_write, 0);
+    }
+
+    #[test]
+    fn test_parse_qwen_multi_turn() {
+        let content = r#"{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:24:56.857Z", "sessionId": "session1", "usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 200, "thoughtsTokenCount": 10, "cachedContentTokenCount": 5}}
+{"type": "assistant", "model": "qwen3-coder-plus", "timestamp": "2026-02-23T14:25:00.000Z", "sessionId": "session1", "usageMetadata": {"promptTokenCount": 300, "candidatesTokenCount": 400, "thoughtsTokenCount": 20, "cachedContentTokenCount": 10}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_qwen_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].model_id, "qwen3.5-plus");
+        assert_eq!(messages[0].tokens.input, 100);
+        assert_eq!(messages[0].tokens.output, 200);
+        assert_eq!(messages[0].tokens.reasoning, 10);
+        assert_eq!(messages[0].tokens.cache_read, 5);
+        assert_eq!(messages[1].model_id, "qwen3-coder-plus");
+        assert_eq!(messages[1].tokens.input, 300);
+        assert_eq!(messages[1].tokens.output, 400);
+        assert_eq!(messages[1].tokens.reasoning, 20);
+        assert_eq!(messages[1].tokens.cache_read, 10);
+    }
+
+    #[test]
+    fn test_parse_qwen_skip_non_assistant() {
+        let content = r#"{"type": "user", "timestamp": "2026-02-23T14:24:50.000Z", "content": "Hello"}
+{"type": "system", "timestamp": "2026-02-23T14:24:51.000Z", "subtype": "ui_telemetry"}
+{"type": "tool_result", "timestamp": "2026-02-23T14:24:52.000Z", "result": "success"}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_qwen_file(file.path());
+
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_parse_qwen_empty_file() {
+        let file = create_test_file("");
+
+        let messages = parse_qwen_file(file.path());
+
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_parse_qwen_malformed_lines() {
+        let content = r#"{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:24:56.857Z", "sessionId": "session1", "usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 200, "thoughtsTokenCount": 10, "cachedContentTokenCount": 5}}
+not valid json at all
+{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:25:00.000Z", "sessionId": "session1", "usageMetadata": {"promptTokenCount": 300, "candidatesTokenCount": 400, "thoughtsTokenCount": 20, "cachedContentTokenCount": 10}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_qwen_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].tokens.input, 100);
+        assert_eq!(messages[1].tokens.input, 300);
+    }
+
+    #[test]
+    fn test_parse_qwen_skips_zero_token_entries() {
+        let content = r#"{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:24:56.857Z", "sessionId": "session1", "usageMetadata": {"promptTokenCount": 0, "candidatesTokenCount": 0, "thoughtsTokenCount": 0, "cachedContentTokenCount": 0}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_qwen_file(file.path());
+
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_parse_qwen_with_cache_and_reasoning() {
+        let content = r#"{"type": "assistant", "model": "qwen3-max-2026-01-23", "timestamp": "2026-02-23T14:24:56.857Z", "sessionId": "session1", "usageMetadata": {"promptTokenCount": 1508, "candidatesTokenCount": 205, "thoughtsTokenCount": 50, "cachedContentTokenCount": 4864}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_qwen_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 1508);
+        assert_eq!(messages[0].tokens.output, 205);
+        assert_eq!(messages[0].tokens.reasoning, 50);
+        assert_eq!(messages[0].tokens.cache_read, 4864);
+        assert_eq!(messages[0].tokens.cache_write, 0);
+    }
+
+    #[test]
+    fn test_parse_qwen_unknown_model_fallback() {
+        let content = r#"{"type": "assistant", "timestamp": "2026-02-23T14:24:56.857Z", "sessionId": "session1", "usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 200, "thoughtsTokenCount": 10, "cachedContentTokenCount": 5}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_qwen_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "unknown");
+        assert_eq!(messages[0].tokens.input, 100);
+    }
+
+    #[test]
+    fn test_session_id_from_json_when_present() {
+        let content = r#"{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:24:56.857Z", "sessionId": "abc123def456", "usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 200, "thoughtsTokenCount": 10, "cachedContentTokenCount": 5}}"#;
+        let (_dir, path) = create_test_file_with_name(content, "json_present");
+
+        let messages = parse_qwen_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        // Should use the sessionId from JSON, not the filename
+        assert_eq!(messages[0].session_id, "abc123def456");
+    }
+
+    #[test]
+    fn test_session_id_fallback_when_empty_string() {
+        let content = r#"{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:24:56.857Z", "sessionId": "", "usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 200, "thoughtsTokenCount": 10, "cachedContentTokenCount": 5}}"#;
+        let (_dir, path) = create_test_file_with_name(content, "json_empty");
+
+        let messages = parse_qwen_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        // Should fallback to path-derived ID (not empty string)
+        assert!(!messages[0].session_id.is_empty());
+        assert_ne!(messages[0].session_id, "");
+        // Verify it's not the JSON empty value
+        assert_ne!(messages[0].session_id, "");
+    }
+
+    #[test]
+    fn test_session_id_fallback_when_missing() {
+        let content = r#"{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:24:56.857Z", "usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 200, "thoughtsTokenCount": 10, "cachedContentTokenCount": 5}}"#;
+        let (_dir, path) = create_test_file_with_name(content, "json_missing");
+
+        let messages = parse_qwen_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        // Should fallback to path-derived ID
+        assert!(!messages[0].session_id.is_empty());
+    }
+
+    #[test]
+    fn test_session_id_fallback_when_null() {
+        let content = r#"{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:24:56.857Z", "sessionId": null, "usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 200, "thoughtsTokenCount": 10, "cachedContentTokenCount": 5}}"#;
+        let (_dir, path) = create_test_file_with_name(content, "json_null");
+
+        let messages = parse_qwen_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        // Should fallback to path-derived ID
+        assert!(!messages[0].session_id.is_empty());
+        assert_ne!(messages[0].session_id, "null");
+    }
+
+    #[test]
+    fn test_cross_project_session_id_uniqueness() {
+        let content = r#"{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:24:56.857Z", "usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 200, "thoughtsTokenCount": 10, "cachedContentTokenCount": 5}}"#;
+
+        // Create two files with same name in different projects
+        let (_dir1, path1) = create_test_file_with_name(content, "session");
+
+        // Manually create a second file in a different project
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path2 = temp_dir.path().join("other_project/chats/session.jsonl");
+        std::fs::create_dir_all(path2.parent().unwrap()).unwrap();
+        let mut file2 = std::fs::File::create(&path2).unwrap();
+        file2.write_all(content.as_bytes()).unwrap();
+
+        let messages1 = parse_qwen_file(&path1);
+        let messages2 = parse_qwen_file(&path2);
+
+        assert_eq!(messages1.len(), 1);
+        assert_eq!(messages2.len(), 1);
+
+        // Session IDs should be different despite same filename
+        assert_ne!(messages1[0].session_id, messages2[0].session_id);
+    }
+
+    #[test]
+    fn test_extract_session_id_with_fallback_uses_json_value() {
+        let path = Path::new("/home/user/.qwen/projects/myapp/chats/abc123.jsonl");
+        let json_session_id = Some("json_session_456");
+
+        let result = extract_session_id_with_fallback(path, json_session_id);
+
+        assert_eq!(result, "json_session_456");
+    }
+
+    #[test]
+    fn test_extract_session_id_with_fallback_empty_uses_path() {
+        let path = Path::new("/home/user/.qwen/projects/myapp/chats/abc123.jsonl");
+        let json_session_id = Some("");
+
+        let result = extract_session_id_with_fallback(path, json_session_id);
+
+        // Should use path-derived ID containing project and filename
+        assert!(result.contains("myapp") || result.contains("abc123"));
+    }
+
+    #[test]
+    fn test_extract_session_id_with_fallback_none_uses_path() {
+        let path = Path::new("/home/user/.qwen/projects/myapp/chats/abc123.jsonl");
+        let json_session_id: Option<&str> = None;
+
+        let result = extract_session_id_with_fallback(path, json_session_id);
+
+        // Should use path-derived ID containing project and filename
+        assert!(result.contains("myapp") || result.contains("abc123"));
+    }
+
+    #[test]
+    fn test_path_derived_session_id_includes_project() {
+        let path = Path::new("/home/user/.qwen/projects/some-project/chats/chat-session.jsonl");
+        let result = extract_session_id_with_fallback(path, None);
+
+        // Should include both project name and filename stem
+        assert!(
+            result.contains("some-project"),
+            "Session ID should contain project name"
+        );
+        assert!(
+            result.contains("chat-session"),
+            "Session ID should contain filename"
+        );
+    }
+
+    #[test]
+    fn test_multi_turn_same_session_id() {
+        let content = r#"{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:24:56.857Z", "sessionId": "shared_session", "usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 200, "thoughtsTokenCount": 10, "cachedContentTokenCount": 5}}
+{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:25:00.000Z", "sessionId": "shared_session", "usageMetadata": {"promptTokenCount": 300, "candidatesTokenCount": 400, "thoughtsTokenCount": 20, "cachedContentTokenCount": 10}}"#;
+        let (_dir, path) = create_test_file_with_name(content, "multi");
+
+        let messages = parse_qwen_file(&path);
+
+        assert_eq!(messages.len(), 2);
+        // Both messages should have the same session ID from JSON
+        assert_eq!(messages[0].session_id, "shared_session");
+        assert_eq!(messages[1].session_id, "shared_session");
+    }
+
+    #[test]
+    fn test_mixed_session_id_in_file() {
+        let content = r#"{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:24:56.857Z", "sessionId": "valid_id", "usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 200, "thoughtsTokenCount": 10, "cachedContentTokenCount": 5}}
+{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:25:00.000Z", "usageMetadata": {"promptTokenCount": 300, "candidatesTokenCount": 400, "thoughtsTokenCount": 20, "cachedContentTokenCount": 10}}
+{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:26:00.000Z", "sessionId": "", "usageMetadata": {"promptTokenCount": 500, "candidatesTokenCount": 600, "thoughtsTokenCount": 30, "cachedContentTokenCount": 15}}"#;
+        let (_dir, path) = create_test_file_with_name(content, "mixed");
+
+        let messages = parse_qwen_file(&path);
+
+        assert_eq!(messages.len(), 3);
+        // First message uses JSON sessionId
+        assert_eq!(messages[0].session_id, "valid_id");
+        // Second message (no sessionId) uses fallback
+        assert!(
+            messages[1].session_id.contains("mixed")
+                || messages[1].session_id.contains("test_project")
+        );
+        // Third message (empty sessionId) uses fallback
+        assert!(
+            messages[2].session_id.contains("mixed")
+                || messages[2].session_id.contains("test_project")
+        );
+    }
+}

--- a/vendor/tokscale-core/src/sessions/roocode.rs
+++ b/vendor/tokscale-core/src/sessions/roocode.rs
@@ -1,0 +1,362 @@
+//! Roo Code task parser
+//!
+//! Parses task-based logs from VS Code globalStorage directories:
+//! - tasks/<taskId>/ui_messages.json
+//! - tasks/<taskId>/api_conversation_history.json
+
+use super::utils::{extract_i64, parse_timestamp_str};
+use super::UnifiedMessage;
+use crate::TokenBreakdown;
+use serde::Deserialize;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Deserialize)]
+struct UiMessageEntry {
+    #[serde(rename = "type")]
+    entry_type: Option<String>,
+    say: Option<String>,
+    text: Option<String>,
+    ts: Option<Value>,
+}
+
+pub fn parse_roocode_file(path: &Path) -> Vec<UnifiedMessage> {
+    parse_roo_kilo_file(path, "roocode")
+}
+
+pub(crate) fn parse_roo_kilo_file(path: &Path, source: &str) -> Vec<UnifiedMessage> {
+    let data = match std::fs::read(path) {
+        Ok(d) => d,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut bytes = data;
+    let entries: Vec<UiMessageEntry> = match simd_json::from_slice(&mut bytes) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+
+    let session_id = extract_session_id(path);
+    let (model_id, agent) = read_task_metadata(path);
+
+    let mut messages = Vec::new();
+    for entry in entries {
+        if entry.entry_type.as_deref() != Some("say")
+            || entry.say.as_deref() != Some("api_req_started")
+        {
+            continue;
+        }
+
+        let text = match entry.text {
+            Some(t) => t,
+            None => continue,
+        };
+
+        let timestamp = match parse_entry_timestamp(entry.ts.as_ref()) {
+            Some(ts) => ts,
+            None => continue,
+        };
+
+        let payload = match parse_api_req_started_payload(&text) {
+            Some(p) => p,
+            None => continue,
+        };
+
+        let provider = provider_from_api_protocol(payload.api_protocol.as_deref());
+
+        messages.push(UnifiedMessage::new_with_agent(
+            source,
+            model_id.clone(),
+            provider,
+            session_id.clone(),
+            timestamp,
+            TokenBreakdown {
+                input: payload.tokens_in,
+                output: payload.tokens_out,
+                cache_read: payload.cache_reads,
+                cache_write: payload.cache_writes,
+                reasoning: 0,
+            },
+            payload.cost,
+            agent.clone(),
+        ));
+    }
+
+    messages
+}
+
+fn extract_session_id(path: &Path) -> String {
+    path.parent()
+        .and_then(|parent| parent.file_name())
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn read_task_metadata(ui_messages_path: &Path) -> (String, Option<String>) {
+    let history_path = sibling_history_path(ui_messages_path);
+    let content = match std::fs::read_to_string(&history_path) {
+        Ok(c) => c,
+        Err(_) => return ("unknown".to_string(), None),
+    };
+
+    extract_model_and_agent(&content)
+}
+
+fn sibling_history_path(ui_messages_path: &Path) -> PathBuf {
+    ui_messages_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("api_conversation_history.json")
+}
+
+fn extract_model_and_agent(content: &str) -> (String, Option<String>) {
+    const ENV_START: &str = "<environment_details>";
+    const ENV_END: &str = "</environment_details>";
+
+    let mut offset = 0usize;
+    let mut last_model: Option<String> = None;
+    let mut last_slug: Option<String> = None;
+    let mut last_name: Option<String> = None;
+
+    while let Some(start_rel) = content[offset..].find(ENV_START) {
+        let start_idx = offset + start_rel + ENV_START.len();
+        let rest = &content[start_idx..];
+
+        let Some(end_rel) = rest.find(ENV_END) else {
+            break;
+        };
+        let end_idx = start_idx + end_rel;
+        let block = &content[start_idx..end_idx];
+
+        if let Some(model) = extract_tag_value(block, "model") {
+            last_model = Some(model);
+        }
+        if let Some(slug) = extract_tag_value(block, "slug") {
+            last_slug = Some(slug);
+        }
+        if let Some(name) = extract_tag_value(block, "name") {
+            last_name = Some(name);
+        }
+
+        offset = end_idx + ENV_END.len();
+    }
+
+    let model = last_model.unwrap_or_else(|| "unknown".to_string());
+    let agent = last_slug.or(last_name);
+    (model, agent)
+}
+
+fn extract_tag_value(block: &str, tag: &str) -> Option<String> {
+    let open = format!("<{}>", tag);
+    let close = format!("</{}>", tag);
+
+    let start_idx = block.find(&open)? + open.len();
+    let rest = &block[start_idx..];
+    let end_rel = rest.find(&close)?;
+    let value = rest[..end_rel].trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+fn parse_entry_timestamp(ts: Option<&Value>) -> Option<i64> {
+    let value = ts?;
+    let ts_str = if let Some(s) = value.as_str() {
+        s.to_string()
+    } else if let Some(i) = value.as_i64() {
+        i.to_string()
+    } else if let Some(u) = value.as_u64() {
+        u.to_string()
+    } else {
+        return None;
+    };
+
+    parse_timestamp_str(&ts_str)
+}
+
+struct ApiReqStartedPayload {
+    cost: f64,
+    tokens_in: i64,
+    tokens_out: i64,
+    cache_reads: i64,
+    cache_writes: i64,
+    api_protocol: Option<String>,
+}
+
+fn parse_api_req_started_payload(text: &str) -> Option<ApiReqStartedPayload> {
+    let mut bytes = text.as_bytes().to_vec();
+    let value: Value = simd_json::from_slice(&mut bytes).ok()?;
+
+    let cost = extract_f64(value.get("cost")).unwrap_or(0.0).max(0.0);
+    let tokens_in = extract_i64(value.get("tokensIn")).unwrap_or(0).max(0);
+    let tokens_out = extract_i64(value.get("tokensOut")).unwrap_or(0).max(0);
+    let cache_reads = extract_i64(value.get("cacheReads")).unwrap_or(0).max(0);
+    let cache_writes = extract_i64(value.get("cacheWrites")).unwrap_or(0).max(0);
+    let api_protocol = value
+        .get("apiProtocol")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    Some(ApiReqStartedPayload {
+        cost,
+        tokens_in,
+        tokens_out,
+        cache_reads,
+        cache_writes,
+        api_protocol,
+    })
+}
+
+fn extract_f64(value: Option<&Value>) -> Option<f64> {
+    value.and_then(|val| {
+        val.as_f64()
+            .or_else(|| val.as_i64().map(|v| v as f64))
+            .or_else(|| val.as_u64().map(|v| v as f64))
+            .or_else(|| val.as_str().and_then(|s| s.parse::<f64>().ok()))
+    })
+}
+
+fn provider_from_api_protocol(api_protocol: Option<&str>) -> &'static str {
+    match api_protocol {
+        Some("anthropic") => "anthropic",
+        Some("openai") => "openai",
+        _ => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn setup_task(
+        dir: &TempDir,
+        task_id: &str,
+        ui_messages_content: &str,
+        history_content: Option<&str>,
+    ) -> PathBuf {
+        let task_dir = dir.path().join("tasks").join(task_id);
+        fs::create_dir_all(&task_dir).unwrap();
+        fs::write(task_dir.join("ui_messages.json"), ui_messages_content).unwrap();
+        if let Some(history) = history_content {
+            fs::write(task_dir.join("api_conversation_history.json"), history).unwrap();
+        }
+        task_dir.join("ui_messages.json")
+    }
+
+    #[test]
+    fn test_parse_roocode_valid_api_req_started() {
+        let dir = TempDir::new().unwrap();
+        let ui_messages = r#"[
+  {
+    "type": "say",
+    "say": "api_req_started",
+    "ts": "2026-02-18T12:00:00Z",
+    "text": "{\"cost\":0.12,\"tokensIn\":100,\"tokensOut\":50,\"cacheReads\":20,\"cacheWrites\":5,\"apiProtocol\":\"anthropic\"}"
+  },
+  {
+    "type": "say",
+    "say": "assistant_message",
+    "ts": "2026-02-18T12:00:01Z",
+    "text": "{}"
+  }
+]"#;
+        let history = r#"before
+<environment_details>
+<model>claude-sonnet-4</model>
+<slug>architect</slug>
+<name>Architect</name>
+</environment_details>
+after"#;
+        let path = setup_task(&dir, "task-abc", ui_messages, Some(history));
+
+        let messages = parse_roocode_file(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, "roocode");
+        assert_eq!(messages[0].model_id, "claude-sonnet-4");
+        assert_eq!(messages[0].provider_id, "anthropic");
+        assert_eq!(messages[0].session_id, "task-abc");
+        assert_eq!(messages[0].tokens.input, 100);
+        assert_eq!(messages[0].tokens.output, 50);
+        assert_eq!(messages[0].tokens.cache_read, 20);
+        assert_eq!(messages[0].tokens.cache_write, 5);
+        assert_eq!(messages[0].cost, 0.12);
+        assert_eq!(messages[0].agent.as_deref(), Some("architect"));
+    }
+
+    #[test]
+    fn test_parse_roocode_skips_malformed_payload_entry() {
+        let dir = TempDir::new().unwrap();
+        let ui_messages = r#"[
+  {
+    "type": "say",
+    "say": "api_req_started",
+    "ts": "2026-02-18T12:00:00Z",
+    "text": "not-json"
+  },
+  {
+    "type": "say",
+    "say": "api_req_started",
+    "ts": "2026-02-18T12:00:02Z",
+    "text": "{\"cost\":0.03,\"tokensIn\":10,\"tokensOut\":2,\"cacheReads\":1,\"cacheWrites\":0,\"apiProtocol\":\"openai\"}"
+  }
+]"#;
+        let path = setup_task(&dir, "task-def", ui_messages, None);
+
+        let messages = parse_roocode_file(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].provider_id, "openai");
+        assert_eq!(messages[0].model_id, "unknown");
+        assert_eq!(messages[0].agent, None);
+    }
+
+    #[test]
+    fn test_parse_roocode_skips_invalid_timestamp() {
+        let dir = TempDir::new().unwrap();
+        let ui_messages = r#"[
+  {
+    "type": "say",
+    "say": "api_req_started",
+    "ts": "not-a-time",
+    "text": "{\"cost\":0.12,\"tokensIn\":100,\"tokensOut\":50,\"cacheReads\":20,\"cacheWrites\":5,\"apiProtocol\":\"anthropic\"}"
+  }
+]"#;
+        let path = setup_task(&dir, "task-time", ui_messages, None);
+
+        let messages = parse_roocode_file(&path);
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_parse_roocode_invalid_file_json_is_ignored() {
+        let dir = TempDir::new().unwrap();
+        let path = setup_task(&dir, "task-invalid", "{not-json", None);
+
+        let messages = parse_roocode_file(&path);
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_extract_model_and_agent_prefers_slug_then_name() {
+        let content = r#"
+<environment_details>
+<model>gpt-5</model>
+<name>Builder</name>
+</environment_details>
+<environment_details>
+<model>gpt-5.1</model>
+<slug>reviewer</slug>
+<name>Reviewer</name>
+</environment_details>
+"#;
+
+        let (model, agent) = extract_model_and_agent(content);
+        assert_eq!(model, "gpt-5.1");
+        assert_eq!(agent.as_deref(), Some("reviewer"));
+    }
+}

--- a/vendor/tokscale-core/src/sessions/synthetic.rs
+++ b/vendor/tokscale-core/src/sessions/synthetic.rs
@@ -1,0 +1,368 @@
+//! Synthetic.new detection and Octofriend session parser
+//!
+//! Detects synthetic.new API usage across existing agent sessions by model/provider patterns,
+//! and parses Octofriend's SQLite database when token data is available.
+
+use super::UnifiedMessage;
+use crate::TokenBreakdown;
+use std::path::Path;
+
+// =============================================================================
+// Detection Functions (Strategy 1: detect synthetic.new usage in other sources)
+// =============================================================================
+
+/// Check if a model ID indicates synthetic.new API usage.
+///
+/// synthetic.new uses `hf:` prefixed model IDs in requests and may return
+/// provider-prefixed model IDs like `accounts/fireworks/models/...` in responses.
+pub fn is_synthetic_model(model_id: &str) -> bool {
+    let lower = model_id.to_lowercase();
+
+    // HuggingFace-style model IDs used by synthetic.new
+    if lower.starts_with("hf:") {
+        return true;
+    }
+
+    // Fireworks provider-prefixed responses
+    if lower.starts_with("accounts/fireworks/") {
+        return true;
+    }
+
+    // Together AI provider-prefixed responses
+    if lower.starts_with("accounts/together/") {
+        return true;
+    }
+
+    false
+}
+
+/// Check if a provider ID indicates synthetic.new API usage.
+pub fn is_synthetic_provider(provider_id: &str) -> bool {
+    let lower = provider_id.to_lowercase();
+    matches!(
+        lower.as_str(),
+        "synthetic" | "glhf" | "synthetic.new" | "octofriend"
+    )
+}
+
+/// Check if a message appears to have been routed through Synthetic's gateway.
+pub fn is_synthetic_gateway(model_id: &str, provider_id: &str) -> bool {
+    is_synthetic_model(model_id) || is_synthetic_provider(provider_id)
+}
+
+// =============================================================================
+// Model name normalization (strip synthetic.new prefixes for pricing lookup)
+// =============================================================================
+
+/// Normalize a synthetic.new model ID to a standard form for pricing lookup.
+/// e.g. "hf:deepseek-ai/DeepSeek-V3-0324" -> "deepseek-v3-0324"
+/// e.g. "accounts/fireworks/models/deepseek-v3-0324" -> "deepseek-v3-0324"
+pub fn normalize_synthetic_model(model_id: &str) -> String {
+    let lower = model_id.to_lowercase();
+
+    // Strip "hf:" prefix and org name
+    if let Some(rest) = lower.strip_prefix("hf:") {
+        // "hf:deepseek-ai/DeepSeek-V3-0324" -> "deepseek-v3-0324"
+        if let Some((_org, model)) = rest.split_once('/') {
+            return model.to_string();
+        }
+        return rest.to_string();
+    }
+
+    // Strip "accounts/<provider>/models/" prefix
+    if let Some(rest) = lower.strip_prefix("accounts/") {
+        // "accounts/fireworks/models/deepseek-v3-0324" -> "deepseek-v3-0324"
+        if let Some(models_rest) = rest.split_once("/models/") {
+            return models_rest.1.to_string();
+        }
+    }
+
+    lower
+}
+
+/// Normalize synthetic gateway fields without changing the originating client.
+pub fn normalize_synthetic_gateway_fields(model_id: &mut String, provider_id: &mut String) -> bool {
+    if !is_synthetic_gateway(model_id, provider_id) {
+        return false;
+    }
+
+    *model_id = normalize_synthetic_model(model_id);
+    if provider_id.is_empty() || provider_id.eq_ignore_ascii_case("unknown") {
+        *provider_id = "synthetic".to_string();
+    }
+
+    true
+}
+
+/// Compatibility matcher for `--synthetic` / synthetic source selection.
+pub fn matches_synthetic_filter(client: &str, model_id: &str, provider_id: &str) -> bool {
+    client.eq_ignore_ascii_case("synthetic") || is_synthetic_gateway(model_id, provider_id)
+}
+
+// =============================================================================
+// Octofriend SQLite Parser (Strategy 2: parse Octofriend sessions)
+// =============================================================================
+
+/// Parse Octofriend's SQLite database for token usage data.
+///
+/// Currently Octofriend only stores input_history (no token data).
+/// This function checks for token-related tables and parses them when available,
+/// making it future-proof for when Octofriend adds token persistence.
+pub fn parse_octofriend_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
+    let conn = match rusqlite::Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    ) {
+        Ok(conn) => conn,
+        Err(_) => return Vec::new(),
+    };
+
+    // Check if a token-tracking table exists (future-proofing)
+    // Octofriend may add tables like 'messages', 'sessions', or 'token_usage'
+    let has_messages_table: bool = conn
+        .query_row(
+            "SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ('messages', 'sessions', 'token_usage')",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map(|count| count > 0)
+        .unwrap_or(false);
+
+    if !has_messages_table {
+        return Vec::new();
+    }
+
+    // If messages table exists, attempt to parse it
+    // This follows the OpenCode SQLite pattern:
+    // SELECT id, session_id, data FROM messages WHERE role = 'assistant' AND tokens IS NOT NULL
+    let mut messages = Vec::new();
+
+    // Try 'messages' table first (most likely schema)
+    if let Ok(mut stmt) = conn.prepare(
+        "SELECT id, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens, cost, timestamp, session_id, provider FROM messages WHERE input_tokens IS NOT NULL OR output_tokens IS NOT NULL",
+    ) {
+        if let Ok(rows) = stmt.query_map([], |row| {
+            let id: String = row.get(0)?;
+            let model_id: String = row.get::<_, String>(1).unwrap_or_default();
+            let input: i64 = row.get::<_, i64>(2).unwrap_or(0);
+            let output: i64 = row.get::<_, i64>(3).unwrap_or(0);
+            let cache_read: i64 = row.get::<_, i64>(4).unwrap_or(0);
+            let cache_write: i64 = row.get::<_, i64>(5).unwrap_or(0);
+            let reasoning: i64 = row.get::<_, i64>(6).unwrap_or(0);
+            let cost: f64 = row.get::<_, f64>(7).unwrap_or(0.0);
+            let timestamp: f64 = row.get::<_, f64>(8).unwrap_or(0.0);
+            let session_id: String = row.get::<_, String>(9).unwrap_or_else(|_| "unknown".to_string());
+            let provider: String = row.get::<_, String>(10).unwrap_or_else(|_| "synthetic".to_string());
+
+            Ok((id, model_id, input, output, cache_read, cache_write, reasoning, cost, timestamp, session_id, provider))
+        }) {
+            for row_result in rows.flatten() {
+                let (id, model_id, input, output, cache_read, cache_write, reasoning, cost, timestamp, session_id, provider) = row_result;
+
+                let total = input + output + cache_read + cache_write + reasoning;
+                if total == 0 {
+                    continue;
+                }
+
+                let ts_ms = if timestamp > 1e12 {
+                    timestamp as i64
+                } else {
+                    (timestamp * 1000.0) as i64
+                };
+
+                let mut msg = UnifiedMessage::new(
+                    "synthetic",
+                    normalize_synthetic_model(&model_id),
+                    provider,
+                    session_id,
+                    ts_ms,
+                    TokenBreakdown {
+                        input: input.max(0),
+                        output: output.max(0),
+                        cache_read: cache_read.max(0),
+                        cache_write: cache_write.max(0),
+                        reasoning: reasoning.max(0),
+                    },
+                    cost.max(0.0),
+                );
+                msg.dedup_key = Some(id);
+                messages.push(msg);
+            }
+        }
+    }
+
+    // Try 'token_usage' table as alternative schema
+    if messages.is_empty() {
+        if let Ok(mut stmt) = conn.prepare(
+            "SELECT id, model, input_tokens, output_tokens, timestamp, session_id FROM token_usage WHERE input_tokens > 0 OR output_tokens > 0",
+        ) {
+            if let Ok(rows) = stmt.query_map([], |row| {
+                let id: String = row.get(0)?;
+                let model_id: String = row.get::<_, String>(1).unwrap_or_default();
+                let input: i64 = row.get::<_, i64>(2).unwrap_or(0);
+                let output: i64 = row.get::<_, i64>(3).unwrap_or(0);
+                let timestamp: f64 = row.get::<_, f64>(4).unwrap_or(0.0);
+                let session_id: String = row.get::<_, String>(5).unwrap_or_else(|_| "unknown".to_string());
+
+                Ok((id, model_id, input, output, timestamp, session_id))
+            }) {
+                for row_result in rows.flatten() {
+                    let (id, model_id, input, output, timestamp, session_id) = row_result;
+
+                    let ts_ms = if timestamp > 1e12 {
+                        timestamp as i64
+                    } else {
+                        (timestamp * 1000.0) as i64
+                    };
+
+                    let mut msg = UnifiedMessage::new(
+                        "synthetic",
+                        normalize_synthetic_model(&model_id),
+                        "synthetic",
+                        session_id,
+                        ts_ms,
+                        TokenBreakdown {
+                            input: input.max(0),
+                            output: output.max(0),
+                            cache_read: 0,
+                            cache_write: 0,
+                            reasoning: 0,
+                        },
+                        0.0,
+                    );
+                    msg.dedup_key = Some(id);
+                    messages.push(msg);
+                }
+            }
+        }
+    }
+
+    messages
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_synthetic_model_hf_prefix() {
+        assert!(is_synthetic_model("hf:deepseek-ai/DeepSeek-V3-0324"));
+        assert!(is_synthetic_model("hf:zai-org/GLM-4.7"));
+        assert!(is_synthetic_model("hf:moonshotai/Kimi-K2.5"));
+        assert!(is_synthetic_model("hf:MiniMaxAI/MiniMax-M2.1"));
+    }
+
+    #[test]
+    fn test_is_synthetic_model_fireworks_prefix() {
+        assert!(is_synthetic_model(
+            "accounts/fireworks/models/deepseek-v3-0324"
+        ));
+        assert!(is_synthetic_model("accounts/fireworks/models/glm-4.7"));
+    }
+
+    #[test]
+    fn test_is_synthetic_model_together_prefix() {
+        assert!(is_synthetic_model("accounts/together/models/qwen3-235b"));
+    }
+
+    #[test]
+    fn test_is_synthetic_model_negative() {
+        assert!(!is_synthetic_model("claude-sonnet-4-5"));
+        assert!(!is_synthetic_model("gpt-5.2-codex"));
+        assert!(!is_synthetic_model("deepseek-v3"));
+        assert!(!is_synthetic_model("gemini-2.5-pro"));
+    }
+
+    #[test]
+    fn test_is_synthetic_provider() {
+        assert!(is_synthetic_provider("synthetic"));
+        assert!(is_synthetic_provider("glhf"));
+        assert!(is_synthetic_provider("Synthetic"));
+        assert!(is_synthetic_provider("GLHF"));
+        assert!(is_synthetic_provider("synthetic.new"));
+        assert!(is_synthetic_provider("octofriend"));
+    }
+
+    #[test]
+    fn test_is_synthetic_provider_negative() {
+        assert!(!is_synthetic_provider("anthropic"));
+        assert!(!is_synthetic_provider("openai"));
+        assert!(!is_synthetic_provider("moonshot"));
+        assert!(!is_synthetic_provider("fireworks"));
+    }
+
+    #[test]
+    fn test_normalize_synthetic_model_hf() {
+        assert_eq!(
+            normalize_synthetic_model("hf:deepseek-ai/DeepSeek-V3-0324"),
+            "deepseek-v3-0324"
+        );
+        assert_eq!(normalize_synthetic_model("hf:zai-org/GLM-4.7"), "glm-4.7");
+        assert_eq!(
+            normalize_synthetic_model("hf:moonshotai/Kimi-K2.5"),
+            "kimi-k2.5"
+        );
+    }
+
+    #[test]
+    fn test_normalize_synthetic_model_fireworks() {
+        assert_eq!(
+            normalize_synthetic_model("accounts/fireworks/models/deepseek-v3-0324"),
+            "deepseek-v3-0324"
+        );
+    }
+
+    #[test]
+    fn test_normalize_synthetic_model_passthrough() {
+        assert_eq!(
+            normalize_synthetic_model("claude-sonnet-4-5"),
+            "claude-sonnet-4-5"
+        );
+        assert_eq!(normalize_synthetic_model("gpt-4o"), "gpt-4o");
+    }
+
+    #[test]
+    fn test_normalize_synthetic_gateway_fields_sets_provider_when_unknown() {
+        let mut model_id = "hf:deepseek-ai/DeepSeek-V3-0324".to_string();
+        let mut provider_id = "unknown".to_string();
+
+        let matched = normalize_synthetic_gateway_fields(&mut model_id, &mut provider_id);
+
+        assert!(matched);
+        assert_eq!(model_id, "deepseek-v3-0324");
+        assert_eq!(provider_id, "synthetic");
+    }
+
+    #[test]
+    fn test_normalize_synthetic_gateway_fields_preserves_existing_provider() {
+        let mut model_id = "accounts/fireworks/models/deepseek-v3-0324".to_string();
+        let mut provider_id = "fireworks".to_string();
+
+        let matched = normalize_synthetic_gateway_fields(&mut model_id, &mut provider_id);
+
+        assert!(matched);
+        assert_eq!(model_id, "deepseek-v3-0324");
+        assert_eq!(provider_id, "fireworks");
+    }
+
+    #[test]
+    fn test_matches_synthetic_filter_accepts_gateway_traffic_without_rewriting_client() {
+        assert!(matches_synthetic_filter(
+            "opencode",
+            "hf:deepseek-ai/DeepSeek-V3-0324",
+            "unknown"
+        ));
+        assert!(matches_synthetic_filter(
+            "claude",
+            "claude-sonnet-4-5",
+            "glhf"
+        ));
+        assert!(!matches_synthetic_filter("opencode", "gpt-4o", "anthropic"));
+    }
+
+    #[test]
+    fn test_parse_octofriend_sqlite_nonexistent() {
+        let result = parse_octofriend_sqlite(Path::new("/nonexistent/path/sqlite.db"));
+        assert!(result.is_empty());
+    }
+}

--- a/vendor/tokscale-core/src/sessions/utils.rs
+++ b/vendor/tokscale-core/src/sessions/utils.rs
@@ -1,0 +1,57 @@
+//! Shared parsing helpers for session logs.
+
+use serde_json::Value;
+use std::path::Path;
+use std::time::SystemTime;
+
+pub(crate) fn extract_i64(value: Option<&Value>) -> Option<i64> {
+    value.and_then(|val| {
+        val.as_i64()
+            .or_else(|| val.as_u64().map(|v| v as i64))
+            .or_else(|| val.as_str().and_then(|s| s.parse::<i64>().ok()))
+    })
+}
+
+pub(crate) fn extract_string(value: Option<&Value>) -> Option<String> {
+    value.and_then(|val| val.as_str().map(|s| s.to_string()))
+}
+
+pub(crate) fn parse_timestamp_value(value: &Value) -> Option<i64> {
+    if let Some(ts) = value.as_str() {
+        return parse_timestamp_str(ts);
+    }
+
+    let numeric = value
+        .as_i64()
+        .or_else(|| value.as_u64().map(|v| v as i64))?;
+    // Heuristic: values >= 1e12 are treated as milliseconds, smaller values as seconds.
+    if numeric >= 1_000_000_000_000 {
+        Some(numeric)
+    } else {
+        Some(numeric * 1000)
+    }
+}
+
+pub(crate) fn parse_timestamp_str(value: &str) -> Option<i64> {
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(value) {
+        return Some(dt.timestamp_millis());
+    }
+
+    if let Ok(numeric) = value.parse::<i64>() {
+        if numeric >= 1_000_000_000_000 {
+            return Some(numeric);
+        }
+        return Some(numeric * 1000);
+    }
+
+    None
+}
+
+pub(crate) fn file_modified_timestamp_ms(path: &Path) -> i64 {
+    std::fs::metadata(path)
+        .and_then(|meta| meta.modified())
+        .ok()
+        .and_then(|time| time.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis() as i64)
+        .unwrap_or_else(|| chrono::Utc::now().timestamp_millis())
+}


### PR DESCRIPTION
### Motivation
- Prevent lost HTML attributes on chart containers by forwarding unknown `div` props to the rendered element. 
- Remove duplicated sources of truth for `TokenUsageUpdate.query` to avoid inconsistent serialized payloads. 
- Ensure monthly token totals are computed once and reused to avoid divergence between breakdown and top-level totals. 
- Eliminate fragile git-hosted dependency on a personal repo by vendoring `tokscale-core` to avoid supply-chain breakage.

### Description
- Chart: `ChartContainer` now collects remaining `div` props via rest syntax (`...props`) and spreads them onto the rendered `<div>`. (apps/web/src/components/ui/chart.tsx)
- TokenUsageUpdate: removed the top-level `query` field from `TokenUsageUpdate` and now rely on `overview.query` as the single source of truth; publishing code was updated to stop sending a duplicated `query`. (crates/token-usage/src/models.rs, crates/token-usage/src/service.rs)
- Tests: updated unit tests to reference the query through `update.overview.query` and adjusted an assertion formatting for readability. (crates/token-usage/src/tests.rs)
- Monthly usage: refactored `build_monthly_usage` to compute `total_tokens` once and reuse it for both the `breakdown.total_tokens` and the outer `total_tokens`; added a comment that `reasoning_tokens` is `0` because upstream `tokscale_core::MonthlyUsage` currently does not expose reasoning. (crates/token-usage/src/service.rs)
- Dependency vendoring: replaced the git dependency for `tokscale-core` with a local path (`vendor/tokscale-core`) and added a vendored copy of `tokscale-core` under `vendor/` to remove external git-host dependency. (crates/token-usage/Cargo.toml, vendor/tokscale-core/*)
- Formatting: ran `cargo fmt --all` to normalize formatting across modified files.

### Testing
- Ran `cargo fmt --all` which completed successfully across the workspace. 
- Attempted to run `cargo test -p token-usage`, but the full test run could not complete in this environment because building native `openssl-sys` failed when attempting to build OpenSSL from source (error: missing/failed `perl ./Configure` step), so the test job aborted before running all unit tests. 
- Unit test adjustments for token-usage were updated and are self-consistent; local `cargo test` should pass on a machine with a working OpenSSL toolchain (or with vendor/toolchain adjustments to avoid building openssl-src).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2b9b8570c8328bc56c45580441392)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost HTML attributes in charts, unifies token usage query and monthly totals for consistent payloads, and vendors `tokscale-core` to remove the git dependency.

- **Bug Fixes**
  - `ChartContainer` now forwards remaining `div` props to the rendered element.
  - `TokenUsageUpdate` now uses `overview.query` as the single source of truth; monthly totals are computed once and reused to avoid mismatches.
  - Replaced the git dependency with a vendored `tokscale-core`.

- **Migration**
  - Replace any `update.query` reads with `update.overview.query`.

<sup>Written for commit f249443641877252d5c4a4ce1e15187227184b81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

