### PR TITLE
Codex/wiki ask chat panel

### DIFF
--- a/apps/web/src/components/agent/AgentChatPanel.tsx
+++ b/apps/web/src/components/agent/AgentChatPanel.tsx
@@ -1876,6 +1876,8 @@ export function AgentChatPanel({
     removeQueuedAgentChatPrompt,
     updateQueuedAgentChatPrompt,
     moveQueuedAgentChatPrompt,
+    setAgentChatDraft,
+    clearAgentChatDraft,
   } = useDialogStore();
   const isPanelOpen = variant === "sidebar" ? true : isAgentChatOpen;
   const [newSessionAgentsOpen, setNewSessionAgentsOpen] = useState(false);
@@ -2359,6 +2361,7 @@ export function AgentChatPanel({
     () => agentChatPromptQueues[queueKey] ?? [],
     [agentChatPromptQueues, queueKey]
   );
+  const agentChatDraft = useDialogStore((s) => s.agentChatDrafts[queueKey] ?? "");
   const queuedPromptHead = queuedPrompts[0] ?? null;
 
 
@@ -2966,10 +2969,12 @@ export function AgentChatPanel({
         sessionTitle: sessionTitleForPrompt,
         origin: "panel",
       });
+      clearAgentChatDraft(sessionWorkspaceId, sessionProjectId, chatMode);
     },
     [
       chatMode,
       canUseCurrentMode,
+      clearAgentChatDraft,
       enqueueAgentChatPrompt,
       entries.length,
       isConnected,
@@ -3652,6 +3657,14 @@ export function AgentChatPanel({
                     : "Select agent to connect"
                 }
                 disabled={!isConnected || !canUseCurrentMode}
+                value={agentChatDraft}
+                onChange={(e) =>
+                  setAgentChatDraft(
+                    sessionWorkspaceId,
+                    sessionProjectId,
+                    chatMode,
+                    e.currentTarget.value
+                  )}
               />
             </PromptInputBody>
             <PromptInputFooter>

--- a/apps/web/src/components/layout/RightSidebar.tsx
+++ b/apps/web/src/components/layout/RightSidebar.tsx
@@ -68,7 +68,7 @@ import {
   GitCommit as GitCommitIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useQueryStates } from "nuqs";
+import { useQueryState, useQueryStates } from "nuqs";
 import {
   centerStageParams,
   rightSidebarParams,
@@ -464,7 +464,7 @@ const RightSidebar: React.FC<RightSidebarProps> = () => {
 
   const [{ rsTab: activeTab, rsView: changesView }, setSidebarParams] =
     useQueryStates(rightSidebarParams);
-  const [{ tab: activeCenterTab }] = useQueryStates(centerStageParams);
+  const [activeCenterTab] = useQueryState("tab", centerStageParams.tab);
   const [
     { rsPr: activePrNumber, rsRunId: activeRunId, rsCreatePr },
     setModalParams,

--- a/apps/web/src/components/selection/SelectionPopover.tsx
+++ b/apps/web/src/components/selection/SelectionPopover.tsx
@@ -149,7 +149,7 @@ export const SelectionPopover: React.FC<SelectionPopoverProps> = ({
         type: 'error',
       });
     }
-  }, [buildFormattedText, displayInfo, onCopied, onDismiss]);
+  }, [buildFormattedText, displayInfo, onCopied, onDismiss, type]);
 
   const handleAttach = useCallback(async (includeNote: boolean = false) => {
     if (!displayInfo || !onAttach) return;
@@ -167,6 +167,8 @@ export const SelectionPopover: React.FC<SelectionPopoverProps> = ({
       setCopied(false);
       onDismiss();
       setUserNote('');
+    } catch {
+      // Swallow attach failures to avoid unhandled rejections without adding extra UI noise.
     } finally {
       setAttaching(false);
     }
@@ -214,18 +216,6 @@ export const SelectionPopover: React.FC<SelectionPopoverProps> = ({
       <Popover open={isExpanded} onOpenChange={(open) => !open && onDismiss()}>
         <PopoverAnchor asChild>
           <div className="flex items-center gap-0.5 rounded-md border border-border bg-popover p-0.5 shadow-md">
-            {canAttach ? (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7"
-                onClick={() => void handleAttach(false)}
-                title="Attach to Wiki Ask"
-                disabled={attaching}
-              >
-                <Paperclip className="h-3.5 w-3.5" />
-              </Button>
-            ) : null}
             <Button
               variant="ghost"
               size="icon"
@@ -239,6 +229,18 @@ export const SelectionPopover: React.FC<SelectionPopoverProps> = ({
                 <Copy className="h-3.5 w-3.5" />
               )}
             </Button>
+            {canAttach ? (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                onClick={() => void handleAttach(false)}
+                title="Attach to Wiki Ask"
+                disabled={attaching}
+              >
+                <Paperclip className="h-3.5 w-3.5" />
+              </Button>
+            ) : null}
             <Button
               variant="ghost"
               size="icon"

--- a/apps/web/src/components/wiki/WikiContent.tsx
+++ b/apps/web/src/components/wiki/WikiContent.tsx
@@ -64,8 +64,8 @@ export const WikiContent: React.FC<WikiContentProps> = ({
   const { workspaceId, projectId } = useContextParams();
   const { activeContent, activePage, contentLoading, contentError } =
     useWikiContext(contextId);
-  const { projects, fetchProjects } = useProjectStore();
-  const enqueueAgentChatPrompt = useDialogStore((s) => s.enqueueAgentChatPrompt);
+  const fetchProjects = useProjectStore((s) => s.fetchProjects);
+  const appendAgentChatDraft = useDialogStore((s) => s.appendAgentChatDraft);
   const topRef = useRef<HTMLDivElement>(null);
   const previewContainerRef = useRef<HTMLDivElement>(null);
   const wikiContentRootRef = useRef<HTMLDivElement>(null);
@@ -229,10 +229,10 @@ export const WikiContent: React.FC<WikiContentProps> = ({
     let queueProjectId: string | null | undefined = projectId;
 
     if (workspaceId) {
-      const resolveParentProjectId = (items: typeof projects) =>
+      const resolveParentProjectId = (items: ReturnType<typeof useProjectStore.getState>["projects"]) =>
         items.find((project) => project.workspaces.some((workspace) => workspace.id === workspaceId))?.id ?? null;
 
-      let parentProjectId = resolveParentProjectId(projects);
+      let parentProjectId = resolveParentProjectId(useProjectStore.getState().projects);
       if (!parentProjectId) {
         try {
           await fetchProjects();
@@ -248,20 +248,13 @@ export const WikiContent: React.FC<WikiContentProps> = ({
       }
     }
 
-    enqueueAgentChatPrompt({
-      prompt: payload.formattedText,
-      workspaceId: queueWorkspaceId,
-      projectId: queueProjectId,
-      mode: "wiki_ask",
-      origin: "wiki_selection_attach",
-    });
-
-    toastManager.add({
-      title: "Attached to Wiki Ask",
-      description: "The selected wiki excerpt was added to the right sidebar chat.",
-      type: "success",
-    });
-  }, [workspaceId, projectId, projects, fetchProjects, enqueueAgentChatPrompt]);
+    appendAgentChatDraft(
+      queueWorkspaceId,
+      queueProjectId,
+      "wiki_ask",
+      payload.formattedText,
+    );
+  }, [workspaceId, projectId, fetchProjects, appendAgentChatDraft]);
 
   if (contentLoading && !activeContent) {
     return (

--- a/apps/web/src/hooks/use-dialog-store.ts
+++ b/apps/web/src/hooks/use-dialog-store.ts
@@ -21,6 +21,7 @@ export interface QueuedAgentPrompt {
 }
 
 type AgentPromptQueueMap = Record<string, QueuedAgentPrompt[]>;
+type AgentChatDraftMap = Record<string, string>;
 
 export function getAgentPromptQueueKey(
   workspaceId: string | null | undefined,
@@ -66,7 +67,30 @@ interface DialogStore {
   consumePendingAgentChatMode: () => AgentChatMode | null;
 
   agentChatPromptQueues: AgentPromptQueueMap;
+  agentChatDrafts: AgentChatDraftMap;
   enqueueAgentChatPrompt: (data: Omit<QueuedAgentPrompt, "id" | "createdAt">) => string;
+  getAgentChatDraft: (
+    workspaceId: string | null | undefined,
+    projectId: string | null | undefined,
+    mode: AgentChatMode,
+  ) => string;
+  setAgentChatDraft: (
+    workspaceId: string | null | undefined,
+    projectId: string | null | undefined,
+    mode: AgentChatMode,
+    value: string,
+  ) => void;
+  appendAgentChatDraft: (
+    workspaceId: string | null | undefined,
+    projectId: string | null | undefined,
+    mode: AgentChatMode,
+    value: string,
+  ) => void;
+  clearAgentChatDraft: (
+    workspaceId: string | null | undefined,
+    projectId: string | null | undefined,
+    mode: AgentChatMode,
+  ) => void;
   peekQueuedAgentChatPrompt: (
     workspaceId: string | null | undefined,
     projectId: string | null | undefined,
@@ -134,6 +158,7 @@ export const useDialogStore = create<DialogStore>((set) => ({
   },
 
   agentChatPromptQueues: {},
+  agentChatDrafts: {},
   enqueueAgentChatPrompt: (data) => {
     const item: QueuedAgentPrompt = {
       ...data,
@@ -152,6 +177,38 @@ export const useDialogStore = create<DialogStore>((set) => ({
     });
     return item.id;
   },
+  getAgentChatDraft: (workspaceId, projectId, mode) => {
+    let value = "";
+    set((state) => {
+      value = state.agentChatDrafts[getAgentPromptQueueKey(workspaceId, projectId, mode)] ?? "";
+      return state;
+    });
+    return value;
+  },
+  setAgentChatDraft: (workspaceId, projectId, mode, value) => set((state) => ({
+    agentChatDrafts: {
+      ...state.agentChatDrafts,
+      [getAgentPromptQueueKey(workspaceId, projectId, mode)]: value,
+    },
+  })),
+  appendAgentChatDraft: (workspaceId, projectId, mode, value) => set((state) => {
+    const key = getAgentPromptQueueKey(workspaceId, projectId, mode);
+    const existing = state.agentChatDrafts[key]?.trim();
+    const nextValue = existing ? `${existing}\n\n${value}` : value;
+    return {
+      agentChatDrafts: {
+        ...state.agentChatDrafts,
+        [key]: nextValue,
+      },
+    };
+  }),
+  clearAgentChatDraft: (workspaceId, projectId, mode) => set((state) => {
+    const key = getAgentPromptQueueKey(workspaceId, projectId, mode);
+    if (!(key in state.agentChatDrafts)) return state;
+    const nextDrafts = { ...state.agentChatDrafts };
+    delete nextDrafts[key];
+    return { agentChatDrafts: nextDrafts };
+  }),
   peekQueuedAgentChatPrompt: (workspaceId, projectId, mode) => {
     let item: QueuedAgentPrompt | null = null;
     set((state) => {


### PR DESCRIPTION
## Summary

Refactor Wiki Ask ACP Chat to live in the right sidebar when the Wiki tab is active, while keeping the existing Chat panel UI/logic as the shared implementation.

This PR:
- renders Wiki Ask directly in the right sidebar on Wiki pages instead of opening it as a modal
- removes the default/wiki mode toggle from the modal chat panel and keeps modal chat as default chat only
- keeps Wiki Ask sidebar state mounted so switching pages or workspaces within the same project does not drop local chat state
- adds Wiki-only `Attach` actions to the selection popover so selected wiki excerpts can be sent directly into Wiki Ask
- softens the sidebar mode switch with a lightweight transition layer instead of a hard cut

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] Additional checks (describe below)

Additional checks:
- `git diff --check`

Notes:
- Full frontend validation was not run because this worktree does not currently have web dependencies installed.

## Checklist

- [ ] I updated documentation if behavior changed
- [ ] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Embed Wiki Ask chat in the right sidebar on Wiki pages with the shared `AgentChatPanel`, and let users attach selected wiki text (with an optional note) straight into the chat draft; modal chat remains default-only.

- **New Features**
  - Keep the sidebar chat mounted so conversation and draft persist across project navigation.
  - Add “Attach to Wiki Ask” in the wiki selection popover to append the formatted excerpt to the draft.

- **Refactors**
  - `AgentChatPanel` adds `variant`, `mode`, and `publishStatus`; removed the in-panel mode toggle and last-mode persistence; gates connection/input when `wiki_ask` isn’t available.
  - Per-context chat drafts in `use-dialog-store`; the input binds to the draft and clears on send.
  - `RightSidebar` renders the panel in `sidebar` mode on Wiki pages and hides standard tabs; the sidebar panel doesn’t publish global chat status.

<sup>Written for commit 232547e7f5d2253c5beebeee274e443e2a857424. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aruni-01/atmos/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent Chat Panel now supports modal or sidebar display and shows appropriate titles, controls, and open/closed behavior.
  * Selection attachment for wiki content: attach highlighted text (with optional note) directly into agent conversations.
  * Drafts per workspace/project/mode are now preserved and restored for agent chats.

* **Bug Fixes / UX**
  * Wiki-Ask availability is reflected in the UI (disabled inputs, prompts, and empty states) and prevents unavailable actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->