### PR TITLE
[codex] Fix PTY leak on terminal refresh

### DIFF
--- a/crates/core-service/src/service/terminal.rs
+++ b/crates/core-service/src/service/terminal.rs
@@ -713,6 +713,21 @@ impl TerminalService {
             )));
         }
 
+        // Browser refreshes or hot reloads can race with WebSocket teardown and
+        // leave the previous PTY client alive for the same tmux window. Before
+        // we attach a replacement client, proactively evict any older session
+        // handles targeting this exact window so grouped tmux clients do not
+        // accumulate indefinitely.
+        let replaced = self
+            .evict_conflicting_tmux_window_sessions(&session_id, &tmux_session, final_window_index)
+            .await;
+        if replaced > 0 {
+            info!(
+                "Replaced {} stale terminal session(s) for tmux window {}:{}",
+                replaced, tmux_session, final_window_index
+            );
+        }
+
         // Capture recent history before attaching (match tmux history-limit)
         let history = self
             .tmux_engine
@@ -742,6 +757,38 @@ impl TerminalService {
             .await?;
 
         Ok((rx, history))
+    }
+
+    async fn evict_conflicting_tmux_window_sessions(
+        &self,
+        session_id: &str,
+        tmux_session: &str,
+        window_index: u32,
+    ) -> usize {
+        let socket_path = std::path::PathBuf::from(self.tmux_engine.socket_file_path());
+        let mut sessions = self.sessions.lock().await;
+        let conflicting_ids: Vec<String> = sessions
+            .iter()
+            .filter(|(existing_id, handle)| {
+                existing_id.as_str() != session_id
+                    && handle.tmux_session.as_deref() == Some(tmux_session)
+                    && handle.tmux_window_index == Some(window_index)
+            })
+            .map(|(existing_id, _)| existing_id.clone())
+            .collect();
+
+        let mut evicted = 0;
+        for conflicting_id in conflicting_ids {
+            if let Some(handle) = sessions.remove(&conflicting_id) {
+                let _ = handle.command_tx.send(SessionCommand::Close {
+                    client_session: handle.client_session.clone(),
+                    socket_path: Some(socket_path.clone()),
+                });
+                evicted += 1;
+            }
+        }
+
+        evicted
     }
 
     /// Internal: Attach PTY to a tmux window
@@ -1802,5 +1849,46 @@ mod tests {
         let service = TerminalService::new();
         let available = service.is_tmux_available();
         println!("tmux available: {}", available);
+    }
+
+    #[tokio::test]
+    async fn evict_conflicting_tmux_window_sessions_closes_previous_handle() {
+        let service = TerminalService::new();
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+
+        service.sessions.lock().await.insert(
+            "old-session".to_string(),
+            SessionHandle {
+                command_tx,
+                workspace_id: "workspace-1".to_string(),
+                tmux_session: Some("tmux-workspace".to_string()),
+                tmux_window_index: Some(3),
+                client_session: Some("atmos_client_old_session".to_string()),
+                session_type: SessionType::Tmux,
+                project_name: None,
+                workspace_name: None,
+                terminal_name: Some("3".to_string()),
+                cwd: None,
+                created_at: Instant::now(),
+            },
+        );
+
+        let evicted = service
+            .evict_conflicting_tmux_window_sessions("new-session", "tmux-workspace", 3)
+            .await;
+
+        assert_eq!(evicted, 1);
+        assert!(!service.session_exists("old-session").await);
+
+        match command_rx.recv().await {
+            Some(SessionCommand::Close {
+                client_session,
+                socket_path,
+            }) => {
+                assert_eq!(client_session.as_deref(), Some("atmos_client_old_session"));
+                assert!(socket_path.is_some());
+            }
+            other => panic!("expected close command, got {:?}", other),
+        }
     }
 }


### PR DESCRIPTION
## Summary

- proactively evict stale tmux client sessions before attaching a replacement terminal to the same tmux window
- prevent browser refreshes and hot reloads from stacking `atmos_client_*` PTY sessions when the previous websocket teardown lags
- add a regression test covering the conflicting-session eviction path

## Related Issue


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] Additional checks (describe below)

Additional checks:
- `cargo fmt --package core-service --all`
- `cargo test -p core-service service::terminal::tests`

## Checklist

- [ ] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aruni-01/atmos/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PTY leaks on terminal refresh by evicting any stale client attached to the same tmux session/window before attaching a new one. Prevents stacking `atmos_client_*` PTYs when WebSocket teardown lags and includes a regression test for the eviction path (closes #64).

<sup>Written for commit 2d11c55d241fe54a0ec5f152ebad07e44a07c77f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced terminal session attachment to proactively remove any conflicting connections targeting the same window and session, preventing connection conflicts and ensuring consistent session state across reattachment attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->