### PR TITLE
feat(web): add grouped tab navigator for center stage tabs

### DIFF
--- a/apps/web/src/components/layout/CenterStage.tsx
+++ b/apps/web/src/components/layout/CenterStage.tsx
@@ -1110,8 +1110,8 @@ const CenterStage: React.FC = () => {
   const renderTabGroupItemContent = React.useCallback((tab: TabGroupItem, isActive: boolean) => {
     const textClassName = cn(
       "min-w-0 truncate text-[13px] font-medium whitespace-nowrap",
-      tab.kind === "diff" && !isActive && "text-success-foreground",
-      tab.kind === "conflict" && !isActive && "text-warning-foreground",
+      tab.kind === "diff" && !isActive && "text-success",
+      tab.kind === "conflict" && !isActive && "text-warning",
       tab.file?.isPreview && "italic",
     );
 

--- a/apps/web/src/components/layout/CenterStage.tsx
+++ b/apps/web/src/components/layout/CenterStage.tsx
@@ -1013,31 +1013,6 @@ const CenterStage: React.FC = () => {
   const groupedTabItems = React.useMemo(() => {
     const groups: Array<{ key: string; label: string; tabs: TabGroupItem[] }> = [];
 
-    if (effectiveContextId && projectWikiTabVisible) {
-      groups.push({
-        key: "project-wiki",
-        label: "Project Wiki",
-        tabs: [{
-          id: "project-wiki",
-          label: "Project Wiki",
-          value: "project-wiki",
-          kind: "project-wiki",
-        }],
-      });
-    }
-    if (effectiveContextId && codeReviewTabVisible) {
-      groups.push({
-        key: "code-review",
-        label: "Code Review",
-        tabs: [{
-          id: "code-review",
-          label: "Code Review",
-          value: "code-review",
-          kind: "code-review",
-        }],
-      });
-    }
-
     const fileTabsGroup = openFiles
       .filter((file) => !isDiffEditorPath(file.path) && !isConflictResolveEditorPath(file.path))
       .map((file) => ({

--- a/apps/web/src/components/layout/CenterStage.tsx
+++ b/apps/web/src/components/layout/CenterStage.tsx
@@ -1170,9 +1170,9 @@ const CenterStage: React.FC = () => {
     return (
       <>
         {tab.kind === "diff" ? (
-          <GitCompare className="size-3.5 shrink-0 text-success-foreground" />
+          <GitCompare className="size-3.5 shrink-0 text-success" />
         ) : tab.kind === "conflict" ? (
-          <GitMergeIcon className="size-3.5 shrink-0 text-warning-foreground" />
+          <GitMergeIcon className="size-3.5 shrink-0 text-warning" />
         ) : (
           <FileIcon name={tab.file.name} className="size-3.5 shrink-0" />
         )}

--- a/apps/web/src/components/layout/CenterStage.tsx
+++ b/apps/web/src/components/layout/CenterStage.tsx
@@ -25,6 +25,18 @@ import {
   Popover,
   PopoverContent,
   PopoverTrigger,
+  DndContext,
+  type DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+  CSS,
+  arrayMove,
+  restrictToVerticalAxis,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -34,7 +46,7 @@ import {
   getFileIconProps,
   LayoutDashboard,
 } from "@workspace/ui";
-import { GitMergeIcon, Rows4 } from "lucide-react";
+import { GitMergeIcon, GripVertical, Rows4 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   useEditorStore,
@@ -138,6 +150,7 @@ function FileIcon({ name, className }: { name: string; className?: string }) {
 
 const FIXED_TABS = new Set<string>(["overview", "wiki", "project-wiki", "code-review"]);
 const LAST_ACTIVE_TAB_STORAGE_KEY = "atmos-last-active-tab-by-context";
+const TAB_GROUP_ORDER_STORAGE_KEY = "atmos-center-tab-group-order-by-context";
 type TabGroupItem = {
   id: string;
   label: string;
@@ -145,6 +158,46 @@ type TabGroupItem = {
   kind: "overview" | "wiki" | "terminal" | "project-wiki" | "code-review" | "file" | "diff" | "conflict";
   file?: OpenFile;
 };
+type TabGroupOrderByContext = Record<string, Record<string, string[]>>;
+
+function readTabGroupOrderStorage(): TabGroupOrderByContext {
+  if (typeof window === "undefined") return {};
+
+  try {
+    const raw = window.sessionStorage.getItem(TAB_GROUP_ORDER_STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : {};
+    return parsed && typeof parsed === "object" ? parsed as TabGroupOrderByContext : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeTabGroupOrderStorage(orderByContext: TabGroupOrderByContext) {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.sessionStorage.setItem(TAB_GROUP_ORDER_STORAGE_KEY, JSON.stringify(orderByContext));
+  } catch {
+    // Ignore storage quota/privacy failures; ordering still works for this render.
+  }
+}
+
+function applySavedTabGroupOrder(group: { key: string; label: string; tabs: TabGroupItem[] }, savedOrder?: string[]) {
+  if (!savedOrder?.length) return group;
+
+  const orderIndex = new Map(savedOrder.map((id, index) => [id, index]));
+  return {
+    ...group,
+    tabs: [...group.tabs].sort((left, right) => {
+      const leftIndex = orderIndex.get(left.id);
+      const rightIndex = orderIndex.get(right.id);
+      if (leftIndex === undefined && rightIndex === undefined) return 0;
+      if (leftIndex === undefined) return 1;
+      if (rightIndex === undefined) return -1;
+      return leftIndex - rightIndex;
+    }),
+  };
+}
 
 // Inner component: only subscribes to agent store, receives pane IDs as stable prop.
 function TerminalTabAgentIndicator({ stablePaneIds }: { stablePaneIds: string[] }) {
@@ -175,6 +228,89 @@ function TerminalTabAgentIndicatorWithPanes({ contextId, tabId }: { contextId: s
     })
   );
   return <TerminalTabAgentIndicator stablePaneIds={stablePaneIds} />;
+}
+
+function SortableTabGroupItem({
+  groupKey,
+  tab,
+  isActive,
+  children,
+  closable,
+  onSelect,
+  onClose,
+}: {
+  groupKey: string;
+  tab: TabGroupItem;
+  isActive: boolean;
+  children: React.ReactNode;
+  closable: boolean;
+  onSelect: () => void;
+  onClose: () => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: tab.id,
+    data: { groupKey },
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        onSelect();
+      }}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }}
+      className={cn(
+        "group/tab-item relative flex h-10 w-full min-w-max cursor-pointer items-center gap-1.5 rounded-md pl-2 pr-3 text-left transition-colors",
+        isActive
+          ? "bg-sidebar-accent text-sidebar-foreground shadow-xs hover:bg-sidebar-accent"
+          : "text-muted-foreground hover:bg-sidebar-accent/70 hover:text-sidebar-foreground dark:hover:bg-muted/45",
+        isDragging && "z-10 opacity-70 shadow-md"
+      )}
+    >
+      <span
+        ref={setActivatorNodeRef}
+        {...attributes}
+        {...listeners}
+        className="-ml-0.5 -mr-1.5 flex size-4 shrink-0 cursor-grab items-center justify-center text-muted-foreground opacity-0 transition-colors hover:text-foreground active:cursor-grabbing group-hover/tab-item:opacity-100"
+        aria-label={`Drag ${tab.label}`}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <GripVertical className="size-3" />
+      </span>
+      {children}
+      {closable ? (
+        <span
+          role="button"
+          tabIndex={-1}
+          aria-label={`Close ${tab.label}`}
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.stopPropagation();
+            onClose();
+          }}
+          className="ml-1 flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-sm text-muted-foreground opacity-0 transition-all hover:bg-muted-foreground/20 hover:text-foreground group-hover/tab-item:opacity-100"
+        >
+          <X className="size-3" />
+        </span>
+      ) : null}
+    </div>
+  );
 }
 
 function isTerminalCenterTabValue(value: string | null | undefined): value is string {
@@ -212,6 +348,11 @@ const CenterStage: React.FC = () => {
     filePath: string;
   } | null>(null);
   const [tabGroupPopoverOpen, setTabGroupPopoverOpen] = React.useState(false);
+  const [tabGroupOrderByContext, setTabGroupOrderByContext] =
+    React.useState<TabGroupOrderByContext>(() => readTabGroupOrderStorage());
+  const tabGroupDndSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
 
   // Agent dropdown state
   const [agentDropdownTabId, setAgentDropdownTabId] = React.useState<string | null>(null);
@@ -931,6 +1072,11 @@ const CenterStage: React.FC = () => {
     return groups;
   }, [codeReviewTabVisible, effectiveContextId, openFiles, projectWikiTabVisible, visibleTerminalTabs]);
 
+  const orderedGroupedTabItems = React.useMemo(() => {
+    const contextOrder = effectiveContextId ? tabGroupOrderByContext[effectiveContextId] : undefined;
+    return groupedTabItems.map((group) => applySavedTabGroupOrder(group, contextOrder?.[group.key]));
+  }, [effectiveContextId, groupedTabItems, tabGroupOrderByContext]);
+
   const { currentRepoPath } = useGitStore();
 
   const renderTabGroupItemContent = React.useCallback((tab: TabGroupItem, isActive: boolean) => {
@@ -1041,6 +1187,35 @@ const CenterStage: React.FC = () => {
       handleCloseFile(tab.file);
     }
   }, [handleCloseFile, handleCloseTerminalCenterTab]);
+
+  const handleTabGroupDragEnd = React.useCallback((event: DragEndEvent) => {
+    if (!effectiveContextId || !event.over || event.active.id === event.over.id) return;
+
+    const activeGroupKey = event.active.data.current?.groupKey;
+    const overGroupKey = event.over.data.current?.groupKey;
+    if (typeof activeGroupKey !== "string" || activeGroupKey !== overGroupKey) return;
+
+    const group = orderedGroupedTabItems.find((item) => item.key === activeGroupKey);
+    if (!group) return;
+
+    const ids = group.tabs.map((tab) => tab.id);
+    const oldIndex = ids.indexOf(String(event.active.id));
+    const newIndex = ids.indexOf(String(event.over.id));
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const nextOrder = arrayMove(ids, oldIndex, newIndex);
+    setTabGroupOrderByContext((current) => {
+      const next: TabGroupOrderByContext = {
+        ...current,
+        [effectiveContextId]: {
+          ...(current[effectiveContextId] ?? {}),
+          [activeGroupKey]: nextOrder,
+        },
+      };
+      writeTabGroupOrderStorage(next);
+      return next;
+    });
+  }, [effectiveContextId, orderedGroupedTabItems]);
 
   // Derive workspace and project info for OverviewTab
   const { currentProject, currentWorkspace } = (() => {
@@ -1585,7 +1760,7 @@ const CenterStage: React.FC = () => {
               <PopoverContent align="end" className="w-auto max-w-[calc(100vw-2rem)] border-border/70 bg-popover/68 p-2 shadow-xl backdrop-blur-2xl">
                 <div className="scrollbar-on-hover max-h-[420px] overflow-auto">
                   <div className="grid min-w-max grid-flow-col auto-cols-max gap-2">
-                    {groupedTabItems.map((group) => (
+                    {orderedGroupedTabItems.map((group) => (
                       <section
                         key={group.key}
                         className="flex max-h-[396px] min-h-0 min-w-40 max-w-80 flex-col overflow-hidden rounded-md border border-border/45 bg-muted/45 backdrop-blur-md dark:bg-background/72"
@@ -1596,45 +1771,34 @@ const CenterStage: React.FC = () => {
                           </div>
                         </header>
                         <div className="scrollbar-on-hover min-h-0 flex-1 space-y-1 overflow-y-auto p-2 pt-0">
-                          {group.tabs.map((tab) => (
-                            <div
-                              key={tab.id}
-                              role="button"
-                              tabIndex={0}
-                              onClick={() => {
-                                handleCenterStageTabChange(tab.value);
-                                setTabGroupPopoverOpen(false);
-                              }}
-                              onKeyDown={(event) => {
-                                if (event.key !== "Enter" && event.key !== " ") return;
-                                event.preventDefault();
-                                handleCenterStageTabChange(tab.value);
-                                setTabGroupPopoverOpen(false);
-                              }}
-                              className={cn(
-                                "group/tab-item relative flex h-10 w-full min-w-max cursor-pointer items-center gap-2 rounded-md px-3 text-left transition-colors",
-                                activeValue === tab.value
-                                  ? "bg-sidebar-accent text-sidebar-foreground shadow-xs hover:bg-sidebar-accent"
-                                  : "text-muted-foreground hover:bg-sidebar-accent/70 hover:text-sidebar-foreground dark:hover:bg-muted/45"
-                              )}
+                          <DndContext
+                            sensors={tabGroupDndSensors}
+                            collisionDetection={closestCenter}
+                            modifiers={[restrictToVerticalAxis]}
+                            onDragEnd={handleTabGroupDragEnd}
+                          >
+                            <SortableContext
+                              items={group.tabs.map((tab) => tab.id)}
+                              strategy={verticalListSortingStrategy}
                             >
-                              {renderTabGroupItemContent(tab, activeValue === tab.value)}
-                              {isTabGroupItemClosable(tab) ? (
-                                <span
-                                  role="button"
-                                  tabIndex={-1}
-                                  aria-label={`Close ${tab.label}`}
-                                  onClick={(event) => {
-                                    event.stopPropagation();
-                                    handleCloseTabGroupItem(tab);
+                              {group.tabs.map((tab) => (
+                                <SortableTabGroupItem
+                                  key={tab.id}
+                                  groupKey={group.key}
+                                  tab={tab}
+                                  isActive={activeValue === tab.value}
+                                  closable={isTabGroupItemClosable(tab)}
+                                  onSelect={() => {
+                                    handleCenterStageTabChange(tab.value);
+                                    setTabGroupPopoverOpen(false);
                                   }}
-                                  className="ml-1 flex size-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground opacity-0 transition-all hover:bg-muted-foreground/20 hover:text-foreground group-hover/tab-item:opacity-100"
+                                  onClose={() => handleCloseTabGroupItem(tab)}
                                 >
-                                  <X className="size-3" />
-                                </span>
-                              ) : null}
-                            </div>
-                          ))}
+                                  {renderTabGroupItemContent(tab, activeValue === tab.value)}
+                                </SortableTabGroupItem>
+                              ))}
+                            </SortableContext>
+                          </DndContext>
                         </div>
                       </section>
                     ))}

--- a/apps/web/src/components/layout/CenterStage.tsx
+++ b/apps/web/src/components/layout/CenterStage.tsx
@@ -27,6 +27,7 @@ import {
   PopoverTrigger,
   DndContext,
   type DragEndEvent,
+  KeyboardSensor,
   PointerSensor,
   useSensor,
   useSensors,
@@ -37,6 +38,7 @@ import {
   CSS,
   arrayMove,
   restrictToVerticalAxis,
+  sortableKeyboardCoordinates,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -166,7 +168,23 @@ function readTabGroupOrderStorage(): TabGroupOrderByContext {
   try {
     const raw = window.sessionStorage.getItem(TAB_GROUP_ORDER_STORAGE_KEY);
     const parsed = raw ? JSON.parse(raw) : {};
-    return parsed && typeof parsed === "object" ? parsed as TabGroupOrderByContext : {};
+    if (!parsed || typeof parsed !== "object") return {};
+
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>).map(([contextId, groups]) => [
+        contextId,
+        groups && typeof groups === "object"
+          ? Object.fromEntries(
+              Object.entries(groups as Record<string, unknown>).map(([groupKey, savedOrder]) => [
+                groupKey,
+                Array.isArray(savedOrder)
+                  ? savedOrder.filter((item): item is string => typeof item === "string")
+                  : [],
+              ])
+            )
+          : {},
+      ])
+    ) as TabGroupOrderByContext;
   } catch {
     return {};
   }
@@ -183,9 +201,12 @@ function writeTabGroupOrderStorage(orderByContext: TabGroupOrderByContext) {
 }
 
 function applySavedTabGroupOrder(group: { key: string; label: string; tabs: TabGroupItem[] }, savedOrder?: string[]) {
-  if (!savedOrder?.length) return group;
+  const normalizedSavedOrder = Array.isArray(savedOrder)
+    ? savedOrder.filter((item): item is string => typeof item === "string")
+    : [];
+  if (!normalizedSavedOrder.length) return group;
 
-  const orderIndex = new Map(savedOrder.map((id, index) => [id, index]));
+  const orderIndex = new Map(normalizedSavedOrder.map((id, index) => [id, index]));
   return {
     ...group,
     tabs: [...group.tabs].sort((left, right) => {
@@ -297,10 +318,16 @@ function SortableTabGroupItem({
       {closable ? (
         <span
           role="button"
-          tabIndex={-1}
+          tabIndex={0}
           aria-label={`Close ${tab.label}`}
           onPointerDown={(event) => event.stopPropagation()}
           onClick={(event) => {
+            event.stopPropagation();
+            onClose();
+          }}
+          onKeyDown={(event) => {
+            if (event.key !== "Enter" && event.key !== " ") return;
+            event.preventDefault();
             event.stopPropagation();
             onClose();
           }}
@@ -352,6 +379,7 @@ const CenterStage: React.FC = () => {
     React.useState<TabGroupOrderByContext>(() => readTabGroupOrderStorage());
   const tabGroupDndSensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 
   // Agent dropdown state
@@ -1082,8 +1110,8 @@ const CenterStage: React.FC = () => {
   const renderTabGroupItemContent = React.useCallback((tab: TabGroupItem, isActive: boolean) => {
     const textClassName = cn(
       "min-w-0 truncate text-[13px] font-medium whitespace-nowrap",
-      tab.kind === "diff" && !isActive && "text-emerald-500",
-      tab.kind === "conflict" && !isActive && "text-amber-500",
+      tab.kind === "diff" && !isActive && "text-success-foreground",
+      tab.kind === "conflict" && !isActive && "text-warning-foreground",
       tab.file?.isPreview && "italic",
     );
 
@@ -1117,7 +1145,7 @@ const CenterStage: React.FC = () => {
     if (tab.kind === "code-review") {
       return (
         <>
-          <TerminalIcon className="size-3.5 shrink-0 text-blue-500" />
+          <TerminalIcon className="size-3.5 shrink-0 text-primary-foreground" />
           <span className={textClassName}>{tab.label}</span>
         </>
       );
@@ -1142,9 +1170,9 @@ const CenterStage: React.FC = () => {
     return (
       <>
         {tab.kind === "diff" ? (
-          <GitCompare className="size-3.5 shrink-0 text-emerald-500" />
+          <GitCompare className="size-3.5 shrink-0 text-success-foreground" />
         ) : tab.kind === "conflict" ? (
-          <GitMergeIcon className="size-3.5 shrink-0 text-amber-500" />
+          <GitMergeIcon className="size-3.5 shrink-0 text-warning-foreground" />
         ) : (
           <FileIcon name={tab.file.name} className="size-3.5 shrink-0" />
         )}

--- a/apps/web/src/components/layout/CenterStage.tsx
+++ b/apps/web/src/components/layout/CenterStage.tsx
@@ -48,7 +48,7 @@ import {
   getFileIconProps,
   LayoutDashboard,
 } from "@workspace/ui";
-import { GitMergeIcon, GripVertical, Rows4 } from "lucide-react";
+import { GitMergeIcon, GripVertical, List } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   useEditorStore,
@@ -297,7 +297,7 @@ function SortableTabGroupItem({
         transition,
       }}
       className={cn(
-        "group/tab-item relative flex h-10 w-full min-w-max cursor-pointer items-center gap-1.5 rounded-md pl-2 pr-3 text-left transition-colors",
+        "group/tab-item relative flex h-10 w-full min-w-max cursor-pointer items-center gap-1 rounded-md pl-2 pr-2 text-left transition-colors",
         isActive
           ? "bg-sidebar-accent text-sidebar-foreground shadow-xs hover:bg-sidebar-accent"
           : "text-muted-foreground hover:bg-sidebar-accent/70 hover:text-sidebar-foreground dark:hover:bg-muted/45",
@@ -331,7 +331,7 @@ function SortableTabGroupItem({
             event.stopPropagation();
             onClose();
           }}
-          className="ml-1 flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-sm text-muted-foreground opacity-0 transition-all hover:bg-muted-foreground/20 hover:text-foreground group-hover/tab-item:opacity-100"
+          className="ml-0.5 flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-sm text-muted-foreground opacity-0 transition-all hover:bg-muted-foreground/20 hover:text-foreground group-hover/tab-item:opacity-100"
         >
           <X className="size-3" />
         </span>
@@ -1013,50 +1013,30 @@ const CenterStage: React.FC = () => {
   const groupedTabItems = React.useMemo(() => {
     const groups: Array<{ key: string; label: string; tabs: TabGroupItem[] }> = [];
 
-    const fixedTabsGroup: TabGroupItem[] = [];
-    if (effectiveContextId) {
-      fixedTabsGroup.push({ id: "overview", label: "Overview", value: "overview", kind: "overview" });
-      fixedTabsGroup.push({ id: "wiki", label: "Wiki", value: "wiki", kind: "wiki" });
-    }
-    if (fixedTabsGroup.length > 0) {
-      groups.push({ key: "fixed", label: "View", tabs: fixedTabsGroup });
-    }
-
-    const terminalTabsGroup: TabGroupItem[] = [];
-
-    terminalTabsGroup.push({
-      id: FIXED_TERMINAL_TAB_VALUE,
-      label: "Term",
-      value: FIXED_TERMINAL_TAB_VALUE,
-      kind: "terminal",
-    });
-    visibleTerminalTabs
-      .filter((tab) => tab.id !== FIXED_TERMINAL_TAB_VALUE)
-      .forEach((tab) => {
-        terminalTabsGroup.push({
-          id: tab.id,
-          label: tab.title,
-          value: tab.id,
-          kind: "terminal",
-        });
-      });
     if (effectiveContextId && projectWikiTabVisible) {
-      terminalTabsGroup.push({
-        id: "project-wiki",
+      groups.push({
+        key: "project-wiki",
         label: "Project Wiki",
-        value: "project-wiki",
-        kind: "project-wiki",
+        tabs: [{
+          id: "project-wiki",
+          label: "Project Wiki",
+          value: "project-wiki",
+          kind: "project-wiki",
+        }],
       });
     }
     if (effectiveContextId && codeReviewTabVisible) {
-      terminalTabsGroup.push({
-        id: "code-review",
+      groups.push({
+        key: "code-review",
         label: "Code Review",
-        value: "code-review",
-        kind: "code-review",
+        tabs: [{
+          id: "code-review",
+          label: "Code Review",
+          value: "code-review",
+          kind: "code-review",
+        }],
       });
     }
-    groups.push({ key: "term", label: "Terminal", tabs: terminalTabsGroup });
 
     const fileTabsGroup = openFiles
       .filter((file) => !isDiffEditorPath(file.path) && !isConflictResolveEditorPath(file.path))
@@ -1782,7 +1762,7 @@ const CenterStage: React.FC = () => {
                   className="h-full rounded-none border-0 px-4 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
                   aria-label="Open tab groups"
                 >
-                  <Rows4 className="size-4" />
+                  <List className="size-4" />
                 </Button>
               </PopoverTrigger>
               <PopoverContent align="end" className="w-auto max-w-[calc(100vw-2rem)] border-border/70 bg-popover/68 p-2 shadow-xl backdrop-blur-2xl">
@@ -1791,14 +1771,14 @@ const CenterStage: React.FC = () => {
                     {orderedGroupedTabItems.map((group) => (
                       <section
                         key={group.key}
-                        className="flex max-h-[396px] min-h-0 min-w-40 max-w-80 flex-col overflow-hidden rounded-md border border-border/45 bg-muted/45 backdrop-blur-md dark:bg-background/72"
+                        className="flex max-h-[396px] min-h-0 w-fit flex-col overflow-hidden rounded-md border border-border/45 bg-muted/45 backdrop-blur-md dark:bg-background/72"
                       >
                         <header className="sticky top-0 z-10 h-10 shrink-0 px-3">
                           <div className="flex h-full items-center text-[11px] font-semibold tracking-wide text-muted-foreground">
                             {group.label}
                           </div>
                         </header>
-                        <div className="scrollbar-on-hover min-h-0 flex-1 space-y-1 overflow-y-auto p-2 pt-0">
+                        <div className="scrollbar-on-hover min-h-0 flex-1 w-full space-y-1 overflow-y-auto p-2 pt-0">
                           <DndContext
                             sensors={tabGroupDndSensors}
                             collisionDetection={closestCenter}
@@ -1809,22 +1789,24 @@ const CenterStage: React.FC = () => {
                               items={group.tabs.map((tab) => tab.id)}
                               strategy={verticalListSortingStrategy}
                             >
-                              {group.tabs.map((tab) => (
-                                <SortableTabGroupItem
-                                  key={tab.id}
-                                  groupKey={group.key}
-                                  tab={tab}
-                                  isActive={activeValue === tab.value}
-                                  closable={isTabGroupItemClosable(tab)}
-                                  onSelect={() => {
-                                    handleCenterStageTabChange(tab.value);
-                                    setTabGroupPopoverOpen(false);
-                                  }}
-                                  onClose={() => handleCloseTabGroupItem(tab)}
-                                >
-                                  {renderTabGroupItemContent(tab, activeValue === tab.value)}
-                                </SortableTabGroupItem>
-                              ))}
+                              <div className="w-fit">
+                                {group.tabs.map((tab) => (
+                                  <SortableTabGroupItem
+                                    key={tab.id}
+                                    groupKey={group.key}
+                                    tab={tab}
+                                    isActive={activeValue === tab.value}
+                                    closable={isTabGroupItemClosable(tab)}
+                                    onSelect={() => {
+                                      handleCenterStageTabChange(tab.value);
+                                      setTabGroupPopoverOpen(false);
+                                    }}
+                                    onClose={() => handleCloseTabGroupItem(tab)}
+                                  >
+                                    {renderTabGroupItemContent(tab, activeValue === tab.value)}
+                                  </SortableTabGroupItem>
+                                ))}
+                              </div>
                             </SortableContext>
                           </DndContext>
                         </div>

--- a/apps/web/src/components/layout/CenterStage.tsx
+++ b/apps/web/src/components/layout/CenterStage.tsx
@@ -22,6 +22,9 @@ import {
   DialogDescription,
   DialogFooter,
   Button,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -31,7 +34,7 @@ import {
   getFileIconProps,
   LayoutDashboard,
 } from "@workspace/ui";
-import { GitMergeIcon } from "lucide-react";
+import { GitMergeIcon, Rows4 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   useEditorStore,
@@ -135,6 +138,11 @@ function FileIcon({ name, className }: { name: string; className?: string }) {
 
 const FIXED_TABS = new Set<string>(["overview", "wiki", "project-wiki", "code-review"]);
 const LAST_ACTIVE_TAB_STORAGE_KEY = "atmos-last-active-tab-by-context";
+type TabGroupItem = {
+  id: string;
+  label: string;
+  value: string;
+};
 
 // Inner component: only subscribes to agent store, receives pane IDs as stable prop.
 function TerminalTabAgentIndicator({ stablePaneIds }: { stablePaneIds: string[] }) {
@@ -201,6 +209,7 @@ const CenterStage: React.FC = () => {
     y: number;
     filePath: string;
   } | null>(null);
+  const [tabGroupPopoverOpen, setTabGroupPopoverOpen] = React.useState(false);
 
   // Agent dropdown state
   const [agentDropdownTabId, setAgentDropdownTabId] = React.useState<string | null>(null);
@@ -813,6 +822,91 @@ const CenterStage: React.FC = () => {
     }
   }, [activeValue, closeTerminalTab, effectiveContextId, setUrlParams]);
 
+  const handleCenterStageTabChange = React.useCallback((val: string) => {
+    if (isTerminalCenterTabValue(val)) {
+      if (effectiveContextId) {
+        setActiveTerminalTab(effectiveContextId, val);
+      }
+      setUrlParams({ tab: val, wikiPage: null });
+      setActiveFile(null, effectiveContextId || undefined);
+    } else if (FIXED_TABS.has(val)) {
+      setFixedTab(val as FixedTab);
+      setActiveFile(null, effectiveContextId || undefined);
+    } else {
+      setActiveFile(val, effectiveContextId || undefined);
+      // Clear tab param when opening a file
+      setUrlParams({ tab: null, wikiPage: null });
+    }
+  }, [effectiveContextId, setActiveFile, setActiveTerminalTab, setFixedTab, setUrlParams]);
+
+  const groupedTabItems = React.useMemo(() => {
+    const groups: Array<{ key: string; label: string; tabs: TabGroupItem[] }> = [];
+    const terminalTabsGroup: TabGroupItem[] = [];
+
+    terminalTabsGroup.push({
+      id: FIXED_TERMINAL_TAB_VALUE,
+      label: "Term",
+      value: FIXED_TERMINAL_TAB_VALUE,
+    });
+    visibleTerminalTabs
+      .filter((tab) => tab.id !== FIXED_TERMINAL_TAB_VALUE)
+      .forEach((tab) => {
+        terminalTabsGroup.push({
+          id: tab.id,
+          label: tab.title,
+          value: tab.id,
+        });
+      });
+    if (effectiveContextId && projectWikiTabVisible) {
+      terminalTabsGroup.push({
+        id: "project-wiki",
+        label: "Project Wiki",
+        value: "project-wiki",
+      });
+    }
+    if (effectiveContextId && codeReviewTabVisible) {
+      terminalTabsGroup.push({
+        id: "code-review",
+        label: "Code Review",
+        value: "code-review",
+      });
+    }
+    groups.push({ key: "term", label: "term", tabs: terminalTabsGroup });
+
+    const fixedTabsGroup: TabGroupItem[] = [];
+    if (effectiveContextId) {
+      fixedTabsGroup.push({ id: "overview", label: "Overview", value: "overview" });
+      fixedTabsGroup.push({ id: "wiki", label: "Wiki", value: "wiki" });
+    }
+    if (fixedTabsGroup.length > 0) {
+      groups.push({ key: "fixed", label: "view", tabs: fixedTabsGroup });
+    }
+
+    const fileTabsGroup = openFiles
+      .filter((file) => !isDiffEditorPath(file.path) && !isConflictResolveEditorPath(file.path))
+      .map((file) => ({
+        id: file.path,
+        label: file.name,
+        value: file.path,
+      }));
+    if (fileTabsGroup.length > 0) {
+      groups.push({ key: "file", label: "file", tabs: fileTabsGroup });
+    }
+
+    const diffTabsGroup = openFiles
+      .filter((file) => isDiffEditorPath(file.path) || isConflictResolveEditorPath(file.path))
+      .map((file) => ({
+        id: file.path,
+        label: file.name,
+        value: file.path,
+      }));
+    if (diffTabsGroup.length > 0) {
+      groups.push({ key: "diff", label: "diff", tabs: diffTabsGroup });
+    }
+
+    return groups;
+  }, [codeReviewTabVisible, effectiveContextId, openFiles, projectWikiTabVisible, visibleTerminalTabs]);
+
   const { currentRepoPath } = useGitStore();
 
   // Derive workspace and project info for OverviewTab
@@ -889,22 +983,7 @@ const CenterStage: React.FC = () => {
     <main className="h-full flex flex-col overflow-hidden">
       <Tabs
         value={activeValue}
-        onValueChange={(val) => {
-          if (isTerminalCenterTabValue(val)) {
-            if (effectiveContextId) {
-              setActiveTerminalTab(effectiveContextId, val);
-            }
-            setUrlParams({ tab: val, wikiPage: null });
-            setActiveFile(null, effectiveContextId || undefined);
-          } else if (FIXED_TABS.has(val)) {
-            setFixedTab(val as FixedTab);
-            setActiveFile(null, effectiveContextId || undefined);
-          } else {
-            setActiveFile(val, effectiveContextId || undefined);
-            // Clear tab param when opening a file
-            setUrlParams({ tab: null, wikiPage: null });
-          }
-        }}
+        onValueChange={handleCenterStageTabChange}
         className="flex-1 flex flex-col gap-0 min-h-0 overflow-hidden"
       >
         {/* Top Tab Bar */}
@@ -1358,6 +1437,53 @@ const CenterStage: React.FC = () => {
               </Tooltip>
             );
           })}
+          </div>
+          <div className="sticky right-0 z-20 flex h-full shrink-0 items-center border-l border-sidebar-border/70 bg-background/95 px-1 backdrop-blur-sm">
+            <Popover open={tabGroupPopoverOpen} onOpenChange={setTabGroupPopoverOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-8 text-muted-foreground hover:text-foreground"
+                  aria-label="Open tab groups"
+                >
+                  <Rows4 className="size-4" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent align="end" className="w-[320px] p-2">
+                <div className="max-h-80 overflow-auto">
+                  <div className="flex min-w-[420px] flex-col gap-2">
+                    {groupedTabItems.map((group) => (
+                      <div key={group.key} className="rounded-md border border-border/70 bg-muted/20">
+                        <div className="border-b border-border/60 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                          {group.label}
+                        </div>
+                        <div className="flex flex-col gap-1 p-1">
+                          {group.tabs.map((tab) => (
+                            <button
+                              key={tab.id}
+                              type="button"
+                              onClick={() => {
+                                handleCenterStageTabChange(tab.value);
+                                setTabGroupPopoverOpen(false);
+                              }}
+                              className={cn(
+                                "w-full rounded-sm px-2 py-1.5 text-left text-xs transition-colors",
+                                activeValue === tab.value
+                                  ? "bg-accent text-accent-foreground"
+                                  : "text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+                              )}
+                            >
+                              {tab.label}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </PopoverContent>
+            </Popover>
           </div>
         </TabsList>
 

--- a/apps/web/src/components/layout/CenterStage.tsx
+++ b/apps/web/src/components/layout/CenterStage.tsx
@@ -1145,7 +1145,7 @@ const CenterStage: React.FC = () => {
     if (tab.kind === "code-review") {
       return (
         <>
-          <TerminalIcon className="size-3.5 shrink-0 text-primary-foreground" />
+          <TerminalIcon className="size-3.5 shrink-0 text-primary" />
           <span className={textClassName}>{tab.label}</span>
         </>
       );

--- a/apps/web/src/components/layout/CenterStage.tsx
+++ b/apps/web/src/components/layout/CenterStage.tsx
@@ -297,10 +297,9 @@ function SortableTabGroupItem({
         transition,
       }}
       className={cn(
-        "group/tab-item relative flex h-10 w-full min-w-max cursor-pointer items-center gap-1 rounded-md pl-2 pr-2 text-left transition-colors",
-        isActive
-          ? "bg-sidebar-accent text-sidebar-foreground shadow-xs hover:bg-sidebar-accent"
-          : "text-muted-foreground hover:bg-sidebar-accent/70 hover:text-sidebar-foreground dark:hover:bg-muted/45",
+        "group/tab-item relative flex h-10 w-full min-w-max cursor-pointer items-center gap-1 rounded-md pl-2 pr-2 text-left text-muted-foreground transition-colors",
+        "hover:bg-sidebar-accent/70 hover:text-sidebar-foreground dark:hover:bg-muted/45",
+        isActive && "bg-muted/40 hover:bg-sidebar-accent/70",
         isDragging && "z-10 opacity-70 shadow-md"
       )}
     >
@@ -1065,8 +1064,8 @@ const CenterStage: React.FC = () => {
   const renderTabGroupItemContent = React.useCallback((tab: TabGroupItem, isActive: boolean) => {
     const textClassName = cn(
       "min-w-0 truncate text-[13px] font-medium whitespace-nowrap",
-      tab.kind === "diff" && !isActive && "text-success",
-      tab.kind === "conflict" && !isActive && "text-warning",
+      tab.kind === "diff" && "text-emerald-500",
+      tab.kind === "conflict" && "text-amber-500",
       tab.file?.isPreview && "italic",
     );
 
@@ -1125,9 +1124,9 @@ const CenterStage: React.FC = () => {
     return (
       <>
         {tab.kind === "diff" ? (
-          <GitCompare className="size-3.5 shrink-0 text-success" />
+          <GitCompare className="size-3.5 shrink-0 text-emerald-500" />
         ) : tab.kind === "conflict" ? (
-          <GitMergeIcon className="size-3.5 shrink-0 text-warning" />
+          <GitMergeIcon className="size-3.5 shrink-0 text-amber-500" />
         ) : (
           <FileIcon name={tab.file.name} className="size-3.5 shrink-0" />
         )}

--- a/apps/web/src/components/layout/CenterStage.tsx
+++ b/apps/web/src/components/layout/CenterStage.tsx
@@ -142,6 +142,8 @@ type TabGroupItem = {
   id: string;
   label: string;
   value: string;
+  kind: "overview" | "wiki" | "terminal" | "project-wiki" | "code-review" | "file" | "diff" | "conflict";
+  file?: OpenFile;
 };
 
 // Inner component: only subscribes to agent store, receives pane IDs as stable prop.
@@ -841,12 +843,23 @@ const CenterStage: React.FC = () => {
 
   const groupedTabItems = React.useMemo(() => {
     const groups: Array<{ key: string; label: string; tabs: TabGroupItem[] }> = [];
+
+    const fixedTabsGroup: TabGroupItem[] = [];
+    if (effectiveContextId) {
+      fixedTabsGroup.push({ id: "overview", label: "Overview", value: "overview", kind: "overview" });
+      fixedTabsGroup.push({ id: "wiki", label: "Wiki", value: "wiki", kind: "wiki" });
+    }
+    if (fixedTabsGroup.length > 0) {
+      groups.push({ key: "fixed", label: "View", tabs: fixedTabsGroup });
+    }
+
     const terminalTabsGroup: TabGroupItem[] = [];
 
     terminalTabsGroup.push({
       id: FIXED_TERMINAL_TAB_VALUE,
       label: "Term",
       value: FIXED_TERMINAL_TAB_VALUE,
+      kind: "terminal",
     });
     visibleTerminalTabs
       .filter((tab) => tab.id !== FIXED_TERMINAL_TAB_VALUE)
@@ -855,6 +868,7 @@ const CenterStage: React.FC = () => {
           id: tab.id,
           label: tab.title,
           value: tab.id,
+          kind: "terminal",
         });
       });
     if (effectiveContextId && projectWikiTabVisible) {
@@ -862,6 +876,7 @@ const CenterStage: React.FC = () => {
         id: "project-wiki",
         label: "Project Wiki",
         value: "project-wiki",
+        kind: "project-wiki",
       });
     }
     if (effectiveContextId && codeReviewTabVisible) {
@@ -869,18 +884,10 @@ const CenterStage: React.FC = () => {
         id: "code-review",
         label: "Code Review",
         value: "code-review",
+        kind: "code-review",
       });
     }
-    groups.push({ key: "term", label: "term", tabs: terminalTabsGroup });
-
-    const fixedTabsGroup: TabGroupItem[] = [];
-    if (effectiveContextId) {
-      fixedTabsGroup.push({ id: "overview", label: "Overview", value: "overview" });
-      fixedTabsGroup.push({ id: "wiki", label: "Wiki", value: "wiki" });
-    }
-    if (fixedTabsGroup.length > 0) {
-      groups.push({ key: "fixed", label: "view", tabs: fixedTabsGroup });
-    }
+    groups.push({ key: "term", label: "Terminal", tabs: terminalTabsGroup });
 
     const fileTabsGroup = openFiles
       .filter((file) => !isDiffEditorPath(file.path) && !isConflictResolveEditorPath(file.path))
@@ -888,26 +895,152 @@ const CenterStage: React.FC = () => {
         id: file.path,
         label: file.name,
         value: file.path,
+        kind: "file" as const,
+        file,
       }));
     if (fileTabsGroup.length > 0) {
-      groups.push({ key: "file", label: "file", tabs: fileTabsGroup });
+      groups.push({ key: "file", label: "File", tabs: fileTabsGroup });
     }
 
     const diffTabsGroup = openFiles
-      .filter((file) => isDiffEditorPath(file.path) || isConflictResolveEditorPath(file.path))
+      .filter((file) => isDiffEditorPath(file.path))
       .map((file) => ({
         id: file.path,
         label: file.name,
         value: file.path,
+        kind: "diff" as const,
+        file,
       }));
     if (diffTabsGroup.length > 0) {
-      groups.push({ key: "diff", label: "diff", tabs: diffTabsGroup });
+      groups.push({ key: "diff", label: "Diff", tabs: diffTabsGroup });
+    }
+
+    const conflictTabsGroup = openFiles
+      .filter((file) => isConflictResolveEditorPath(file.path))
+      .map((file) => ({
+        id: file.path,
+        label: file.name,
+        value: file.path,
+        kind: "conflict" as const,
+        file,
+      }));
+    if (conflictTabsGroup.length > 0) {
+      groups.push({ key: "conflict", label: "Conflict Resolve", tabs: conflictTabsGroup });
     }
 
     return groups;
   }, [codeReviewTabVisible, effectiveContextId, openFiles, projectWikiTabVisible, visibleTerminalTabs]);
 
   const { currentRepoPath } = useGitStore();
+
+  const renderTabGroupItemContent = React.useCallback((tab: TabGroupItem, isActive: boolean) => {
+    const textClassName = cn(
+      "min-w-0 truncate text-[13px] font-medium whitespace-nowrap",
+      tab.kind === "diff" && !isActive && "text-emerald-500",
+      tab.kind === "conflict" && !isActive && "text-amber-500",
+      tab.file?.isPreview && "italic",
+    );
+
+    if (tab.kind === "overview") {
+      return (
+        <>
+          <LayoutDashboard className="size-3.5 shrink-0" />
+          <span className={textClassName}>{tab.label}</span>
+        </>
+      );
+    }
+
+    if (tab.kind === "wiki") {
+      return (
+        <>
+          <BookOpen className="size-3.5 shrink-0" />
+          <span className={textClassName}>{tab.label}</span>
+        </>
+      );
+    }
+
+    if (tab.kind === "project-wiki") {
+      return (
+        <>
+          <TerminalIcon className="size-3.5 shrink-0" />
+          <span className={textClassName}>{tab.label}</span>
+        </>
+      );
+    }
+
+    if (tab.kind === "code-review") {
+      return (
+        <>
+          <TerminalIcon className="size-3.5 shrink-0 text-blue-500" />
+          <span className={textClassName}>{tab.label}</span>
+        </>
+      );
+    }
+
+    if (tab.kind === "terminal") {
+      return (
+        <>
+          <TerminalIcon className="size-3.5 shrink-0" />
+          <span className={textClassName}>{tab.label}</span>
+          {effectiveContextId ? (
+            <TerminalTabAgentIndicatorWithPanes contextId={effectiveContextId} tabId={tab.value} />
+          ) : null}
+        </>
+      );
+    }
+
+    if (!tab.file) {
+      return <span className={textClassName}>{tab.label}</span>;
+    }
+
+    return (
+      <>
+        {tab.kind === "diff" ? (
+          <GitCompare className="size-3.5 shrink-0 text-emerald-500" />
+        ) : tab.kind === "conflict" ? (
+          <GitMergeIcon className="size-3.5 shrink-0 text-amber-500" />
+        ) : (
+          <FileIcon name={tab.file.name} className="size-3.5 shrink-0" />
+        )}
+        <span className={textClassName}>{tab.file.name}</span>
+        <span className="relative ml-auto flex size-4 shrink-0 items-center justify-center">
+          {tab.file.isDirty ? <Circle className="size-1.5 fill-current text-muted-foreground" /> : null}
+        </span>
+      </>
+    );
+  }, [effectiveContextId]);
+
+  const isTabGroupItemClosable = React.useCallback((tab: TabGroupItem) => {
+    return (
+      (tab.kind === "terminal" && tab.value !== FIXED_TERMINAL_TAB_VALUE) ||
+      tab.kind === "project-wiki" ||
+      tab.kind === "code-review" ||
+      tab.kind === "file" ||
+      tab.kind === "diff" ||
+      tab.kind === "conflict"
+    );
+  }, []);
+
+  const handleCloseTabGroupItem = React.useCallback((tab: TabGroupItem) => {
+    if (tab.kind === "terminal" && tab.value !== FIXED_TERMINAL_TAB_VALUE) {
+      handleCloseTerminalCenterTab(tab.value);
+      return;
+    }
+
+    if (tab.kind === "project-wiki") {
+      setProjectWikiCloseConfirmOpen(true);
+      return;
+    }
+
+    if (tab.kind === "code-review") {
+      setCodeReviewCloseConfirmOpen(true);
+      return;
+    }
+
+    if (tab.file) {
+      handleCloseFile(tab.file);
+    }
+  }, [handleCloseFile, handleCloseTerminalCenterTab]);
 
   // Derive workspace and project info for OverviewTab
   const { currentProject, currentWorkspace } = (() => {
@@ -1438,47 +1571,72 @@ const CenterStage: React.FC = () => {
             );
           })}
           </div>
-          <div className="sticky right-0 z-20 flex h-full shrink-0 items-center border-l border-sidebar-border/70 bg-background/95 px-1 backdrop-blur-sm">
+          <div className="sticky right-0 z-20 flex h-full shrink-0 items-stretch border-l border-sidebar-border/70 bg-background/95 backdrop-blur-sm">
             <Popover open={tabGroupPopoverOpen} onOpenChange={setTabGroupPopoverOpen}>
               <PopoverTrigger asChild>
                 <Button
                   variant="ghost"
-                  size="icon"
-                  className="size-8 text-muted-foreground hover:text-foreground"
+                  className="h-full rounded-none border-0 px-4 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
                   aria-label="Open tab groups"
                 >
                   <Rows4 className="size-4" />
                 </Button>
               </PopoverTrigger>
-              <PopoverContent align="end" className="w-[320px] p-2">
-                <div className="max-h-80 overflow-auto">
-                  <div className="flex min-w-[420px] flex-col gap-2">
+              <PopoverContent align="end" className="w-auto max-w-[calc(100vw-2rem)] border-border/70 bg-popover/68 p-2 shadow-xl backdrop-blur-2xl">
+                <div className="scrollbar-on-hover max-h-[420px] overflow-auto">
+                  <div className="grid min-w-max grid-flow-col auto-cols-max gap-2">
                     {groupedTabItems.map((group) => (
-                      <div key={group.key} className="rounded-md border border-border/70 bg-muted/20">
-                        <div className="border-b border-border/60 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                          {group.label}
-                        </div>
-                        <div className="flex flex-col gap-1 p-1">
+                      <section
+                        key={group.key}
+                        className="flex max-h-[396px] min-h-0 min-w-40 max-w-80 flex-col overflow-hidden rounded-md border border-border/45 bg-muted/45 backdrop-blur-md dark:bg-background/72"
+                      >
+                        <header className="sticky top-0 z-10 h-10 shrink-0 px-3">
+                          <div className="flex h-full items-center text-[11px] font-semibold tracking-wide text-muted-foreground">
+                            {group.label}
+                          </div>
+                        </header>
+                        <div className="scrollbar-on-hover min-h-0 flex-1 space-y-1 overflow-y-auto p-2 pt-0">
                           {group.tabs.map((tab) => (
-                            <button
+                            <div
                               key={tab.id}
-                              type="button"
+                              role="button"
+                              tabIndex={0}
                               onClick={() => {
                                 handleCenterStageTabChange(tab.value);
                                 setTabGroupPopoverOpen(false);
                               }}
+                              onKeyDown={(event) => {
+                                if (event.key !== "Enter" && event.key !== " ") return;
+                                event.preventDefault();
+                                handleCenterStageTabChange(tab.value);
+                                setTabGroupPopoverOpen(false);
+                              }}
                               className={cn(
-                                "w-full rounded-sm px-2 py-1.5 text-left text-xs transition-colors",
+                                "group/tab-item relative flex h-10 w-full min-w-max cursor-pointer items-center gap-2 rounded-md px-3 text-left transition-colors",
                                 activeValue === tab.value
-                                  ? "bg-accent text-accent-foreground"
-                                  : "text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+                                  ? "bg-sidebar-accent text-sidebar-foreground shadow-xs hover:bg-sidebar-accent"
+                                  : "text-muted-foreground hover:bg-sidebar-accent/70 hover:text-sidebar-foreground dark:hover:bg-muted/45"
                               )}
                             >
-                              {tab.label}
-                            </button>
+                              {renderTabGroupItemContent(tab, activeValue === tab.value)}
+                              {isTabGroupItemClosable(tab) ? (
+                                <span
+                                  role="button"
+                                  tabIndex={-1}
+                                  aria-label={`Close ${tab.label}`}
+                                  onClick={(event) => {
+                                    event.stopPropagation();
+                                    handleCloseTabGroupItem(tab);
+                                  }}
+                                  className="ml-1 flex size-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground opacity-0 transition-all hover:bg-muted-foreground/20 hover:text-foreground group-hover/tab-item:opacity-100"
+                                >
+                                  <X className="size-3" />
+                                </span>
+                              ) : null}
+                            </div>
                           ))}
                         </div>
-                      </div>
+                      </section>
                     ))}
                   </div>
                 </div>


### PR DESCRIPTION
### Motivation
- Improve discoverability and fast-jump for many center-stage tabs by providing a single, fixed grouped navigator at the right end of the tab strip.
- Avoid duplicating navigation logic between tab clicks and quick-jump actions by centralizing tab switching behavior.

### Description
- Added a right-anchored popover trigger button (Rows4 icon) to the center tab strip and implemented a grouped tab navigator in `apps/web/src/components/layout/CenterStage.tsx` using `Popover`, `PopoverTrigger`, and `PopoverContent`.
- Introduced `handleCenterStageTabChange` to centralize the tab-switching logic and wired `Tabs`' `onValueChange` to this handler so both direct tab clicks and popover quick-jumps use the same behavior.
- Built `groupedTabItems` (memoized) which organizes tabs into `term`, `view` (fixed tabs), `file`, and `diff` groups by inspecting terminal tabs, fixed tabs (overview/wiki), open files, and diff/conflict editors.
- Popover UI presents groups vertically, includes scroll bounds (`max-h` + `overflow-auto`) and a `min-w` inside to allow vertical and horizontal scrolling for long lists, and closes on selection.

### Testing
- Ran `bun run typecheck` in `apps/web`, which failed in this environment due to missing frontend dependencies/type declarations (errors for `react`, `next`, and workspace packages), so full typecheck could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0ebc5f4c8328806e74bb3c8aa63d)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a right-anchored grouped tab navigator for quick jumps, now focused on Files, Diffs, and Conflicts only. Simplifies the popover, supports keyboard DnD reordering, and persists per-context order.

- **New Features**
  - `List` trigger opens a scrollable `Popover` with groups: File, Diff, Conflict (removed View and Terminal from the popover).
  - Reorder items within a group via drag handle or keyboard (vertical-only); order persists per context and group; inline close actions; closes on selection.
  - Centralized tab switching via `handleCenterStageTabChange` so tab clicks and popover jumps behave the same.

- **Bug Fixes**
  - Use `text-emerald-500` for Diff and `text-amber-500` for Conflict icons to replace undefined tokens and refine active/semantic colors.

<sup>Written for commit 6a152599899dce58b08e9ec3c22cc1bdbc56133e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sticky right-side popover for organized tab navigation, grouping tabs by functional categories (View, Terminal, File, Diff, Conflict Resolve).
  * Drag-and-drop reordering of tab groups with a visible handle and close controls.
  * Per-context ordering persists across sessions for consistent workspace layout.
* **Refactor**
  * Centralized tab switching so selecting tabs/routes and related UI state behave consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->