### PR TITLE
Add immutable label field to terminal panes for stable display names

### DIFF
--- a/apps/web/src/components/layout/CenterStage.tsx
+++ b/apps/web/src/components/layout/CenterStage.tsx
@@ -50,6 +50,7 @@ import { AGENT_STATE, useAgentHooksStore } from "@/hooks/use-agent-hooks-store";
 import { AgentHookStatusIndicator } from "@/components/agent/AgentHookStatusIndicator";
 import { codeAgentCustomApi, type CodeAgentCustomEntry, functionSettingsApi } from "@/api/ws-api";
 import type { TerminalGridHandle } from "@/components/terminal/TerminalGrid";
+import type { TerminalPaneAgent } from "@/components/terminal/types";
 import WelcomePage from "@/components/welcome/WelcomePage";
 import { useQueryStates } from "nuqs";
 import { centerStageParams } from "@/lib/nuqs/searchParams";
@@ -605,7 +606,7 @@ const CenterStage: React.FC = () => {
     const cmd = projectWikiPendingCommand;
     setProjectWikiPendingCommand(null);
     projectWikiTerminalGridRef.current?.createOrFocusAndRunTerminal({
-      title: PROJECT_WIKI_WINDOW_NAME,
+      label: PROJECT_WIKI_WINDOW_NAME,
       command: cmd,
     });
     // Clear user-triggered ref after delay so check result can apply for future navigations
@@ -622,7 +623,7 @@ const CenterStage: React.FC = () => {
     const cmd = codeReviewPendingCommand;
     setCodeReviewPendingCommand(null);
     codeReviewTerminalGridRef.current?.createOrFocusAndRunTerminal({
-      title: CODE_REVIEW_WINDOW_NAME,
+      label: CODE_REVIEW_WINDOW_NAME,
       command: cmd,
     });
     const t = setTimeout(() => {
@@ -682,25 +683,56 @@ const CenterStage: React.FC = () => {
         const cmd = custom?.cmd?.trim() || agent.cmd;
         const flags = custom?.flags?.trim() || agent.yoloFlag || "";
         return {
-          id: agent.id,
-          label: agent.label,
+          agent: {
+            id: agent.id,
+            label: agent.label,
+            command: cmd,
+            iconType: "built-in",
+          } satisfies TerminalPaneAgent,
           command: flags ? `${cmd} ${flags}` : cmd,
-          iconType: "built-in" as const,
         };
       }),
       ...visibleCustomAgents.map((agent) => {
         const cmd = agent.cmd.trim();
         const flags = agent.flags?.trim() || "";
         return {
-          id: agent.id,
-          label: agent.label,
+          agent: {
+            id: agent.id,
+            label: agent.label,
+            command: cmd,
+            iconType: "custom",
+          } satisfies TerminalPaneAgent,
           command: flags ? `${cmd} ${flags}` : cmd,
-          iconType: "custom" as const,
         };
       }),
     ],
     [agentCustomSettings, visibleBuiltInAgents, visibleCustomAgents]
   );
+
+  function runWhenTerminalGridReady(
+    targetTerminalTabId: string,
+    callback: (grid: TerminalGridHandle) => void,
+    attemptsLeft = 20,
+  ) {
+    const targetGrid =
+      targetTerminalTabId === FIXED_TERMINAL_TAB_VALUE
+        ? terminalGridRef.current
+        : terminalGridRefs.current[targetTerminalTabId];
+
+    if (targetGrid) {
+      callback(targetGrid);
+      return;
+    }
+
+    if (attemptsLeft <= 0) {
+      return;
+    }
+
+    window.setTimeout(() => {
+      runWhenTerminalGridReady(targetTerminalTabId, callback, attemptsLeft - 1);
+    }, 50);
+  }
+
   const handleAddAgent = (agentId: string, targetTerminalTabId: string = FIXED_TERMINAL_TAB_VALUE) => {
     if (!effectiveContextId) return;
 
@@ -720,7 +752,11 @@ const CenterStage: React.FC = () => {
       const flags = custom?.flags?.trim() || builtIn.yoloFlag || "";
       const command = flags ? `${cmd} ${flags}` : cmd;
       runWhenTerminalGridReady(targetTerminalTabId, (grid) => {
-        void grid.createAndRunTerminal({ title: builtIn.label, command });
+        void grid.createAndRunTerminal({
+          label: builtIn.label,
+          command,
+          agent: { id: builtIn.id, label: builtIn.label, command: cmd, iconType: "built-in" },
+        });
       });
       return;
     }
@@ -731,7 +767,11 @@ const CenterStage: React.FC = () => {
       const flags = customAgent.flags?.trim() || "";
       const command = flags ? `${cmd} ${flags}` : cmd;
       runWhenTerminalGridReady(targetTerminalTabId, (grid) => {
-        void grid.createAndRunTerminal({ title: customAgent.label, command });
+        void grid.createAndRunTerminal({
+          label: customAgent.label,
+          command,
+          agent: { id: customAgent.id, label: customAgent.label, command: cmd, iconType: "custom" },
+        });
       });
     }
   };
@@ -757,33 +797,6 @@ const CenterStage: React.FC = () => {
       setAgentDropdownTabId(null);
     }, 150);
   };
-
-  const runWhenTerminalGridReady = React.useCallback(
-    (
-      targetTerminalTabId: string,
-      callback: (grid: TerminalGridHandle) => void,
-      attemptsLeft = 20,
-    ) => {
-      const targetGrid =
-        targetTerminalTabId === FIXED_TERMINAL_TAB_VALUE
-          ? terminalGridRef.current
-          : terminalGridRefs.current[targetTerminalTabId];
-
-      if (targetGrid) {
-        callback(targetGrid);
-        return;
-      }
-
-      if (attemptsLeft <= 0) {
-        return;
-      }
-
-      window.setTimeout(() => {
-        runWhenTerminalGridReady(targetTerminalTabId, callback, attemptsLeft - 1);
-      }, 50);
-    },
-    [],
-  );
 
   const handleCreateTerminalCenterTab = React.useCallback(() => {
     if (!effectiveContextId) return;

--- a/apps/web/src/components/terminal/TerminalGrid.tsx
+++ b/apps/web/src/components/terminal/TerminalGrid.tsx
@@ -23,32 +23,15 @@ import {
 
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, cn } from "@workspace/ui";
 import { Terminal, TerminalRef } from "./Terminal";
+import type { TerminalPaneAgent } from "./types";
 import { useTerminalStore } from "@/hooks/use-terminal-store";
 import { useProjectStore } from "@/hooks/use-project-store";
 import { AgentIcon } from "@/components/agent/AgentIcon";
-import { AGENT_OPTIONS } from "@/components/wiki/AgentSelect";
 import { AGENT_STATE, useAgentHooksStore } from "@/hooks/use-agent-hooks-store";
 import { AgentHookStatusIndicator } from "@/components/agent/AgentHookStatusIndicator";
 
 import "react-mosaic-component/react-mosaic-component.css";
 import "./terminal-grid.css";
-
-// Hash map: normalized string → registry ID for O(1) lookup.
-// Covers both agent labels (pane.title from createAndRunTerminal) and
-// process names (pane.dynamicTitle from shell shim CMD_START sequences).
-const PANE_TITLE_TO_REGISTRY_ID: Record<string, string> = {
-  // Labels — set as pane.title when launching an agent terminal
-  ...Object.fromEntries(AGENT_OPTIONS.map((a) => [a.label.toLowerCase(), a.id])),
-  // Primary commands — reported by the shim as CMD_START when the agent runs
-  ...Object.fromEntries(AGENT_OPTIONS.map((a) => [a.cmd.toLowerCase(), a.id])),
-  // Additional command aliases not captured above
-  "cursor-agent": "cursor",
-};
-
-// Strip the "-N" uniqueness suffix added by getUniqueAgentName (e.g. "Claude Code-2" → "Claude Code")
-function getBasePaneTitle(title: string): string {
-  return title.replace(/-\d+$/, "");
-}
 
 type TerminalGridScope = "default" | "project-wiki" | "code-review";
 
@@ -67,10 +50,8 @@ interface TerminalGridProps {
   className?: string;
   terminalTabId?: string;
   quickOpenAgents?: Array<{
-    id: string;
-    label: string;
+    agent: TerminalPaneAgent;
     command: string;
-    iconType: "built-in" | "custom";
   }>;
   /** When "project-wiki", uses separate panes/layout (does not affect main Terminal tab) */
   scope?: TerminalGridScope;
@@ -81,15 +62,15 @@ interface TerminalGridProps {
 }
 
 export interface TerminalGridHandle {
-  addTerminal: (title?: string) => void;
+  addTerminal: (label?: string, agent?: TerminalPaneAgent) => void;
   /** Create a new terminal tab and run command after session is ready */
-  createAndRunTerminal: (options: { title: string; command: string }) => Promise<void>;
-  /** Create or focus terminal by title (e.g. "Generate Project Wiki") and run command. Reuses existing pane if found. */
-  createOrFocusAndRunTerminal: (options: { title: string; command: string }) => Promise<void>;
+  createAndRunTerminal: (options: { label: string; command: string; agent?: TerminalPaneAgent }) => Promise<void>;
+  /** Create or focus terminal by label/window name (e.g. "Generate Project Wiki") and run command. Reuses existing pane if found. */
+  createOrFocusAndRunTerminal: (options: { label: string; command: string; agent?: TerminalPaneAgent }) => Promise<void>;
   /** Remove terminal pane by tmux window name. Used when killing backend tmux window before replace. */
   removeTerminalByTmuxWindowName: (tmuxWindowName: string) => void;
   /** Create a new terminal and pre-fill command text without executing it */
-  prefillTerminal: (options: { title: string; command: string }) => void;
+  prefillTerminal: (options: { label: string; command: string; agent?: TerminalPaneAgent }) => void;
   destroyAllTerminals: () => void;
 }
 
@@ -98,6 +79,56 @@ const DEFAULT_TOOLBAR_ACTIONS: Required<TerminalToolbarActions> = {
   maximize: true,
   close: true,
 };
+
+function normalizeAgentCommand(value: string): string {
+  const firstToken = value.trim().split(/\s+/)[0] ?? "";
+  const withoutPath = firstToken.split("/").filter(Boolean).pop() ?? firstToken;
+  return withoutPath.toLowerCase();
+}
+
+function isPathLikeTitle(value: string | undefined): boolean {
+  if (!value) return false;
+  const trimmed = value.trim();
+  return (
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("~/") ||
+    trimmed === "~" ||
+    trimmed === "." ||
+    trimmed === ".." ||
+    trimmed.startsWith("../") ||
+    trimmed.includes("/")
+  );
+}
+
+function isVersionLikeTitle(value: string | undefined): boolean {
+  if (!value) return false;
+  return /^v?\d+(?:\.\d+)+(?:[-+][\w.-]+)?$/i.test(value.trim());
+}
+
+function resolveAgentForTitle(
+  title: string | undefined,
+  agents: TerminalPaneAgent[],
+): TerminalPaneAgent | undefined {
+  if (!title || isPathLikeTitle(title)) return undefined;
+  const normalizedTitle = normalizeAgentCommand(title);
+  if (!normalizedTitle) return undefined;
+  return agents.find((agent) => {
+    const normalizedCommand = normalizeAgentCommand(agent.command);
+    return (
+      normalizedCommand !== "" &&
+      normalizedTitle.includes(normalizedCommand)
+    );
+  });
+}
+
+function resolveAgentForLabel(
+  label: string | undefined,
+  agents: TerminalPaneAgent[],
+): TerminalPaneAgent | undefined {
+  if (!label) return undefined;
+  const normalizedLabel = label.trim().toLowerCase();
+  return agents.find((agent) => agent.label.trim().toLowerCase() === normalizedLabel);
+}
 
 function TerminalPaneAgentStatus({ paneId }: { paneId: string; contextId: string }) {
   // Only show status for this specific pane – do NOT fall back to context-level
@@ -127,7 +158,14 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
 
   const isProjectWiki = scope === "project-wiki";
   const isCodeReview = scope === "code-review";
-  const actions = { ...DEFAULT_TOOLBAR_ACTIONS, ...toolbarActions };
+  const actions = React.useMemo(
+    () => ({ ...DEFAULT_TOOLBAR_ACTIONS, ...toolbarActions }),
+    [toolbarActions],
+  );
+  const configuredAgents = React.useMemo(
+    () => quickOpenAgents.map(({ agent }) => agent),
+    [quickOpenAgents],
+  );
 
   const {
     getPanes,
@@ -142,6 +180,7 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
     toggleMaximize,
     getMaximizedTerminalId,
     setDynamicTitle,
+    setPaneAgent,
     getProjectWikiPanes,
     getProjectWikiLayout,
     setProjectWikiLayout,
@@ -151,6 +190,7 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
     initProjectWikiWorkspace,
     getProjectWikiPaneIdByTmuxWindowName,
     setProjectWikiDynamicTitle,
+    setProjectWikiPaneAgent,
     toggleProjectWikiMaximize,
     isProjectWikiReady,
     projectWikiMaximizedIds,
@@ -163,6 +203,7 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
     initCodeReviewWorkspace,
     getCodeReviewPaneIdByTmuxWindowName,
     setCodeReviewDynamicTitle,
+    setCodeReviewPaneAgent,
     toggleCodeReviewMaximize,
     isCodeReviewReady,
     codeReviewMaximizedIds,
@@ -230,31 +271,50 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
 
   const hasPanes = Object.keys(panes).length > 0;
 
-  const getPaneId = isCodeReview
-    ? getCodeReviewPaneIdByTmuxWindowName
-    : isProjectWiki
-    ? getProjectWikiPaneIdByTmuxWindowName
-    : (ctxWorkspaceId: string, tmuxWindowName: string) =>
-        getPaneIdByTmuxWindowName(ctxWorkspaceId, tmuxWindowName, terminalTabId);
-  const addTerminal = isCodeReview
-    ? (title?: string) => addCodeReviewTerminal(workspaceId, title)
-    : isProjectWiki
-    ? (title?: string) => addProjectWikiTerminal(workspaceId, title)
-    : (title?: string) => addTerminalToStore(workspaceId, title, terminalTabId);
-  const removeTerminalFromScope = isCodeReview
-    ? (id: string) => removeCodeReviewTerminal(workspaceId, id)
-    : isProjectWiki
-    ? (id: string) => removeProjectWikiTerminal(workspaceId, id)
-    : (id: string) => removeTerminalFromStore(workspaceId, id, terminalTabId);
+  const getPaneId = useCallback((ctxWorkspaceId: string, tmuxWindowName: string) => {
+    if (isCodeReview) {
+      return getCodeReviewPaneIdByTmuxWindowName(ctxWorkspaceId, tmuxWindowName);
+    }
+    if (isProjectWiki) {
+      return getProjectWikiPaneIdByTmuxWindowName(ctxWorkspaceId, tmuxWindowName);
+    }
+    return getPaneIdByTmuxWindowName(ctxWorkspaceId, tmuxWindowName, terminalTabId);
+  }, [getCodeReviewPaneIdByTmuxWindowName, getPaneIdByTmuxWindowName, getProjectWikiPaneIdByTmuxWindowName, isCodeReview, isProjectWiki, terminalTabId]);
+  const getPaneIdByLabelOrWindowName = useCallback((labelOrWindowName: string) => {
+    const entry = Object.entries(panes).find(([, pane]) =>
+      pane.label === labelOrWindowName || pane.tmuxWindowName === labelOrWindowName
+    );
+    return entry?.[0] ?? getPaneId(workspaceId, labelOrWindowName);
+  }, [getPaneId, panes, workspaceId]);
+  const addTerminal = useCallback((label?: string, agent?: TerminalPaneAgent) => {
+    if (isCodeReview) {
+      return addCodeReviewTerminal(workspaceId, label, agent);
+    }
+    if (isProjectWiki) {
+      return addProjectWikiTerminal(workspaceId, label, agent);
+    }
+    return addTerminalToStore(workspaceId, label, terminalTabId, agent);
+  }, [addCodeReviewTerminal, addProjectWikiTerminal, addTerminalToStore, isCodeReview, isProjectWiki, terminalTabId, workspaceId]);
+  const removeTerminalFromScope = useCallback((id: string) => {
+    if (isCodeReview) {
+      removeCodeReviewTerminal(workspaceId, id);
+      return;
+    }
+    if (isProjectWiki) {
+      removeProjectWikiTerminal(workspaceId, id);
+      return;
+    }
+    removeTerminalFromStore(workspaceId, id, terminalTabId);
+  }, [isCodeReview, isProjectWiki, removeCodeReviewTerminal, removeProjectWikiTerminal, removeTerminalFromStore, terminalTabId, workspaceId]);
 
   React.useImperativeHandle(ref, () => ({
-    addTerminal: (title?: string) => addTerminal(title),
-    createAndRunTerminal: async ({ title, command }) => {
-      const paneId = addTerminal(title);
+    addTerminal: (label?: string, agent?: TerminalPaneAgent) => addTerminal(label, agent),
+    createAndRunTerminal: async ({ label, command, agent }) => {
+      const paneId = addTerminal(label, agent);
       pendingCommandsRef.current.set(paneId, command + "\r");
     },
-    createOrFocusAndRunTerminal: async ({ title, command }) => {
-      const existingPaneId = getPaneId(workspaceId, title);
+    createOrFocusAndRunTerminal: async ({ label, command, agent }) => {
+      const existingPaneId = getPaneIdByLabelOrWindowName(label);
       const cmd = command.trim() + "\r";
       if (existingPaneId) {
         const termRef = terminalRefsMap.current.get(existingPaneId);
@@ -265,7 +325,7 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
         }
         return;
       }
-      const paneId = addTerminal(title);
+      const paneId = addTerminal(label, agent);
       pendingCommandsRef.current.set(paneId, cmd);
     },
     removeTerminalByTmuxWindowName: (tmuxWindowName: string) => {
@@ -278,8 +338,8 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
       }
       removeTerminalFromScope(paneId);
     },
-    prefillTerminal: ({ title, command }) => {
-      const paneId = addTerminal(title);
+    prefillTerminal: ({ label, command, agent }) => {
+      const paneId = addTerminal(label, agent);
       // Pre-fill without \r so the command is typed but not executed
       pendingCommandsRef.current.set(paneId, command);
     },
@@ -289,18 +349,13 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
       }
       terminalRefsMap.current.clear();
     },
-  }), [workspaceId, addTerminal, getPaneId, removeTerminalFromScope]);
+  }), [workspaceId, addTerminal, getPaneId, getPaneIdByLabelOrWindowName, removeTerminalFromScope]);
 
   const setLayoutForScope = isCodeReview
     ? setCodeReviewLayout
     : isProjectWiki
     ? setProjectWikiLayout
     : setLayout;
-  const splitTerminalForScope = isCodeReview
-    ? splitCodeReviewTerminal
-    : isProjectWiki
-    ? splitProjectWikiTerminal
-    : splitTerminalInStore;
   const toggleMaximizeForScope = isCodeReview
     ? toggleCodeReviewMaximize
     : isProjectWiki
@@ -311,6 +366,11 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
     : isProjectWiki
     ? setProjectWikiDynamicTitle
     : setDynamicTitle;
+  const setPaneAgentForScope = isCodeReview
+    ? setCodeReviewPaneAgent
+    : isProjectWiki
+    ? setProjectWikiPaneAgent
+    : setPaneAgent;
 
   const onChange = useCallback((newLayout: MosaicNode<string> | null) => {
     if (isCodeReview || isProjectWiki) {
@@ -327,17 +387,20 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
       terminalRefsMap.current.delete(id);
     }
     removeTerminalFromScope(id);
-  }, [workspaceId, removeTerminalFromScope]);
+  }, [removeTerminalFromScope]);
 
-  const splitTerminal = useCallback((id: string, direction: "row" | "column") => {
-    if (isCodeReview || isProjectWiki) {
-      return splitTerminalForScope(workspaceId, id, direction);
+  const splitTerminal = useCallback((id: string, direction: "row" | "column", agent?: TerminalPaneAgent) => {
+    if (isCodeReview) {
+      return splitCodeReviewTerminal(workspaceId, id, direction, agent);
     }
-    return splitTerminalForScope(workspaceId, id, direction, terminalTabId);
-  }, [workspaceId, splitTerminalForScope, isCodeReview, isProjectWiki, terminalTabId]);
+    if (isProjectWiki) {
+      return splitProjectWikiTerminal(workspaceId, id, direction, agent);
+    }
+    return splitTerminalInStore(workspaceId, id, direction, terminalTabId, agent);
+  }, [workspaceId, isCodeReview, isProjectWiki, splitCodeReviewTerminal, splitProjectWikiTerminal, splitTerminalInStore, terminalTabId]);
 
-  const splitAndRunAgent = useCallback((id: string, direction: "row" | "column", command: string) => {
-    const newPaneId = splitTerminal(id, direction);
+  const splitAndRunAgent = useCallback((id: string, direction: "row" | "column", command: string, agent: TerminalPaneAgent) => {
+    const newPaneId = splitTerminal(id, direction, agent);
     if (!newPaneId) return;
     pendingCommandsRef.current.set(newPaneId, command.trim() + "\r");
     setSplitMenuKey(null);
@@ -368,8 +431,18 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
     const pane = panes[id];
     if (!pane) return <div className="p-4 text-xs text-muted-foreground">Pane not found: {id}</div>;
 
-    // label is the immutable user-visible name; fall back to title for legacy panes.
-    const displayTitle = pane.dynamicTitle || pane.label || pane.title;
+    const dynamicTitleIsVersion = isVersionLikeTitle(pane.dynamicTitle);
+    const matchedDynamicAgent = resolveAgentForTitle(pane.dynamicTitle, configuredAgents);
+    const labelAgent = dynamicTitleIsVersion
+      ? resolveAgentForLabel(pane.label, configuredAgents)
+      : undefined;
+    const fallbackAgent = !pane.dynamicTitle
+      ? pane.agent
+      : dynamicTitleIsVersion
+      ? labelAgent ?? pane.agent
+      : undefined;
+    const toolbarAgent = matchedDynamicAgent ?? fallbackAgent ?? labelAgent;
+    const displayTitle = toolbarAgent?.label ?? (dynamicTitleIsVersion ? pane.label : pane.dynamicTitle) ?? pane.label;
 
     return (
       <MosaicWindow<string>
@@ -379,18 +452,13 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
         onDragStart={() => setIsPaneDragging(true)}
         onDragEnd={() => setIsPaneDragging(false)}
         renderToolbar={() => {
-          // Check displayTitle first (reflects active process name from shim CMD_START),
-          // then fall back to pane.label (immutable user-visible name set at creation).
-          const staticLabel = pane.label || pane.title;
-          const agentRegistryId =
-            PANE_TITLE_TO_REGISTRY_ID[getBasePaneTitle(displayTitle).toLowerCase()] ??
-            PANE_TITLE_TO_REGISTRY_ID[getBasePaneTitle(staticLabel).toLowerCase()];
-
           return (
             <div className="terminal-mosaic-toolbar group/toolbar">
               <div className="terminal-mosaic-toolbar-left">
-                {agentRegistryId ? (
-                  <AgentIcon registryId={agentRegistryId} name={staticLabel} size={14} />
+                {toolbarAgent?.iconType === "built-in" ? (
+                  <AgentIcon registryId={toolbarAgent.id} name={toolbarAgent.label} size={14} />
+                ) : toolbarAgent?.iconType === "custom" ? (
+                  <Bot className="size-3.5 text-muted-foreground" />
                 ) : (
                   <div className="size-2 rounded-full bg-emerald-500" />
                 )}
@@ -429,8 +497,8 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
                               onMouseLeave={handleSplitMenuLeave}
                               onCloseAutoFocus={(e) => e.preventDefault()}
                             >
-                              {quickOpenAgents.map((agent) => (
-                                <DropdownMenuItem key={`row-${agent.id}`} onClick={() => splitAndRunAgent(id, "row", agent.command)}>
+                              {quickOpenAgents.map(({ agent, command }) => (
+                                <DropdownMenuItem key={`row-${agent.id}`} onClick={() => splitAndRunAgent(id, "row", command, agent)}>
                                   {agent.iconType === "built-in" ? (
                                     <AgentIcon registryId={agent.id} name={agent.label} size={16} />
                                   ) : (
@@ -465,8 +533,8 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
                               onMouseLeave={handleSplitMenuLeave}
                               onCloseAutoFocus={(e) => e.preventDefault()}
                             >
-                              {quickOpenAgents.map((agent) => (
-                                <DropdownMenuItem key={`column-${agent.id}`} onClick={() => splitAndRunAgent(id, "column", agent.command)}>
+                              {quickOpenAgents.map(({ agent, command }) => (
+                                <DropdownMenuItem key={`column-${agent.id}`} onClick={() => splitAndRunAgent(id, "column", command, agent)}>
                                   {agent.iconType === "built-in" ? (
                                     <AgentIcon registryId={agent.id} name={agent.label} size={16} />
                                   ) : (
@@ -539,11 +607,18 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
               project.id === workspaceId || project.workspaces.some((workspace) => workspace.id === workspaceId)
             )?.mainFilePath}
             onTitleChange={(title) => {
+              const detectedAgent = resolveAgentForTitle(title, configuredAgents);
               if (isCodeReview || isProjectWiki) {
                 setDynamicTitleForScope(workspaceId, id, title);
+                if (detectedAgent) {
+                  setPaneAgentForScope(workspaceId, id, detectedAgent);
+                }
                 return;
               }
               setDynamicTitleForScope(workspaceId, id, title, terminalTabId);
+              if (detectedAgent) {
+                setPaneAgentForScope(workspaceId, id, detectedAgent, terminalTabId);
+              }
             }}
             onSessionReady={() => {
               const cmd = pendingCommandsRef.current.get(id);
@@ -566,7 +641,9 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
     workspaceId,
     onToggleMaximize,
     setDynamicTitleForScope,
+    setPaneAgentForScope,
     actions,
+    configuredAgents,
     projects,
     isCodeReview,
     isProjectWiki,

--- a/apps/web/src/components/terminal/TerminalGrid.tsx
+++ b/apps/web/src/components/terminal/TerminalGrid.tsx
@@ -26,11 +26,22 @@ import { Terminal, TerminalRef } from "./Terminal";
 import { useTerminalStore } from "@/hooks/use-terminal-store";
 import { useProjectStore } from "@/hooks/use-project-store";
 import { AgentIcon } from "@/components/agent/AgentIcon";
+import { AGENT_OPTIONS } from "@/components/wiki/AgentSelect";
 import { AGENT_STATE, useAgentHooksStore } from "@/hooks/use-agent-hooks-store";
 import { AgentHookStatusIndicator } from "@/components/agent/AgentHookStatusIndicator";
 
 import "react-mosaic-component/react-mosaic-component.css";
 import "./terminal-grid.css";
+
+// Hash map: normalized agent label → registry ID for O(1) pane title lookup
+const PANE_TITLE_TO_REGISTRY_ID: Record<string, string> = Object.fromEntries(
+  AGENT_OPTIONS.map((a) => [a.label.toLowerCase(), a.id])
+);
+
+// Strip the "-N" uniqueness suffix added by getUniqueAgentName (e.g. "Claude Code-2" → "Claude Code")
+function getBasePaneTitle(title: string): string {
+  return title.replace(/-\d+$/, "");
+}
 
 type TerminalGridScope = "default" | "project-wiki" | "code-review";
 
@@ -360,13 +371,16 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
         onDragStart={() => setIsPaneDragging(true)}
         onDragEnd={() => setIsPaneDragging(false)}
         renderToolbar={() => {
-          const isClaude = pane.title.toLowerCase().includes("claude");
-          const statusColor = isClaude ? "bg-yellow-500" : "bg-emerald-500";
+          const agentRegistryId = PANE_TITLE_TO_REGISTRY_ID[getBasePaneTitle(pane.title).toLowerCase()];
 
           return (
             <div className="terminal-mosaic-toolbar group/toolbar">
               <div className="terminal-mosaic-toolbar-left">
-                <div className={cn("size-2 rounded-full", statusColor)} />
+                {agentRegistryId ? (
+                  <AgentIcon registryId={agentRegistryId} name={pane.title} size={14} />
+                ) : (
+                  <div className="size-2 rounded-full bg-emerald-500" />
+                )}
 
                 <span className="terminal-mosaic-title flex items-center gap-1.5 ml-1">
                   {displayTitle}

--- a/apps/web/src/components/terminal/TerminalGrid.tsx
+++ b/apps/web/src/components/terminal/TerminalGrid.tsx
@@ -368,7 +368,8 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
     const pane = panes[id];
     if (!pane) return <div className="p-4 text-xs text-muted-foreground">Pane not found: {id}</div>;
 
-    const displayTitle = pane.dynamicTitle || pane.title;
+    // label is the immutable user-visible name; fall back to title for legacy panes.
+    const displayTitle = pane.dynamicTitle || pane.label || pane.title;
 
     return (
       <MosaicWindow<string>
@@ -379,16 +380,17 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
         onDragEnd={() => setIsPaneDragging(false)}
         renderToolbar={() => {
           // Check displayTitle first (reflects active process name from shim CMD_START),
-          // then fall back to pane.title (the static label set when the pane was created).
+          // then fall back to pane.label (immutable user-visible name set at creation).
+          const staticLabel = pane.label || pane.title;
           const agentRegistryId =
             PANE_TITLE_TO_REGISTRY_ID[getBasePaneTitle(displayTitle).toLowerCase()] ??
-            PANE_TITLE_TO_REGISTRY_ID[getBasePaneTitle(pane.title).toLowerCase()];
+            PANE_TITLE_TO_REGISTRY_ID[getBasePaneTitle(staticLabel).toLowerCase()];
 
           return (
             <div className="terminal-mosaic-toolbar group/toolbar">
               <div className="terminal-mosaic-toolbar-left">
                 {agentRegistryId ? (
-                  <AgentIcon registryId={agentRegistryId} name={pane.title} size={14} />
+                  <AgentIcon registryId={agentRegistryId} name={staticLabel} size={14} />
                 ) : (
                   <div className="size-2 rounded-full bg-emerald-500" />
                 )}

--- a/apps/web/src/components/terminal/TerminalGrid.tsx
+++ b/apps/web/src/components/terminal/TerminalGrid.tsx
@@ -33,10 +33,17 @@ import { AgentHookStatusIndicator } from "@/components/agent/AgentHookStatusIndi
 import "react-mosaic-component/react-mosaic-component.css";
 import "./terminal-grid.css";
 
-// Hash map: normalized agent label → registry ID for O(1) pane title lookup
-const PANE_TITLE_TO_REGISTRY_ID: Record<string, string> = Object.fromEntries(
-  AGENT_OPTIONS.map((a) => [a.label.toLowerCase(), a.id])
-);
+// Hash map: normalized string → registry ID for O(1) lookup.
+// Covers both agent labels (pane.title from createAndRunTerminal) and
+// process names (pane.dynamicTitle from shell shim CMD_START sequences).
+const PANE_TITLE_TO_REGISTRY_ID: Record<string, string> = {
+  // Labels — set as pane.title when launching an agent terminal
+  ...Object.fromEntries(AGENT_OPTIONS.map((a) => [a.label.toLowerCase(), a.id])),
+  // Primary commands — reported by the shim as CMD_START when the agent runs
+  ...Object.fromEntries(AGENT_OPTIONS.map((a) => [a.cmd.toLowerCase(), a.id])),
+  // Additional command aliases not captured above
+  "cursor-agent": "cursor",
+};
 
 // Strip the "-N" uniqueness suffix added by getUniqueAgentName (e.g. "Claude Code-2" → "Claude Code")
 function getBasePaneTitle(title: string): string {
@@ -371,7 +378,11 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
         onDragStart={() => setIsPaneDragging(true)}
         onDragEnd={() => setIsPaneDragging(false)}
         renderToolbar={() => {
-          const agentRegistryId = PANE_TITLE_TO_REGISTRY_ID[getBasePaneTitle(pane.title).toLowerCase()];
+          // Check displayTitle first (reflects active process name from shim CMD_START),
+          // then fall back to pane.title (the static label set when the pane was created).
+          const agentRegistryId =
+            PANE_TITLE_TO_REGISTRY_ID[getBasePaneTitle(displayTitle).toLowerCase()] ??
+            PANE_TITLE_TO_REGISTRY_ID[getBasePaneTitle(pane.title).toLowerCase()];
 
           return (
             <div className="terminal-mosaic-toolbar group/toolbar">

--- a/apps/web/src/components/terminal/types.ts
+++ b/apps/web/src/components/terminal/types.ts
@@ -60,6 +60,17 @@ export interface TerminalProps {
 
 export interface TerminalPaneProps {
   id: string;
+  /**
+   * User-visible display name. Set once at creation (e.g., "Claude Code", "Codex", "1").
+   * NEVER overwritten by tmux window name changes after initial creation.
+   * Persisted to backend. Falls back to `title` for legacy panes that predate this field.
+   */
+  label: string;
+  /**
+   * tmux window identifier used for session attach/create operations.
+   * Kept in sync with the actual tmux window name — may drift from `label`
+   * if tmux auto-renames the window.
+   */
   title: string;
   sessionId: string;
   workspaceId: string;
@@ -68,12 +79,12 @@ export interface TerminalPaneProps {
   projectName?: string;
   /** Workspace name for human-readable tmux session naming */
   workspaceName?: string;
-  /** 
+  /**
    * If true, this is a newly created pane that doesn't have a tmux window yet.
    * The Terminal will send terminal_name (to create) instead of tmux_window_name (to attach).
    */
   isNewPane?: boolean;
-  /** 
+  /**
    * Dynamic title from shell shim (e.g., running command name or current directory).
    * This is transient and NOT persisted to backend — only used for tab display.
    */

--- a/apps/web/src/components/terminal/types.ts
+++ b/apps/web/src/components/terminal/types.ts
@@ -58,23 +58,30 @@ export interface TerminalProps {
   onTitleChange?: (title: string) => void;
 }
 
+export interface TerminalPaneAgent {
+  id: string;
+  label: string;
+  command: string;
+  iconType: "built-in" | "custom";
+}
+
 export interface TerminalPaneProps {
   id: string;
   /**
    * User-visible display name. Set once at creation (e.g., "Claude Code", "Codex", "1").
    * NEVER overwritten by tmux window name changes after initial creation.
-   * Persisted to backend. Falls back to `title` for legacy panes that predate this field.
+   * Persisted to backend.
    */
   label: string;
   /**
-   * tmux window identifier used for session attach/create operations.
-   * Kept in sync with the actual tmux window name — may drift from `label`
-   * if tmux auto-renames the window.
+   * tmux window identifier used for session attach/create operations. This is
+   * the only pane field that tracks tmux window renames.
    */
-  title: string;
+  tmuxWindowName?: string;
+  /** Code Agent metadata used for toolbar icon rendering. */
+  agent?: TerminalPaneAgent;
   sessionId: string;
   workspaceId: string;
-  tmuxWindowName?: string;
   /** Project name for human-readable tmux session naming */
   projectName?: string;
   /** Workspace name for human-readable tmux session naming */

--- a/apps/web/src/components/wiki/WikiSetup.tsx
+++ b/apps/web/src/components/wiki/WikiSetup.tsx
@@ -139,7 +139,7 @@ export const WikiSetup: React.FC<WikiSetupProps> = ({
         });
       } else if (terminalGridRef.current?.createAndRunTerminal) {
         terminalGridRef.current.createAndRunTerminal({
-          title: "Generate Project Wiki",
+          label: "Generate Project Wiki",
           command,
         });
         onSwitchToTerminal();

--- a/apps/web/src/components/wiki/WikiSpecifyDialog.tsx
+++ b/apps/web/src/components/wiki/WikiSpecifyDialog.tsx
@@ -129,7 +129,7 @@ export const WikiSpecifyDialog: React.FC<WikiSpecifyDialogProps> = ({
         });
       } else if (terminalGridRef?.current?.createAndRunTerminal) {
         terminalGridRef.current.createAndRunTerminal({
-          title: "Specify Project Wiki",
+          label: "Specify Project Wiki",
           command,
         });
         onSwitchToTerminal?.();

--- a/apps/web/src/components/wiki/WikiUpdateDialog.tsx
+++ b/apps/web/src/components/wiki/WikiUpdateDialog.tsx
@@ -115,7 +115,7 @@ export const WikiUpdateDialog: React.FC<WikiUpdateDialogProps> = ({
         });
       } else if (terminalGridRef?.current?.createAndRunTerminal) {
         terminalGridRef.current.createAndRunTerminal({
-          title: "Generate Project Wiki",
+          label: "Generate Project Wiki",
           command,
         });
         onSwitchToTerminal?.();

--- a/apps/web/src/components/workspace/WorkspaceSetupProgress.tsx
+++ b/apps/web/src/components/workspace/WorkspaceSetupProgress.tsx
@@ -236,12 +236,14 @@ export const WorkspaceSetupProgressView: React.FC<WorkspaceSetupProgressProps> =
   // the backend may have finished silently (e.g. plan build failure, lost WS events).
   // Skip detection when waiting for user confirmation (requiresConfirmation).
   useEffect(() => {
-    if (status === "completed" || status === "error" || status === "setting_up" || progress.requiresConfirmation) {
+    if (status === "completed" || status === "error" || progress.requiresConfirmation) {
       setIsStale(false);
       return;
     }
     setIsStale(false);
-    const timer = setTimeout(() => setIsStale(true), 90_000);
+    // Allow a longer timeout for setup scripts which may take a while to run.
+    const timeoutMs = status === "setting_up" ? 120_000 : 90_000;
+    const timer = setTimeout(() => setIsStale(true), timeoutMs);
     return () => clearTimeout(timer);
   }, [status, stepKey, stepTitle, output, progress.requiresConfirmation]);
 

--- a/apps/web/src/hooks/use-terminal-store.ts
+++ b/apps/web/src/hooks/use-terminal-store.ts
@@ -153,8 +153,9 @@ interface TerminalStore {
 function getNextWindowName(existingPanes: Record<string, TerminalPaneProps>): string {
   const values = Object.values(existingPanes);
   const usedNames = new Set([
-     ...values.map(p => p.tmuxWindowName),
-     ...values.map(p => p.title)
+    ...values.map(p => p.tmuxWindowName),
+    ...values.map(p => p.title),
+    ...values.map(p => p.label),
   ].filter(Boolean));
   
   let num = 1;
@@ -179,10 +180,11 @@ function getUniqueAgentName(baseName: string, existingPanes: Record<string, Term
 
   const values = Object.values(existingPanes);
   const usedNames = new Set([
-     ...values.map(p => p.tmuxWindowName),
-     ...values.map(p => p.title)
+    ...values.map(p => p.tmuxWindowName),
+    ...values.map(p => p.title),
+    ...values.map(p => p.label),
   ].filter(Boolean));
-  
+
   // If base name is not used, return it directly
   if (!usedNames.has(baseName)) {
     return baseName;
@@ -359,11 +361,15 @@ function hydratePersistedTab(
   for (const [id, pane] of Object.entries(tab.panes)) {
     const windowName = pane.tmuxWindowName || pane.title || getNextWindowName(validatedPanes);
     const windowExists = existingWindowNames.has(windowName);
+    // Migration: old persisted panes (before `label` was added) don't have a label field.
+    // Cast to access the optional field without a TypeScript error, then fall back to title.
+    const persistedLabel = (pane as TerminalPaneProps & { label?: string }).label;
 
     validatedPanes[id] = {
       ...pane,
       workspaceId,
-      title: windowName,
+      label: persistedLabel ?? pane.title,  // preserved user-visible name, never overwritten
+      title: windowName,                     // tmux identifier (may drift via auto-rename)
       tmuxWindowName: windowName,
       sessionId: uuidv4(),
       isNewPane: !windowExists,
@@ -391,6 +397,7 @@ function createInitialLayout(
     panes: {
       [initialId]: {
         id: initialId,
+        label: windowName,
         title: windowName,
         sessionId: uuidv4(),
         workspaceId,
@@ -774,6 +781,7 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
     
     const newPane: TerminalPaneProps = {
       id: newId,
+      label: windowName,
       title: windowName,
       sessionId: uuidv4(),
       workspaceId,
@@ -782,7 +790,7 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
     };
 
     const nextPanes = { ...panes, [newId]: newPane };
-    
+
     let nextLayout: MosaicNode<string>;
     if (!layout) {
       nextLayout = newId;
@@ -868,6 +876,7 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
     
     const newPane: TerminalPaneProps = {
       id: newId,
+      label: windowName,
       title: windowName,
       sessionId: uuidv4(),
       workspaceId,
@@ -1139,6 +1148,7 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
           paneIds.push(id);
           panes[id] = {
             id,
+            label: win.name,
             title: win.name,
             sessionId: uuidv4(),
             workspaceId,
@@ -1252,6 +1262,7 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
           for (const [id, pane] of Object.entries(panes)) {
             cleanPanes[id] = {
               id: pane.id,
+              label: pane.label,
               title: pane.title,
               workspaceId: pane.workspaceId,
               tmuxWindowName: pane.tmuxWindowName,
@@ -1314,23 +1325,25 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
     const scopeKey = getScopeKey(workspaceId, terminalTabId);
     const panes = get().workspacePanes[scopeKey];
     if (!panes || !panes[paneId]) return;
-    
+
     const updatedPanes = {
       ...panes,
       [paneId]: {
         ...panes[paneId],
+        // Keep tmux identifiers in sync with the actual window name.
+        // Do NOT touch `label` — it is the immutable user-visible display name.
         tmuxWindowName,
         title: tmuxWindowName,
       },
     };
-    
+
     set((state) => ({
       workspacePanes: {
         ...state.workspacePanes,
         [scopeKey]: updatedPanes,
       },
     }));
-    
+
     get().saveToBackend(workspaceId);
   },
 
@@ -1395,6 +1408,7 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
     const newId = uuidv4();
     const newPane: TerminalPaneProps = {
       id: newId,
+      label: title,
       title,
       sessionId: uuidv4(),
       workspaceId,
@@ -1422,6 +1436,7 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
     const newId = uuidv4();
     const newPane: TerminalPaneProps = {
       id: newId,
+      label: PROJECT_WIKI_WINDOW_NAME + "-2",
       title: PROJECT_WIKI_WINDOW_NAME + "-2",
       sessionId: uuidv4(),
       workspaceId,
@@ -1495,6 +1510,7 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
           const newId = uuidv4();
           const newPane: TerminalPaneProps = {
             id: newId,
+            label: PROJECT_WIKI_WINDOW_NAME,
             title: PROJECT_WIKI_WINDOW_NAME,
             sessionId: uuidv4(),
             workspaceId,
@@ -1572,6 +1588,7 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
     const newId = uuidv4();
     const newPane: TerminalPaneProps = {
       id: newId,
+      label: title,
       title,
       sessionId: uuidv4(),
       workspaceId,
@@ -1633,6 +1650,7 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
           const newId = uuidv4();
           const newPane: TerminalPaneProps = {
             id: newId,
+            label: CODE_REVIEW_WINDOW_NAME,
             title: CODE_REVIEW_WINDOW_NAME,
             sessionId: uuidv4(),
             workspaceId,
@@ -1697,6 +1715,7 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
     const newId = uuidv4();
     const newPane: TerminalPaneProps = {
       id: newId,
+      label: CODE_REVIEW_WINDOW_NAME + "-2",
       title: CODE_REVIEW_WINDOW_NAME + "-2",
       sessionId: uuidv4(),
       workspaceId,

--- a/apps/web/src/hooks/use-terminal-store.ts
+++ b/apps/web/src/hooks/use-terminal-store.ts
@@ -4,7 +4,7 @@ import { create } from "zustand";
 import { v4 as uuidv4 } from "uuid";
 import { MosaicNode, MosaicDirection, getLeaves } from "react-mosaic-component";
 import { workspaceLayoutApi, projectLayoutApi, systemApi, TmuxWindow } from "@/api/rest-api";
-import type { TerminalPaneProps } from "@/components/terminal/types";
+import type { TerminalPaneAgent, TerminalPaneProps } from "@/components/terminal/types";
 
 const SAVE_DEBOUNCE_MS = 500;
 export const FIXED_TERMINAL_TAB_VALUE = "terminal";
@@ -15,10 +15,6 @@ export interface TerminalCenterTab {
   id: string;
   title: string;
   closable: boolean;
-}
-
-interface PersistedTerminalPane {
-  panes: Record<string, Omit<TerminalPaneProps, "sessionId" | "dynamicTitle">>;
 }
 
 interface PersistedTerminalTab {
@@ -94,9 +90,9 @@ interface TerminalStore {
   /** Check if workspace has been fully loaded and is ready for rendering */
   isWorkspaceReady: (workspaceId: string, terminalTabId?: string) => boolean;
   setLayout: (workspaceId: string, layout: MosaicNode<string> | null, terminalTabId?: string) => void;
-  addTerminal: (workspaceId: string, title?: string, terminalTabId?: string) => string;
+  addTerminal: (workspaceId: string, label?: string, terminalTabId?: string, agent?: TerminalPaneAgent) => string;
   removeTerminal: (workspaceId: string, id: string, terminalTabId?: string) => void;
-  splitTerminal: (workspaceId: string, id: string, direction: MosaicDirection, terminalTabId?: string) => string | null;
+  splitTerminal: (workspaceId: string, id: string, direction: MosaicDirection, terminalTabId?: string, agent?: TerminalPaneAgent) => string | null;
   toggleMaximize: (workspaceId: string, id: string, terminalTabId?: string) => void;
   
   // Initialization
@@ -114,19 +110,21 @@ interface TerminalStore {
   
   // Dynamic title (from shell shim OSC sequences)
   setDynamicTitle: (workspaceId: string, paneId: string, dynamicTitle: string, terminalTabId?: string) => void;
+  setPaneAgent: (workspaceId: string, paneId: string, agent: TerminalPaneAgent, terminalTabId?: string) => void;
 
   // Project Wiki scope (separate from main Terminal)
   getProjectWikiPanes: (workspaceId: string) => Record<string, TerminalPaneProps>;
   getProjectWikiLayout: (workspaceId: string) => MosaicNode<string> | null;
   isProjectWikiReady: (workspaceId: string) => boolean;
   setProjectWikiLayout: (workspaceId: string, layout: MosaicNode<string> | null) => void;
-  addProjectWikiTerminal: (workspaceId: string, title?: string) => string;
+  addProjectWikiTerminal: (workspaceId: string, label?: string, agent?: TerminalPaneAgent) => string;
   removeProjectWikiTerminal: (workspaceId: string, id: string) => void;
-  splitProjectWikiTerminal: (workspaceId: string, id: string, direction: MosaicDirection) => string | null;
+  splitProjectWikiTerminal: (workspaceId: string, id: string, direction: MosaicDirection, agent?: TerminalPaneAgent) => string | null;
   initProjectWikiWorkspace: (workspaceId: string) => void;
   loadProjectWikiFromTmux: (workspaceId: string) => Promise<void>;
   getProjectWikiPaneIdByTmuxWindowName: (workspaceId: string, tmuxWindowName: string) => string | null;
   setProjectWikiDynamicTitle: (workspaceId: string, paneId: string, dynamicTitle: string) => void;
+  setProjectWikiPaneAgent: (workspaceId: string, paneId: string, agent: TerminalPaneAgent) => void;
   toggleProjectWikiMaximize: (workspaceId: string, id: string) => void;
 
   // Code Review scope (separate from main Terminal and Project Wiki)
@@ -139,14 +137,15 @@ interface TerminalStore {
   getCodeReviewLayout: (workspaceId: string) => MosaicNode<string> | null;
   isCodeReviewReady: (workspaceId: string) => boolean;
   setCodeReviewLayout: (workspaceId: string, layout: MosaicNode<string> | null) => void;
-  addCodeReviewTerminal: (workspaceId: string, title?: string) => string;
+  addCodeReviewTerminal: (workspaceId: string, label?: string, agent?: TerminalPaneAgent) => string;
   removeCodeReviewTerminal: (workspaceId: string, id: string) => void;
   initCodeReviewWorkspace: (workspaceId: string) => void;
   loadCodeReviewFromTmux: (workspaceId: string) => Promise<void>;
   getCodeReviewPaneIdByTmuxWindowName: (workspaceId: string, tmuxWindowName: string) => string | null;
   setCodeReviewDynamicTitle: (workspaceId: string, paneId: string, dynamicTitle: string) => void;
+  setCodeReviewPaneAgent: (workspaceId: string, paneId: string, agent: TerminalPaneAgent) => void;
   toggleCodeReviewMaximize: (workspaceId: string, id: string) => void;
-  splitCodeReviewTerminal: (workspaceId: string, id: string, direction: MosaicDirection) => string | null;
+  splitCodeReviewTerminal: (workspaceId: string, id: string, direction: MosaicDirection, agent?: TerminalPaneAgent) => string | null;
 }
 
 /** Generate next available window name (1, 2, 3, ...) for numeric names */
@@ -154,7 +153,6 @@ function getNextWindowName(existingPanes: Record<string, TerminalPaneProps>): st
   const values = Object.values(existingPanes);
   const usedNames = new Set([
     ...values.map(p => p.tmuxWindowName),
-    ...values.map(p => p.title),
     ...values.map(p => p.label),
   ].filter(Boolean));
   
@@ -181,7 +179,6 @@ function getUniqueAgentName(baseName: string, existingPanes: Record<string, Term
   const values = Object.values(existingPanes);
   const usedNames = new Set([
     ...values.map(p => p.tmuxWindowName),
-    ...values.map(p => p.title),
     ...values.map(p => p.label),
   ].filter(Boolean));
 
@@ -204,6 +201,36 @@ function createFixedTerminalTab(): TerminalCenterTab {
     title: "Term",
     closable: false,
   };
+}
+
+function createTerminalPane(
+  workspaceId: string,
+  label: string,
+  options: {
+    id?: string;
+    tmuxWindowName?: string;
+    isNewPane: boolean;
+    agent?: TerminalPaneAgent;
+  },
+): TerminalPaneProps {
+  return {
+    id: options.id ?? uuidv4(),
+    label,
+    sessionId: uuidv4(),
+    workspaceId,
+    tmuxWindowName: options.tmuxWindowName ?? label,
+    isNewPane: options.isNewPane,
+    agent: options.agent,
+  };
+}
+
+function samePaneAgent(left: TerminalPaneAgent | undefined, right: TerminalPaneAgent): boolean {
+  return (
+    left?.id === right.id &&
+    left?.label === right.label &&
+    left?.command === right.command &&
+    left?.iconType === right.iconType
+  );
 }
 
 function getScopeKey(workspaceId: string, terminalTabId: string = FIXED_TERMINAL_TAB_VALUE): string {
@@ -359,17 +386,17 @@ function hydratePersistedTab(
 
   const validatedPanes: Record<string, TerminalPaneProps> = {};
   for (const [id, pane] of Object.entries(tab.panes)) {
-    const windowName = pane.tmuxWindowName || pane.title || getNextWindowName(validatedPanes);
+    // `title` is the legacy field name (before the label/tmuxWindowName split).
+    // Fall back to it so old persisted layouts still resolve the correct window name.
+    const legacyTitle = (pane as unknown as { title?: string }).title;
+    const windowName = pane.tmuxWindowName || pane.label || legacyTitle || getNextWindowName(validatedPanes);
     const windowExists = existingWindowNames.has(windowName);
-    // Migration: old persisted panes (before `label` was added) don't have a label field.
-    // Cast to access the optional field without a TypeScript error, then fall back to title.
-    const persistedLabel = (pane as TerminalPaneProps & { label?: string }).label;
 
     validatedPanes[id] = {
       ...pane,
       workspaceId,
-      label: persistedLabel ?? pane.title,  // preserved user-visible name, never overwritten
-      title: windowName,                     // tmux identifier (may drift via auto-rename)
+      // Ensure label is always set — old data only has `title`, not `label`.
+      label: pane.label || legacyTitle || windowName,
       tmuxWindowName: windowName,
       sessionId: uuidv4(),
       isNewPane: !windowExists,
@@ -395,15 +422,11 @@ function createInitialLayout(
     Object.keys(existingPanes).length > 0 ? getNextWindowName(existingPanes) : "1";
   return {
     panes: {
-      [initialId]: {
+      [initialId]: createTerminalPane(workspaceId, windowName, {
         id: initialId,
-        label: windowName,
-        title: windowName,
-        sessionId: uuidv4(),
-        workspaceId,
         tmuxWindowName: windowName,
-        isNewPane: true, // Mark as new so Terminal creates instead of attaches
-      },
+        isNewPane: true,
+      }),
     },
     layout: initialId,
   };
@@ -768,26 +791,23 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
     });
   },
 
-  addTerminal: (workspaceId, title, terminalTabId = FIXED_TERMINAL_TAB_VALUE) => {
+  addTerminal: (workspaceId, label, terminalTabId = FIXED_TERMINAL_TAB_VALUE, agent) => {
     const scopeKey = getScopeKey(workspaceId, terminalTabId);
     const panes = get().workspacePanes[scopeKey] || {};
     const layout = get().workspaceLayouts[scopeKey];
     const allPanes = getAllDefaultPanesForWorkspace(get(), workspaceId);
     const newId = uuidv4();
     // For agent names (non-numeric), use unique suffix logic; otherwise use numeric names
-    const windowName = title 
-      ? getUniqueAgentName(title, allPanes) 
+    const windowName = label
+      ? getUniqueAgentName(label, allPanes)
       : getNextWindowName(allPanes);
-    
-    const newPane: TerminalPaneProps = {
+
+    const newPane = createTerminalPane(workspaceId, windowName, {
       id: newId,
-      label: windowName,
-      title: windowName,
-      sessionId: uuidv4(),
-      workspaceId,
       tmuxWindowName: windowName,
-      isNewPane: true, // Mark as new so Terminal creates instead of attaches
-    };
+      isNewPane: true,
+      agent,
+    });
 
     const nextPanes = { ...panes, [newId]: newPane };
 
@@ -864,7 +884,7 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
     }
   },
 
-  splitTerminal: (workspaceId, id, direction, terminalTabId = FIXED_TERMINAL_TAB_VALUE) => {
+  splitTerminal: (workspaceId, id, direction, terminalTabId = FIXED_TERMINAL_TAB_VALUE, agent) => {
     const scopeKey = getScopeKey(workspaceId, terminalTabId);
     const layout = get().workspaceLayouts[scopeKey];
     const panes = get().workspacePanes[scopeKey] || {};
@@ -872,17 +892,16 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
     if (!layout) return null;
 
     const newId = uuidv4();
-    const windowName = getNextWindowName(allPanes);
+    const windowName = agent
+      ? getUniqueAgentName(agent.label, allPanes)
+      : getNextWindowName(allPanes);
     
-    const newPane: TerminalPaneProps = {
+    const newPane = createTerminalPane(workspaceId, windowName, {
       id: newId,
-      label: windowName,
-      title: windowName,
-      sessionId: uuidv4(),
-      workspaceId,
       tmuxWindowName: windowName,
-      isNewPane: true, // Mark as new so Terminal creates instead of attaches
-    };
+      isNewPane: true,
+      agent,
+    });
 
     const nextPanes = { ...panes, [newId]: newPane };
 
@@ -1146,15 +1165,11 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
         for (const win of existingWindows) {
           const id = uuidv4();
           paneIds.push(id);
-          panes[id] = {
+          panes[id] = createTerminalPane(workspaceId, win.name, {
             id,
-            label: win.name,
-            title: win.name,
-            sessionId: uuidv4(),
-            workspaceId,
             tmuxWindowName: win.name,
             isNewPane: false,
-          };
+          });
         }
 
         let layout: MosaicNode<string> = paneIds[0];
@@ -1263,9 +1278,9 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
             cleanPanes[id] = {
               id: pane.id,
               label: pane.label,
-              title: pane.title,
               workspaceId: pane.workspaceId,
               tmuxWindowName: pane.tmuxWindowName,
+              agent: pane.agent,
               projectName: pane.projectName,
               workspaceName: pane.workspaceName,
               isNewPane: pane.isNewPane,
@@ -1333,7 +1348,6 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
         // Keep tmux identifiers in sync with the actual window name.
         // Do NOT touch `label` — it is the immutable user-visible display name.
         tmuxWindowName,
-        title: tmuxWindowName,
       },
     };
 
@@ -1370,6 +1384,26 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
     // NOTE: Do NOT call saveToBackend — dynamicTitle is transient display-only
   },
 
+  setPaneAgent: (workspaceId, paneId, agent, terminalTabId = FIXED_TERMINAL_TAB_VALUE) => {
+    const scopeKey = getScopeKey(workspaceId, terminalTabId);
+    const panes = get().workspacePanes[scopeKey];
+    if (!panes || !panes[paneId]) return;
+    if (samePaneAgent(panes[paneId].agent, agent)) return;
+
+    set((state) => ({
+      workspacePanes: {
+        ...state.workspacePanes,
+        [scopeKey]: {
+          ...panes,
+          [paneId]: {
+            ...panes[paneId],
+            agent,
+          },
+        },
+      },
+    }));
+  },
+
   // --- Project Wiki scope (in-memory, does not affect main Terminal) ---
   getProjectWikiPanes: (workspaceId) => {
     return get().projectWikiPanes[workspaceId] || {};
@@ -1402,19 +1436,16 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
       },
     }));
   },
-  addProjectWikiTerminal: (workspaceId, title = PROJECT_WIKI_WINDOW_NAME) => {
+  addProjectWikiTerminal: (workspaceId, label = PROJECT_WIKI_WINDOW_NAME, agent) => {
     const panes = get().projectWikiPanes[workspaceId] || {};
     const layout = get().projectWikiLayouts[workspaceId];
     const newId = uuidv4();
-    const newPane: TerminalPaneProps = {
+    const newPane = createTerminalPane(workspaceId, label, {
       id: newId,
-      label: title,
-      title,
-      sessionId: uuidv4(),
-      workspaceId,
-      tmuxWindowName: title,
+      tmuxWindowName: label,
       isNewPane: true,
-    };
+      agent,
+    });
     const nextPanes = { ...panes, [newId]: newPane };
     let nextLayout: MosaicNode<string>;
     if (!layout) {
@@ -1429,20 +1460,18 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
     }));
     return newId;
   },
-  splitProjectWikiTerminal: (workspaceId, id, direction) => {
+  splitProjectWikiTerminal: (workspaceId, id, direction, agent) => {
     const layout = get().projectWikiLayouts[workspaceId];
     const panes = get().projectWikiPanes[workspaceId] || {};
     if (!layout) return null;
     const newId = uuidv4();
-    const newPane: TerminalPaneProps = {
+    const splitName = PROJECT_WIKI_WINDOW_NAME + "-2";
+    const newPane = createTerminalPane(workspaceId, splitName, {
       id: newId,
-      label: PROJECT_WIKI_WINDOW_NAME + "-2",
-      title: PROJECT_WIKI_WINDOW_NAME + "-2",
-      sessionId: uuidv4(),
-      workspaceId,
-      tmuxWindowName: PROJECT_WIKI_WINDOW_NAME + "-2",
+      tmuxWindowName: splitName,
       isNewPane: true,
-    };
+      agent,
+    });
     const nextPanes = { ...panes, [newId]: newPane };
     const splitById = (node: MosaicNode<string>, targetId: string): MosaicNode<string> => {
       if (typeof node === 'string') {
@@ -1508,15 +1537,11 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
         const hasWikiPane = Object.values(panes).some(p => p.tmuxWindowName === PROJECT_WIKI_WINDOW_NAME);
         if (!hasWikiPane) {
           const newId = uuidv4();
-          const newPane: TerminalPaneProps = {
+          const newPane = createTerminalPane(workspaceId, PROJECT_WIKI_WINDOW_NAME, {
             id: newId,
-            label: PROJECT_WIKI_WINDOW_NAME,
-            title: PROJECT_WIKI_WINDOW_NAME,
-            sessionId: uuidv4(),
-            workspaceId,
             tmuxWindowName: PROJECT_WIKI_WINDOW_NAME,
-            isNewPane: false, // Attach to existing tmux window
-          };
+            isNewPane: false,
+          });
           set((state) => ({
             projectWikiPanes: { ...state.projectWikiPanes, [workspaceId]: { ...panes, [newId]: newPane } },
             projectWikiLayouts: { ...state.projectWikiLayouts, [workspaceId]: newId },
@@ -1556,6 +1581,20 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
       },
     }));
   },
+  setProjectWikiPaneAgent: (workspaceId, paneId, agent) => {
+    const panes = get().projectWikiPanes[workspaceId];
+    if (!panes?.[paneId]) return;
+    if (samePaneAgent(panes[paneId].agent, agent)) return;
+    set((state) => ({
+      projectWikiPanes: {
+        ...state.projectWikiPanes,
+        [workspaceId]: {
+          ...panes,
+          [paneId]: { ...panes[paneId], agent },
+        },
+      },
+    }));
+  },
   toggleProjectWikiMaximize: (workspaceId, id) => {
     set((state) => {
       const current = state.projectWikiMaximizedIds[workspaceId];
@@ -1582,19 +1621,16 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
       codeReviewLayouts: { ...state.codeReviewLayouts, [workspaceId]: layout },
     }));
   },
-  addCodeReviewTerminal: (workspaceId, title = CODE_REVIEW_WINDOW_NAME) => {
+  addCodeReviewTerminal: (workspaceId, label = CODE_REVIEW_WINDOW_NAME, agent) => {
     const panes = get().codeReviewPanes[workspaceId] || {};
     const layout = get().codeReviewLayouts[workspaceId];
     const newId = uuidv4();
-    const newPane: TerminalPaneProps = {
+    const newPane = createTerminalPane(workspaceId, label, {
       id: newId,
-      label: title,
-      title,
-      sessionId: uuidv4(),
-      workspaceId,
-      tmuxWindowName: title,
+      tmuxWindowName: label,
       isNewPane: true,
-    };
+      agent,
+    });
     const nextPanes = { ...panes, [newId]: newPane };
     let nextLayout: MosaicNode<string>;
     if (!layout) {
@@ -1648,15 +1684,11 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
         const hasPane = Object.values(panes).some(p => p.tmuxWindowName === CODE_REVIEW_WINDOW_NAME);
         if (!hasPane) {
           const newId = uuidv4();
-          const newPane: TerminalPaneProps = {
+          const newPane = createTerminalPane(workspaceId, CODE_REVIEW_WINDOW_NAME, {
             id: newId,
-            label: CODE_REVIEW_WINDOW_NAME,
-            title: CODE_REVIEW_WINDOW_NAME,
-            sessionId: uuidv4(),
-            workspaceId,
             tmuxWindowName: CODE_REVIEW_WINDOW_NAME,
             isNewPane: false,
-          };
+          });
           set((state) => ({
             codeReviewPanes: { ...state.codeReviewPanes, [workspaceId]: { ...panes, [newId]: newPane } },
             codeReviewLayouts: { ...state.codeReviewLayouts, [workspaceId]: newId },
@@ -1696,6 +1728,20 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
       },
     }));
   },
+  setCodeReviewPaneAgent: (workspaceId, paneId, agent) => {
+    const panes = get().codeReviewPanes[workspaceId];
+    if (!panes?.[paneId]) return;
+    if (samePaneAgent(panes[paneId].agent, agent)) return;
+    set((state) => ({
+      codeReviewPanes: {
+        ...state.codeReviewPanes,
+        [workspaceId]: {
+          ...panes,
+          [paneId]: { ...panes[paneId], agent },
+        },
+      },
+    }));
+  },
   toggleCodeReviewMaximize: (workspaceId, id) => {
     set((state) => {
       const current = state.codeReviewMaximizedIds[workspaceId];
@@ -1708,20 +1754,18 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
       };
     });
   },
-  splitCodeReviewTerminal: (workspaceId, id, direction) => {
+  splitCodeReviewTerminal: (workspaceId, id, direction, agent) => {
     const layout = get().codeReviewLayouts[workspaceId];
     const panes = get().codeReviewPanes[workspaceId] || {};
     if (!layout) return null;
     const newId = uuidv4();
-    const newPane: TerminalPaneProps = {
+    const splitName = CODE_REVIEW_WINDOW_NAME + "-2";
+    const newPane = createTerminalPane(workspaceId, splitName, {
       id: newId,
-      label: CODE_REVIEW_WINDOW_NAME + "-2",
-      title: CODE_REVIEW_WINDOW_NAME + "-2",
-      sessionId: uuidv4(),
-      workspaceId,
-      tmuxWindowName: CODE_REVIEW_WINDOW_NAME + "-2",
+      tmuxWindowName: splitName,
       isNewPane: true,
-    };
+      agent,
+    });
     const nextPanes = { ...panes, [newId]: newPane };
     const splitById = (node: MosaicNode<string>, targetId: string): MosaicNode<string> => {
       if (typeof node === 'string') {

--- a/apps/web/src/hooks/use-terminal-store.ts
+++ b/apps/web/src/hooks/use-terminal-store.ts
@@ -1402,6 +1402,7 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => ({
         },
       },
     }));
+    get().saveToBackend(workspaceId);
   },
 
   // --- Project Wiki scope (in-memory, does not affect main Terminal) ---

--- a/apps/web/src/hooks/use-websocket.ts
+++ b/apps/web/src/hooks/use-websocket.ts
@@ -109,6 +109,8 @@ export type WsAction =
   // Code Agent custom settings
   | "code_agent_custom_get"
   | "code_agent_custom_update"
+  | "agent_behaviour_settings_get"
+  | "agent_behaviour_settings_update"
   // Notification settings
   | "notification_settings_get"
   | "notification_settings_update"

--- a/crates/core-engine/src/tmux/mod.rs
+++ b/crates/core-engine/src/tmux/mod.rs
@@ -428,9 +428,10 @@ impl TmuxEngine {
         workspace_id: &str,
         cwd: Option<&str>,
         shell_command: Option<&[String]>,
+        env_vars: Option<&[(&str, &str)]>,
     ) -> Result<String> {
         let session_name = self.session_name(workspace_id);
-        self.create_session_internal(&session_name, cwd, shell_command)
+        self.create_session_internal(&session_name, cwd, shell_command, env_vars)
     }
 
     /// Create a new tmux session with human-readable names
@@ -441,9 +442,10 @@ impl TmuxEngine {
         workspace_name: &str,
         cwd: Option<&str>,
         shell_command: Option<&[String]>,
+        env_vars: Option<&[(&str, &str)]>,
     ) -> Result<String> {
         let session_name = self.session_name_from_names(project_name, workspace_name);
-        self.create_session_internal(&session_name, cwd, shell_command)
+        self.create_session_internal(&session_name, cwd, shell_command, env_vars)
     }
 
     /// Internal function to create tmux session
@@ -452,6 +454,7 @@ impl TmuxEngine {
         session_name: &str,
         cwd: Option<&str>,
         shell_command: Option<&[String]>,
+        env_vars: Option<&[(&str, &str)]>,
     ) -> Result<String> {
         if self.session_exists(session_name)? {
             self.sync_utf8_environment();
@@ -475,6 +478,13 @@ impl TmuxEngine {
         if let Some(dir) = cwd {
             args.push("-c".to_string());
             args.push(dir.to_string());
+        }
+
+        if let Some(vars) = env_vars {
+            for (key, value) in vars {
+                args.push("-e".to_string());
+                args.push(format!("{}={}", key, value));
+            }
         }
 
         if let Some(cmd) = shell_command {

--- a/crates/core-service/src/service/terminal.rs
+++ b/crates/core-service/src/service/terminal.rs
@@ -389,17 +389,25 @@ impl TerminalService {
             .and_then(|dir| core_engine::shims::build_shell_command(dir, shell.as_deref()));
 
         // Now create or get tmux session for this workspace (protected by lock)
-        // Pass shell_command so the first window "1" also gets shim injection
+        // Pass shell_command so the first window "1" also gets shim injection.
+        // Pass ATMOS env vars so the default window "1" gets them too — otherwise
+        // the "window already exists → attach" shortcut below would skip injection.
+        let default_window_pane_id = format!("{}:1", workspace_id);
+        let session_env_vars: Vec<(&str, &str)> = vec![
+            ("ATMOS_MANAGED", "1"),
+            ("ATMOS_CONTEXT_ID", &workspace_id),
+            ("ATMOS_PANE_ID", &default_window_pane_id),
+        ];
         let tmux_session = if let (Some(ref proj), Some(ref ws)) = (&project_name, &workspace_name)
         {
             self.tmux_engine
-                .create_session_with_names(proj, ws, cwd.as_deref(), shell_command.as_deref())
+                .create_session_with_names(proj, ws, cwd.as_deref(), shell_command.as_deref(), Some(&session_env_vars))
                 .map_err(|e| {
                     ServiceError::Processing(format!("Failed to create tmux session: {}", e))
                 })?
         } else {
             self.tmux_engine
-                .create_session(&workspace_id, cwd.as_deref(), shell_command.as_deref())
+                .create_session(&workspace_id, cwd.as_deref(), shell_command.as_deref(), Some(&session_env_vars))
                 .map_err(|e| {
                     ServiceError::Processing(format!("Failed to create tmux session: {}", e))
                 })?

--- a/crates/core-service/src/service/ws_message.rs
+++ b/crates/core-service/src/service/ws_message.rs
@@ -2537,50 +2537,106 @@ set -x
         drop(pair.slave);
 
         let mut reader = pair.master.try_clone_reader()?;
+        // Drop the master after cloning the reader so the PTY fd is not held
+        // open longer than necessary. On macOS/Unix the reader already has its
+        // own dup'd fd and EOF is driven by the slave side closing.
+        drop(pair.master);
+
         let manager_clone = manager.clone();
         let conn_id_clone = conn_id.to_string();
         let workspace_id_clone = workspace_id.to_string();
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
 
-        // Reading task
+        // Reading task – streams PTY output into the channel.
         std::thread::spawn(move || {
             let mut buf = [0u8; 4096];
-            while let Ok(n) = reader.read(&mut buf) {
-                if n == 0 {
-                    break;
-                }
-                let s = String::from_utf8_lossy(&buf[..n]).to_string();
-                if tx.send(s).is_err() {
-                    break;
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let s = String::from_utf8_lossy(&buf[..n]).to_string();
+                        if tx.send(s).is_err() {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
                 }
             }
         });
 
-        while let Some(output) = rx.recv().await {
-            Self::send_workspace_setup_progress(
-                &manager_clone,
-                &conn_id_clone,
-                WorkspaceSetupProgressNotification {
-                    workspace_id: workspace_id_clone.clone(),
-                    status: "setting_up".to_string(),
-                    step_key: Some("run_setup_script".to_string()),
-                    failed_step_key: None,
-                    step_title: "Running Setup Script".to_string(),
-                    output: Some(output),
-                    replace_output: false,
-                    requires_confirmation: false,
-                    success: true,
-                    countdown: None,
-                    setup_context: None,
-                },
-            )
-            .await;
+        // Wait for the child process concurrently with streaming output.
+        // This avoids hanging forever if the PTY reader never gets EOF
+        // (e.g. a background process inherited the slave fd).
+        let mut wait_handle =
+            tokio::task::spawn_blocking(move || child.wait());
+
+        let exit_status = loop {
+            tokio::select! {
+                biased;
+                Some(output) = rx.recv() => {
+                    Self::send_workspace_setup_progress(
+                        &manager_clone,
+                        &conn_id_clone,
+                        WorkspaceSetupProgressNotification {
+                            workspace_id: workspace_id_clone.clone(),
+                            status: "setting_up".to_string(),
+                            step_key: Some("run_setup_script".to_string()),
+                            failed_step_key: None,
+                            step_title: "Running Setup Script".to_string(),
+                            output: Some(output),
+                            replace_output: false,
+                            requires_confirmation: false,
+                            success: true,
+                            countdown: None,
+                            setup_context: None,
+                        },
+                    )
+                    .await;
+                }
+                result = &mut wait_handle => {
+                    break result??;
+                }
+            }
+        };
+
+        // Best-effort drain: capture any remaining PTY output that was buffered
+        // between the last recv and the child exiting.
+        let drain_deadline =
+            tokio::time::Instant::now() + Duration::from_millis(500);
+        loop {
+            let remaining = drain_deadline
+                .saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match tokio::time::timeout(remaining, rx.recv()).await {
+                Ok(Some(output)) => {
+                    Self::send_workspace_setup_progress(
+                        &manager_clone,
+                        &conn_id_clone,
+                        WorkspaceSetupProgressNotification {
+                            workspace_id: workspace_id_clone.clone(),
+                            status: "setting_up".to_string(),
+                            step_key: Some("run_setup_script".to_string()),
+                            failed_step_key: None,
+                            step_title: "Running Setup Script".to_string(),
+                            output: Some(output),
+                            replace_output: false,
+                            requires_confirmation: false,
+                            success: true,
+                            countdown: None,
+                            setup_context: None,
+                        },
+                    )
+                    .await;
+                }
+                Ok(None) | Err(_) => break,
+            }
         }
 
-        let status = child.wait()?;
-        if !status.success() {
-            anyhow::bail!("Script exited with status {}", status);
+        if !exit_status.success() {
+            anyhow::bail!("Script exited with status {}", exit_status);
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

Introduces a new `label` field to `TerminalPaneProps` that serves as an immutable, user-visible display name for terminal panes. This decouples the display name from the `title` field, which is now reserved for the tmux window identifier that may change due to tmux auto-rename behavior.

**Key changes:**
- Added `label` field to `TerminalPaneProps` interface with documentation explaining its immutability and persistence
- Updated all pane creation sites to initialize `label` alongside `title`
- Modified `getNextWindowName()` and `getUniqueAgentName()` to consider `label` when checking for name conflicts
- Updated `hydratePersistedTab()` to handle migration of legacy persisted panes (before `label` existed) by falling back to `title`
- Updated `TerminalGrid` to display `label` (or `dynamicTitle` if available) instead of `title`
- Replaced simple color-based agent detection with a registry-based lookup using `PANE_TITLE_TO_REGISTRY_ID` hash map for O(1) agent identification
- Added `AgentIcon` display in terminal toolbar instead of generic colored dot
- Fixed whitespace inconsistencies throughout the file

The `label` field is set once at pane creation and never overwritten, ensuring stable display names even if the underlying tmux window is renamed. The `title` field remains the authoritative tmux identifier and is kept in sync with actual window names.

## Related Issue

<!-- e.g. Closes #123 -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] Additional checks: Verified pane creation flows initialize both `label` and `title`; migration path for legacy persisted panes tested via `hydratePersistedTab()`

## Checklist

- [x] I updated documentation if behavior changed (added JSDoc comments to `label` and `title` fields)
- [ ] I added/updated tests where appropriate (existing store tests cover pane creation)
- [x] I followed repository conventions and AGENTS.md guidance

https://claude.ai/code/session_01XWMkzq5qb8FF1D2famNNLT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an immutable `label` to terminal panes and persist per-pane `agent` metadata so display names and toolbar icons stay stable and correct. Also inject ATMOS env vars into the default tmux window and fix setup script hangs for more reliable setup and agent status.

- **New Features**
  - Persisted, immutable `label` for panes; all create/split paths set it and use it for display; uniqueness checks include `label` and `tmuxWindowName`. Legacy panes auto-migrate on hydrate.
  - Added `agent` metadata on panes (persisted) with setters across main, Project Wiki, and Code Review; toolbar renders `AgentIcon` from explicit pane `agent`, or auto-detects from `dynamicTitle` or `label` (ignores path- and version-like titles, matches by command token) with a non-agent fallback.
  - Updated `TerminalGridHandle` to use `label` (not `title`) and optional `agent`; create/focus by label or window name; split accepts `agent`; `quickOpenAgents` now pass `{ agent, command }`. On title change, panes auto-set `agent` when a known command is detected.

- **Bug Fixes**
  - Inject `ATMOS_MANAGED`, `ATMOS_CONTEXT_ID`, and `ATMOS_PANE_ID` into the default tmux session window so agent hooks work in the initial pane.
  - Prevent setup script hangs by streaming PTY output while waiting for child exit and draining final output; detect “setting_up” stalls after 120s.
  - Persist pane `agent` updates when `setPaneAgent()` is called.

<sup>Written for commit cd1fd05d735398bef9b5c81398895acaa894903f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal sessions can receive custom environment variables
  * WebSocket API extended to manage agent behavior settings

* **Bug Fixes**
  * Improved detection of stalled workspace setup with adaptive timeouts
  * More reliable, incremental terminal output delivery during command runs

* **Refactor**
  * Terminal panes now use persistent labels and structured agent metadata for clearer toolbar and split behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->