### PR TITLE
feat(ui): migrate ScrollArea to OverlayScrollbars for consistent scrollbar styling

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -71,6 +71,8 @@
     "next-intl": "^4.7.0",
     "next-themes": "^0.4.6",
     "nuqs": "^2.8.8",
+    "overlayscrollbars": "^2.15.1",
+    "overlayscrollbars-react": "^0.5.6",
     "react": "19.2.3",
     "react-color": "^2.19.3",
     "react-dnd": "^16.0.1",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -5,6 +5,9 @@
 /* Import UI package global styles */
 @import "@workspace/ui/globals.css";
 
+/* OverlayScrollbars base styles (used by ScrollArea / OverlayScroll / root body) */
+@import "overlayscrollbars/overlayscrollbars.css";
+
 /* Tell Tailwind to scan our UI package components */
 @source "../../../../packages/ui/src";
 
@@ -108,9 +111,16 @@ html:not([data-theme-ready="true"]) body {
     width: 100%;
   }
 
+  /*
+   * Native scrollbar fallback. OverlayScrollbars (via ScrollArea /
+   * OverlayScroll) is the primary scrollbar mechanism, but we still ship
+   * this so any scrollable element that isn't wrapped by OverlayScrollbars
+   * (3rd-party widgets, code blocks, xterm, CodeMirror, etc.) renders with
+   * a thumb that visually matches the `os-theme-atmos` look.
+   */
   *::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
+    width: 8px;
+    height: 8px;
   }
 
   *::-webkit-scrollbar-track {
@@ -118,16 +128,85 @@ html:not([data-theme-ready="true"]) body {
   }
 
   *::-webkit-scrollbar-thumb {
-    @apply bg-muted-foreground/20 rounded-full;
+    @apply bg-foreground/20 rounded-full;
+    border: 2px solid transparent;
+    background-clip: padding-box;
   }
 
   *::-webkit-scrollbar-thumb:hover {
-    @apply bg-muted-foreground/40;
+    @apply bg-foreground/35;
   }
 
   *::-webkit-scrollbar-corner {
     background: transparent;
   }
+}
+
+/*
+ * OverlayScrollbars custom theme.
+ *
+ * The `.os-theme-atmos` class is used by ScrollArea / OverlayScroll so the
+ * entire web app shares one scrollbar look across pages, modals, popovers
+ * and dialogs.
+ */
+.os-theme-atmos {
+  --os-size: 10px;
+  --os-padding-perpendicular: 2px;
+  --os-padding-axis: 2px;
+  --os-track-border-radius: 9999px;
+  --os-track-bg: transparent;
+  --os-track-bg-hover: transparent;
+  --os-track-bg-active: transparent;
+  --os-handle-border-radius: 9999px;
+  --os-handle-bg: color-mix(in srgb, var(--foreground) 22%, transparent);
+  --os-handle-bg-hover: color-mix(in srgb, var(--foreground) 38%, transparent);
+  --os-handle-bg-active: color-mix(in srgb, var(--foreground) 50%, transparent);
+  --os-handle-min-size: 24px;
+  --os-handle-perpendicular-size: 6px;
+  --os-handle-perpendicular-size-hover: 8px;
+  --os-handle-perpendicular-size-active: 8px;
+}
+
+.dark .os-theme-atmos {
+  --os-handle-bg: color-mix(in srgb, var(--foreground) 28%, transparent);
+  --os-handle-bg-hover: color-mix(in srgb, var(--foreground) 50%, transparent);
+  --os-handle-bg-active: color-mix(in srgb, var(--foreground) 65%, transparent);
+}
+
+/*
+ * scrollFade: soft mask on edges that have overflowing content. Mirrors the
+ * old base-ui ScrollArea API. We use a reasonable static fade size; callers
+ * that want tighter control can opt out and apply their own mask classes.
+ */
+.atmos-scroll-area--fade [data-overlayscrollbars-viewport] {
+  --fade-size: 1.5rem;
+  mask-image: linear-gradient(
+      to bottom,
+      transparent 0,
+      black var(--fade-size),
+      black calc(100% - var(--fade-size)),
+      transparent 100%
+    ),
+    linear-gradient(
+      to right,
+      transparent 0,
+      black var(--fade-size),
+      black calc(100% - var(--fade-size)),
+      transparent 100%
+    );
+  mask-composite: intersect;
+}
+
+/*
+ * scrollbarGutter: reserve space so content doesn't shift when the scrollbar
+ * appears. With OverlayScrollbars, the scrollbar is overlaid by default; this
+ * variant simply pads the viewport so the thumb never overlaps content.
+ */
+.atmos-scroll-area--gutter [data-overlayscrollbars-viewport] {
+  scroll-padding-right: 0.625rem;
+  scroll-padding-bottom: 0.625rem;
+  padding-right: 0.625rem;
+  padding-bottom: 0.625rem;
 }
 
 @layer utilities {

--- a/apps/web/src/components/github/ActionsDetailModal.tsx
+++ b/apps/web/src/components/github/ActionsDetailModal.tsx
@@ -14,6 +14,7 @@ import {
   Avatar,
   AvatarImage,
   AvatarFallback,
+  OverlayScroll,
   Skeleton,
 } from '@workspace/ui';
 import { useWebSocketStore } from '@/hooks/use-websocket';
@@ -149,7 +150,8 @@ export function ActionsDetailModal({ owner, repo, run, runId, isOpen, onOpenChan
           isFullscreen ? "max-w-none sm:max-w-none w-screen sm:w-screen h-screen max-h-screen px-6 pb-6 pt-0 m-0 border-none rounded-none" : "max-w-2xl sm:max-w-2xl w-full h-[80vh] px-6 pb-6 pt-0"
         )}
       >
-        <div className="flex-1 overflow-y-auto min-h-[400px] pr-4 -mr-4 pb-16 relative no-scrollbar">
+        <OverlayScroll className="flex-1 min-h-[400px] pr-4 -mr-4">
+          <div className="pb-16 relative">
           <DialogHeader className="pr-24 flex flex-row items-center gap-3 space-y-0 pt-6 pb-4 shrink-0 relative">
             <WorkflowIcon className="size-4.5 text-muted-foreground/60" />
             <div className="flex items-center gap-2.5 min-w-0">
@@ -376,7 +378,8 @@ export function ActionsDetailModal({ owner, repo, run, runId, isOpen, onOpenChan
 
             </div>
           </div>
-        </div>
+          </div>
+        </OverlayScroll>
 
         <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-10 flex sm:justify-between items-center bg-background/90 backdrop-blur-md px-4 py-2.5 rounded-xl border border-dashed border-border/80 shadow-xl gap-6">
           <div className="flex gap-2.5">

--- a/apps/web/src/components/github/ActionsPanel.tsx
+++ b/apps/web/src/components/github/ActionsPanel.tsx
@@ -3,7 +3,7 @@ import { useGithubActionsList } from '@/hooks/use-github';
 import { ExternalLink, Search, Loader2, Workflow, CheckCircle2, XCircle, FileText, Rocket, Github, AlertCircle } from 'lucide-react';
 import { formatDistanceToNow, format, parseISO } from 'date-fns';
 import { cn } from '@/lib/utils';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, Button } from '@workspace/ui';
+import { OverlayScroll, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, Button } from '@workspace/ui';
 
 export interface ActionRun {
   databaseId: number;
@@ -134,7 +134,8 @@ export function ActionsPanel({ owner, repo, branch, onRunClick, refreshKey }: Ac
             <ActionsSummaryHeader stats={stats} />
           </div>
 
-          <div className="flex-1 overflow-y-auto no-scrollbar p-2 space-y-2">
+          <OverlayScroll className="flex-1 min-h-0">
+            <div className="p-2 space-y-2">
             {latestRuns.map((run) => {
               const isSuccess = run.conclusion === 'success';
               const isFailure = run.conclusion === 'failure';
@@ -198,7 +199,8 @@ export function ActionsPanel({ owner, repo, branch, onRunClick, refreshKey }: Ac
                 </div>
               );
             })}
-          </div>
+            </div>
+          </OverlayScroll>
 
           <div className="p-3 border-t border-sidebar-border/50 bg-sidebar-accent/5 flex flex-col gap-2">
             <p className="text-[11px] text-muted-foreground leading-normal">

--- a/apps/web/src/components/github/CommitsPanel.tsx
+++ b/apps/web/src/components/github/CommitsPanel.tsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo, useState, useCallback, useEffect } from 'react';
 import { GitCommit as GitCommitIcon, ChevronLeft, ChevronRight, Copy, Check, Loader2, Github } from 'lucide-react';
-import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@workspace/ui';
+import { OverlayScroll, Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@workspace/ui';
 import { cn } from '@/lib/utils';
 import { useGitLog, type GitCommit } from '@/hooks/use-github';
 import { formatDistanceToNow, format, fromUnixTime } from 'date-fns';
@@ -237,7 +237,8 @@ export function CommitsPanel({
     <TooltipProvider delayDuration={300}>
       <div className="flex flex-col h-full w-full">
         {/* Commit list — scrollable */}
-        <div className="flex-1 overflow-y-auto no-scrollbar">
+        <OverlayScroll className="flex-1 min-h-0">
+          <div>
           {grouped.map((group) => (
             <div key={group.dateLabel}>
               {/* Day header — sticky */}
@@ -308,7 +309,8 @@ export function CommitsPanel({
               <div className="flex-1" />
             </div>
           )}
-        </div>
+          </div>
+        </OverlayScroll>
       </div>
     </TooltipProvider>
   );

--- a/apps/web/src/components/github/PRPanel.tsx
+++ b/apps/web/src/components/github/PRPanel.tsx
@@ -16,6 +16,7 @@ import {
   Avatar,
   AvatarImage,
   AvatarFallback,
+  OverlayScroll,
   Tooltip,
   TooltipTrigger,
   TooltipContent,
@@ -115,7 +116,8 @@ export function PRPanel({ owner, repo, branch, onPrClick }: PRPanelProps) {
           </Tabs>
         </div>
 
-        <div className="flex-1 overflow-y-auto no-scrollbar p-2">
+        <OverlayScroll className="flex-1 min-h-0">
+          <div className="p-2">
           {loading && !prs ? (
             <div className="flex flex-col items-center justify-center min-h-[300px] text-muted-foreground gap-3">
               <Loader2 className="size-5 animate-spin opacity-50" />
@@ -245,7 +247,8 @@ export function PRPanel({ owner, repo, branch, onPrClick }: PRPanelProps) {
               })}
             </div>
           )}
-        </div>
+          </div>
+        </OverlayScroll>
       </div>
     </TooltipProvider>
   );

--- a/bun.lock
+++ b/bun.lock
@@ -148,6 +148,8 @@
         "next-intl": "^4.7.0",
         "next-themes": "^0.4.6",
         "nuqs": "^2.8.8",
+        "overlayscrollbars": "^2.15.1",
+        "overlayscrollbars-react": "^0.5.6",
         "react": "19.2.3",
         "react-color": "^2.19.3",
         "react-dnd": "^16.0.1",
@@ -262,6 +264,8 @@
         "motion": "^12.38.0",
         "nanoid": "^5.1.6",
         "next-themes": "^0.4.6",
+        "overlayscrollbars": "^2.15.1",
+        "overlayscrollbars-react": "^0.5.6",
         "postprocessing": "^6.39.1",
         "radix-ui": "^1.4.3",
         "react-day-picker": "^9.14.0",
@@ -2068,6 +2072,10 @@
     "oniguruma-to-es": ["oniguruma-to-es@4.3.4", "", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "overlayscrollbars": ["overlayscrollbars@2.15.1", "", {}, "sha512-glX26JwjL+Tkzv0JNOWdW4VozP5dGXO+Wx8+TPrdTEJTSYT/8eJS8yXM+fewjU0nFq/JeCa+X+BqABNjC4YZSA=="],
+
+    "overlayscrollbars-react": ["overlayscrollbars-react@0.5.6", "", { "peerDependencies": { "overlayscrollbars": "^2.0.0", "react": ">=16.8.0" } }, "sha512-E5To04bL5brn9GVCZ36SnfGanxa2I2MDkWoa4Cjo5wol7l+diAgi4DBc983V7l2nOk/OLJ6Feg4kySspQEGDBw=="],
 
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -50,6 +50,8 @@
     "motion": "^12.38.0",
     "nanoid": "^5.1.6",
     "next-themes": "^0.4.6",
+    "overlayscrollbars": "^2.15.1",
+    "overlayscrollbars-react": "^0.5.6",
     "postprocessing": "^6.39.1",
     "radix-ui": "^1.4.3",
     "react-day-picker": "^9.14.0",

--- a/packages/ui/src/components/ui/scroll-area.tsx
+++ b/packages/ui/src/components/ui/scroll-area.tsx
@@ -1,64 +1,299 @@
 "use client";
 
-import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
+import * as React from "react";
+import {
+  OverlayScrollbarsComponent,
+  type OverlayScrollbarsComponentProps,
+  type OverlayScrollbarsComponentRef,
+} from "overlayscrollbars-react";
+import type {
+  EventListenerArgs,
+  EventListeners,
+  PartialOptions,
+} from "overlayscrollbars";
+import "overlayscrollbars/overlayscrollbars.css";
 
 import { cn } from "../../lib/utils";
 
-function ScrollArea({
+function invokeListener<K extends keyof EventListenerArgs>(
+  listener: EventListeners[K] | undefined,
+  args: EventListenerArgs[K],
+) {
+  if (!listener) return;
+  const listeners = (Array.isArray(listener)
+    ? listener
+    : [listener]) as Array<
+    (...listenerArgs: EventListenerArgs[K]) => void
+  >;
+  for (const fn of listeners) {
+    fn(...args);
+  }
+}
+
+/**
+ * Default OverlayScrollbars options shared by every scrollable surface in the
+ * web app. Individual call-sites can extend / override via the `options` prop.
+ */
+const DEFAULT_OS_OPTIONS: PartialOptions = {
+  paddingAbsolute: true,
+  scrollbars: {
+    theme: "os-theme-atmos",
+    visibility: "auto",
+    autoHide: "leave",
+    autoHideDelay: 800,
+    dragScroll: true,
+    clickScroll: true,
+    pointers: ["mouse", "touch", "pen"],
+  },
+  overflow: {
+    x: "scroll",
+    y: "scroll",
+  },
+};
+
+function mergeOptions(custom?: PartialOptions): PartialOptions {
+  if (!custom) return DEFAULT_OS_OPTIONS;
+  return {
+    ...DEFAULT_OS_OPTIONS,
+    ...custom,
+    scrollbars: {
+      ...DEFAULT_OS_OPTIONS.scrollbars,
+      ...(custom.scrollbars ?? {}),
+    },
+    overflow: {
+      ...DEFAULT_OS_OPTIONS.overflow,
+      ...(custom.overflow ?? {}),
+    },
+  };
+}
+
+type CommonOverlayProps = Omit<
+  OverlayScrollbarsComponentProps,
+  "options" | "events" | "element" | "ref"
+>;
+
+interface OverlayScrollExtraProps {
+  /** Tag of the root element. Defaults to `div`. */
+  as?: OverlayScrollbarsComponentProps["element"];
+  /** Override / extend OverlayScrollbars options. */
+  options?: PartialOptions;
+  /** OverlayScrollbars events. `initialized`/`destroyed` are composed with
+   *  internal viewport ref-tracking, so consumers can still hook in. */
+  events?: OverlayScrollbarsComponentProps["events"];
+  /** Defer initialization to a browser idle period. Defaults to true. */
+  defer?: OverlayScrollbarsComponentProps["defer"];
+  /** Receives the OverlayScrollbarsComponent imperative ref. */
+  componentRef?: React.Ref<OverlayScrollbarsComponentRef>;
+  /** Receives the underlying scrollable viewport element. Useful for code
+   *  that needs to read `scrollTop` / call `scrollIntoView` on the actual
+   *  scroll container produced by OverlayScrollbars. */
+  viewportRef?: React.Ref<HTMLElement | null>;
+}
+
+/* ----------------------------- ScrollArea ----------------------------- */
+
+export interface ScrollAreaProps
+  extends CommonOverlayProps,
+    OverlayScrollExtraProps {
+  className?: string;
+  children?: React.ReactNode;
+  /** Apply a soft mask fade on the edges where content overflows. Kept for
+   *  API compatibility with the previous base-ui ScrollArea. */
+  scrollFade?: boolean;
+  /** Reserve gutter space for the scrollbar so content doesn't shift. Kept
+   *  for API compatibility with the previous base-ui ScrollArea. */
+  scrollbarGutter?: boolean;
+}
+
+function useViewportRefSync(
+  ref: React.Ref<HTMLElement | null> | undefined,
+) {
+  const lastViewportRef = React.useRef<HTMLElement | null>(null);
+
+  return React.useCallback(
+    (value: HTMLElement | null) => {
+      if (value === lastViewportRef.current) return;
+      lastViewportRef.current = value;
+      if (typeof ref === "function") {
+        ref(value);
+      } else if (ref && typeof ref === "object") {
+        (ref as React.MutableRefObject<HTMLElement | null>).current = value;
+      }
+    },
+    [ref],
+  );
+}
+
+/**
+ * Drop-in replacement for the old `ScrollArea` that renders OverlayScrollbars
+ * under the hood so every scrollable surface in the app shares one consistent
+ * scrollbar style. The component preserves the previous public API
+ * (className, children, `scrollFade`, `scrollbarGutter`).
+ */
+export function ScrollArea({
   className,
   children,
   scrollFade = false,
   scrollbarGutter = false,
-  ...props
-}: ScrollAreaPrimitive.Root.Props & {
-  scrollFade?: boolean;
-  scrollbarGutter?: boolean;
-}) {
-  return (
-    <ScrollAreaPrimitive.Root
-      className={cn("size-full min-h-0", className)}
-      {...props}
-    >
-      <ScrollAreaPrimitive.Viewport
-        className={cn(
-          "h-full rounded-[inherit] outline-none transition-shadows focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background data-has-overflow-x:overscroll-x-contain",
-          scrollFade &&
-          "mask-t-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-y-start)))] mask-b-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-y-end)))] mask-l-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-x-start)))] mask-r-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-x-end)))] [--fade-size:1.5rem]",
-          scrollbarGutter &&
-          "data-has-overflow-y:pe-2.5 data-has-overflow-x:pb-2.5",
-        )}
-        data-slot="scroll-area-viewport"
-      >
-        {children}
-      </ScrollAreaPrimitive.Viewport>
-      <ScrollBar orientation="vertical" />
-      <ScrollBar orientation="horizontal" />
-      <ScrollAreaPrimitive.Corner data-slot="scroll-area-corner" />
-    </ScrollAreaPrimitive.Root>
-  );
-}
+  options,
+  events,
+  defer = true,
+  as = "div",
+  componentRef,
+  viewportRef,
+  ...rest
+}: ScrollAreaProps) {
+  const setViewport = useViewportRefSync(viewportRef);
 
-function ScrollBar({
-  className,
-  orientation = "vertical",
-  ...props
-}: ScrollAreaPrimitive.Scrollbar.Props) {
+  const handleRef = React.useCallback(
+    (value: OverlayScrollbarsComponentRef | null) => {
+      if (typeof componentRef === "function") {
+        componentRef(value);
+      } else if (componentRef && typeof componentRef === "object") {
+        (componentRef as React.MutableRefObject<OverlayScrollbarsComponentRef | null>).current =
+          value;
+      }
+    },
+    [componentRef],
+  );
+
+  const composedEvents = React.useMemo<OverlayScrollbarsComponentProps["events"]>(
+    () => {
+      const baseEvents: EventListeners | undefined =
+        events && typeof events === "object" ? (events as EventListeners) : undefined;
+      return {
+        ...(baseEvents ?? {}),
+        initialized: (instance) => {
+          const viewport = instance.elements().viewport as HTMLElement | undefined;
+          if (viewport) {
+            // Maintain compatibility with code that selects the viewport via
+            // [data-slot='scroll-area-viewport'] (e.g. WikiContent).
+            viewport.dataset.slot = "scroll-area-viewport";
+            setViewport(viewport);
+          }
+          invokeListener(baseEvents?.initialized, [instance]);
+        },
+        destroyed: (instance, canceled) => {
+          setViewport(null);
+          invokeListener(baseEvents?.destroyed, [instance, canceled]);
+        },
+      };
+    },
+    [events, setViewport],
+  );
+
   return (
-    <ScrollAreaPrimitive.Scrollbar
+    <OverlayScrollbarsComponent
+      ref={handleRef}
+      element={as}
+      defer={defer}
+      data-slot="scroll-area"
       className={cn(
-        "absolute z-50 m-1 opacity-0 transition-opacity delay-300 data-[orientation=horizontal]:h-1.5 data-[orientation=vertical]:w-1.5 data-[orientation=horizontal]:flex-col data-hovering:opacity-100 data-scrolling:opacity-100 data-hovering:delay-0 data-scrolling:delay-0 data-hovering:duration-100 data-scrolling:duration-100 data-[orientation=horizontal]:hidden data-[orientation=vertical]:hidden data-[orientation=horizontal]:data-[has-overflow-x]:flex data-[orientation=vertical]:data-[has-overflow-y]:flex",
+        "atmos-scroll-area size-full min-h-0",
+        scrollFade && "atmos-scroll-area--fade",
+        scrollbarGutter && "atmos-scroll-area--gutter",
         className,
       )}
-      data-slot="scroll-area-scrollbar"
-      orientation={orientation}
-      {...props}
+      options={mergeOptions(options)}
+      events={composedEvents}
+      {...rest}
     >
-      <ScrollAreaPrimitive.Thumb
-        className="relative flex-1 rounded-full bg-foreground/20"
-        data-slot="scroll-area-thumb"
-      />
-    </ScrollAreaPrimitive.Scrollbar>
+      {children}
+    </OverlayScrollbarsComponent>
   );
 }
 
-export { ScrollArea, ScrollBar };
+/* ----------------------------- ScrollBar ----------------------------- */
+
+/**
+ * Compatibility shim. The previous base-ui implementation rendered explicit
+ * `ScrollBar` children; OverlayScrollbars renders its own scrollbars
+ * automatically, so this is a no-op kept around to avoid breaking imports.
+ */
+export function ScrollBar(_props: {
+  orientation?: "horizontal" | "vertical";
+  className?: string;
+}) {
+  return null;
+}
+
+/* ----------------------------- OverlayScroll ----------------------------- */
+
+export interface OverlayScrollProps
+  extends CommonOverlayProps,
+    OverlayScrollExtraProps {
+  className?: string;
+  children?: React.ReactNode;
+}
+
+/**
+ * Lightweight wrapper around OverlayScrollbarsComponent for places that used
+ * raw `overflow-*-auto` divs. Unlike `ScrollArea`, this wrapper does not
+ * enforce `size-full` or `min-h-0`, so it can be dropped into existing
+ * layouts that already control sizing on the parent.
+ */
+export function OverlayScroll({
+  className,
+  children,
+  options,
+  events,
+  defer = true,
+  as = "div",
+  componentRef,
+  viewportRef,
+  ...rest
+}: OverlayScrollProps) {
+  const setViewport = useViewportRefSync(viewportRef);
+
+  const handleRef = React.useCallback(
+    (value: OverlayScrollbarsComponentRef | null) => {
+      if (typeof componentRef === "function") {
+        componentRef(value);
+      } else if (componentRef && typeof componentRef === "object") {
+        (componentRef as React.MutableRefObject<OverlayScrollbarsComponentRef | null>).current =
+          value;
+      }
+    },
+    [componentRef],
+  );
+
+  const composedEvents = React.useMemo<OverlayScrollbarsComponentProps["events"]>(
+    () => {
+      const baseEvents: EventListeners | undefined =
+        events && typeof events === "object" ? (events as EventListeners) : undefined;
+      return {
+        ...(baseEvents ?? {}),
+        initialized: (instance) => {
+          const viewport = instance.elements().viewport as HTMLElement | undefined;
+          if (viewport) {
+            viewport.dataset.slot = "scroll-area-viewport";
+            setViewport(viewport);
+          }
+          invokeListener(baseEvents?.initialized, [instance]);
+        },
+        destroyed: (instance, canceled) => {
+          setViewport(null);
+          invokeListener(baseEvents?.destroyed, [instance, canceled]);
+        },
+      };
+    },
+    [events, setViewport],
+  );
+
+  return (
+    <OverlayScrollbarsComponent
+      ref={handleRef}
+      element={as}
+      defer={defer}
+      data-slot="overlay-scroll"
+      className={cn("atmos-scroll-area", className)}
+      options={mergeOptions(options)}
+      events={composedEvents}
+      {...rest}
+    >
+      {children}
+    </OverlayScrollbarsComponent>
+  );
+}
+
+export type { OverlayScrollbarsComponentRef };

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -8,7 +8,14 @@ export * from "./components/ui/input";
 export * from "./components/ui/input-group";
 export * from "./components/ui/label";
 export * from "./components/ui/dialog";
-export * from "./components/ui/scroll-area";
+export {
+  ScrollArea,
+  ScrollBar,
+  OverlayScroll,
+  type ScrollAreaProps,
+  type OverlayScrollProps,
+  type OverlayScrollbarsComponentRef,
+} from "./components/ui/scroll-area";
 export * from "./components/ui/select";
 export * from "./components/ui/toast";
 export * from "./components/theme-toggle";


### PR DESCRIPTION
## Summary

- Replace the base-ui `ScrollArea` implementation with [OverlayScrollbars](https://kingsora.github.io/OverlayScrollbars/), bringing a unified `os-theme-atmos` scrollbar look across the entire web app
- Introduce `OverlayScroll` component for lightweight scrollable containers (no `size-full` / `min-h-0` enforcement)
- Preserve backward-compatible API (`scrollFade`, `scrollbarGutter`, `viewportRef`, `componentRef`) — `ScrollBar` is now a no-op shim to avoid breaking imports
- Update `ActionsPanel`, `ActionsDetailModal`, `CommitsPanel`, and `PRPanel` to use `OverlayScroll`
- Add native WebKit scrollbar fallback styles that visually match `os-theme-atmos`

## Related Issue

<!-- e.g. Closes #123 -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [ ] Additional checks (describe below)

## Checklist

- [ ] I updated documentation if behavior changed
- [ ] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aruni-01/atmos/pull/90" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies scrollbar styling across the app by migrating `ScrollArea` to OverlayScrollbars and adding a lightweight `OverlayScroll`. Also adds workspace archive/branch settings, improves tmux session detection, fixes Tauri paste on desktop, and enables OpenCode Go cloud usage.

- **New Features**
  - UI: Replace base `ScrollArea` with `overlayscrollbars` + `overlayscrollbars-react`, add `OverlayScroll`, and ship a unified `os-theme-atmos` with native WebKit fallback; keeps `scrollFade`, `scrollbarGutter`, `viewportRef`, `componentRef` (old `ScrollBar` is a no-op).
  - Workspace: Add branch prefix and archive behavior settings (confirm, kill tmux, close ACP); sidebar uses confirm-on-archive; core applies the branch prefix on branch creation.
  - AI Usage: Fetch OpenCode Go usage from the opencode.ai workspace via browser session cookie, with local DB fallback and reset info.
  - Tmux: Identify sessions via `@atmos_managed` instead of an `atmos_` prefix, with fallback to legacy names.

- **Bug Fixes**
  - Terminal (Tauri): Intercept paste and Shift+Enter to preserve bracketed paste, fix clipboard image reads, and work around `navigator.userActivation` on WebKit.
  - Usage Display: Correct fraction-to-percent conversion and improve collapsed subtitles in the usage popover.

<sup>Written for commit 2e5b7cd7dad3c5eb9c25bfa3079c40349efc0094. Summary will update on new commits. <a href="https://cubic.dev/pr/AruNi-01/atmos/pull/90?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned scrollbars with improved visual styling throughout the app
  * Added archive confirmation dialog for workspaces
  * Added configurable branch naming prefix for workspace branches
  * Added archive behavior controls (kill tmux session and close ACP options)
  * Enabled cloud dashboard usage data fetching for OpenCode provider

* **Bug Fixes**
  * Improved terminal clipboard handling in Tauri runtime
  * Enhanced usage label fallback display logic

* **Refactoring**
  * Reorganized workspace settings interface for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #192