### PR TITLE
feat: add AmpCode agent hook support via Plugin API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "atmos-desktop"
-version = "1.0.0"
+version = "1.1.0-rc.2"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/apps/api/src/api/hooks/mod.rs
+++ b/apps/api/src/api/hooks/mod.rs
@@ -35,6 +35,7 @@ pub fn routes() -> Router<AppState> {
         .route("/factory-droid", post(handle_factory_droid_hook))
         .route("/kiro", post(handle_kiro_hook))
         .route("/opencode", post(handle_opencode_hook))
+        .route("/ampcode", post(handle_ampcode_hook))
         .route("/sessions", get(list_hook_sessions))
         .route("/sessions/clear-idle", post(clear_idle_sessions))
         .route(
@@ -82,6 +83,18 @@ async fn handle_opencode_hook(
     state
         .agent_hooks_service
         .handle_opencode_event(&payload, &ctx);
+    Json(serde_json::json!({ "ok": true }))
+}
+
+async fn handle_ampcode_hook(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(payload): Json<Value>,
+) -> Json<Value> {
+    let ctx = extract_atmos_context(&headers);
+    state
+        .agent_hooks_service
+        .handle_ampcode_event(&payload, &ctx);
     Json(serde_json::json!({ "ok": true }))
 }
 

--- a/apps/api/src/api/hooks/mod.rs
+++ b/apps/api/src/api/hooks/mod.rs
@@ -49,6 +49,8 @@ pub fn routes() -> Router<AppState> {
         .route("/install", post(install_hooks))
         .route("/uninstall", post(uninstall_hooks))
         .route("/status", get(hooks_status))
+        .route("/{tool}/install", post(install_hook))
+        .route("/{tool}/uninstall", post(uninstall_hook))
         .route("/refresh-projects", post(refresh_project_paths))
 }
 
@@ -265,6 +267,24 @@ async fn install_hooks(State(state): State<AppState>) -> Json<Value> {
 async fn uninstall_hooks() -> Json<Value> {
     let report = core_engine::agent_hooks::uninstall_all_hooks();
     Json(serde_json::to_value(report).unwrap_or_default())
+}
+
+async fn install_hook(
+    State(state): State<AppState>,
+    Path(tool): Path<String>,
+) -> impl IntoResponse {
+    let port = state.api_port.load(std::sync::atomic::Ordering::SeqCst);
+    match core_engine::agent_hooks::install_hook(&tool, port) {
+        Some(status) => (StatusCode::OK, Json(serde_json::to_value(status).unwrap_or_default())),
+        None => (StatusCode::NOT_FOUND, Json(serde_json::json!({ "error": "unknown tool" }))),
+    }
+}
+
+async fn uninstall_hook(Path(tool): Path<String>) -> impl IntoResponse {
+    match core_engine::agent_hooks::uninstall_hook(&tool) {
+        Some(status) => (StatusCode::OK, Json(serde_json::to_value(status).unwrap_or_default())),
+        None => (StatusCode::NOT_FOUND, Json(serde_json::json!({ "error": "unknown tool" }))),
+    }
 }
 
 async fn hooks_status() -> Json<Value> {

--- a/apps/web/src/components/agent/AssistantTurnView.tsx
+++ b/apps/web/src/components/agent/AssistantTurnView.tsx
@@ -143,11 +143,10 @@ export function AssistantTurnView({
     return -1;
   }, [entry.blocks]);
 
-  const isStreamingFinalText = entry.isStreaming === true
-    && lastVisibleTextIndex >= 0
-    && !entry.blocks.slice(lastVisibleTextIndex + 1).some(b => b.type === "text");
-
-  const canCollapse = lastVisibleTextIndex >= 0 && (!entry.isStreaming || isStreamingFinalText);
+  // Only collapse after the assistant turn has fully finished streaming.
+  // During streaming we keep everything expanded so the user can see progress
+  // of tool calls / thinking / intermediate text in real time.
+  const canCollapse = lastVisibleTextIndex >= 0 && !entry.isStreaming;
 
   const intermediateBlocks = useMemo(() => {
     if (!canCollapse) return [];
@@ -258,11 +257,14 @@ export function AssistantTurnView({
             {trailingBlocks.map(({ block, origIndex }) => (
               <React.Fragment key={origIndex}>{renderBlock(block, origIndex)}</React.Fragment>
             ))}
-            <div className="flex w-full items-center gap-2 py-1">
+            <CollapsibleTrigger
+              aria-label="Collapse process"
+              className="flex w-full cursor-pointer items-center gap-2 py-1 text-muted-foreground transition-colors hover:text-foreground"
+            >
               <div className="h-px flex-1 bg-border" />
-              <span className="shrink-0 text-xs text-muted-foreground">Process end</span>
+              <span className="shrink-0 text-xs leading-none">Collapse process</span>
               <div className="h-px flex-1 bg-border" />
-            </div>
+            </CollapsibleTrigger>
           </CollapsibleContent>
         </Collapsible>
 

--- a/apps/web/src/components/dialogs/SettingsModal.tsx
+++ b/apps/web/src/components/dialogs/SettingsModal.tsx
@@ -297,6 +297,7 @@ interface AgentHookInstallReport {
   factory_droid: AgentHookToolStatus;
   kiro: AgentHookToolStatus;
   opencode: AgentHookToolStatus;
+  ampcode: AgentHookToolStatus;
 }
 
 const HOOK_TOOL_META: { key: keyof AgentHookInstallReport; label: string }[] = [
@@ -307,6 +308,7 @@ const HOOK_TOOL_META: { key: keyof AgentHookInstallReport; label: string }[] = [
   { key: "factory_droid", label: "Factory Droid" },
   { key: "kiro", label: "Kiro" },
   { key: "opencode", label: "OpenCode" },
+  { key: "ampcode", label: "AMP" },
 ];
 
 function AgentHookStatusCard() {

--- a/apps/web/src/components/dialogs/SettingsModal.tsx
+++ b/apps/web/src/components/dialogs/SettingsModal.tsx
@@ -418,6 +418,7 @@ function AgentHookStatusCard() {
           </Button>
           {anyInstalled && (
             <Button variant="outline" size="sm" onClick={handleUninstallAll} disabled={acting || loading} className="text-destructive hover:text-destructive">
+              <Trash2 className="size-4" />
               Uninstall All
             </Button>
           )}

--- a/apps/web/src/components/dialogs/SettingsModal.tsx
+++ b/apps/web/src/components/dialogs/SettingsModal.tsx
@@ -53,6 +53,8 @@ import {
   Building2,
   Check,
   ChevronDown,
+  CircleCheck,
+  CircleX,
   Download,
   ExternalLink,
   House,
@@ -433,34 +435,37 @@ function AgentHookStatusCard() {
               const isBusy = actingTool === key;
               return (
                 <div key={key} className="border-b border-border px-2 py-3 last:border-b-0">
-                  <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-4 items-center">
-                    <div className="flex items-center gap-2.5 min-w-0">
-                      <span className="text-sm font-medium text-foreground shrink-0">{label}</span>
+                  <div className="flex items-center gap-3">
+                    <span className="text-sm font-medium text-foreground w-28 shrink-0">{label}</span>
+                    <div className="flex flex-1 items-center gap-2 min-w-0">
+                      {tool.detected && (
+                        tool.installed
+                          ? <CircleCheck className="size-3.5 shrink-0 text-emerald-500" />
+                          : <CircleX className="size-3.5 shrink-0 text-amber-500" />
+                      )}
                       {tool.config_path && (
                         <span className="text-[10px] text-muted-foreground font-mono truncate" title={tool.config_path}>
                           {tool.config_path.split(/[\\/]/).slice(-2).join("/")}
                         </span>
                       )}
-                    </div>
-                    <div className="flex items-center gap-2 shrink-0">
-                      {!tool.detected ? (
+                      {!tool.detected && (
                         <span className="text-xs text-muted-foreground">Not detected</span>
-                      ) : tool.error ? (
-                        <span className="text-xs text-destructive truncate max-w-[140px]" title={tool.error}>Error: {tool.error}</span>
-                      ) : tool.installed ? (
-                        <>
-                          <span className="text-xs font-medium text-emerald-500">Installed</span>
+                      )}
+                      {tool.error && (
+                        <span className="text-xs text-destructive truncate" title={tool.error}>Error: {tool.error}</span>
+                      )}
+                    </div>
+                    <div className="shrink-0">
+                      {tool.detected && !tool.error && (
+                        tool.installed ? (
                           <Button variant="ghost" size="sm" className="h-6 px-2 text-xs text-destructive hover:text-destructive" disabled={isBusy || acting} onClick={() => handleUninstallTool(key)}>
                             {isBusy ? <LoaderCircle className="size-3 animate-spin" /> : "Uninstall"}
                           </Button>
-                        </>
-                      ) : (
-                        <>
-                          <span className="text-xs text-amber-500">Not installed</span>
+                        ) : (
                           <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" disabled={isBusy || acting} onClick={() => handleInstallTool(key)}>
                             {isBusy ? <LoaderCircle className="size-3 animate-spin" /> : "Install"}
                           </Button>
-                        </>
+                        )
                       )}
                     </div>
                   </div>

--- a/apps/web/src/components/dialogs/SettingsModal.tsx
+++ b/apps/web/src/components/dialogs/SettingsModal.tsx
@@ -436,13 +436,14 @@ function AgentHookStatusCard() {
               return (
                 <div key={key} className="border-b border-border px-2 py-3 last:border-b-0">
                   <div className="flex items-center gap-3">
+                    {tool.detected
+                      ? tool.installed
+                        ? <CircleCheck className="size-3.5 shrink-0 text-emerald-500" />
+                        : <CircleX className="size-3.5 shrink-0 text-amber-500" />
+                      : <span className="size-3.5 shrink-0" />
+                    }
                     <span className="text-sm font-medium text-foreground w-28 shrink-0">{label}</span>
                     <div className="flex flex-1 items-center gap-2 min-w-0">
-                      {tool.detected && (
-                        tool.installed
-                          ? <CircleCheck className="size-3.5 shrink-0 text-emerald-500" />
-                          : <CircleX className="size-3.5 shrink-0 text-amber-500" />
-                      )}
                       {tool.config_path && (
                         <span className="text-[10px] text-muted-foreground font-mono truncate" title={tool.config_path}>
                           {tool.config_path.split(/[\\/]/).slice(-2).join("/")}

--- a/apps/web/src/components/dialogs/SettingsModal.tsx
+++ b/apps/web/src/components/dialogs/SettingsModal.tsx
@@ -315,47 +315,76 @@ function AgentHookStatusCard() {
   const [report, setReport] = React.useState<AgentHookInstallReport | null>(null);
   const [loading, setLoading] = React.useState(false);
   const [acting, setActing] = React.useState(false);
+  const [actingTool, setActingTool] = React.useState<string | null>(null);
   const [expanded, setExpanded] = React.useState(true);
+
+  const getBase = React.useCallback(async () => {
+    const config = await import("@/lib/desktop-runtime").then(m => m.getRuntimeApiConfig());
+    return (await import("@/lib/desktop-runtime")).httpBase(config);
+  }, []);
 
   const fetchStatus = React.useCallback(async () => {
     setLoading(true);
     try {
-      const config = await import("@/lib/desktop-runtime").then(m => m.getRuntimeApiConfig());
-      const base = (await import("@/lib/desktop-runtime")).httpBase(config);
+      const base = await getBase();
       const res = await fetch(`${base}/hooks/status`);
       if (res.ok) setReport(await res.json());
     } catch { /* ignore */ } finally {
       setLoading(false);
     }
-  }, []);
+  }, [getBase]);
 
   React.useEffect(() => { void fetchStatus(); }, [fetchStatus]);
 
-  const handleInstall = React.useCallback(async () => {
+  const handleInstallAll = React.useCallback(async () => {
     setActing(true);
     try {
-      const config = await import("@/lib/desktop-runtime").then(m => m.getRuntimeApiConfig());
-      const base = (await import("@/lib/desktop-runtime")).httpBase(config);
+      const base = await getBase();
       const res = await fetch(`${base}/hooks/install`, { method: "POST" });
       if (res.ok) setReport(await res.json());
     } catch { /* ignore */ } finally {
       setActing(false);
     }
-  }, []);
+  }, [getBase]);
 
-  const handleUninstall = React.useCallback(async () => {
+  const handleUninstallAll = React.useCallback(async () => {
     setActing(true);
     try {
-      const config = await import("@/lib/desktop-runtime").then(m => m.getRuntimeApiConfig());
-      const base = (await import("@/lib/desktop-runtime")).httpBase(config);
+      const base = await getBase();
       const res = await fetch(`${base}/hooks/uninstall`, { method: "POST" });
-      if (res.ok) {
-        setReport(await res.json());
-      }
+      if (res.ok) setReport(await res.json());
     } catch { /* ignore */ } finally {
       setActing(false);
     }
-  }, []);
+  }, [getBase]);
+
+  const handleInstallTool = React.useCallback(async (key: string) => {
+    setActingTool(key);
+    try {
+      const base = await getBase();
+      const res = await fetch(`${base}/hooks/${key}/install`, { method: "POST" });
+      if (res.ok) {
+        const status: AgentHookToolStatus = await res.json();
+        setReport(prev => prev ? { ...prev, [key]: status } : prev);
+      }
+    } catch { /* ignore */ } finally {
+      setActingTool(null);
+    }
+  }, [getBase]);
+
+  const handleUninstallTool = React.useCallback(async (key: string) => {
+    setActingTool(key);
+    try {
+      const base = await getBase();
+      const res = await fetch(`${base}/hooks/${key}/uninstall`, { method: "POST" });
+      if (res.ok) {
+        const status: AgentHookToolStatus = await res.json();
+        setReport(prev => prev ? { ...prev, [key]: status } : prev);
+      }
+    } catch { /* ignore */ } finally {
+      setActingTool(null);
+    }
+  }, [getBase]);
 
   const anyInstalled = report && HOOK_TOOL_META.some(t => report[t.key].installed);
   const anyDetected = report && HOOK_TOOL_META.some(t => report[t.key].detected);
@@ -380,13 +409,13 @@ function AgentHookStatusCard() {
           </div>
         </CollapsibleTrigger>
         <div className="flex items-center justify-end gap-2">
-          <Button variant="outline" size="sm" onClick={handleInstall} disabled={acting || loading}>
+          <Button variant="outline" size="sm" onClick={handleInstallAll} disabled={acting || loading}>
             {acting ? <LoaderCircle className="size-4 animate-spin" /> : <Download className="size-4" />}
-            Install
+            Install All
           </Button>
           {anyInstalled && (
-            <Button variant="outline" size="sm" onClick={handleUninstall} disabled={acting || loading} className="text-destructive hover:text-destructive">
-              Uninstall
+            <Button variant="outline" size="sm" onClick={handleUninstallAll} disabled={acting || loading} className="text-destructive hover:text-destructive">
+              Uninstall All
             </Button>
           )}
         </div>
@@ -401,26 +430,37 @@ function AgentHookStatusCard() {
           ) : report ? (
             HOOK_TOOL_META.map(({ key, label }) => {
               const tool = report[key];
+              const isBusy = actingTool === key;
               return (
                 <div key={key} className="border-b border-border px-2 py-3 last:border-b-0">
-                  <div className="grid grid-cols-[minmax(0,1fr)_200px] gap-8">
-                    <div className="flex items-center gap-2.5">
-                      <span className="text-sm font-medium text-foreground">{label}</span>
+                  <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-4 items-center">
+                    <div className="flex items-center gap-2.5 min-w-0">
+                      <span className="text-sm font-medium text-foreground shrink-0">{label}</span>
                       {tool.config_path && (
-                        <span className="text-[10px] text-muted-foreground font-mono truncate max-w-[200px]" title={tool.config_path}>
+                        <span className="text-[10px] text-muted-foreground font-mono truncate" title={tool.config_path}>
                           {tool.config_path.split(/[\\/]/).slice(-2).join("/")}
                         </span>
                       )}
                     </div>
-                    <div className="flex items-center justify-end gap-2">
+                    <div className="flex items-center gap-2 shrink-0">
                       {!tool.detected ? (
                         <span className="text-xs text-muted-foreground">Not detected</span>
-                      ) : tool.installed ? (
-                        <span className="text-xs font-medium text-emerald-500">Installed</span>
                       ) : tool.error ? (
-                        <span className="text-xs text-destructive truncate max-w-[180px]" title={tool.error}>Error: {tool.error}</span>
+                        <span className="text-xs text-destructive truncate max-w-[140px]" title={tool.error}>Error: {tool.error}</span>
+                      ) : tool.installed ? (
+                        <>
+                          <span className="text-xs font-medium text-emerald-500">Installed</span>
+                          <Button variant="ghost" size="sm" className="h-6 px-2 text-xs text-destructive hover:text-destructive" disabled={isBusy || acting} onClick={() => handleUninstallTool(key)}>
+                            {isBusy ? <LoaderCircle className="size-3 animate-spin" /> : "Uninstall"}
+                          </Button>
+                        </>
                       ) : (
-                        <span className="text-xs text-amber-500">Not installed</span>
+                        <>
+                          <span className="text-xs text-amber-500">Not installed</span>
+                          <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" disabled={isBusy || acting} onClick={() => handleInstallTool(key)}>
+                            {isBusy ? <LoaderCircle className="size-3 animate-spin" /> : "Install"}
+                          </Button>
+                        </>
                       )}
                     </div>
                   </div>

--- a/apps/web/src/components/dialogs/SettingsModal.tsx
+++ b/apps/web/src/components/dialogs/SettingsModal.tsx
@@ -460,12 +460,12 @@ function AgentHookStatusCard() {
                     <div className="shrink-0">
                       {tool.detected && !tool.error && (
                         tool.installed ? (
-                          <Button variant="secondary" size="sm" className="h-6 px-2 text-xs text-destructive hover:text-destructive" disabled={isBusy || acting} onClick={() => handleUninstallTool(key)}>
-                            {isBusy ? <LoaderCircle className="size-3 animate-spin" /> : "Uninstall"}
+                          <Button variant="secondary" size="icon" className="size-6" disabled={isBusy || acting} onClick={() => handleUninstallTool(key)}>
+                            {isBusy ? <LoaderCircle className="size-3 animate-spin" /> : <Trash2 className="size-3" />}
                           </Button>
                         ) : (
-                          <Button variant="secondary" size="sm" className="h-6 px-2 text-xs" disabled={isBusy || acting} onClick={() => handleInstallTool(key)}>
-                            {isBusy ? <LoaderCircle className="size-3 animate-spin" /> : "Install"}
+                          <Button variant="secondary" size="icon" className="size-6" disabled={isBusy || acting} onClick={() => handleInstallTool(key)}>
+                            {isBusy ? <LoaderCircle className="size-3 animate-spin" /> : <Download className="size-3" />}
                           </Button>
                         )
                       )}

--- a/apps/web/src/components/dialogs/SettingsModal.tsx
+++ b/apps/web/src/components/dialogs/SettingsModal.tsx
@@ -461,11 +461,11 @@ function AgentHookStatusCard() {
                     <div className="shrink-0">
                       {tool.detected && !tool.error && (
                         tool.installed ? (
-                          <Button variant="secondary" size="icon" className="size-6" disabled={isBusy || acting} onClick={() => handleUninstallTool(key)}>
+                          <Button variant="secondary" size="icon" className="size-6 text-amber-500 hover:text-amber-500" disabled={isBusy || acting} onClick={() => handleUninstallTool(key)}>
                             {isBusy ? <LoaderCircle className="size-3 animate-spin" /> : <Trash2 className="size-3" />}
                           </Button>
                         ) : (
-                          <Button variant="secondary" size="icon" className="size-6" disabled={isBusy || acting} onClick={() => handleInstallTool(key)}>
+                          <Button variant="secondary" size="icon" className="size-6 text-emerald-500 hover:text-emerald-500" disabled={isBusy || acting} onClick={() => handleInstallTool(key)}>
                             {isBusy ? <LoaderCircle className="size-3 animate-spin" /> : <Download className="size-3" />}
                           </Button>
                         )

--- a/apps/web/src/components/dialogs/SettingsModal.tsx
+++ b/apps/web/src/components/dialogs/SettingsModal.tsx
@@ -54,6 +54,7 @@ import {
   Check,
   ChevronDown,
   CircleCheck,
+  CircleMinus,
   CircleX,
   Download,
   ExternalLink,
@@ -440,7 +441,7 @@ function AgentHookStatusCard() {
                       ? tool.installed
                         ? <CircleCheck className="size-3.5 shrink-0 text-emerald-500" />
                         : <CircleX className="size-3.5 shrink-0 text-amber-500" />
-                      : <span className="size-3.5 shrink-0" />
+                      : <CircleMinus className="size-3.5 shrink-0 text-muted-foreground/50" />
                     }
                     <span className="text-sm font-medium text-foreground w-28 shrink-0">{label}</span>
                     <div className="flex flex-1 items-center gap-2 min-w-0">
@@ -459,11 +460,11 @@ function AgentHookStatusCard() {
                     <div className="shrink-0">
                       {tool.detected && !tool.error && (
                         tool.installed ? (
-                          <Button variant="ghost" size="sm" className="h-6 px-2 text-xs text-destructive hover:text-destructive" disabled={isBusy || acting} onClick={() => handleUninstallTool(key)}>
+                          <Button variant="secondary" size="sm" className="h-6 px-2 text-xs text-destructive hover:text-destructive" disabled={isBusy || acting} onClick={() => handleUninstallTool(key)}>
                             {isBusy ? <LoaderCircle className="size-3 animate-spin" /> : "Uninstall"}
                           </Button>
                         ) : (
-                          <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" disabled={isBusy || acting} onClick={() => handleInstallTool(key)}>
+                          <Button variant="secondary" size="sm" className="h-6 px-2 text-xs" disabled={isBusy || acting} onClick={() => handleInstallTool(key)}>
                             {isBusy ? <LoaderCircle className="size-3 animate-spin" /> : "Install"}
                           </Button>
                         )

--- a/apps/web/src/components/dialogs/SettingsModal.tsx
+++ b/apps/web/src/components/dialogs/SettingsModal.tsx
@@ -461,7 +461,7 @@ function AgentHookStatusCard() {
                     <div className="shrink-0">
                       {tool.detected && !tool.error && (
                         tool.installed ? (
-                          <Button variant="secondary" size="icon" className="size-6 text-amber-500 hover:text-amber-500" disabled={isBusy || acting} onClick={() => handleUninstallTool(key)}>
+                          <Button variant="secondary" size="icon" className="size-6 text-destructive hover:text-destructive" disabled={isBusy || acting} onClick={() => handleUninstallTool(key)}>
                             {isBusy ? <LoaderCircle className="size-3 animate-spin" /> : <Trash2 className="size-3" />}
                           </Button>
                         ) : (

--- a/apps/web/src/hooks/use-agent-hooks-store.ts
+++ b/apps/web/src/hooks/use-agent-hooks-store.ts
@@ -21,6 +21,7 @@ export const AGENT_TOOL = {
   FACTORY_DROID: "factory-droid",
   KIRO: "kiro",
   OPENCODE: "opencode",
+  AMPCODE: "ampcode",
 } as const;
 
 export type AgentToolType = (typeof AGENT_TOOL)[keyof typeof AGENT_TOOL];
@@ -33,6 +34,7 @@ export const AGENT_TOOL_LABELS: Record<AgentToolType, string> = {
   [AGENT_TOOL.FACTORY_DROID]: "Factory Droid",
   [AGENT_TOOL.KIRO]: "Kiro",
   [AGENT_TOOL.OPENCODE]: "OpenCode",
+  [AGENT_TOOL.AMPCODE]: "AMP",
 };
 
 

--- a/crates/core-engine/src/agent_hooks/ampcode.rs
+++ b/crates/core-engine/src/agent_hooks/ampcode.rs
@@ -56,7 +56,8 @@ export default function (amp: PluginAPI) {{
   }})
 
   amp.on("tool.call", async (event, _ctx) => {{
-    await post({{ hook_event_name: "ToolCall", tool: event.tool }})
+    // Fire-and-forget: do not await so tool execution is never stalled by hook latency
+    post({{ hook_event_name: "ToolCall", tool: event.tool }})
     return {{ action: "allow" }}
   }})
 
@@ -133,8 +134,9 @@ pub(super) fn uninstall() -> AgentHookToolStatus {
 
     let path_str = plugin_file.display().to_string();
 
-    if let Ok(content) = std::fs::read_to_string(&plugin_file) {
-        if !content.contains(PLUGIN_MARKER) {
+    match std::fs::read_to_string(&plugin_file) {
+        Err(e) => return AgentHookToolStatus::failed(&path_str, e.to_string()),
+        Ok(content) if !content.contains(PLUGIN_MARKER) => {
             return AgentHookToolStatus {
                 detected: true,
                 installed: false,
@@ -142,6 +144,7 @@ pub(super) fn uninstall() -> AgentHookToolStatus {
                 error: None,
             };
         }
+        Ok(_) => {}
     }
 
     match std::fs::remove_file(&plugin_file) {

--- a/crates/core-engine/src/agent_hooks/ampcode.rs
+++ b/crates/core-engine/src/agent_hooks/ampcode.rs
@@ -1,0 +1,201 @@
+use tracing::{debug, info};
+
+use super::{home_dir, AgentHookToolStatus};
+
+fn plugin_path() -> Option<std::path::PathBuf> {
+    home_dir().ok().map(|h| {
+        h.join(".config")
+            .join("amp")
+            .join("plugins")
+            .join("atmos-hook.ts")
+    })
+}
+
+fn plugin_dir_path() -> Option<std::path::PathBuf> {
+    home_dir()
+        .ok()
+        .map(|h| h.join(".config").join("amp").join("plugins"))
+}
+
+const PLUGIN_MARKER: &str = "// Atmos agent hook plugin";
+
+fn build_plugin_source(port: u16) -> String {
+    // All 5 AmpCode plugin events are handled:
+    //   session.start  → Idle   (session init, idempotent baseline)
+    //   agent.start    → Running
+    //   tool.call      → Running (idempotent: skip broadcast if already Running)
+    //   tool.result    → Running (idempotent: skip broadcast if already Running)
+    //   agent.end      → Idle   (done/error/cancelled all map to Idle — compensates for any missed event)
+    format!(
+        r#"// Atmos agent hook plugin
+import type {{ PluginAPI }} from "@ampcode/plugin"
+
+const ATMOS_URL = "http://localhost:{port}/hooks/ampcode"
+
+export default function (amp: PluginAPI) {{
+  if (process.env.ATMOS_MANAGED !== "1") return
+
+  const post = (body: object) =>
+    fetch(ATMOS_URL, {{
+      method: "POST",
+      headers: {{
+        "Content-Type": "application/json",
+        "X-Atmos-Context": process.env.ATMOS_CONTEXT_ID ?? "",
+        "X-Atmos-Pane": process.env.ATMOS_PANE_ID ?? "",
+      }},
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(3000),
+    }}).catch(() => {{}})
+
+  amp.on("session.start", async (_event, _ctx) => {{
+    await post({{ hook_event_name: "SessionStart" }})
+  }})
+
+  amp.on("agent.start", async (_event, _ctx) => {{
+    await post({{ hook_event_name: "AgentStart" }})
+  }})
+
+  amp.on("tool.call", async (event, _ctx) => {{
+    await post({{ hook_event_name: "ToolCall", tool: event.tool }})
+    return {{ action: "allow" }}
+  }})
+
+  amp.on("tool.result", async (_event, _ctx) => {{
+    await post({{ hook_event_name: "ToolResult" }})
+  }})
+
+  amp.on("agent.end", async (event, _ctx) => {{
+    await post({{ hook_event_name: "AgentEnd", status: event.status }})
+  }})
+}}
+"#,
+        port = port,
+    )
+}
+
+pub(super) fn install(port: u16) -> AgentHookToolStatus {
+    let plugin_file = match plugin_path() {
+        Some(p) => p,
+        None => return AgentHookToolStatus::not_detected(),
+    };
+
+    let plugin_dir = match plugin_dir_path() {
+        Some(d) => d,
+        None => return AgentHookToolStatus::not_detected(),
+    };
+
+    // Detect by config dir OR binary in PATH
+    let amp_config_dir = plugin_dir.parent().unwrap();
+    let has_config = amp_config_dir.exists();
+    let has_binary = which_exists("amp");
+    if !has_config && !has_binary {
+        debug!("amp not detected (no config dir, not in PATH), skipping");
+        return AgentHookToolStatus::not_detected();
+    }
+
+    let path_str = plugin_file.display().to_string();
+
+    if !plugin_dir.exists() {
+        if let Err(e) = std::fs::create_dir_all(&plugin_dir) {
+            return AgentHookToolStatus::failed(&path_str, e.to_string());
+        }
+    }
+
+    let source = build_plugin_source(port);
+
+    // Idempotent write: skip if content unchanged
+    if plugin_file.exists() {
+        if let Ok(existing) = std::fs::read_to_string(&plugin_file) {
+            if existing == source {
+                return AgentHookToolStatus::success(&path_str);
+            }
+        }
+    }
+
+    match std::fs::write(&plugin_file, &source) {
+        Ok(()) => {
+            info!(
+                "ampcode plugin installed at {} ({} bytes). Run `plugins: reload` in amp to activate.",
+                path_str,
+                source.len()
+            );
+            AgentHookToolStatus::success(&path_str)
+        }
+        Err(e) => AgentHookToolStatus::failed(&path_str, e.to_string()),
+    }
+}
+
+pub(super) fn uninstall() -> AgentHookToolStatus {
+    let plugin_file = match plugin_path() {
+        Some(p) if p.exists() => p,
+        _ => return AgentHookToolStatus::not_detected(),
+    };
+
+    let path_str = plugin_file.display().to_string();
+
+    if let Ok(content) = std::fs::read_to_string(&plugin_file) {
+        if !content.contains(PLUGIN_MARKER) {
+            return AgentHookToolStatus {
+                detected: true,
+                installed: false,
+                config_path: Some(path_str),
+                error: None,
+            };
+        }
+    }
+
+    match std::fs::remove_file(&plugin_file) {
+        Ok(()) => {
+            let mut status = AgentHookToolStatus::success(&path_str);
+            status.installed = false;
+            status
+        }
+        Err(e) => AgentHookToolStatus::failed(&path_str, e.to_string()),
+    }
+}
+
+pub(super) fn check() -> AgentHookToolStatus {
+    let plugin_file = match plugin_path() {
+        Some(p) => p,
+        None => return AgentHookToolStatus::not_detected(),
+    };
+
+    let amp_config_dir = plugin_file.parent().and_then(|d| d.parent());
+    let has_config = amp_config_dir.is_some_and(|d| d.exists());
+    let has_binary = which_exists("amp");
+    if !has_config && !has_binary {
+        return AgentHookToolStatus::not_detected();
+    }
+
+    let path_str = plugin_file.display().to_string();
+
+    if !plugin_file.exists() {
+        return AgentHookToolStatus {
+            detected: true,
+            installed: false,
+            config_path: Some(path_str),
+            error: None,
+        };
+    }
+
+    let installed = std::fs::read_to_string(&plugin_file)
+        .map(|content| content.contains(PLUGIN_MARKER))
+        .unwrap_or(false);
+
+    AgentHookToolStatus {
+        detected: true,
+        installed,
+        config_path: Some(path_str),
+        error: None,
+    }
+}
+
+fn which_exists(cmd: &str) -> bool {
+    std::process::Command::new("which")
+        .arg(cmd)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}

--- a/crates/core-engine/src/agent_hooks/ampcode.rs
+++ b/crates/core-engine/src/agent_hooks/ampcode.rs
@@ -63,6 +63,7 @@ export default function (amp: PluginAPI) {{
 
   amp.on("tool.result", async (_event, _ctx) => {{
     await post({{ hook_event_name: "ToolResult" }})
+    return {{ action: "allow" }}
   }})
 
   amp.on("agent.end", async (event, _ctx) => {{

--- a/crates/core-engine/src/agent_hooks/mod.rs
+++ b/crates/core-engine/src/agent_hooks/mod.rs
@@ -151,3 +151,33 @@ fn home_dir() -> Result<PathBuf> {
     dirs::home_dir()
         .ok_or_else(|| EngineError::Processing("Cannot determine home directory".into()))
 }
+
+/// Install hook for a single tool. Returns `None` if `tool` is not a known tool name.
+pub fn install_hook(tool: &str, port: u16) -> Option<AgentHookToolStatus> {
+    Some(match tool {
+        "claude_code" => claude_code::install(port),
+        "codex" => codex::install(port),
+        "cursor" => cursor::install(port),
+        "gemini" => gemini::install(port),
+        "factory_droid" => factory_droid::install(port),
+        "kiro" => kiro::install(port),
+        "opencode" => opencode::install(port),
+        "ampcode" => ampcode::install(port),
+        _ => return None,
+    })
+}
+
+/// Uninstall hook for a single tool. Returns `None` if `tool` is not a known tool name.
+pub fn uninstall_hook(tool: &str) -> Option<AgentHookToolStatus> {
+    Some(match tool {
+        "claude_code" => claude_code::uninstall(),
+        "codex" => codex::uninstall(),
+        "cursor" => cursor::uninstall(),
+        "gemini" => gemini::uninstall(),
+        "factory_droid" => factory_droid::uninstall(),
+        "kiro" => kiro::uninstall(),
+        "opencode" => opencode::uninstall(),
+        "ampcode" => ampcode::uninstall(),
+        _ => return None,
+    })
+}

--- a/crates/core-engine/src/agent_hooks/mod.rs
+++ b/crates/core-engine/src/agent_hooks/mod.rs
@@ -1,3 +1,4 @@
+mod ampcode;
 mod claude_code;
 mod codex;
 mod cursor;
@@ -22,6 +23,7 @@ pub struct AgentHookInstallReport {
     pub factory_droid: AgentHookToolStatus,
     pub kiro: AgentHookToolStatus,
     pub opencode: AgentHookToolStatus,
+    pub ampcode: AgentHookToolStatus,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -73,9 +75,10 @@ pub fn install_all_hooks(port: u16) -> AgentHookInstallReport {
     let factory = factory_droid::install(port);
     let kiro_status = kiro::install(port);
     let opencode = opencode::install(port);
+    let ampcode = ampcode::install(port);
 
     info!(
-        "Agent hook install complete: claude_code={}, codex={}, cursor={}, gemini={}, factory_droid={}, kiro={}, opencode={}",
+        "Agent hook install complete: claude_code={}, codex={}, cursor={}, gemini={}, factory_droid={}, kiro={}, opencode={}, ampcode={}",
         if claude.installed { "ok" } else { "skip" },
         if codex.installed { "ok" } else { "skip" },
         if cursor.installed { "ok" } else { "skip" },
@@ -83,6 +86,7 @@ pub fn install_all_hooks(port: u16) -> AgentHookInstallReport {
         if factory.installed { "ok" } else { "skip" },
         if kiro_status.installed { "ok" } else { "skip" },
         if opencode.installed { "ok" } else { "skip" },
+        if ampcode.installed { "ok" } else { "skip" },
     );
 
     AgentHookInstallReport {
@@ -93,6 +97,7 @@ pub fn install_all_hooks(port: u16) -> AgentHookInstallReport {
         factory_droid: factory,
         kiro: kiro_status,
         opencode,
+        ampcode,
     }
 }
 
@@ -106,6 +111,7 @@ pub fn uninstall_all_hooks() -> AgentHookInstallReport {
     let factory = factory_droid::uninstall();
     let kiro_status = kiro::uninstall();
     let opencode = opencode::uninstall();
+    let ampcode = ampcode::uninstall();
 
     AgentHookInstallReport {
         claude_code: claude,
@@ -115,6 +121,7 @@ pub fn uninstall_all_hooks() -> AgentHookInstallReport {
         factory_droid: factory,
         kiro: kiro_status,
         opencode,
+        ampcode,
     }
 }
 
@@ -126,6 +133,7 @@ pub fn check_all_hooks() -> AgentHookInstallReport {
     let factory = factory_droid::check();
     let kiro_status = kiro::check();
     let opencode = opencode::check();
+    let ampcode = ampcode::check();
 
     AgentHookInstallReport {
         claude_code: claude,
@@ -135,6 +143,7 @@ pub fn check_all_hooks() -> AgentHookInstallReport {
         factory_droid: factory,
         kiro: kiro_status,
         opencode,
+        ampcode,
     }
 }
 

--- a/crates/core-service/src/service/agent_hooks.rs
+++ b/crates/core-service/src/service/agent_hooks.rs
@@ -1,3 +1,4 @@
+mod ampcode;
 mod claude_code;
 mod codex;
 mod cursor;
@@ -47,6 +48,7 @@ pub enum AgentToolType {
     FactoryDroid,
     Kiro,
     Opencode,
+    Ampcode,
 }
 
 impl std::fmt::Display for AgentToolType {
@@ -59,6 +61,7 @@ impl std::fmt::Display for AgentToolType {
             Self::FactoryDroid => write!(f, "factory-droid"),
             Self::Kiro => write!(f, "kiro"),
             Self::Opencode => write!(f, "opencode"),
+            Self::Ampcode => write!(f, "ampcode"),
         }
     }
 }
@@ -339,6 +342,10 @@ impl AgentHooksService {
 
     pub fn handle_opencode_event(&self, payload: &Value, ctx: &AtmosContext) {
         opencode::handle_event(self, payload, ctx);
+    }
+
+    pub fn handle_ampcode_event(&self, payload: &Value, ctx: &AtmosContext) {
+        ampcode::handle_event(self, payload, ctx);
     }
 
     /// Prefer Atmos pane_id (stable, per-terminal-pane) > payload session_id > fallback.

--- a/crates/core-service/src/service/agent_hooks/ampcode.rs
+++ b/crates/core-service/src/service/agent_hooks/ampcode.rs
@@ -1,0 +1,144 @@
+use serde_json::Value;
+use tracing::debug;
+
+use super::{AgentHookState, AgentHooksService, AgentToolType, AtmosContext};
+
+pub(super) fn handle_event(service: &AgentHooksService, payload: &Value, ctx: &AtmosContext) {
+    let hook_event = payload
+        .get("hook_event_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let session_id = service.resolve_session_id(payload, AgentToolType::Ampcode, ctx);
+    let project_path = AgentHooksService::extract_cwd(payload).map(String::from);
+
+    debug!("ampcode hook event: {} session_id={}", hook_event, session_id);
+
+    match hook_event {
+        // Session init → Idle baseline
+        "SessionStart" => {
+            service.update_state(
+                &session_id,
+                AgentToolType::Ampcode,
+                AgentHookState::Idle,
+                project_path,
+                ctx,
+            );
+        }
+        // Agent begins a turn → Running
+        "AgentStart" => {
+            service.update_state(
+                &session_id,
+                AgentToolType::Ampcode,
+                AgentHookState::Running,
+                project_path,
+                ctx,
+            );
+        }
+        // Tool events → Running, idempotent: skip broadcast if already Running
+        "ToolCall" | "ToolResult" => {
+            let current = service.sessions.read().get(&session_id).map(|s| s.state);
+            if current != Some(AgentHookState::Running) {
+                service.update_state(
+                    &session_id,
+                    AgentToolType::Ampcode,
+                    AgentHookState::Running,
+                    project_path,
+                    ctx,
+                );
+            }
+        }
+        // Agent turn finished (done/error/cancelled) → Idle
+        // This is the compensation event: even if AgentStart or ToolCall were lost,
+        // AgentEnd always fires and resets state to Idle.
+        "AgentEnd" => {
+            service.update_state(
+                &session_id,
+                AgentToolType::Ampcode,
+                AgentHookState::Idle,
+                project_path,
+                ctx,
+            );
+        }
+        _ => {
+            debug!("Unhandled ampcode hook event: {}", hook_event);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_start_sets_idle() {
+        let service = AgentHooksService::new();
+        let payload = serde_json::json!({
+            "hook_event_name": "SessionStart",
+            "session_id": "amp-session-1",
+        });
+        handle_event(&service, &payload, &AtmosContext::default());
+        let sessions = service.get_all_sessions();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].tool, AgentToolType::Ampcode);
+        assert_eq!(sessions[0].state, AgentHookState::Idle);
+    }
+
+    #[test]
+    fn agent_start_sets_running() {
+        let service = AgentHooksService::new();
+        let payload = serde_json::json!({
+            "hook_event_name": "AgentStart",
+            "session_id": "amp-session-1",
+        });
+        handle_event(&service, &payload, &AtmosContext::default());
+        let sessions = service.get_all_sessions();
+        assert_eq!(sessions[0].state, AgentHookState::Running);
+    }
+
+    #[test]
+    fn tool_call_idempotent_when_already_running() {
+        let service = AgentHooksService::new();
+        let ctx = AtmosContext::default();
+        let start = serde_json::json!({ "hook_event_name": "AgentStart", "session_id": "s1" });
+        let tool_call = serde_json::json!({ "hook_event_name": "ToolCall", "session_id": "s1", "tool": "bash" });
+        handle_event(&service, &start, &ctx);
+        handle_event(&service, &tool_call, &ctx);
+        // Still Running, no duplicate broadcast needed
+        let sessions = service.get_all_sessions();
+        assert_eq!(sessions[0].state, AgentHookState::Running);
+    }
+
+    #[test]
+    fn agent_end_compensates_for_missed_start() {
+        let service = AgentHooksService::new();
+        let ctx = AtmosContext::default();
+        // Simulate: AgentStart was lost, only AgentEnd arrives
+        let end = serde_json::json!({
+            "hook_event_name": "AgentEnd",
+            "session_id": "s1",
+            "status": "done",
+        });
+        handle_event(&service, &end, &ctx);
+        let sessions = service.get_all_sessions();
+        assert_eq!(sessions[0].state, AgentHookState::Idle);
+    }
+
+    #[test]
+    fn agent_end_error_and_cancelled_also_set_idle() {
+        for status in ["error", "cancelled"] {
+            let service = AgentHooksService::new();
+            let ctx = AtmosContext::default();
+            let start = serde_json::json!({ "hook_event_name": "AgentStart", "session_id": "s1" });
+            let end = serde_json::json!({
+                "hook_event_name": "AgentEnd",
+                "session_id": "s1",
+                "status": status,
+            });
+            handle_event(&service, &start, &ctx);
+            handle_event(&service, &end, &ctx);
+            let sessions = service.get_all_sessions();
+            assert_eq!(sessions[0].state, AgentHookState::Idle, "status={}", status);
+        }
+    }
+}

--- a/crates/core-service/src/service/notification.rs
+++ b/crates/core-service/src/service/notification.rs
@@ -348,6 +348,7 @@ fn tool_display_name(tool: &AgentToolType) -> &'static str {
         AgentToolType::FactoryDroid => "Factory Droid",
         AgentToolType::Kiro => "Kiro",
         AgentToolType::Opencode => "OpenCode",
+        AgentToolType::Ampcode => "AmpCode",
     }
 }
 

--- a/crates/core-service/src/service/notification.rs
+++ b/crates/core-service/src/service/notification.rs
@@ -348,7 +348,7 @@ fn tool_display_name(tool: &AgentToolType) -> &'static str {
         AgentToolType::FactoryDroid => "Factory Droid",
         AgentToolType::Kiro => "Kiro",
         AgentToolType::Opencode => "OpenCode",
-        AgentToolType::Ampcode => "AmpCode",
+        AgentToolType::Ampcode => "AMP",
     }
 }
 


### PR DESCRIPTION
## Summary

Add agent hook support for AmpCode (`amp` CLI) using its Plugin API. Installs a TypeScript plugin to `~/.config/amp/plugins/atmos-hook.ts` that listens to all 5 lifecycle events and POSTs status changes to Atmos.

All events are handled with idempotency and a compensation mechanism to prevent stuck states:

| Plugin Event | Hook Event | State |
|---|---|---|
| `session.start` | `SessionStart` | Idle (baseline) |
| `agent.start` | `AgentStart` | Running |
| `tool.call` | `ToolCall` | Running (idempotent: skip if already Running) |
| `tool.result` | `ToolResult` | Running (idempotent: skip if already Running) |
| `agent.end` (done/error/cancelled) | `AgentEnd` | Idle (**compensation**: always resets, even if earlier events were lost) |

## Related Issue

Closes #98

## Type of Change

- [x] New feature

## Validation

- [x] `cargo build -p core-engine -p core-service -p api` — clean
- [x] `cargo test -p core-service agent_hooks::ampcode` — 5/5 passed

## Checklist

- [x] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AmpCode agent hook support via the `amp` Plugin API and `/hooks/ampcode`, with idempotent lifecycle updates and a compensation reset. Also adds per‑tool install/uninstall APIs and a Settings UI; the hook shows as “AMP” in Settings and notifications.

- **New Features**
  - Installs a TypeScript plugin at `~/.config/amp/plugins/atmos-hook.ts` (uses `@ampcode/plugin`) that POSTs `SessionStart`, `AgentStart`, `ToolCall`, `ToolResult`, and `AgentEnd` to `/hooks/ampcode`; run `plugins: reload` in `amp` after install.
  - Adds `/hooks/ampcode` and integrates `AgentToolType::Ampcode` into session state, notifications, and Settings (displayed as “AMP”).
  - Per-tool management: `POST /hooks/{tool}/install` and `POST /hooks/{tool}/uninstall`; Settings adds icon-only Install/Uninstall buttons, status icons (CircleCheck/CircleX/CircleMinus) at the front, secondary button styling, and a Trash icon for “Uninstall All”.

- **Bug Fixes**
  - `tool.call` posts are fire-and-forget; `tool.result` returns `allow` per the Plugin API.
  - Uninstall is safer: handles read errors and only removes files with the plugin marker.
  - Agent chat: keep the process expanded while streaming; the bottom divider is now a clickable trigger to collapse.

<sup>Written for commit 04c6eaedd9ca338712ec159f6cf5a8eb29c851b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced AmpCode as a new agent hook tool with install/uninstall/check and UI settings integration.
  * Added AmpCode event handling with session state management and notification display.
  * Added an API endpoint to receive AmpCode hook events.

* **Tests**
  * Added unit tests covering AmpCode event handling and session state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->