### PR TITLE
feat(review): project-level review sessions (APP-013)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "atmos-desktop"
-version = "1.1.0-rc.2"
+version = "1.1.0-rc.3"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -1224,12 +1224,15 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "sea-orm",
+ "sea-orm-migration",
  "serde",
  "serde_json",
  "similar",
+ "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "urlencoding",
  "uuid",
 ]
@@ -2958,6 +2961,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "tokio-tungstenite 0.28.0",

--- a/apps/web/src/api/ws-api.ts
+++ b/apps/web/src/api/ws-api.ts
@@ -397,7 +397,7 @@ export interface ReviewSessionDto {
   created_at: string;
   updated_at: string;
   is_deleted: boolean;
-  workspace_guid: string;
+  workspace_guid: string | null;
   project_guid: string;
   repo_path: string;
   storage_root_rel_path: string;
@@ -1508,15 +1508,20 @@ export const wsWorkspaceApi = {
   },
 };
 
+export type ReviewTarget =
+  | { kind: "workspace"; workspaceId: string }
+  | { kind: "project"; projectId: string };
+
 export const reviewWsApi = {
   listSessions: async (
-    workspaceGuid: string,
+    target: ReviewTarget,
     includeArchived = false,
   ): Promise<ReviewSessionDto[]> => {
-    return wsRequest<ReviewSessionDto[]>("review_session_list", {
-      workspace_guid: workspaceGuid,
-      include_archived: includeArchived,
-    });
+    const payload =
+      target.kind === "workspace"
+        ? { workspace_guid: target.workspaceId, include_archived: includeArchived }
+        : { project_guid: target.projectId, include_archived: includeArchived };
+    return wsRequest<ReviewSessionDto[]>("review_session_list", payload);
   },
 
   getSession: async (sessionGuid: string): Promise<ReviewSessionDto | null> => {
@@ -1526,15 +1531,23 @@ export const reviewWsApi = {
   },
 
   createSession: async (data: {
-    workspaceGuid: string;
+    target: ReviewTarget;
     title?: string | null;
     createdBy?: string | null;
   }): Promise<ReviewSessionDto> => {
-    return wsRequest<ReviewSessionDto>("review_session_create", {
-      workspace_guid: data.workspaceGuid,
-      title: data.title ?? null,
-      created_by: data.createdBy ?? null,
-    }, 60_000);
+    const targetPayload =
+      data.target.kind === "workspace"
+        ? { workspace_guid: data.target.workspaceId }
+        : { project_guid: data.target.projectId };
+    return wsRequest<ReviewSessionDto>(
+      "review_session_create",
+      {
+        ...targetPayload,
+        title: data.title ?? null,
+        created_by: data.createdBy ?? null,
+      },
+      60_000,
+    );
   },
 
   closeSession: async (sessionGuid: string): Promise<{ ok: boolean }> => {

--- a/apps/web/src/components/code-review/CodeReviewDialog.tsx
+++ b/apps/web/src/components/code-review/CodeReviewDialog.tsx
@@ -19,7 +19,7 @@ import { Terminal, Bot, Loader2, AlertTriangle } from "lucide-react";
 import { AgentSelect, buildCommand, type AgentId } from "@/components/wiki/AgentSelect";
 import { skillsApi, agentApi, reviewWsApi } from "@/api/ws-api";
 import { systemApi } from "@/api/rest-api";
-import type { RegistryAgent, CustomAgent } from "@/api/ws-api";
+import type { RegistryAgent, CustomAgent, ReviewTarget } from "@/api/ws-api";
 import { cn } from "@/lib/utils";
 import { useDialogStore } from "@/hooks/use-dialog-store";
 import { useAgentChatUrl } from "@/hooks/use-agent-chat-url";
@@ -119,8 +119,10 @@ export function buildCodeReviewCommand(
 export interface CodeReviewDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** Workspace ID for context */
+  /** Workspace ID for context (kept for backward compat; prefer reviewTarget) */
   workspaceId?: string;
+  /** Review target (workspace or project scope). Takes precedence over workspaceId. */
+  reviewTarget?: ReviewTarget;
   /** Changed file paths from git diff, used to infer default skill */
   changedFilePaths?: string[];
   /** Called when user chooses Terminal Tab mode (first launch) */
@@ -143,6 +145,7 @@ export const CodeReviewDialog: React.FC<CodeReviewDialogProps> = ({
   open,
   onOpenChange,
   workspaceId,
+  reviewTarget,
   changedFilePaths = [],
   onStartTerminalMode,
   onReplaceTerminalAndRun,
@@ -244,14 +247,18 @@ export const CodeReviewDialog: React.FC<CodeReviewDialogProps> = ({
 
   const createReviewAgentRun = useCallback(
     async (mode: "copy_prompt" | "agent_chat") => {
-      if (!workspaceId) return null;
-      const sessions = await reviewWsApi.listSessions(workspaceId, true);
+      // Resolve the effective target: prefer explicit reviewTarget, fall back to workspaceId prop
+      const effectiveTarget: ReviewTarget | null =
+        reviewTarget ??
+        (workspaceId ? { kind: "workspace", workspaceId } : null);
+      if (!effectiveTarget) return null;
+      const sessions = await reviewWsApi.listSessions(effectiveTarget, true);
       let session = sessions.find((item) => item.status === "active") ?? null;
       if (!session) {
         const now = new Date();
         const pad = (value: number) => String(value).padStart(2, "0");
         session = await reviewWsApi.createSession({
-          workspaceGuid: workspaceId,
+          target: effectiveTarget,
           title: `Review_${pad(now.getMonth() + 1)}.${pad(now.getDate())}-${pad(now.getHours())}:${pad(now.getMinutes())}`,
         });
       }
@@ -263,7 +270,7 @@ export const CodeReviewDialog: React.FC<CodeReviewDialogProps> = ({
         skillId,
       });
     },
-    [skillId, workspaceId],
+    [skillId, workspaceId, reviewTarget],
   );
 
   /** Generate report file path: {projectMainPath}/.atmos/reviews/{workspaceId}/{project}_{branch}_{timestamp}_{topic}.md */

--- a/apps/web/src/components/code-review/CodeReviewDialog.tsx
+++ b/apps/web/src/components/code-review/CodeReviewDialog.tsx
@@ -288,9 +288,13 @@ export const CodeReviewDialog: React.FC<CodeReviewDialogProps> = ({
       .filter(Boolean)
       .join("_");
     const base = projectMainPath || workspacePath || ".";
-    const ctxId = workspaceId || "default";
+    // Derive context id from effective target
+    const effectiveTarget = reviewTarget ?? (workspaceId ? { kind: "workspace", workspaceId } : null);
+    const ctxId = effectiveTarget
+      ? (effectiveTarget.kind === "workspace" ? effectiveTarget.workspaceId : effectiveTarget.projectId)
+      : "default";
     return `${base}/.atmos/reviews/${ctxId}/${parts}.md`;
-  }, [projectName, currentBranch, projectMainPath, workspacePath, workspaceId]);
+  }, [projectName, currentBranch, projectMainPath, workspacePath, workspaceId, reviewTarget]);
 
   const handleStart = useCallback(
     async () => {

--- a/apps/web/src/components/diff/ReviewView.tsx
+++ b/apps/web/src/components/diff/ReviewView.tsx
@@ -28,9 +28,12 @@ import { MarkdownRenderer } from "@/components/markdown/MarkdownRenderer";
 const REVIEW_FILE_VIEW_MODE_STORAGE_KEY = "atmos:right-sidebar:review-file-view-mode";
 
 const ReviewView: React.FC = () => {
-  const { workspaceId } = useContextParams();
+  const { workspaceId, projectId } = useContextParams();
+  // For review-diff editor tabs, use workspaceId if available, else a synthetic
+  // project-scoped key. This key is ONLY used for EDITOR_REVIEW_DIFF_PREFIX paths.
+  const reviewEditorKey = workspaceId ?? (projectId ? `project:${projectId}` : null);
   const getActiveFilePath = useEditorStore((s) => s.getActiveFilePath);
-  const rawFilePath = (workspaceId && getActiveFilePath(workspaceId)) || "";
+  const rawFilePath = (reviewEditorKey && getActiveFilePath(reviewEditorKey)) || "";
   const filePath = rawFilePath.startsWith(EDITOR_REVIEW_DIFF_PREFIX)
     ? getEditorSourcePath(rawFilePath)
     : "";
@@ -109,10 +112,10 @@ const ReviewView: React.FC = () => {
     }
   }, [summaryRunGuid, hasLoadedSummary, artifactLoading, handlePreviewArtifact]);
 
-  if (!workspaceId) {
+  if (!reviewEditorKey) {
     return (
       <div className="p-3 text-xs text-muted-foreground">
-        No workspace selected.
+        No project or workspace selected.
       </div>
     );
   }
@@ -153,6 +156,10 @@ const ReviewView: React.FC = () => {
       {/* Inline stats line */}
       <div className="flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground shrink-0 border-b border-sidebar-border/50">
         <div className="flex min-w-0 flex-1 items-center gap-2">
+          {/* N2: scope badge */}
+          <span className="shrink-0 rounded px-1 py-0.5 text-[10px] font-medium bg-muted text-muted-foreground border border-border">
+            {currentSession.workspace_guid ? "Workspace" : "Project"}
+          </span>
           <span>{openCommentCount} open</span>
           <span>·</span>
           <span>
@@ -213,7 +220,7 @@ const ReviewView: React.FC = () => {
                       label,
                       filePath: snapFilePath,
                     });
-                    void openFile(`${EDITOR_REVIEW_DIFF_PREFIX}${snapshotGuid}/${snapFilePath}`, workspaceId, { preview: true });
+                    void openFile(`${EDITOR_REVIEW_DIFF_PREFIX}${snapshotGuid}/${snapFilePath}`, reviewEditorKey, { preview: true });
                   }}
                   onDoubleClickFile={(snapshotGuid, snapFilePath) => {
                     const tabPath = `${EDITOR_REVIEW_DIFF_PREFIX}${snapshotGuid}/${snapFilePath}`;
@@ -222,8 +229,8 @@ const ReviewView: React.FC = () => {
                       label: revisionLabel,
                       filePath: snapFilePath,
                     });
-                    void openFile(tabPath, workspaceId, { preview: false });
-                    pinFile(tabPath, workspaceId || undefined);
+                    void openFile(tabPath, reviewEditorKey, { preview: false });
+                    pinFile(tabPath, reviewEditorKey ?? undefined);
                   }}
                   onToggleReviewed={handleToggleReviewed}
                   revisionLabel={revisionLabel}
@@ -324,7 +331,7 @@ const ReviewView: React.FC = () => {
                               label: revisionLabel,
                               filePath: snapFilePath,
                             });
-                            void openFile(tabPath, workspaceId, {
+                            void openFile(tabPath, reviewEditorKey, {
                               preview: true,
                               line: targetComment.anchor_start_line,
                               reviewCommentGuid: targetComment.guid,

--- a/apps/web/src/components/diff/ReviewView.tsx
+++ b/apps/web/src/components/diff/ReviewView.tsx
@@ -126,7 +126,7 @@ const ReviewView: React.FC = () => {
         <div className="rounded-lg border border-dashed border-sidebar-border bg-background/70 p-4 text-center">
           <p className="text-sm text-foreground">No review session yet</p>
           <p className="mt-1 text-xs text-muted-foreground">
-            Start a session to track comments and fix runs for this workspace.
+            Start a session to track comments and fix runs for this workspace or project.
           </p>
           <Button
             size="sm"

--- a/apps/web/src/components/diff/ReviewView.tsx
+++ b/apps/web/src/components/diff/ReviewView.tsx
@@ -20,6 +20,7 @@ import { FrozenFileList } from "@/components/diff/review/FrozenFileList";
 import {
   compareReviewTimestamps,
   formatReviewDateTime,
+  getScopeBadgeText,
   isOpenReviewCommentStatus,
   sortComments,
 } from "@/components/diff/review/utils";
@@ -28,10 +29,10 @@ import { MarkdownRenderer } from "@/components/markdown/MarkdownRenderer";
 const REVIEW_FILE_VIEW_MODE_STORAGE_KEY = "atmos:right-sidebar:review-file-view-mode";
 
 const ReviewView: React.FC = () => {
-  const { workspaceId, projectId } = useContextParams();
-  // For review-diff editor tabs, use workspaceId if available, else a synthetic
-  // project-scoped key. This key is ONLY used for EDITOR_REVIEW_DIFF_PREFIX paths.
-  const reviewEditorKey = workspaceId ?? (projectId ? `project:${projectId}` : null);
+  const { effectiveContextId } = useContextParams();
+  // For review-diff editor tabs, use the same context key as the main editor
+  // to ensure file/comment navigation opens in the correct tab namespace.
+  const reviewEditorKey = effectiveContextId;
   const getActiveFilePath = useEditorStore((s) => s.getActiveFilePath);
   const rawFilePath = (reviewEditorKey && getActiveFilePath(reviewEditorKey)) || "";
   const filePath = rawFilePath.startsWith(EDITOR_REVIEW_DIFF_PREFIX)
@@ -158,7 +159,7 @@ const ReviewView: React.FC = () => {
         <div className="flex min-w-0 flex-1 items-center gap-2">
           {/* N2: scope badge */}
           <span className="shrink-0 rounded px-1 py-0.5 text-[10px] font-medium bg-muted text-muted-foreground border border-border">
-            {currentSession.workspace_guid ? "Workspace" : "Project"}
+            {getScopeBadgeText(currentSession)}
           </span>
           <span>{openCommentCount} open</span>
           <span>·</span>

--- a/apps/web/src/components/diff/__tests__/ReviewView.scope-badge.test.ts
+++ b/apps/web/src/components/diff/__tests__/ReviewView.scope-badge.test.ts
@@ -1,0 +1,51 @@
+/**
+ * S11 — N2: scope badge in session header
+ *
+ * Verifies that ReviewSessionDto.workspace_guid drives the "Project" / "Workspace"
+ * badge text. This is a pure logic test — no DOM rendering required.
+ */
+
+// @ts-ignore bun:test is available at runtime but not in tsconfig types
+import { describe, it, expect } from "bun:test";
+import type { ReviewSessionDto } from "@/api/ws-api";
+
+/** Mirrors the badge logic in ReviewView.tsx */
+function getScopeBadgeText(session: Pick<ReviewSessionDto, "workspace_guid">): string {
+  return session.workspace_guid ? "Workspace" : "Project";
+}
+
+const baseSession: Omit<ReviewSessionDto, "workspace_guid"> = {
+  guid: "sess-1",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  is_deleted: false,
+  project_guid: "pj-1",
+  repo_path: "/tmp/repo",
+  storage_root_rel_path: "/tmp/storage",
+  base_ref: "main",
+  base_commit: null,
+  head_commit: "abc123",
+  current_revision_guid: "rev-1",
+  status: "active",
+  title: null,
+  created_by: null,
+  closed_at: null,
+  archived_at: null,
+  revisions: [],
+  runs: [],
+  open_comment_count: 0,
+  reviewed_file_count: 0,
+  reviewed_then_changed_count: 0,
+};
+
+describe("S11 — N2 scope badge", () => {
+  it("shows 'Project' badge when workspace_guid is null", () => {
+    const session: ReviewSessionDto = { ...baseSession, workspace_guid: null };
+    expect(getScopeBadgeText(session)).toBe("Project");
+  });
+
+  it("shows 'Workspace' badge when workspace_guid is set", () => {
+    const session: ReviewSessionDto = { ...baseSession, workspace_guid: "ws-1" };
+    expect(getScopeBadgeText(session)).toBe("Workspace");
+  });
+});

--- a/apps/web/src/components/diff/__tests__/ReviewView.scope-badge.test.ts
+++ b/apps/web/src/components/diff/__tests__/ReviewView.scope-badge.test.ts
@@ -5,7 +5,7 @@
  * badge text. This is a pure logic test — no DOM rendering required.
  */
 
-// @ts-ignore bun:test is available at runtime but not in tsconfig types
+// @ts-expect-error bun:test is available at runtime but not in tsconfig types
 import { describe, it, expect } from "bun:test";
 import type { ReviewSessionDto } from "@/api/ws-api";
 

--- a/apps/web/src/components/diff/__tests__/ReviewView.scope-badge.test.ts
+++ b/apps/web/src/components/diff/__tests__/ReviewView.scope-badge.test.ts
@@ -2,17 +2,13 @@
  * S11 — N2: scope badge in session header
  *
  * Verifies that ReviewSessionDto.workspace_guid drives the "Project" / "Workspace"
- * badge text. This is a pure logic test — no DOM rendering required.
+ * badge text. This tests the shared utility function used by ReviewView.
  */
 
 // @ts-expect-error bun:test is available at runtime but not in tsconfig types
 import { describe, it, expect } from "bun:test";
 import type { ReviewSessionDto } from "@/api/ws-api";
-
-/** Mirrors the badge logic in ReviewView.tsx */
-function getScopeBadgeText(session: Pick<ReviewSessionDto, "workspace_guid">): string {
-  return session.workspace_guid ? "Workspace" : "Project";
-}
+import { getScopeBadgeText } from "@/components/diff/review/utils";
 
 const baseSession: Omit<ReviewSessionDto, "workspace_guid"> = {
   guid: "sess-1",

--- a/apps/web/src/components/diff/review/ReviewContextProvider.tsx
+++ b/apps/web/src/components/diff/review/ReviewContextProvider.tsx
@@ -2,23 +2,24 @@
 
 import React, { createContext, useContext, useMemo } from "react";
 import { useReviewContext, type ReviewContext } from "@/hooks/use-review-context";
+import type { ReviewTarget } from "@/api/ws-api";
 
 const ReviewCtx = createContext<ReviewContext | null>(null);
 
 interface ReviewContextProviderProps {
-  workspaceId: string | null;
+  target: ReviewTarget | null;
   filePath: string;
   fileSnapshotGuid?: string | null;
   children: React.ReactNode;
 }
 
 export const ReviewContextProvider: React.FC<ReviewContextProviderProps> = ({
-  workspaceId,
+  target,
   filePath,
   fileSnapshotGuid,
   children,
 }) => {
-  const ctx = useReviewContext({ workspaceId, filePath, fileSnapshotGuid });
+  const ctx = useReviewContext({ target, filePath, fileSnapshotGuid });
 
   // Memoize context value to avoid unnecessary re-renders
   const contextValue = useMemo(() => ctx, [

--- a/apps/web/src/components/diff/review/utils.ts
+++ b/apps/web/src/components/diff/review/utils.ts
@@ -132,4 +132,8 @@ export function sortComments(
   });
 }
 
+export function getScopeBadgeText(session: Pick<ReviewSessionDto, "workspace_guid">): string {
+  return session.workspace_guid ? "Workspace" : "Project";
+}
+
 export const REVIEW_AGENT_STORAGE_KEY = "atmos.review.default_agent_id";

--- a/apps/web/src/components/layout/CenterStage.tsx
+++ b/apps/web/src/components/layout/CenterStage.tsx
@@ -76,6 +76,7 @@ import { AgentIcon } from "@/components/agent/AgentIcon";
 import { AGENT_STATE, useAgentHooksStore } from "@/hooks/use-agent-hooks-store";
 import { AgentHookStatusIndicator } from "@/components/agent/AgentHookStatusIndicator";
 import { codeAgentCustomApi, type CodeAgentCustomEntry, functionSettingsApi } from "@/api/ws-api";
+import type { ReviewTarget } from "@/api/ws-api";
 import type { TerminalGridHandle } from "@/components/terminal/TerminalGrid";
 import type { TerminalPaneAgent } from "@/components/terminal/types";
 import WelcomePage from "@/components/welcome/WelcomePage";
@@ -439,7 +440,7 @@ const CenterStage: React.FC = () => {
   // Wait for editor store hydration to avoid SSR mismatch
   useEditorStoreHydration();
 
-  const { workspaceId, effectiveContextId, currentView } = useContextParams();
+  const { workspaceId, projectId: projectIdFromUrl, effectiveContextId, currentView } = useContextParams();
   const {
     terminalTabs,
     createTerminalTab,
@@ -607,6 +608,12 @@ const CenterStage: React.FC = () => {
   const projects = useProjectStore(s => s.projects);
   const clearSetupProgress = useProjectStore(s => s.clearSetupProgress);
   const { currentBranch } = useGitInfoStore();
+
+  const reviewTarget = React.useMemo((): ReviewTarget | null => {
+    if (workspaceId) return { kind: "workspace", workspaceId };
+    if (projectIdFromUrl) return { kind: "project", projectId: projectIdFromUrl };
+    return null;
+  }, [workspaceId, projectIdFromUrl]);
 
   const closeFilesSafely = (files: OpenFile[]) => {
     if (files.length === 0) return;
@@ -2253,7 +2260,7 @@ const CenterStage: React.FC = () => {
           >
             {isDiffEditorPath(file.path) && currentRepoPath ? (
                 <ReviewContextProvider
-                  workspaceId={workspaceId}
+                  target={reviewTarget}
                   filePath={getEditorSourcePath(file.path)}
                   fileSnapshotGuid={
                     file.path.startsWith('review-diff://')
@@ -2460,6 +2467,7 @@ const CenterStage: React.FC = () => {
           open={isCodeReviewDialogOpen}
           onOpenChange={setCodeReviewDialogOpen}
           workspaceId={effectiveContextId}
+          reviewTarget={reviewTarget ?? undefined}
           projectName={currentProject?.name}
           workspacePath={currentWorkspace?.localPath || currentProject?.mainFilePath || ""}
           projectMainPath={currentProject?.mainFilePath}

--- a/apps/web/src/components/layout/RightSidebar.tsx
+++ b/apps/web/src/components/layout/RightSidebar.tsx
@@ -58,6 +58,7 @@ import { ChangeSection } from "@/components/layout/sidebar/ChangeSection";
 import { CommitActions } from "@/components/layout/sidebar/CommitActions";
 import { RightSidebarDialogs } from "@/components/layout/sidebar/RightSidebarDialogs";
 import { ReviewContextProvider } from "@/components/diff/review/ReviewContextProvider";
+import type { ReviewTarget } from "@/api/ws-api";
 import { ReviewActions } from "@/components/diff/review/ReviewActions";
 import { RefreshableTabsTab } from "@/components/ui/RefreshableTabsTab";
 
@@ -138,6 +139,12 @@ const RightSidebar: React.FC<RightSidebarProps> = () => {
   );
 
   const effectiveContextId = workspaceId || projectIdFromUrl;
+
+  const reviewTarget = useMemo((): ReviewTarget | null => {
+    if (workspaceId) return { kind: "workspace", workspaceId };
+    if (projectIdFromUrl) return { kind: "project", projectId: projectIdFromUrl };
+    return null;
+  }, [workspaceId, projectIdFromUrl]);
 
   const {
     stagedFiles,
@@ -696,7 +703,7 @@ const RightSidebar: React.FC<RightSidebarProps> = () => {
           >
             {hasWorkingContext ? (
               <ReviewContextProvider
-                workspaceId={workspaceId}
+                target={reviewTarget}
                 filePath={filePath}
               >
                 {/* Review actions bar */}

--- a/apps/web/src/components/layout/RightSidebar.tsx
+++ b/apps/web/src/components/layout/RightSidebar.tsx
@@ -103,7 +103,8 @@ const RightSidebar: React.FC<RightSidebarProps> = () => {
   const { workspaceId, projectId: projectIdFromUrl } = useContextParams();
   const currentProjectPath = useEditorStore((s) => s.currentProjectPath);
   const getActiveFilePath = useEditorStore((s) => s.getActiveFilePath);
-  const filePath = (workspaceId && getActiveFilePath(workspaceId)) || "";
+  const contextId = workspaceId || projectIdFromUrl;
+  const filePath = (contextId && getActiveFilePath(contextId)) || "";
   const projects = useProjectStore((s) => s.projects);
   const { enqueueAgentChatPrompt, setPendingAgentChatMode } = useDialogStore();
   const [, setAgentChatOpen] = useAgentChatUrl();

--- a/apps/web/src/hooks/use-review-context.ts
+++ b/apps/web/src/hooks/use-review-context.ts
@@ -315,9 +315,10 @@ export function useReviewContext({ target, filePath, fileSnapshotGuid }: UseRevi
       setSelectedSessionGuid(session.guid);
       setSelectedRevisionGuid(session.current_revision_guid);
       setSessions((prev) => [session, ...prev]);
+      const targetKind = target.kind === "workspace" ? "workspace" : "project";
       toastManager.add({
         title: "Review session started",
-        description: "Comments and reviewed file state are now tracked for this workspace.",
+        description: `Comments and reviewed file state are now tracked for this ${targetKind}.`,
         type: "success",
       });
     } catch (error) {

--- a/apps/web/src/hooks/use-review-context.ts
+++ b/apps/web/src/hooks/use-review-context.ts
@@ -10,6 +10,7 @@ import {
   type ReviewMessageDto,
   type ReviewSessionDto,
   type ReviewCommentDto,
+  type ReviewTarget,
 } from "@/api/ws-api";
 import { buildCommand, type AgentId } from "@/components/wiki/AgentSelect";
 import { useDialogStore } from "@/hooks/use-dialog-store";
@@ -32,7 +33,7 @@ export interface ArtifactPreview {
 }
 
 interface UseReviewContextArgs {
-  workspaceId: string | null;
+  target: ReviewTarget | null;
   filePath: string;
   fileSnapshotGuid?: string | null;
 }
@@ -43,7 +44,7 @@ function readStoredAgentId(): AgentId {
   return stored ? (stored as AgentId) : "codex";
 }
 
-export function useReviewContext({ workspaceId, filePath, fileSnapshotGuid }: UseReviewContextArgs) {
+export function useReviewContext({ target, filePath, fileSnapshotGuid }: UseReviewContextArgs) {
   const onWsEvent = useWebSocketStore((state) => state.onEvent);
   const enqueueAgentChatPrompt = useDialogStore((state) => state.enqueueAgentChatPrompt);
   const setPendingAgentChatMode = useDialogStore(
@@ -78,13 +79,13 @@ export function useReviewContext({ workspaceId, filePath, fileSnapshotGuid }: Us
   }, []);
 
   const loadSessions = useCallback(async () => {
-    if (!workspaceId) {
+    if (!target) {
       setSessions([]);
       return;
     }
     setIsLoading(true);
     try {
-      const nextSessions = await reviewWsApi.listSessions(workspaceId, true);
+      const nextSessions = await reviewWsApi.listSessions(target, true);
       setSessions(nextSessions);
     } catch (error) {
       console.error("Failed to load review sessions", error);
@@ -97,7 +98,7 @@ export function useReviewContext({ workspaceId, filePath, fileSnapshotGuid }: Us
     } finally {
       setIsLoading(false);
     }
-  }, [workspaceId]);
+  }, [target]);
 
   useEffect(() => {
     void loadSessions();
@@ -298,7 +299,7 @@ export function useReviewContext({ workspaceId, filePath, fileSnapshotGuid }: Us
   const autoLoadedSummaryRunRef = useRef<string | null>(null);
 
   const handleCreateSession = useCallback(async () => {
-    if (!workspaceId) return;
+    if (!target) return;
     setIsCreating(true);
     try {
       const now = new Date();
@@ -308,7 +309,7 @@ export function useReviewContext({ workspaceId, filePath, fileSnapshotGuid }: Us
       const min = String(now.getMinutes()).padStart(2, "0");
       const defaultTitle = `Review_${mm}.${dd}-${hh}:${min}`;
       const session = await reviewWsApi.createSession({
-        workspaceGuid: workspaceId,
+        target,
         title: defaultTitle,
       });
       setSelectedSessionGuid(session.guid);
@@ -329,7 +330,7 @@ export function useReviewContext({ workspaceId, filePath, fileSnapshotGuid }: Us
     } finally {
       setIsCreating(false);
     }
-  }, [workspaceId]);
+  }, [target]);
 
   const handleCloseSession = useCallback(async () => {
     if (!currentSession) return;
@@ -584,7 +585,9 @@ export function useReviewContext({ workspaceId, filePath, fileSnapshotGuid }: Us
 
   const handleSendAgentRunToAgentChat = useCallback(
     async (selectedCommentGuids?: string[]) => {
-      if (!workspaceId) return;
+      if (!target) return;
+      const workspaceId = target.kind === "workspace" ? target.workspaceId : null;
+      const projectId = target.kind === "project" ? target.projectId : null;
       setIsCreatingAgentRun(true);
       try {
         const result = await createAgentRun("fix", "agent_chat", null, selectedCommentGuids);
@@ -593,7 +596,7 @@ export function useReviewContext({ workspaceId, filePath, fileSnapshotGuid }: Us
         enqueueAgentChatPrompt({
           prompt: result.prompt,
           workspaceId,
-          projectId: null,
+          projectId,
           mode: "default",
           origin: "review_session",
           sessionTitle: `Review Fix ${filePath.split("/").pop() || filePath}`,
@@ -626,7 +629,7 @@ export function useReviewContext({ workspaceId, filePath, fileSnapshotGuid }: Us
       setSelectedRevisionGuid,
       setAgentChatOpen,
       setPendingAgentChatMode,
-      workspaceId,
+      target,
     ],
   );
 
@@ -686,13 +689,15 @@ export function useReviewContext({ workspaceId, filePath, fileSnapshotGuid }: Us
             description: "Paste it into your agent CLI or chat to process the review.",
             type: "success",
           });
-        } else if (executionMode === "agent_chat" && workspaceId) {
+        } else if (executionMode === "agent_chat" && target) {
+          const workspaceId = target.kind === "workspace" ? target.workspaceId : null;
+          const projectId = target.kind === "project" ? target.projectId : null;
           setPendingAgentChatMode("default");
           setAgentChatOpen(true);
           await enqueueAgentChatPrompt({
             prompt: result.prompt,
             workspaceId,
-            projectId: null,
+            projectId,
             mode: "default",
             origin: "review_session",
             sessionTitle: `Review ${filePath.split("/").pop() || filePath}`,
@@ -711,7 +716,7 @@ export function useReviewContext({ workspaceId, filePath, fileSnapshotGuid }: Us
         setIsCreatingAgentRun(false);
       }
     },
-    [createAgentRun, currentRevision, currentSession, filePath, loadSessions, setSelectedRevisionGuid, workspaceId, enqueueAgentChatPrompt, setAgentChatOpen, setPendingAgentChatMode],
+    [createAgentRun, currentRevision, currentSession, filePath, loadSessions, setSelectedRevisionGuid, target, enqueueAgentChatPrompt, setAgentChatOpen, setPendingAgentChatMode],
   );
 
   const handleCopyAgentReviewPrompt = useCallback(

--- a/crates/core-service/Cargo.toml
+++ b/crates/core-service/Cargo.toml
@@ -30,3 +30,8 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 urlencoding = "2.1"
 similar = "2.7"
 base64 = "0.22"
+
+[dev-dependencies]
+tempfile = "3"
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
+sea-orm-migration = { version = "1.1", default-features = false, features = ["sqlx-sqlite", "runtime-tokio-rustls"] }

--- a/crates/core-service/src/service/review.rs
+++ b/crates/core-service/src/service/review.rs
@@ -178,9 +178,16 @@ pub struct ReviewSessionDto {
     pub reviewed_then_changed_count: usize,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ReviewTarget {
+    Workspace { workspace_guid: String },
+    Project { project_guid: String },
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct CreateReviewSessionInput {
-    pub workspace_guid: String,
+    pub target: ReviewTarget,
     #[serde(default)]
     pub title: Option<String>,
     #[serde(default)]
@@ -284,7 +291,7 @@ pub struct SetReviewAgentRunStatusInput {
 struct SessionManifest {
     schema_version: i32,
     session_guid: String,
-    workspace_guid: String,
+    workspace_guid: Option<String>,
     repo_path: String,
     base_ref: Option<String>,
     base_commit: Option<String>,
@@ -367,6 +374,22 @@ pub struct ReviewService {
     git_engine: GitEngine,
 }
 
+#[derive(Debug)]
+struct RepoContext {
+    project_guid: String,
+    workspace_guid: Option<String>,
+    repo_path: std::path::PathBuf,
+    base_ref: Option<String>,
+    base_ref_origin: BaseRefOrigin,
+}
+
+#[derive(PartialEq, Debug)]
+enum BaseRefOrigin {
+    ProjectTargetBranch,
+    DefaultBranchFallback,
+    WorkspaceBaseBranch,
+}
+
 const VALID_RUN_KINDS: &[&str] = &["review", "fix"];
 const VALID_EXECUTION_MODES: &[&str] = &["copy_prompt", "agent_chat", "terminal_cli"];
 
@@ -394,6 +417,22 @@ impl ReviewService {
         Ok(items)
     }
 
+    pub async fn list_sessions_by_project(
+        &self,
+        project_guid: String,
+        include_archived: bool,
+    ) -> Result<Vec<ReviewSessionDto>> {
+        let repo = ReviewRepo::new(&self.db);
+        let sessions = repo
+            .list_sessions_by_project(&project_guid, include_archived)
+            .await?;
+        let mut items = Vec::with_capacity(sessions.len());
+        for session in sessions {
+            items.push(self.build_session_dto(session).await?);
+        }
+        Ok(items)
+    }
+
     pub async fn get_session(&self, session_guid: String) -> Result<Option<ReviewSessionDto>> {
         let repo = ReviewRepo::new(&self.db);
         let Some(session) = repo.find_session_by_guid(&session_guid).await? else {
@@ -402,36 +441,85 @@ impl ReviewService {
         Ok(Some(self.build_session_dto(session).await?))
     }
 
+    async fn resolve_repo_context(&self, target: &ReviewTarget) -> Result<RepoContext> {
+        match target {
+            ReviewTarget::Workspace { workspace_guid } => {
+                let workspace = WorkspaceRepo::new(&self.db)
+                    .find_by_guid(workspace_guid)
+                    .await?
+                    .ok_or_else(|| {
+                        ServiceError::NotFound(format!("Workspace {} not found", workspace_guid))
+                    })?;
+                let project = ProjectRepo::new(&self.db)
+                    .find_by_guid(&workspace.project_guid)
+                    .await?
+                    .ok_or_else(|| {
+                        ServiceError::NotFound(format!(
+                            "Project {} not found",
+                            workspace.project_guid
+                        ))
+                    })?;
+                let repo_path = self
+                    .git_engine
+                    .get_worktree_path(&workspace.name)
+                    .map_err(ServiceError::Engine)?;
+                Ok(RepoContext {
+                    project_guid: project.guid,
+                    workspace_guid: Some(workspace.guid),
+                    repo_path,
+                    base_ref: Some(workspace.base_branch),
+                    base_ref_origin: BaseRefOrigin::WorkspaceBaseBranch,
+                })
+            }
+            ReviewTarget::Project { project_guid } => {
+                let project = ProjectRepo::new(&self.db)
+                    .find_by_guid(project_guid)
+                    .await?
+                    .ok_or_else(|| {
+                        ServiceError::NotFound(format!("Project {} not found", project_guid))
+                    })?;
+                let repo_path = std::path::PathBuf::from(&project.main_file_path);
+                let (base_ref, base_ref_origin) = if let Some(branch) = project.target_branch {
+                    (Some(branch), BaseRefOrigin::ProjectTargetBranch)
+                } else {
+                    match self.git_engine.get_default_branch(&repo_path) {
+                        Ok(Some(branch)) => {
+                            tracing::warn!(
+                                target: "review",
+                                project_guid = %project_guid,
+                                "target_branch missing, falling back to repo default branch"
+                            );
+                            (Some(branch), BaseRefOrigin::DefaultBranchFallback)
+                        }
+                        _ => {
+                            return Err(ServiceError::Validation(
+                                "Project has no target branch configured. Set one from the topbar before starting a review session.".to_string(),
+                            ));
+                        }
+                    }
+                };
+                Ok(RepoContext {
+                    project_guid: project.guid,
+                    workspace_guid: None,
+                    repo_path,
+                    base_ref,
+                    base_ref_origin,
+                })
+            }
+        }
+    }
+
     pub async fn create_session(
         &self,
         input: CreateReviewSessionInput,
     ) -> Result<ReviewSessionDto> {
-        let workspace_repo = WorkspaceRepo::new(&self.db);
-        let project_repo = ProjectRepo::new(&self.db);
         let review_repo = ReviewRepo::new(&self.db);
 
-        let workspace = workspace_repo
-            .find_by_guid(&input.workspace_guid)
-            .await?
-            .ok_or_else(|| {
-                ServiceError::NotFound(format!("Workspace {} not found", input.workspace_guid))
-            })?;
-
-        let project = project_repo
-            .find_by_guid(&workspace.project_guid)
-            .await?
-            .ok_or_else(|| {
-                ServiceError::NotFound(format!("Project {} not found", workspace.project_guid))
-            })?;
-
-        let workspace_root = self
-            .git_engine
-            .get_worktree_path(&workspace.name)
-            .map_err(ServiceError::Engine)?;
+        let ctx = self.resolve_repo_context(&input.target).await?;
 
         let changed = self
             .git_engine
-            .get_changed_files(&workspace_root, Some(&workspace.base_branch), false)
+            .get_changed_files(&ctx.repo_path, ctx.base_ref.as_deref(), false)
             .map_err(ServiceError::Engine)?;
 
         let mut ordered_paths = Vec::new();
@@ -465,15 +553,15 @@ impl ReviewService {
             .to_string();
         let head_commit = self
             .git_engine
-            .get_head_commit(&workspace_root)
+            .get_head_commit(&ctx.repo_path)
             .unwrap_or_else(|_| "HEAD".to_string());
 
         let session = review_repo
             .create_session(
                 Some(session_guid.clone()),
-                workspace.guid.clone(),
-                project.guid.clone(),
-                project.main_file_path.clone(),
+                ctx.workspace_guid.clone(),
+                ctx.project_guid.clone(),
+                ctx.repo_path.to_string_lossy().to_string(),
                 session_storage_root,
                 changed.compare_ref.clone(),
                 None,
@@ -489,17 +577,19 @@ impl ReviewService {
         // `current_revision_guid` that does not yet exist on disk or in the DB.
         // If any step below fails we must soft-delete the session to avoid
         // leaving an orphaned row with a dangling forward reference.
+        let repo_path_str = ctx.repo_path.to_string_lossy().to_string();
+        let base_ref_str = ctx.base_ref.clone().unwrap_or_default();
         let build_result = self
             .populate_initial_session(
                 &review_repo,
                 &session,
                 &revision_guid,
                 &revision_storage_root,
-                &workspace_root,
+                &ctx.repo_path,
                 ordered_paths,
-                &workspace.base_branch,
+                &base_ref_str,
                 input.created_by.clone(),
-                &project.main_file_path,
+                &repo_path_str,
                 &head_commit,
             )
             .await;
@@ -1979,19 +2069,26 @@ impl ReviewService {
                 .ok_or_else(|| {
                     ServiceError::NotFound(format!("Review session {} not found", run.session_guid))
                 })?;
-            let workspace = WorkspaceRepo::new(&self.db)
-                .find_by_guid(&session.workspace_guid)
-                .await?
-                .ok_or_else(|| {
-                    ServiceError::NotFound(format!(
-                        "Workspace {} not found",
-                        session.workspace_guid
-                    ))
-                })?;
-            let workspace_root = self
-                .git_engine
-                .get_worktree_path(&workspace.name)
-                .map_err(ServiceError::Engine)?;
+            // Use session.repo_path as the source of truth for the working tree.
+            // Fall back to workspace worktree resolution only for legacy rows where
+            // repo_path is empty (should not occur for sessions created after APP-013).
+            let workspace_root = if !session.repo_path.is_empty() {
+                std::path::PathBuf::from(&session.repo_path)
+            } else if let Some(ref ws_guid) = session.workspace_guid {
+                let workspace = WorkspaceRepo::new(&self.db)
+                    .find_by_guid(ws_guid)
+                    .await?
+                    .ok_or_else(|| {
+                        ServiceError::NotFound(format!("Workspace {} not found", ws_guid))
+                    })?;
+                self.git_engine
+                    .get_worktree_path(&workspace.name)
+                    .map_err(ServiceError::Engine)?
+            } else {
+                return Err(ServiceError::Processing(
+                    "Review session has no repo_path and no workspace_guid".to_string(),
+                ));
+            };
             let base_revision = review_repo
                 .find_revision_by_guid(&run.base_revision_guid)
                 .await
@@ -2231,7 +2328,7 @@ impl ReviewService {
 
             let changed = self
                 .git_engine
-                .get_changed_files(&workspace_root, Some(&workspace.base_branch), false)
+                .get_changed_files(&workspace_root, session.base_ref.as_deref(), false)
                 .map_err(ServiceError::Engine)?;
             let mut ordered_new_paths = Vec::new();
             for file in changed
@@ -2667,4 +2764,386 @@ fn xml_escape(text: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\'', "&apos;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use infra::db::repo::{ProjectRepo, ReviewRepo};
+    use sea_orm::Database;
+    use sea_orm_migration::MigratorTrait;
+    use std::sync::Arc;
+
+    async fn setup_db() -> Arc<sea_orm::DatabaseConnection> {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        infra::Migrator::up(&db, None).await.unwrap();
+        Arc::new(db)
+    }
+    // ── S2: resolve_repo_context — project with target_branch set ─────────────
+
+    #[tokio::test]
+    async fn s2_resolve_repo_context_project_target_branch() {
+        let db = setup_db().await;
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = tmp.path().to_string_lossy().to_string();
+
+        // Init a bare git repo so GitEngine doesn't fail on get_default_branch
+        std::process::Command::new("git")
+            .args(["init", "-b", "main"])
+            .current_dir(tmp.path())
+            .output()
+            .ok();
+
+        let project = ProjectRepo::new(&db)
+            .create(
+                "test-project".into(),
+                repo_path.clone(),
+                0,
+                None,
+                Some("main".into()),
+            )
+            .await
+            .unwrap();
+
+        let service = ReviewService::new(db);
+        let ctx = service
+            .resolve_repo_context(&ReviewTarget::Project {
+                project_guid: project.guid.clone(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(ctx.project_guid, project.guid);
+        assert!(ctx.workspace_guid.is_none());
+        assert_eq!(ctx.base_ref.as_deref(), Some("main"));
+        assert_eq!(ctx.base_ref_origin, BaseRefOrigin::ProjectTargetBranch);
+    }
+
+    // ── S3: resolve_repo_context — target_branch NULL, origin/HEAD resolves ──
+
+    #[tokio::test]
+    async fn s3_resolve_repo_context_fallback_to_default_branch() {
+        let db = setup_db().await;
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Init a git repo with a commit so origin/HEAD can be resolved locally
+        std::process::Command::new("git")
+            .args(["init", "-b", "main"])
+            .current_dir(tmp.path())
+            .output()
+            .ok();
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(tmp.path())
+            .output()
+            .ok();
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(tmp.path())
+            .output()
+            .ok();
+        // Create a file and commit so HEAD exists
+        std::fs::write(tmp.path().join("README.md"), "test").unwrap();
+        std::process::Command::new("git")
+            .args(["add", "."])
+            .current_dir(tmp.path())
+            .output()
+            .ok();
+        std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(tmp.path())
+            .output()
+            .ok();
+
+        let repo_path = tmp.path().to_string_lossy().to_string();
+        let project = ProjectRepo::new(&db)
+            .create("test-project".into(), repo_path, 0, None, None)
+            .await
+            .unwrap();
+
+        let service = ReviewService::new(db);
+
+        // Capture tracing events to verify warn is emitted
+        let subscriber = tracing_subscriber::fmt()
+            .with_test_writer()
+            .with_max_level(tracing::Level::WARN)
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let ctx = service
+            .resolve_repo_context(&ReviewTarget::Project {
+                project_guid: project.guid.clone(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(ctx.project_guid, project.guid);
+        assert!(ctx.workspace_guid.is_none());
+        // base_ref should be Some (the default branch from git)
+        assert!(ctx.base_ref.is_some());
+        assert_eq!(ctx.base_ref_origin, BaseRefOrigin::DefaultBranchFallback);
+    }
+
+    // ── S4: resolve_repo_context — both target_branch and origin/HEAD missing ─
+
+    #[tokio::test]
+    async fn s4_resolve_repo_context_hard_fail() {
+        let db = setup_db().await;
+        let tmp = tempfile::tempdir().unwrap();
+        // No git init — no remote, no default branch
+        let repo_path = tmp.path().to_string_lossy().to_string();
+
+        let project = ProjectRepo::new(&db)
+            .create("test-project".into(), repo_path, 0, None, None)
+            .await
+            .unwrap();
+
+        let service = ReviewService::new(db);
+        let result = service
+            .resolve_repo_context(&ReviewTarget::Project {
+                project_guid: project.guid,
+            })
+            .await;
+
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("target branch"),
+            "error should mention target branch: {err}"
+        );
+    }
+
+    // ── S5: empty changeset returns validation error ───────────────────────────
+
+    #[tokio::test]
+    async fn s5_create_session_empty_changeset() {
+        let db = setup_db().await;
+        let bare = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+
+        // Create a bare repo to act as the remote
+        std::process::Command::new("git")
+            .args(["init", "--bare", "-b", "main"])
+            .current_dir(bare.path())
+            .output()
+            .ok();
+
+        // Clone it so we have a proper remote
+        std::process::Command::new("git")
+            .args(["clone", bare.path().to_str().unwrap(), work.path().to_str().unwrap()])
+            .output()
+            .ok();
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(work.path())
+            .output()
+            .ok();
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(work.path())
+            .output()
+            .ok();
+        // Commit and push so origin/main exists
+        std::fs::write(work.path().join("README.md"), "test").unwrap();
+        std::process::Command::new("git")
+            .args(["add", "."])
+            .current_dir(work.path())
+            .output()
+            .ok();
+        std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(work.path())
+            .output()
+            .ok();
+        std::process::Command::new("git")
+            .args(["push", "-u", "origin", "main"])
+            .current_dir(work.path())
+            .output()
+            .ok();
+
+        let repo_path = work.path().to_string_lossy().to_string();
+        let project = ProjectRepo::new(&db)
+            .create("test-project".into(), repo_path, 0, None, Some("main".into()))
+            .await
+            .unwrap();
+
+        let service = ReviewService::new(db);
+        let result = service
+            .create_session(CreateReviewSessionInput {
+                target: ReviewTarget::Project {
+                    project_guid: project.guid,
+                },
+                title: None,
+                created_by: None,
+            })
+            .await;
+
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("no changed files"),
+            "error should mention no changed files: {err}"
+        );
+    }
+
+    // ── S7: list_sessions_by_project returns only project-scoped sessions ─────
+
+    #[tokio::test]
+    async fn s7_list_sessions_by_project_excludes_workspace_sessions() {
+        let db = setup_db().await;
+        let review_repo = ReviewRepo::new(&db);
+
+        let project_guid = uuid::Uuid::new_v4().to_string();
+        let workspace_guid = uuid::Uuid::new_v4().to_string();
+
+        // Create a project-scoped session (workspace_guid = None)
+        let project_session = review_repo
+            .create_session(
+                None,
+                None, // project-scoped
+                project_guid.clone(),
+                "/tmp/repo".into(),
+                "/tmp/storage".into(),
+                Some("main".into()),
+                None,
+                "HEAD".into(),
+                uuid::Uuid::new_v4().to_string(),
+                "active".into(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Create a workspace-scoped session (workspace_guid = Some)
+        review_repo
+            .create_session(
+                None,
+                Some(workspace_guid.clone()),
+                project_guid.clone(),
+                "/tmp/worktree".into(),
+                "/tmp/storage2".into(),
+                Some("main".into()),
+                None,
+                "HEAD".into(),
+                uuid::Uuid::new_v4().to_string(),
+                "active".into(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let sessions = review_repo
+            .list_sessions_by_project(&project_guid, false)
+            .await
+            .unwrap();
+
+        assert_eq!(sessions.len(), 1, "should return exactly one project-scoped session");
+        assert_eq!(sessions[0].guid, project_session.guid);
+        assert!(sessions[0].workspace_guid.is_none());
+    }
+
+    // ── S8: workspace flow unchanged ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn s8_workspace_session_has_workspace_guid() {
+        let db = setup_db().await;
+        let review_repo = ReviewRepo::new(&db);
+
+        let project_guid = uuid::Uuid::new_v4().to_string();
+        let workspace_guid = uuid::Uuid::new_v4().to_string();
+
+        let session = review_repo
+            .create_session(
+                None,
+                Some(workspace_guid.clone()),
+                project_guid.clone(),
+                "/tmp/worktree".into(),
+                "/tmp/storage".into(),
+                Some("feature".into()),
+                None,
+                "HEAD".into(),
+                uuid::Uuid::new_v4().to_string(),
+                "active".into(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(session.workspace_guid, Some(workspace_guid.clone()));
+        assert_eq!(session.project_guid, project_guid);
+
+        let sessions = review_repo
+            .list_sessions_by_workspace(&workspace_guid, false)
+            .await
+            .unwrap();
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].guid, session.guid);
+    }
+
+    // ── S9: coexistence — project + workspace sessions are independent ─────────
+
+    #[tokio::test]
+    async fn s9_project_and_workspace_sessions_coexist() {
+        let db = setup_db().await;
+        let review_repo = ReviewRepo::new(&db);
+
+        let project_guid = uuid::Uuid::new_v4().to_string();
+        let workspace_guid = uuid::Uuid::new_v4().to_string();
+
+        // Project-scoped session
+        let project_session = review_repo
+            .create_session(
+                None,
+                None,
+                project_guid.clone(),
+                "/tmp/repo".into(),
+                "/tmp/storage-p".into(),
+                Some("main".into()),
+                None,
+                "HEAD".into(),
+                uuid::Uuid::new_v4().to_string(),
+                "active".into(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Workspace-scoped session
+        let workspace_session = review_repo
+            .create_session(
+                None,
+                Some(workspace_guid.clone()),
+                project_guid.clone(),
+                "/tmp/worktree".into(),
+                "/tmp/storage-w".into(),
+                Some("feature".into()),
+                None,
+                "HEAD".into(),
+                uuid::Uuid::new_v4().to_string(),
+                "active".into(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // list_sessions_by_project returns only the project session
+        let project_sessions = review_repo
+            .list_sessions_by_project(&project_guid, false)
+            .await
+            .unwrap();
+        assert_eq!(project_sessions.len(), 1);
+        assert_eq!(project_sessions[0].guid, project_session.guid);
+
+        // list_sessions_by_workspace returns only the workspace session
+        let workspace_sessions = review_repo
+            .list_sessions_by_workspace(&workspace_guid, false)
+            .await
+            .unwrap();
+        assert_eq!(workspace_sessions.len(), 1);
+        assert_eq!(workspace_sessions[0].guid, workspace_session.guid);
+    }
 }

--- a/crates/core-service/src/service/review.rs
+++ b/crates/core-service/src/service/review.rs
@@ -563,7 +563,7 @@ impl ReviewService {
                 ctx.project_guid.clone(),
                 ctx.repo_path.to_string_lossy().to_string(),
                 session_storage_root,
-                changed.compare_ref.clone(),
+                ctx.base_ref.clone().or_else(|| changed.compare_ref.clone()),
                 None,
                 head_commit.clone(),
                 revision_guid.clone(),
@@ -2779,6 +2779,18 @@ mod tests {
         infra::Migrator::up(&db, None).await.unwrap();
         Arc::new(db)
     }
+
+    fn run_cmd_assert_success(cmd: &mut std::process::Command) {
+        let output = cmd.output().expect("Command failed to execute");
+        assert!(
+            output.status.success(),
+            "Command failed with status {}: stdout: {}, stderr: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
     // ── S2: resolve_repo_context — project with target_branch set ─────────────
 
     #[tokio::test]
@@ -2788,11 +2800,11 @@ mod tests {
         let repo_path = tmp.path().to_string_lossy().to_string();
 
         // Init a bare git repo so GitEngine doesn't fail on get_default_branch
-        std::process::Command::new("git")
-            .args(["init", "-b", "main"])
-            .current_dir(tmp.path())
-            .output()
-            .ok();
+        run_cmd_assert_success(
+            &mut std::process::Command::new("git")
+                .args(["init", "-b", "main"])
+                .current_dir(tmp.path()),
+        );
 
         let project = ProjectRepo::new(&db)
             .create(
@@ -2827,33 +2839,33 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
 
         // Init a git repo with a commit so origin/HEAD can be resolved locally
-        std::process::Command::new("git")
-            .args(["init", "-b", "main"])
-            .current_dir(tmp.path())
-            .output()
-            .ok();
-        std::process::Command::new("git")
-            .args(["config", "user.email", "test@test.com"])
-            .current_dir(tmp.path())
-            .output()
-            .ok();
-        std::process::Command::new("git")
-            .args(["config", "user.name", "Test"])
-            .current_dir(tmp.path())
-            .output()
-            .ok();
+        run_cmd_assert_success(
+            &mut std::process::Command::new("git")
+                .args(["init", "-b", "main"])
+                .current_dir(tmp.path()),
+        );
+        run_cmd_assert_success(
+            &mut std::process::Command::new("git")
+                .args(["config", "user.email", "test@test.com"])
+                .current_dir(tmp.path()),
+        );
+        run_cmd_assert_success(
+            &mut std::process::Command::new("git")
+                .args(["config", "user.name", "Test"])
+                .current_dir(tmp.path()),
+        );
         // Create a file and commit so HEAD exists
         std::fs::write(tmp.path().join("README.md"), "test").unwrap();
-        std::process::Command::new("git")
-            .args(["add", "."])
-            .current_dir(tmp.path())
-            .output()
-            .ok();
-        std::process::Command::new("git")
-            .args(["commit", "-m", "init"])
-            .current_dir(tmp.path())
-            .output()
-            .ok();
+        run_cmd_assert_success(
+            &mut std::process::Command::new("git")
+                .args(["add", "."])
+                .current_dir(tmp.path()),
+        );
+        run_cmd_assert_success(
+            &mut std::process::Command::new("git")
+                .args(["commit", "-m", "init"])
+                .current_dir(tmp.path()),
+        );
 
         let repo_path = tmp.path().to_string_lossy().to_string();
         let project = ProjectRepo::new(&db)
@@ -2921,44 +2933,44 @@ mod tests {
         let work = tempfile::tempdir().unwrap();
 
         // Create a bare repo to act as the remote
-        std::process::Command::new("git")
-            .args(["init", "--bare", "-b", "main"])
-            .current_dir(bare.path())
-            .output()
-            .ok();
+        run_cmd_assert_success(
+            &mut std::process::Command::new("git")
+                .args(["init", "--bare", "-b", "main"])
+                .current_dir(bare.path()),
+        );
 
         // Clone it so we have a proper remote
-        std::process::Command::new("git")
-            .args(["clone", bare.path().to_str().unwrap(), work.path().to_str().unwrap()])
-            .output()
-            .ok();
-        std::process::Command::new("git")
-            .args(["config", "user.email", "test@test.com"])
-            .current_dir(work.path())
-            .output()
-            .ok();
-        std::process::Command::new("git")
-            .args(["config", "user.name", "Test"])
-            .current_dir(work.path())
-            .output()
-            .ok();
+        run_cmd_assert_success(
+            &mut std::process::Command::new("git")
+                .args(["clone", bare.path().to_str().unwrap(), work.path().to_str().unwrap()]),
+        );
+        run_cmd_assert_success(
+            &mut std::process::Command::new("git")
+                .args(["config", "user.email", "test@test.com"])
+                .current_dir(work.path()),
+        );
+        run_cmd_assert_success(
+            &mut std::process::Command::new("git")
+                .args(["config", "user.name", "Test"])
+                .current_dir(work.path()),
+        );
         // Commit and push so origin/main exists
         std::fs::write(work.path().join("README.md"), "test").unwrap();
-        std::process::Command::new("git")
-            .args(["add", "."])
-            .current_dir(work.path())
-            .output()
-            .ok();
-        std::process::Command::new("git")
-            .args(["commit", "-m", "init"])
-            .current_dir(work.path())
-            .output()
-            .ok();
-        std::process::Command::new("git")
-            .args(["push", "-u", "origin", "main"])
-            .current_dir(work.path())
-            .output()
-            .ok();
+        run_cmd_assert_success(
+            &mut std::process::Command::new("git")
+                .args(["add", "."])
+                .current_dir(work.path()),
+        );
+        run_cmd_assert_success(
+            &mut std::process::Command::new("git")
+                .args(["commit", "-m", "init"])
+                .current_dir(work.path()),
+        );
+        run_cmd_assert_success(
+            &mut std::process::Command::new("git")
+                .args(["push", "-u", "origin", "main"])
+                .current_dir(work.path()),
+        );
 
         let repo_path = work.path().to_string_lossy().to_string();
         let project = ProjectRepo::new(&db)

--- a/crates/core-service/src/service/review.rs
+++ b/crates/core-service/src/service/review.rs
@@ -2069,12 +2069,10 @@ impl ReviewService {
                 .ok_or_else(|| {
                     ServiceError::NotFound(format!("Review session {} not found", run.session_guid))
                 })?;
-            // Use session.repo_path as the source of truth for the working tree.
-            // Fall back to workspace worktree resolution only for legacy rows where
-            // repo_path is empty (should not occur for sessions created after APP-013).
-            let workspace_root = if !session.repo_path.is_empty() {
-                std::path::PathBuf::from(&session.repo_path)
-            } else if let Some(ref ws_guid) = session.workspace_guid {
+            // For workspace-scoped sessions, always resolve the workspace worktree
+            // to ensure legacy sessions use the correct path. For project-scoped
+            // sessions (workspace_guid is None), use session.repo_path.
+            let workspace_root = if let Some(ref ws_guid) = session.workspace_guid {
                 let workspace = WorkspaceRepo::new(&self.db)
                     .find_by_guid(ws_guid)
                     .await?
@@ -2084,6 +2082,8 @@ impl ReviewService {
                 self.git_engine
                     .get_worktree_path(&workspace.name)
                     .map_err(ServiceError::Engine)?
+            } else if !session.repo_path.is_empty() {
+                std::path::PathBuf::from(&session.repo_path)
             } else {
                 return Err(ServiceError::Processing(
                     "Review session has no repo_path and no workspace_guid".to_string(),

--- a/crates/core-service/src/service/ws_message.rs
+++ b/crates/core-service/src/service/ws_message.rs
@@ -4547,6 +4547,16 @@ set -x
         workspace_guid: Option<String>,
         project_guid: Option<String>,
     ) -> Result<ReviewTarget> {
+        // Normalize inputs: trim whitespace and treat empty strings as None
+        let workspace_guid = workspace_guid.and_then(|s| {
+            let trimmed = s.trim();
+            if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
+        });
+        let project_guid = project_guid.and_then(|s| {
+            let trimmed = s.trim();
+            if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
+        });
+
         match (workspace_guid, project_guid) {
             (Some(w), None) => Ok(ReviewTarget::Workspace { workspace_guid: w }),
             (None, Some(p)) => Ok(ReviewTarget::Project { project_guid: p }),

--- a/crates/core-service/src/service/ws_message.rs
+++ b/crates/core-service/src/service/ws_message.rs
@@ -77,8 +77,9 @@ use crate::error::{Result, ServiceError};
 use crate::service::git_commit_message::GitCommitMessageGenerator;
 use crate::service::review::{
     AddReviewMessageInput, CreateReviewAgentRunInput, CreateReviewCommentInput,
-    CreateReviewSessionInput, DeleteReviewMessageInput, ReviewAnchor, SetReviewAgentRunStatusInput,
-    SetReviewFileReviewedInput, UpdateReviewCommentStatusInput, UpdateReviewMessageInput,
+    CreateReviewSessionInput, DeleteReviewMessageInput, ReviewAnchor, ReviewTarget,
+    SetReviewAgentRunStatusInput, SetReviewFileReviewedInput, UpdateReviewCommentStatusInput,
+    UpdateReviewMessageInput,
 };
 use crate::{
     AgentService, AgentSessionService, ProjectService, ReviewService, TerminalService,
@@ -4542,11 +4543,36 @@ set -x
         Ok(json!({ "ok": true }))
     }
 
+    fn parse_target(
+        workspace_guid: Option<String>,
+        project_guid: Option<String>,
+    ) -> Result<ReviewTarget> {
+        match (workspace_guid, project_guid) {
+            (Some(w), None) => Ok(ReviewTarget::Workspace { workspace_guid: w }),
+            (None, Some(p)) => Ok(ReviewTarget::Project { project_guid: p }),
+            (Some(_), Some(_)) => Err(ServiceError::Validation(
+                "Specify exactly one of workspace_guid or project_guid".to_string(),
+            )),
+            (None, None) => Err(ServiceError::Validation(
+                "workspace_guid or project_guid is required".to_string(),
+            )),
+        }
+    }
+
     async fn handle_review_session_list(&self, req: ReviewSessionListRequest) -> Result<Value> {
-        let sessions = self
-            .review_service
-            .list_sessions_by_workspace(req.workspace_guid, req.include_archived)
-            .await?;
+        let target = Self::parse_target(req.workspace_guid, req.project_guid)?;
+        let sessions = match target {
+            ReviewTarget::Workspace { workspace_guid } => {
+                self.review_service
+                    .list_sessions_by_workspace(workspace_guid, req.include_archived)
+                    .await?
+            }
+            ReviewTarget::Project { project_guid } => {
+                self.review_service
+                    .list_sessions_by_project(project_guid, req.include_archived)
+                    .await?
+            }
+        };
         Ok(json!(sessions))
     }
 
@@ -4556,10 +4582,11 @@ set -x
     }
 
     async fn handle_review_session_create(&self, req: ReviewSessionCreateRequest) -> Result<Value> {
+        let target = Self::parse_target(req.workspace_guid, req.project_guid)?;
         let session = self
             .review_service
             .create_session(CreateReviewSessionInput {
-                workspace_guid: req.workspace_guid,
+                target,
                 title: req.title,
                 created_by: req.created_by,
             })
@@ -5504,5 +5531,45 @@ impl WsMessageHandler for WsMessageService {
 
     async fn on_disconnect(&self, conn_id: &str) {
         tracing::info!("[WsMessageService] Client disconnected: {}", conn_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::review::ReviewTarget;
+
+    // ── S10: parse_target unit tests ──────────────────────────────────────────
+
+    #[test]
+    fn s10_parse_target_workspace_only() {
+        let result = WsMessageService::parse_target(Some("ws-1".into()), None);
+        match result.unwrap() {
+            ReviewTarget::Workspace { workspace_guid } => assert_eq!(workspace_guid, "ws-1"),
+            _ => panic!("expected Workspace variant"),
+        }
+    }
+
+    #[test]
+    fn s10_parse_target_project_only() {
+        let result = WsMessageService::parse_target(None, Some("pj-1".into()));
+        match result.unwrap() {
+            ReviewTarget::Project { project_guid } => assert_eq!(project_guid, "pj-1"),
+            _ => panic!("expected Project variant"),
+        }
+    }
+
+    #[test]
+    fn s10_parse_target_both_set_returns_error() {
+        let result = WsMessageService::parse_target(Some("ws-1".into()), Some("pj-1".into()));
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("Specify exactly one"));
+    }
+
+    #[test]
+    fn s10_parse_target_neither_set_returns_error() {
+        let result = WsMessageService::parse_target(None, None);
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("required"));
     }
 }

--- a/crates/infra/Cargo.toml
+++ b/crates/infra/Cargo.toml
@@ -20,3 +20,6 @@ sha2 = "0.10"
 hex = "0.4"
 async-trait = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/infra/src/db/entities/review_session.rs
+++ b/crates/infra/src/db/entities/review_session.rs
@@ -11,7 +11,7 @@ pub struct Model {
     pub created_at: DateTime,
     pub updated_at: DateTime,
     pub is_deleted: bool,
-    pub workspace_guid: String,
+    pub workspace_guid: Option<String>,
     pub project_guid: String,
     pub repo_path: String,
     pub storage_root_rel_path: String,

--- a/crates/infra/src/db/migration/m20260507_000023_make_review_session_workspace_optional.rs
+++ b/crates/infra/src/db/migration/m20260507_000023_make_review_session_workspace_optional.rs
@@ -1,0 +1,201 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // SQLite does not support ALTER COLUMN directly.
+        // We rebuild the table to make workspace_guid nullable.
+        let db = manager.get_connection();
+        let backend = manager.get_database_backend();
+
+        if backend == sea_orm::DatabaseBackend::Sqlite {
+            db.execute_unprepared(
+                r#"
+                CREATE TABLE "review_session_new" (
+                    "guid" TEXT NOT NULL PRIMARY KEY,
+                    "created_at" TEXT NOT NULL,
+                    "updated_at" TEXT NOT NULL,
+                    "is_deleted" BOOLEAN NOT NULL DEFAULT 0,
+                    "workspace_guid" TEXT NULL,
+                    "project_guid" TEXT NOT NULL,
+                    "repo_path" TEXT NOT NULL,
+                    "storage_root_rel_path" TEXT NOT NULL,
+                    "base_ref" TEXT NULL,
+                    "base_commit" TEXT NULL,
+                    "head_commit" TEXT NOT NULL,
+                    "current_revision_guid" TEXT NOT NULL,
+                    "status" TEXT NOT NULL,
+                    "title" TEXT NULL,
+                    "created_by" TEXT NULL,
+                    "closed_at" TEXT NULL,
+                    "archived_at" TEXT NULL
+                )
+                "#,
+            )
+            .await?;
+
+            db.execute_unprepared(
+                r#"
+                INSERT INTO "review_session_new"
+                SELECT "guid","created_at","updated_at","is_deleted","workspace_guid",
+                       "project_guid","repo_path","storage_root_rel_path","base_ref",
+                       "base_commit","head_commit","current_revision_guid","status",
+                       "title","created_by","closed_at","archived_at"
+                FROM "review_session"
+                "#,
+            )
+            .await?;
+
+            db.execute_unprepared(r#"DROP TABLE "review_session""#).await?;
+            db.execute_unprepared(r#"ALTER TABLE "review_session_new" RENAME TO "review_session""#)
+                .await?;
+        } else {
+            // Postgres
+            db.execute_unprepared(
+                r#"ALTER TABLE "review_session" ALTER COLUMN "workspace_guid" DROP NOT NULL"#,
+            )
+            .await?;
+        }
+
+        // Drop old index
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx-review_session-workspace-updated")
+                    .table(ReviewSession::Table)
+                    .to_owned(),
+            )
+            .await
+            .ok(); // ignore if it doesn't exist
+
+        // Create replacement indexes
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-review_session-workspace-status-updated")
+                    .table(ReviewSession::Table)
+                    .col(ReviewSession::WorkspaceGuid)
+                    .col(ReviewSession::Status)
+                    .col(ReviewSession::UpdatedAt)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-review_session-project-status-updated")
+                    .table(ReviewSession::Table)
+                    .col(ReviewSession::ProjectGuid)
+                    .col(ReviewSession::Status)
+                    .col(ReviewSession::UpdatedAt)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+        let backend = manager.get_database_backend();
+
+        // Drop new indexes
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx-review_session-workspace-status-updated")
+                    .table(ReviewSession::Table)
+                    .to_owned(),
+            )
+            .await
+            .ok();
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx-review_session-project-status-updated")
+                    .table(ReviewSession::Table)
+                    .to_owned(),
+            )
+            .await
+            .ok();
+
+        if backend == sea_orm::DatabaseBackend::Sqlite {
+            db.execute_unprepared(
+                r#"
+                CREATE TABLE "review_session_old" (
+                    "guid" TEXT NOT NULL PRIMARY KEY,
+                    "created_at" TEXT NOT NULL,
+                    "updated_at" TEXT NOT NULL,
+                    "is_deleted" BOOLEAN NOT NULL DEFAULT 0,
+                    "workspace_guid" TEXT NOT NULL,
+                    "project_guid" TEXT NOT NULL,
+                    "repo_path" TEXT NOT NULL,
+                    "storage_root_rel_path" TEXT NOT NULL,
+                    "base_ref" TEXT NULL,
+                    "base_commit" TEXT NULL,
+                    "head_commit" TEXT NOT NULL,
+                    "current_revision_guid" TEXT NOT NULL,
+                    "status" TEXT NOT NULL,
+                    "title" TEXT NULL,
+                    "created_by" TEXT NULL,
+                    "closed_at" TEXT NULL,
+                    "archived_at" TEXT NULL
+                )
+                "#,
+            )
+            .await?;
+
+            db.execute_unprepared(
+                r#"
+                INSERT INTO "review_session_old"
+                SELECT "guid","created_at","updated_at","is_deleted","workspace_guid",
+                       "project_guid","repo_path","storage_root_rel_path","base_ref",
+                       "base_commit","head_commit","current_revision_guid","status",
+                       "title","created_by","closed_at","archived_at"
+                FROM "review_session"
+                WHERE "workspace_guid" IS NOT NULL
+                "#,
+            )
+            .await?;
+
+            db.execute_unprepared(r#"DROP TABLE "review_session""#).await?;
+            db.execute_unprepared(r#"ALTER TABLE "review_session_old" RENAME TO "review_session""#)
+                .await?;
+        } else {
+            db.execute_unprepared(
+                r#"ALTER TABLE "review_session" ALTER COLUMN "workspace_guid" SET NOT NULL"#,
+            )
+            .await?;
+        }
+
+        // Restore original index
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-review_session-workspace-updated")
+                    .table(ReviewSession::Table)
+                    .col(ReviewSession::WorkspaceGuid)
+                    .col(ReviewSession::UpdatedAt)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Iden)]
+enum ReviewSession {
+    Table,
+    WorkspaceGuid,
+    ProjectGuid,
+    Status,
+    UpdatedAt,
+}

--- a/crates/infra/src/db/migration/m20260507_000023_make_review_session_workspace_optional.rs
+++ b/crates/infra/src/db/migration/m20260507_000023_make_review_session_workspace_optional.rs
@@ -168,6 +168,11 @@ impl MigrationTrait for Migration {
             db.execute_unprepared(r#"ALTER TABLE "review_session_old" RENAME TO "review_session""#)
                 .await?;
         } else {
+            // Prune NULL rows before making the column NOT NULL
+            db.execute_unprepared(
+                r#"DELETE FROM "review_session" WHERE "workspace_guid" IS NULL"#,
+            )
+            .await?;
             db.execute_unprepared(
                 r#"ALTER TABLE "review_session" ALTER COLUMN "workspace_guid" SET NOT NULL"#,
             )

--- a/crates/infra/src/db/migration/m20260507_000023_make_review_session_workspace_optional.rs
+++ b/crates/infra/src/db/migration/m20260507_000023_make_review_session_workspace_optional.rs
@@ -12,6 +12,9 @@ impl MigrationTrait for Migration {
         let backend = manager.get_database_backend();
 
         if backend == sea_orm::DatabaseBackend::Sqlite {
+            // Disable foreign keys to prevent cascade deletion of dependent records
+            db.execute_unprepared(r#"PRAGMA foreign_keys = OFF"#).await?;
+
             db.execute_unprepared(
                 r#"
                 CREATE TABLE "review_session_new" (
@@ -52,6 +55,9 @@ impl MigrationTrait for Migration {
             db.execute_unprepared(r#"DROP TABLE "review_session""#).await?;
             db.execute_unprepared(r#"ALTER TABLE "review_session_new" RENAME TO "review_session""#)
                 .await?;
+
+            // Re-enable foreign keys
+            db.execute_unprepared(r#"PRAGMA foreign_keys = ON"#).await?;
         } else {
             // Postgres
             db.execute_unprepared(
@@ -126,6 +132,9 @@ impl MigrationTrait for Migration {
             .ok();
 
         if backend == sea_orm::DatabaseBackend::Sqlite {
+            // Disable foreign keys to prevent cascade deletion of dependent records
+            db.execute_unprepared(r#"PRAGMA foreign_keys = OFF"#).await?;
+
             db.execute_unprepared(
                 r#"
                 CREATE TABLE "review_session_old" (
@@ -167,6 +176,9 @@ impl MigrationTrait for Migration {
             db.execute_unprepared(r#"DROP TABLE "review_session""#).await?;
             db.execute_unprepared(r#"ALTER TABLE "review_session_old" RENAME TO "review_session""#)
                 .await?;
+
+            // Re-enable foreign keys
+            db.execute_unprepared(r#"PRAGMA foreign_keys = ON"#).await?;
         } else {
             // Prune NULL rows before making the column NOT NULL
             db.execute_unprepared(

--- a/crates/infra/src/db/migration/mod.rs
+++ b/crates/infra/src/db/migration/mod.rs
@@ -28,6 +28,7 @@ mod m20260427_000018_add_workspace_github_pr;
 mod m20260428_000020_add_workspace_create_source;
 mod m20260505_000021_add_agent_run_guid_to_review_revision;
 mod m20260505_000022_add_workspace_label_source;
+mod m20260507_000023_make_review_session_workspace_optional;
 
 pub struct Migrator;
 
@@ -58,6 +59,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260428_000020_add_workspace_create_source::Migration),
             Box::new(m20260505_000021_add_agent_run_guid_to_review_revision::Migration),
             Box::new(m20260505_000022_add_workspace_label_source::Migration),
+            Box::new(m20260507_000023_make_review_session_workspace_optional::Migration),
         ]
     }
 }
@@ -273,6 +275,104 @@ mod tests {
         assert!(manager.has_column(TABLE_NAME, "mode").await?);
         assert!(manager.has_index(TABLE_NAME, MODE_CONTEXT_INDEX).await?);
         assert!(!manager.has_index(TABLE_NAME, LEGACY_CONTEXT_INDEX).await?);
+
+        Ok(())
+    }
+
+    // ── S12: migration applies on fresh and seeded DB ─────────────────────────
+
+    const REVIEW_SESSION_TABLE: &str = "review_session";
+    const OLD_WS_INDEX: &str = "idx-review_session-workspace-updated";
+    const NEW_WS_INDEX: &str = "idx-review_session-workspace-status-updated";
+    const NEW_PJ_INDEX: &str = "idx-review_session-project-status-updated";
+
+    #[tokio::test]
+    async fn s12_migration_applies_on_fresh_db() -> Result<(), DbErr> {
+        let db = Database::connect("sqlite::memory:").await?;
+        let manager = SchemaManager::new(&db);
+
+        // Apply all migrations up to and including 000022
+        m20260117_000001_create_test_message_table::Migration.up(&manager).await?;
+        m20260118_000002_create_project_tables::Migration.up(&manager).await?;
+        m20260422_000019_create_review_tables::Migration.up(&manager).await?;
+
+        // Old index should exist, new ones should not
+        assert!(manager.has_index(REVIEW_SESSION_TABLE, OLD_WS_INDEX).await?);
+        assert!(!manager.has_index(REVIEW_SESSION_TABLE, NEW_WS_INDEX).await?);
+        assert!(!manager.has_index(REVIEW_SESSION_TABLE, NEW_PJ_INDEX).await?);
+
+        // Apply the new migration
+        m20260507_000023_make_review_session_workspace_optional::Migration
+            .up(&manager)
+            .await?;
+
+        // New indexes should exist, old one should be gone
+        assert!(!manager.has_index(REVIEW_SESSION_TABLE, OLD_WS_INDEX).await?);
+        assert!(manager.has_index(REVIEW_SESSION_TABLE, NEW_WS_INDEX).await?);
+        assert!(manager.has_index(REVIEW_SESSION_TABLE, NEW_PJ_INDEX).await?);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn s12_migration_applies_on_seeded_db_preserves_existing_rows() -> Result<(), DbErr> {
+        let db = Database::connect("sqlite::memory:").await?;
+        let manager = SchemaManager::new(&db);
+
+        m20260117_000001_create_test_message_table::Migration.up(&manager).await?;
+        m20260118_000002_create_project_tables::Migration.up(&manager).await?;
+        m20260422_000019_create_review_tables::Migration.up(&manager).await?;
+
+        // Seed a row with workspace_guid set
+        db.execute(Statement::from_string(
+            DbBackend::Sqlite,
+            r#"
+            INSERT INTO "review_session" (
+                "guid","created_at","updated_at","is_deleted",
+                "workspace_guid","project_guid","repo_path","storage_root_rel_path",
+                "head_commit","current_revision_guid","status"
+            ) VALUES (
+                'sess-1','2026-01-01 00:00:00','2026-01-01 00:00:00',0,
+                'ws-1','pj-1','/tmp/repo','/tmp/storage',
+                'abc123','rev-1','active'
+            )
+            "#
+            .to_owned(),
+        ))
+        .await?;
+
+        // Apply migration
+        m20260507_000023_make_review_session_workspace_optional::Migration
+            .up(&manager)
+            .await?;
+
+        // Existing row should be preserved
+        let row = db
+            .query_one(Statement::from_string(
+                DbBackend::Sqlite,
+                r#"SELECT "workspace_guid","project_guid" FROM "review_session" WHERE "guid"='sess-1'"#
+                    .to_owned(),
+            ))
+            .await?
+            .expect("seeded row should still exist");
+
+        let ws_guid: Option<String> = row.try_get("", "workspace_guid")?;
+        let pj_guid: String = row.try_get("", "project_guid")?;
+        assert_eq!(ws_guid, Some("ws-1".to_string()));
+        assert_eq!(pj_guid, "pj-1");
+
+        // down() should work without error
+        m20260507_000023_make_review_session_workspace_optional::Migration
+            .down(&manager)
+            .await?;
+
+        // up() again should be idempotent
+        m20260507_000023_make_review_session_workspace_optional::Migration
+            .up(&manager)
+            .await?;
+
+        assert!(manager.has_index(REVIEW_SESSION_TABLE, NEW_WS_INDEX).await?);
+        assert!(manager.has_index(REVIEW_SESSION_TABLE, NEW_PJ_INDEX).await?);
 
         Ok(())
     }

--- a/crates/infra/src/db/repo/review_repo.rs
+++ b/crates/infra/src/db/repo/review_repo.rs
@@ -31,7 +31,7 @@ impl<'a> ReviewRepo<'a> {
     pub async fn create_session(
         &self,
         guid: Option<String>,
-        workspace_guid: String,
+        workspace_guid: Option<String>,
         project_guid: String,
         repo_path: String,
         storage_root_rel_path: String,
@@ -83,6 +83,24 @@ impl<'a> ReviewRepo<'a> {
     ) -> Result<Vec<review_session::Model>> {
         let mut query = review_session::Entity::find()
             .filter(review_session::Column::WorkspaceGuid.eq(workspace_guid))
+            .filter(review_session::Column::IsDeleted.eq(false));
+        if !include_archived {
+            query = query.filter(review_session::Column::Status.ne("archived"));
+        }
+        Ok(query
+            .order_by_desc(review_session::Column::UpdatedAt)
+            .all(self.db)
+            .await?)
+    }
+
+    pub async fn list_sessions_by_project(
+        &self,
+        project_guid: &str,
+        include_archived: bool,
+    ) -> Result<Vec<review_session::Model>> {
+        let mut query = review_session::Entity::find()
+            .filter(review_session::Column::ProjectGuid.eq(project_guid))
+            .filter(review_session::Column::WorkspaceGuid.is_null())
             .filter(review_session::Column::IsDeleted.eq(false));
         if !include_archived {
             query = query.filter(review_session::Column::Status.ne("archived"));

--- a/crates/infra/src/websocket/message.rs
+++ b/crates/infra/src/websocket/message.rs
@@ -577,7 +577,10 @@ pub struct WorkspaceDeleteProgressNotification {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReviewSessionListRequest {
-    pub workspace_guid: String,
+    #[serde(default)]
+    pub workspace_guid: Option<String>,
+    #[serde(default)]
+    pub project_guid: Option<String>,
     #[serde(default)]
     pub include_archived: bool,
 }
@@ -589,7 +592,10 @@ pub struct ReviewSessionGetRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReviewSessionCreateRequest {
-    pub workspace_guid: String,
+    #[serde(default)]
+    pub workspace_guid: Option<String>,
+    #[serde(default)]
+    pub project_guid: Option<String>,
     #[serde(default)]
     pub title: Option<String>,
     #[serde(default)]

--- a/specs/APP/APP-013_project-level-review-session/BRAINSTORM.md
+++ b/specs/APP/APP-013_project-level-review-session/BRAINSTORM.md
@@ -1,0 +1,108 @@
+# Brainstorm · APP-013: Project-Level Review Session
+
+> Problem space and exploration. Settled content graduates to PRD.md; committed architecture graduates to TECH.md.
+
+## Context
+
+Today the right sidebar's **Review** tab only renders when a Workspace is selected. The `ReviewContextProvider` requires a `workspaceId`, and `core-service::review::create_session` strictly resolves the repo path through `workspace_repo + git_engine.get_worktree_path(workspace.name)`.
+
+In practice, a non-trivial slice of Atmos users **work directly on a Project** (its `main_file_path` is a real git repo, often on `main`/`master`) and never spawn a workspace/worktree. For those users the Review tab is dead — they have no way to start a review session, leave inline comments, or trigger an AI fix run on changes they made on the project's main checkout.
+
+The data layer already half-anticipates this: `review_session` stores both `workspace_guid` and `project_guid`, plus `repo_path` (decoupled from worktree resolution). What's missing is making `workspace_guid` optional and teaching the service / WS / web layers to operate in a "project-only" mode.
+
+## Goals (draft)
+
+- **Primary**: a user working directly on a Project (no workspace) can create, view, comment on, and AI-fix a review session for the Project's main checkout, end-to-end through the same right-sidebar UI as today.
+- **Secondary**: keep the existing workspace-scoped flow 100% backward compatible — no behavior change for current users.
+- **Non-goal (this round)**: cross-workspace aggregated review (one session that diffs N workspaces). That's a separate future feature.
+
+## Options
+
+### Option A — `scope` enum on session (preferred shape)
+
+Add a logical `scope` to `review_session`: `Project` or `Workspace`. Storage-wise: make `workspace_guid` nullable; rely on `project_guid` (always set) plus `workspace_guid IS NULL` to mean "project scope". Service exposes a unified `create_session(scope: ReviewScope)`; WS messages carry `scope: { Project { project_guid } | Workspace { workspace_guid } }`.
+
+**Pros**
+- One code path for both modes after the scope is resolved into `(repo_path, base_ref, project_guid, workspace_guid?)`.
+- Cheap migration (nullability change + index tweak).
+- Obvious extension point if "aggregated" scope ever lands.
+
+**Cons**
+- Touches every WS message that takes `workspace_guid` today (≈12 messages). Lots of grep-and-replace.
+- Frontend `ReviewContextProvider` needs a `scope` prop instead of `workspaceId`, rippling into `useReviewContext`, `ReviewActions`, `ReviewView`.
+
+**Unknown**
+- Whether all downstream consumers (e.g. `CodeReviewDialog` auto-create flow, agent fix runs) cleanly accept "no workspace".
+
+### Option B — separate `project_review_session` table
+
+Mirror the full `review_*` schema for project scope, keep current tables untouched.
+
+**Pros**
+- Zero risk to existing workspace flow.
+- Clean conceptual split.
+
+**Cons**
+- Doubles repos, services, WS messages, frontend hooks. Maintenance nightmare.
+- Forces UI to merge two streams to show "all reviews for this project".
+
+**Unknown**
+- Whether the duplication is bounded enough to be worth the safety.
+
+### Option C — synthesize a pseudo-workspace for the project
+
+Auto-create a hidden `workspace` row pointing at `project.main_file_path` whenever a project session is requested.
+
+**Pros**
+- Smallest service-layer change.
+- WS protocol untouched.
+
+**Cons**
+- Pollutes workspace listings, terminal panes, agent chat, etc., with a phantom workspace. Almost certainly leaks into UI somewhere.
+- Inverts the data model: a workspace is supposed to *be* a worktree branch; pretending the main checkout is one breaks invariants in `core-engine/git`.
+
+**Unknown**
+- How many places assume `workspace.branch != project default branch`.
+
+## Key forks in the road
+
+- **Fork 1 — Schema shape**: Option A (nullable `workspace_guid` + scope-by-presence) vs explicit `scope_type` column vs Option B (separate tables). **Still open — decide in TECH.**
+- **Fork 2 — `base_ref` source for project sessions**: ✅ **Resolved (revised)**: prefer `project.target_branch` (auto-set on project creation; topbar disallows clearing). For legacy projects where it is `NULL`, fall back to the repository's default branch (`origin/HEAD`) with a logged warning. Only fail loudly if both resolutions yield nothing.
+- **Fork 3 — Coexistence semantics**: ✅ **Resolved**: a project may have 1 active project-scoped session AND any number of active workspace-scoped sessions simultaneously. They are independent; isolation is at the `repo_path` level (project session works on `project.main_file_path`, workspace sessions work on their own worktree paths).
+- **Fork 4 — Right-sidebar UX on project routes**: ✅ **Resolved**: project-route Review tab shows only the project's own session. Aggregated roll-up of workspace sessions is out of scope for this round.
+- **Fork 5 — Entry from workspace route**: ✅ **Resolved**: no cross-view hint. Workspace Review tab stays exactly as it is today; project session is invisible from there.
+
+## Open questions
+
+- [ ] AI fix run write-back: ✅ resolved per Fork 3 — write directly back to the current branch on the project's working tree, identical to workspace session behavior. (No protected-branch guard added in this round; user owns the risk of running fixes on `main`.)
+- [x] "Changes" definition: same as workspace flow — diff = `staged + unstaged + untracked` against `base_ref` (`project.target_branch`). Empty changeset → same `Cannot create a review session with no changed files` error as today.
+- [ ] Authorization: assume project-scoped sessions are visible to anyone who can see the project (parity with current workspace-session visibility). Confirm during PRD.
+- [ ] Telemetry: add a `scope` dimension to existing review-session events (`workspace` | `project`). Decide in TECH.
+- [ ] UI naming: keep "Review Session" everywhere; disambiguate via context (project route vs workspace route) and the existing session header. Re-examine if user testing shows confusion.
+
+## References
+
+- Backend
+  - [`crates/infra/src/db/entities/review_session.rs`](../../../crates/infra/src/db/entities/review_session.rs) — already stores `project_guid` + `repo_path`.
+  - [`crates/infra/src/db/migration/m20260422_000019_create_review_tables.rs`](../../../crates/infra/src/db/migration/m20260422_000019_create_review_tables.rs) — current `workspace_guid NOT NULL` + workspace-keyed indexes.
+  - [`crates/core-service/src/service/review.rs`](../../../crates/core-service/src/service/review.rs) `create_session` (lines ~405–460) — workspace-only resolution.
+  - [`crates/core-service/src/service/ws_message.rs`](../../../crates/core-service/src/service/ws_message.rs) lines ~302–342 — review WS message catalog.
+- Frontend
+  - [`apps/web/src/components/diff/review/ReviewContextProvider.tsx`](../../../apps/web/src/components/diff/review/ReviewContextProvider.tsx)
+  - [`apps/web/src/components/diff/ReviewView.tsx`](../../../apps/web/src/components/diff/ReviewView.tsx)
+  - [`apps/web/src/components/layout/RightSidebar.tsx`](../../../apps/web/src/components/layout/RightSidebar.tsx) lines ~690–713 — current Review tab wiring.
+  - [`apps/web/src/components/code-review/CodeReviewDialog.tsx`](../../../apps/web/src/components/code-review/CodeReviewDialog.tsx) — auto-creates a session, will need scope awareness.
+- Related entity: [`crates/infra/src/db/entities/project.rs`](../../../crates/infra/src/db/entities/project.rs) — `main_file_path`, `target_branch`.
+- Related specs: none yet.
+
+## Ready to promote
+
+- **Promote to PRD**:
+  - Primary user story: "as a user developing on the Project's main checkout, I can start a review session, comment on my own diff, and trigger an AI fix run, all from the right-sidebar Review tab on a project route."
+  - Backward-compat constraint: workspace flow unchanged.
+  - Resolve Forks 2, 3, 4, 5 as product decisions.
+- **Promote to TECH**:
+  - Option A (nullable `workspace_guid`) as the working baseline; document migration + index changes.
+  - Scope abstraction at the service boundary: `resolve_repo_context(scope) -> RepoContext`.
+  - WS message scope shape: `ReviewTarget = Project { guid } | Workspace { guid }`.
+  - Frontend: `ReviewContextProvider` accepts `scope` instead of `workspaceId`; `RightSidebar` decides scope from URL params.

--- a/specs/APP/APP-013_project-level-review-session/PRD.md
+++ b/specs/APP/APP-013_project-level-review-session/PRD.md
@@ -1,0 +1,85 @@
+# PRD · APP-013: Project-Level Review Session
+
+> Product Requirements · WHAT and WHY. Settled direction for letting users start a Review Session against a Project's main checkout — not just inside a Workspace.
+
+## Context
+
+- **Problem**: today the right-sidebar **Review** tab only works when a Workspace is selected. Users who develop directly on the Project's main checkout (no worktree, just `main`/`master` in `project.main_file_path`) cannot create a review session, leave inline comments, or trigger an AI fix run on their own diff. The Review tab simply renders a "no context" empty state.
+- **Why now**: a meaningful slice of Atmos users skip workspaces and work straight on the project repo. The data model already half-anticipates this — `review_session` stores both `project_guid` and the concrete `repo_path` — so unlocking this scope is incremental, not a redesign.
+- **Related specs**: none directly. Builds on the existing review-session feature shipped under `crates/core-service::service::review` (no formal APP-NNN entry).
+
+## Goals
+
+1. **Primary** — A user on a Project route, with no workspace selected, can create, view, comment on, and AI-fix a review session for the Project's main checkout, end-to-end through the same right-sidebar Review tab as today.
+2. **Secondary** — Zero behavior change for the existing workspace-scoped flow. Existing review sessions, comments, and AI fix runs continue to work exactly as before.
+
+Non-goals are listed in **Out of Scope** below.
+
+## Users & Scenarios
+
+- **Primary persona**: the **Solo Project Developer** — a user who treats a Project as their working repo, edits files on its current branch (often `main`), and never spawns a workspace/worktree.
+- **Secondary persona**: the **Workspace Owner** — unaffected by this change, but should observe no regression.
+
+### Key scenarios
+
+1. **Start a project review.** A solo developer makes changes on the project's main checkout, opens the right sidebar's Review tab on the project route, and clicks "New Review Session". A session is created against `project.target_branch`, listing all changed files.
+2. **Comment & fix.** They expand a changed file in the Review tab, leave inline comments, and trigger an AI fix run. The fix run rewrites the working tree on the project's current branch — same behavior as the workspace flow.
+3. **Coexist with workspace sessions.** While a project session is active, a teammate can independently start a workspace-scoped session in the same project; the two sessions are isolated and do not interfere.
+4. **Misconfiguration error path.** A user tries to start a project session, but the project has no `target_branch` set. The UI surfaces a clear validation error pointing them at the project's settings to configure a target branch.
+
+## User Stories
+
+- As a solo project developer, I want to start a Review Session directly from the project route, so that I can self-review changes on `main` before committing.
+- As a solo project developer, I want to leave inline comments and trigger an AI fix run on my project-level diff, so that I get the same review tooling I'd get inside a workspace.
+- As a workspace owner, I want my existing review sessions to keep working unchanged, so that adopting this feature carries no risk for my flow.
+- As a project member, I want to see only the project-scoped session on the project route (not a roll-up of workspace sessions), so that the Review tab stays focused on my current scope.
+
+## Functional Requirements
+
+### Must Have
+
+- **M1 — Create project session**: From the right-sidebar Review tab on a project route (no workspace selected), the user can create a review session scoped to the Project. The session uses `project.main_file_path` as `repo_path` and `project.target_branch` as `base_ref`.
+- **M2 — Resolve `base_ref` with safe fallback**: session creation uses `project.target_branch` as `base_ref`. In normal operation `target_branch` is auto-set on project creation (`git_engine.get_default_branch`) and the topbar UI does not allow clearing it, so it is effectively always present. For the rare legacy/edge case where `target_branch` is `NULL` (older projects whose lazy-init never fired), fall back to the repository's default branch (`origin/HEAD`) and log a warning. If even that resolution fails, surface a user-facing error with a CTA to configure target branch from the topbar.
+- **M3 — Empty-changeset behavior**: If the project's working tree has no `staged + unstaged + untracked` changes vs `base_ref`, creation fails with the same "no changed files" error already used by the workspace flow.
+- **M4 — Full review surface for project sessions**: project-scoped sessions support the same operations as workspace sessions: list/get session, list revisions, browse changed files, mark files reviewed, list/create/update review comments, add/edit/delete review messages, list/create/finalize agent fix runs, read run artifacts.
+- **M5 — Session listing on project route**: the project route's Review tab lists only the project's own active session (or shows the empty/onboarding state). Workspace sessions in the same project are not displayed here.
+- **M6 — Workspace flow unchanged**: on a workspace route, the Review tab behaves exactly as it does today. No new entries, no cross-scope hints, no schema changes visible to the user.
+- **M7 — Coexistence**: a project may have one active project-scoped session AND any number of active workspace-scoped sessions simultaneously. The two scopes are independent — actions on one never block or mutate the other.
+- **M8 — AI fix write-back parity**: AI fix runs for a project session write back to the project's current branch on the working tree, identical to how workspace-session fix runs write to the worktree's branch.
+
+### Nice to Have
+
+- **N1 — Pre-create branch hint**: when starting a project session on a protected-looking branch (`main`, `master`), surface an informational banner reminding the user that AI fix runs will modify the current branch.
+- **N2 — Session header scope label**: in the session header, render a small "Project" / "Workspace" badge so the user can tell at a glance which scope a session belongs to.
+- **N3 — Empty-state CTA on workspace route**: if the user lands on a project route by mistake while expecting a workspace session, no extra plumbing — but reuse existing copy patterns to make the empty state self-explanatory.
+
+## Out of Scope
+
+- **Aggregated project view** — a single Review tab showing project session **plus** a read-only roll-up of all workspace sessions under that project. Deferred to a future spec.
+- **Cross-scope hints** — surfacing "this project has a project-level session in progress" inside a workspace's Review tab. Explicitly excluded to avoid noise.
+- **Protected-branch guard / dry-run mode** — automatically blocking AI fix runs from writing to `main`, or running them in a "stash + propose patch" mode. Out of scope; users own the risk on the branch they chose.
+- **Cross-workspace review** — one session that diffs N workspaces. Separate problem; will need its own brainstorm.
+- **Project session for non-git project paths** — projects whose `main_file_path` is not a git repository. Same precondition as the workspace flow today.
+- **Renaming the feature** — the surface stays "Review Session" everywhere; no new "Project Review" / "Workspace Review" naming.
+
+## Success Metrics
+
+- **Leading** — within 30 days of release, ≥ X% of projects (X TBD against current usage data) have at least one project-scoped session created.
+- **Lagging** — number of comments and AI fix runs originating from project-scoped sessions trends up week-over-week for the first 6 weeks; workspace-scoped session activity stays flat or grows (no cannibalization).
+- **Qualitative** — at least 3 users from the Solo Project Developer persona confirm the flow matches their expectations without prompting; zero regression reports against the workspace flow in the first 2 weeks.
+
+## Risks & Open Questions
+
+- **Risk — habit inertia**: solo developers who currently work around the gap by spinning up a throwaway workspace may not discover the new project-scope entry. Mitigation: empty-state copy on the project route Review tab should explicitly invite them.
+- **Risk — `main` branch surprise**: AI fix runs writing to `main` is intentional but may surprise users. Mitigation candidate: N1 banner.
+- **Risk — legacy `target_branch=NULL` projects**: in practice `target_branch` is auto-set on project creation and the topbar UI prevents clearing it, but older project rows may still have NULL. M2's fallback to `origin/HEAD` keeps the flow alive; only when both are missing do we fail loudly.
+- **Open (defer to TECH)** — Schema shape for scope: nullable `workspace_guid` + scope-by-presence vs explicit `scope_type` column. BRAINSTORM Fork 1.
+- **Open (defer to TECH)** — How to slice the WS message protocol changes (new `scope` field on existing messages vs net-new project-scoped messages) while keeping backward compatibility.
+- **Open (defer to TECH)** — Telemetry: add a `scope` dimension (`workspace` | `project`) to existing review-session events.
+
+## Milestones
+
+Single-shot release. All Must Have items (M1–M8) and the chosen Nice to Have items ship together; no phased rollout.
+
+- **Single phase — full feature**: backend (`infra` migration + `core-service::review` scope abstraction + WS protocol scope field) and frontend (`ReviewContextProvider` scope-aware, `RightSidebar` wiring, `ReviewView` / `ReviewActions` parity) implemented in one branch, gated by `cargo test --workspace` + `bun test` + manual end-to-end smoke on both project and workspace routes. Push only when all of the above is green.
+- **Nice to Have inclusion**: N2 (scope badge in session header) ships in the same release. N1 / N3 deferred unless explicitly upgraded later.

--- a/specs/APP/APP-013_project-level-review-session/PRD.md
+++ b/specs/APP/APP-013_project-level-review-session/PRD.md
@@ -25,7 +25,7 @@ Non-goals are listed in **Out of Scope** below.
 1. **Start a project review.** A solo developer makes changes on the project's main checkout, opens the right sidebar's Review tab on the project route, and clicks "New Review Session". A session is created against `project.target_branch`, listing all changed files.
 2. **Comment & fix.** They expand a changed file in the Review tab, leave inline comments, and trigger an AI fix run. The fix run rewrites the working tree on the project's current branch — same behavior as the workspace flow.
 3. **Coexist with workspace sessions.** While a project session is active, a teammate can independently start a workspace-scoped session in the same project; the two sessions are isolated and do not interfere.
-4. **Misconfiguration error path.** A user tries to start a project session, but the project has no `target_branch` set. The UI surfaces a clear validation error pointing them at the project's settings to configure a target branch.
+4. **Misconfiguration error path.** A user tries to start a project session, but the project has no `target_branch` set. The system falls back to the repository default branch and only surfaces an error if that fallback also fails. The error message points them at the project's settings to configure a target_branch.
 
 ## User Stories
 

--- a/specs/APP/APP-013_project-level-review-session/TECH.md
+++ b/specs/APP/APP-013_project-level-review-session/TECH.md
@@ -10,7 +10,7 @@ This doc resolves BRAINSTORM Fork 1 (schema shape) and the three "defer to TECH"
 
 ## Architecture overview
 
-```
+```text
 apps/web/components/diff/review        ← scope-aware Provider, View, Actions
         │
         ▼
@@ -256,19 +256,18 @@ No changes. All review traffic flows through the existing WS handler dispatcher 
 
 #### `apps/web/src/api/ws-api.ts`
 
-Update the typed wrappers around `review_session_list` and `review_session_create` to accept either `workspaceGuid` or `projectGuid`:
+Update the typed wrappers around `review_session_list` and `review_session_create` to accept a discriminated union for the target:
 
 ```ts
-export interface ReviewTarget {
-  workspaceGuid?: string;
-  projectGuid?: string;
-}
+export type ReviewTarget =
+  | { kind: "workspace"; workspaceId: string }
+  | { kind: "project"; projectId: string };
 
 reviewWsApi.listSessions(target: ReviewTarget, includeArchived = false)
-reviewWsApi.createSession(target: ReviewTarget, opts?: { title?: string; createdBy?: string })
+reviewWsApi.createSession(data: { target: ReviewTarget; title?: string | null; createdBy?: string | null })
 ```
 
-The runtime payload sends snake_case (`workspace_guid` / `project_guid`) per existing convention.
+The runtime payload sends snake_case (`workspace_guid` / `project_guid`) per existing convention, with the kind field determining which GUID is sent.
 
 #### `apps/web/src/hooks/use-review-context.ts`
 

--- a/specs/APP/APP-013_project-level-review-session/TECH.md
+++ b/specs/APP/APP-013_project-level-review-session/TECH.md
@@ -42,7 +42,7 @@ No external dependencies change. No new background jobs, no Redis surface.
 - **CREATE** two replacement indexes on `review_session`:
   - `idx-review_session-workspace-status-updated` on `(workspace_guid, status, updated_at)` — only useful for rows where `workspace_guid IS NOT NULL`. SQLite/Postgres both index NULLs implicitly; we accept the small cost.
   - `idx-review_session-project-status-updated` on `(project_guid, status, updated_at)` — for the new project-scoped listing.
-- **No data backfill**: every existing row already has both `workspace_guid` and `project_guid` set, so the schema change is forward-only and free of data migration. `down()` re-tightens the column to `NOT NULL` (safe because all current data is non-null).
+- **No data backfill**: every existing row already has both `workspace_guid` and `project_guid` set, so the schema change is forward-only and free of data migration. `down()` re-tightens the column to `NOT NULL` but **is NOT safe** after project-scoped sessions (`workspace_guid = NULL`) have been created — the rollback filters to `WHERE "workspace_guid" IS NOT NULL` (SQLite) or deletes NULL rows (Postgres), which would lose project-scoped session data. Rollback should only be used before any project-scoped sessions are created, or with explicit data migration to preserve those sessions.
 
 #### Entity: `crates/infra/src/db/entities/review_session.rs`
 

--- a/specs/APP/APP-013_project-level-review-session/TECH.md
+++ b/specs/APP/APP-013_project-level-review-session/TECH.md
@@ -1,0 +1,456 @@
+# TECH · APP-013: Project-Level Review Session
+
+> Technical Design · HOW. Implements PRD APP-013: Project-Level Review Session.
+
+## Scope summary
+
+Addresses every Must Have in the PRD (M1–M8) and Nice to Have N2 (scope badge in session header). N1 / N3 deferred. The work spans `crates/infra` (one schema migration + repo additions), `crates/core-service` (`review.rs` scope abstraction), `crates/infra/src/websocket/message.rs` + `crates/core-service/src/service/ws_message.rs` (WS payload reshape), and `apps/web` (`ReviewContextProvider`, `RightSidebar`, `ReviewView`, `ReviewActions`). No new REST endpoints — Atmos is WebSocket-first and the existing review surface is fully WS-based.
+
+This doc resolves BRAINSTORM Fork 1 (schema shape) and the three "defer to TECH" PRD opens (schema, WS shape, telemetry).
+
+## Architecture overview
+
+```
+apps/web/components/diff/review        ← scope-aware Provider, View, Actions
+        │
+        ▼
+apps/web/api/ws-api.ts                  ← typed wrappers over WS payloads
+        │   (WebSocket)
+        ▼
+crates/core-service/service/ws_message  ← handle_review_session_{list,create}
+        │
+        ▼
+crates/core-service/service/review      ← resolve_repo_context(target) + create/list branches
+        │
+        ▼
+crates/infra/db/repo/review_repo        ← list_sessions_by_workspace + new list_sessions_by_project
+crates/core-engine/git                  ← reused: get_default_branch, get_changed_files
+crates/infra/db/entities/review_session ← workspace_guid → Option<String>
+crates/infra/db/migration/m2026...0023  ← ALTER + index
+```
+
+No external dependencies change. No new background jobs, no Redis surface.
+
+## Module-by-module design
+
+### crates/infra
+
+#### DB migration: `m20260507_000023_make_review_session_workspace_optional.rs`
+
+- **ALTER** `review_session.workspace_guid` from `NOT NULL` to nullable.
+- **DROP** the existing index `idx-review_session-workspace-updated` (defined in [`m20260422_000019_create_review_tables.rs#L76`](../../../crates/infra/src/db/migration/m20260422_000019_create_review_tables.rs#L76)).
+- **CREATE** two replacement indexes on `review_session`:
+  - `idx-review_session-workspace-status-updated` on `(workspace_guid, status, updated_at)` — only useful for rows where `workspace_guid IS NOT NULL`. SQLite/Postgres both index NULLs implicitly; we accept the small cost.
+  - `idx-review_session-project-status-updated` on `(project_guid, status, updated_at)` — for the new project-scoped listing.
+- **No data backfill**: every existing row already has both `workspace_guid` and `project_guid` set, so the schema change is forward-only and free of data migration. `down()` re-tightens the column to `NOT NULL` (safe because all current data is non-null).
+
+#### Entity: `crates/infra/src/db/entities/review_session.rs`
+
+- Change `pub workspace_guid: String` → `pub workspace_guid: Option<String>` (line 14). All other fields untouched.
+
+#### Repo: `crates/infra/src/db/repo/review_repo.rs`
+
+- Update `create_session(...)` signature: `workspace_guid: String` → `workspace_guid: Option<String>` (line 34). Body's `workspace_guid: Set(workspace_guid)` (line 55) auto-adapts.
+- Add `list_sessions_by_project(project_guid: &str, include_archived: bool)` mirroring [`list_sessions_by_workspace`](../../../crates/infra/src/db/repo/review_repo.rs#L79-L94) but filtering on `Column::ProjectGuid` AND `Column::WorkspaceGuid IS NULL` (so project listing returns ONLY project-scoped sessions; per PRD M5 it must not roll up workspace sessions).
+
+### crates/core-engine
+
+No new capability. Reuse:
+- `GitEngine::get_default_branch(repo_path)` — for the `target_branch` legacy fallback (PRD M2).
+- `GitEngine::get_changed_files(repo_path, base_branch, false)` — same call shape as the workspace flow today; `repo_path` is just `project.main_file_path` for project scope.
+
+### crates/core-service
+
+All changes in `crates/core-service/src/service/review.rs`.
+
+#### New domain type
+
+```rust
+/// Where a review session lives.
+/// One enum, two variants — keep at the service boundary; do not leak to repo.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ReviewTarget {
+    Workspace { workspace_guid: String },
+    Project { project_guid: String },
+}
+
+/// Resolved working context for a session, regardless of scope.
+struct RepoContext {
+    project_guid: String,
+    workspace_guid: Option<String>, // None => project-scoped session
+    repo_path: String,              // absolute filesystem path of the git working tree
+    base_ref: Option<String>,       // branch name to diff against
+    base_ref_origin: BaseRefOrigin, // for telemetry / warning logs
+}
+
+enum BaseRefOrigin {
+    ProjectTargetBranch,
+    DefaultBranchFallback,
+    WorkspaceBaseBranch, // existing workspace path
+}
+```
+
+#### New helper
+
+```rust
+async fn resolve_repo_context(&self, target: &ReviewTarget) -> Result<RepoContext>;
+```
+
+- **Workspace branch**: same code path as today — `workspace_repo.find_by_guid` → `git_engine.get_worktree_path(workspace.name)` → `base_ref = workspace.base_branch`. Wrap into `RepoContext`.
+- **Project branch** (PRD M2):
+  1. `project_repo.find_by_guid(project_guid)` (404 → `ServiceError::NotFound`).
+  2. `repo_path = project.main_file_path`.
+  3. `base_ref =` first of: `project.target_branch.clone()`, `git_engine.get_default_branch(&repo_path).ok()`. Tag the origin accordingly. If both are `None`/`Err`, return `ServiceError::Validation("Project has no target branch configured. Set one from the topbar before starting a review session.")`.
+- Returned `RepoContext` is the only thing downstream code in `create_session` and `list_sessions_*` reads — they no longer touch `workspace_repo` directly, eliminating the workspace assumption.
+
+#### `CreateReviewSessionInput` reshape
+
+```rust
+#[derive(Debug, Clone, Deserialize)]
+pub struct CreateReviewSessionInput {
+    pub target: ReviewTarget,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub created_by: Option<String>,
+}
+```
+
+`target` replaces the old `workspace_guid: String` field ([`review.rs#L181-L188`](../../../crates/core-service/src/service/review.rs#L181-L188)). Net-net there are no external Rust callers of this DTO outside `ws_message.rs`, so this is a contained change.
+
+#### `create_session` rewrite
+
+Replace the current top of `create_session` (lines ~409–435) with:
+
+```rust
+let ctx = self.resolve_repo_context(&input.target).await?;
+let changed = self
+    .git_engine
+    .get_changed_files(Path::new(&ctx.repo_path), ctx.base_ref.as_deref(), false)
+    .map_err(ServiceError::Engine)?;
+// ... existing ordered_paths / empty-changeset error / snapshot writing logic ...
+review_repo
+    .create_session(
+        Some(session_guid.clone()),
+        ctx.workspace_guid.clone(),       // now Option<String>
+        ctx.project_guid.clone(),
+        ctx.repo_path.clone(),
+        storage_root_rel_path,
+        ctx.base_ref.clone(),
+        base_commit,
+        head_commit,
+        revision_guid.clone(),
+        ReviewSessionStatus::Active.as_str().into(),
+        input.title.clone(),
+        input.created_by.clone(),
+    )
+    .await?;
+```
+
+If `ctx.base_ref_origin == BaseRefOrigin::DefaultBranchFallback`, log `tracing::warn!(target = "review", project_guid = %ctx.project_guid, "target_branch missing, falling back to repo default branch")` (PRD M2 + telemetry open).
+
+#### New listing entry point
+
+```rust
+pub async fn list_sessions_by_project(
+    &self,
+    project_guid: String,
+    include_archived: bool,
+) -> Result<Vec<ReviewSessionDto>> {
+    let repo = ReviewRepo::new(&self.db);
+    let sessions = repo
+        .list_sessions_by_project(&project_guid, include_archived)
+        .await?;
+    let mut items = Vec::with_capacity(sessions.len());
+    for session in sessions {
+        items.push(self.build_session_dto(session).await?);
+    }
+    Ok(items)
+}
+```
+
+Mirrors [`list_sessions_by_workspace`](../../../crates/core-service/src/service/review.rs#L381-L395) one-for-one. `build_session_dto` already keys off `session.guid`, no change needed.
+
+#### Existing helpers that read `workspace_guid`
+
+Audit and patch (current usages at [`review.rs#L1983-L1988`](../../../crates/core-service/src/service/review.rs#L1983-L1988) etc.): wherever code does `workspace_repo.find_by_guid(&session.workspace_guid)` to recover repo path, prefer `session.repo_path` directly (it's already stored). Only fall back to workspace lookup when both `session.workspace_guid` is `Some` AND `session.repo_path` is empty/legacy — defensive only.
+
+### crates/infra/src/websocket/message.rs
+
+Two payloads change. All 10 other review WS payloads are session-keyed and untouched.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewSessionListRequest {
+    /// Either workspace_guid OR project_guid must be set, not both.
+    #[serde(default)]
+    pub workspace_guid: Option<String>,
+    #[serde(default)]
+    pub project_guid: Option<String>,
+    #[serde(default)]
+    pub include_archived: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewSessionCreateRequest {
+    /// Either workspace_guid OR project_guid must be set, not both.
+    #[serde(default)]
+    pub workspace_guid: Option<String>,
+    #[serde(default)]
+    pub project_guid: Option<String>,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub created_by: Option<String>,
+}
+```
+
+**Why two-Option-fields instead of a tagged enum on the wire**: keeps WS payloads flat and JS-friendly; old clients that still send only `workspace_guid` keep working; the handler does the validation. The tagged enum (`ReviewTarget`) lives only inside the Rust service layer.
+
+### crates/core-service/src/service/ws_message.rs
+
+`handle_review_session_list` (line 4545) and `handle_review_session_create` (line 4558) become thin adapters:
+
+```rust
+fn parse_target(workspace_guid: Option<String>, project_guid: Option<String>)
+    -> Result<ReviewTarget>
+{
+    match (workspace_guid, project_guid) {
+        (Some(w), None) => Ok(ReviewTarget::Workspace { workspace_guid: w }),
+        (None, Some(p)) => Ok(ReviewTarget::Project { project_guid: p }),
+        (Some(_), Some(_)) =>
+            Err(ServiceError::Validation("Specify exactly one of workspace_guid or project_guid".into()).into()),
+        (None, None) =>
+            Err(ServiceError::Validation("workspace_guid or project_guid is required".into()).into()),
+    }
+}
+
+async fn handle_review_session_list(&self, req: ReviewSessionListRequest) -> Result<Value> {
+    let target = parse_target(req.workspace_guid, req.project_guid)?;
+    let sessions = match target {
+        ReviewTarget::Workspace { workspace_guid } => self.review_service
+            .list_sessions_by_workspace(workspace_guid, req.include_archived).await?,
+        ReviewTarget::Project { project_guid } => self.review_service
+            .list_sessions_by_project(project_guid, req.include_archived).await?,
+    };
+    Ok(json!({ "sessions": sessions }))
+}
+
+async fn handle_review_session_create(&self, req: ReviewSessionCreateRequest) -> Result<Value> {
+    let target = parse_target(req.workspace_guid, req.project_guid)?;
+    let session = self.review_service.create_session(CreateReviewSessionInput {
+        target, title: req.title, created_by: req.created_by,
+    }).await?;
+    Ok(json!({ "session": session }))
+}
+```
+
+No new `WsAction` variants. No protocol-level rename.
+
+### apps/api
+
+No changes. All review traffic flows through the existing WS handler dispatcher in `crates/core-service/src/service/ws_message.rs`, which is wired by `apps/api` once at boot.
+
+### apps/web
+
+#### `apps/web/src/api/ws-api.ts`
+
+Update the typed wrappers around `review_session_list` and `review_session_create` to accept either `workspaceGuid` or `projectGuid`:
+
+```ts
+export interface ReviewTarget {
+  workspaceGuid?: string;
+  projectGuid?: string;
+}
+
+reviewWsApi.listSessions(target: ReviewTarget, includeArchived = false)
+reviewWsApi.createSession(target: ReviewTarget, opts?: { title?: string; createdBy?: string })
+```
+
+The runtime payload sends snake_case (`workspace_guid` / `project_guid`) per existing convention.
+
+#### `apps/web/src/hooks/use-review-context.ts`
+
+- Replace `workspaceId: string | null` arg with `target: ReviewTarget | null` (typed: `{ kind: 'workspace'; workspaceId: string } | { kind: 'project'; projectId: string }`).
+- Internal calls to `reviewWsApi.listSessions(workspaceId)` and `reviewWsApi.createSession(workspaceId, ...)` pass the resolved `target`.
+- `canEdit`, comment / message / fix-run handlers don't change — they all key off `currentSession.guid`.
+- The query state keys (`reviewSession`, `reviewRevision`) stay the same; sessions are unique by GUID across scopes.
+
+#### `apps/web/src/components/diff/review/ReviewContextProvider.tsx`
+
+Replace `workspaceId: string | null` prop with `target: ReviewTarget | null`. `filePath` and `fileSnapshotGuid` props unchanged. All `useMemo` deps stay; the prop reshape is upstream.
+
+#### `apps/web/src/components/diff/ReviewView.tsx`
+
+- Replace direct read of `workspaceId` (line 31) with `target` from `useReviewCtx()` exposing `currentSession.workspace_guid` / `currentSession.project_guid` for downstream needs.
+- The "No workspace selected" empty state (lines 112–118) becomes "No project or workspace selected" — same pattern, slightly broadened wording.
+- The "New Review Session" button (line 128) keeps the same handler; `handleCreateSession` already pulls scope from context.
+- File-open / pin actions currently call `openFile(..., workspaceId, ...)` (lines 216, 225, 327). For a project-scoped session the editor needs a non-null workspace identifier. Options:
+  - **Chosen**: pass `currentSession.guid` prefixed (e.g., `EDITOR_REVIEW_DIFF_PREFIX` already encodes snapshot guid). The editor store is keyed by workspace; for project scope, fall back to a synthetic editor key `project:<project_guid>` — confined to `EDITOR_REVIEW_DIFF_PREFIX` paths only, so it won't pollute regular file tabs.
+- N2 scope badge: render a small `<span>` inline in the existing session header showing `Project` or `Workspace`, derived from `currentSession.workspace_guid` presence.
+
+#### `apps/web/src/components/diff/review/ReviewActions.tsx`
+
+No structural changes — actions are session-keyed. Add optional disabling of "Mark all reviewed" etc. only if `target` is null (already implicit via `currentSession` being null).
+
+#### `apps/web/src/components/layout/RightSidebar.tsx`
+
+Lines 697–709 currently:
+
+```tsx
+<ReviewContextProvider workspaceId={workspaceId} filePath={filePath}>
+```
+
+becomes:
+
+```tsx
+const reviewTarget: ReviewTarget | null = useMemo(() => {
+  if (workspaceId) return { kind: 'workspace', workspaceId };
+  if (projectIdFromUrl) return { kind: 'project', projectId: projectIdFromUrl };
+  return null;
+}, [workspaceId, projectIdFromUrl]);
+
+// in JSX:
+<ReviewContextProvider target={reviewTarget} filePath={filePath}>
+```
+
+`hasWorkingContext` already evaluates to true on project routes (`effectiveContextId = workspaceId || projectIdFromUrl`), so the Review tab will render its full UI on a project route — no further wiring at the tab-visibility level.
+
+#### `apps/web/src/components/code-review/CodeReviewDialog.tsx`
+
+This dialog auto-creates a session (PRD context). Update its create-session call to forward whatever `ReviewTarget` the parent passes. If invoked from a workspace-only flow, behavior is unchanged.
+
+### packages/ui
+
+No changes. The scope badge in N2 reuses the existing `Badge` primitive.
+
+## Data model
+
+### Database
+
+```sql
+-- m20260507_000023_make_review_session_workspace_optional.rs
+ALTER TABLE review_session
+  ALTER COLUMN workspace_guid DROP NOT NULL;     -- Postgres
+-- (sqlite: emulated via table rebuild — sea-orm-migration handles it)
+
+DROP INDEX IF EXISTS "idx-review_session-workspace-updated";
+
+CREATE INDEX "idx-review_session-workspace-status-updated"
+  ON review_session (workspace_guid, status, updated_at);
+
+CREATE INDEX "idx-review_session-project-status-updated"
+  ON review_session (project_guid, status, updated_at);
+```
+
+### Rust
+
+```rust
+// crates/infra/src/db/entities/review_session.rs
+pub struct Model {
+    // ...
+    pub workspace_guid: Option<String>,   // CHANGED: was String
+    pub project_guid: String,             // unchanged, always set
+    pub repo_path: String,                // unchanged, source-of-truth for working tree
+    // ...
+}
+
+// crates/core-service/src/service/review.rs
+pub enum ReviewTarget {
+    Workspace { workspace_guid: String },
+    Project   { project_guid: String },
+}
+
+pub struct CreateReviewSessionInput {
+    pub target: ReviewTarget,
+    pub title: Option<String>,
+    pub created_by: Option<String>,
+}
+```
+
+### Frontend
+
+```ts
+// apps/web/src/api/ws-api.ts
+export type ReviewTarget =
+  | { kind: 'workspace'; workspaceId: string }
+  | { kind: 'project';   projectId: string };
+
+export interface ReviewSessionDto {
+  // existing fields unchanged
+  workspace_guid: string | null;   // CHANGED: was string
+  project_guid: string;
+  repo_path: string;
+  // ...
+}
+```
+
+## Transport
+
+### WebSocket messages
+
+Two payload shapes change as documented above. Action names (`review_session_list`, `review_session_create`) and all other 10 review actions remain identical.
+
+```jsonc
+// review_session_create — workspace scope (unchanged on the wire)
+{ "action": "review_session_create",
+  "data": { "workspace_guid": "ws-...", "title": "..." } }
+
+// review_session_create — NEW: project scope
+{ "action": "review_session_create",
+  "data": { "project_guid": "pj-...", "title": "..." } }
+
+// review_session_list — workspace scope
+{ "action": "review_session_list",
+  "data": { "workspace_guid": "ws-...", "include_archived": false } }
+
+// review_session_list — NEW: project scope
+{ "action": "review_session_list",
+  "data": { "project_guid": "pj-...", "include_archived": false } }
+```
+
+The handler rejects payloads with both fields set, or neither set.
+
+### REST
+
+None added. Justification: the entire review surface is already WS-based; introducing REST only for project scope would break the consistency rule in the root `AGENTS.md` Transport Rules.
+
+## Security & permissions
+
+- **AuthN**: same as today — WS connection is already authenticated when the user reaches the right sidebar.
+- **AuthZ**: a project-scoped session is visible to anyone who can read the `project` row (parity with workspace-scoped sessions, which are visible to anyone who can read the workspace). No new check is added; reusing the existing project-visibility middleware in the WS handler is sufficient. PRD authorization open question is hereby resolved: **parity with workspace, no new gating**.
+- **Sensitive data**: the project session writes the same kind of file snapshots under the existing review storage root. No new secrets, tokens, or paths are exposed.
+
+## Rollout plan
+
+Per PRD: single-shot release. No feature flag, no phased rollout. Push only when every step below is green.
+
+1. **Migration** — add `m20260507_000023_make_review_session_workspace_optional.rs`, register in [`crates/infra/src/db/migration/mod.rs`](../../../crates/infra/src/db/migration/mod.rs). Run `cargo test -p infra` to confirm the migration applies cleanly on a fresh DB and on a DB seeded with existing fixtures.
+2. **Entity + repo** — flip `workspace_guid` to `Option<String>`, add `list_sessions_by_project`, update `create_session` signature. `cargo build -p infra` clean.
+3. **Service** — introduce `ReviewTarget`, `RepoContext`, `resolve_repo_context`; rewrite `create_session` head; add `list_sessions_by_project`; reshape `CreateReviewSessionInput`. Update existing `workspace_guid` reads (audit grep). `cargo build -p core-service` clean.
+4. **WS payloads** — make both `workspace_guid` fields `Option`, add `project_guid` field; rewrite `handle_review_session_list` + `handle_review_session_create` with `parse_target`. `cargo build --workspace` clean.
+5. **Frontend API client** — update `reviewWsApi.listSessions` / `createSession` signatures, add `ReviewTarget` type, update `ReviewSessionDto` type for nullable `workspace_guid`. `bun typecheck` clean.
+6. **Frontend hook + provider + view** — `useReviewContext` accepts `target`, `ReviewContextProvider` accepts `target`, `ReviewView` empty-state copy + N2 scope badge, `RightSidebar` resolves `target` from URL params, `CodeReviewDialog` forwards target. `bun typecheck && bun lint` clean.
+7. **Manual smoke test** — on a real project: (a) create a project session on a project route, comment, run AI fix; (b) repeat on a workspace route; (c) confirm both sessions coexist; (d) wipe `target_branch` on a test project (via DB) and confirm fallback path + warn log; (e) confirm topbar still works.
+8. **Test pass** — `just test` (= `cargo test --workspace` + `bun test`) green. Then push.
+
+## Risks & tradeoffs
+
+- **Tradeoff — flat WS payload over tagged enum**: chose two `Option<String>` fields on the wire instead of a serde-tagged `ReviewTarget`. Wins JS ergonomics and trivially keeps existing clients building, at the cost of a 4-line `parse_target` validator on the handler. Worth it.
+- **Tradeoff — schema-by-presence over `scope_type` column**: chose nullable `workspace_guid` to encode scope, instead of adding an explicit `scope_type` enum column. Wins zero data backfill. Cost: a small ergonomic loss when reading rows without context. Mitigation: helper `Model::scope() -> Scope` derived from `workspace_guid.is_some()` if call sites multiply.
+- **Risk — synthetic editor key for project-scoped review files**: the editor store is keyed by workspace today. Using `project:<project_guid>` as a fallback key for `EDITOR_REVIEW_DIFF_PREFIX` paths is novel. **Rollback path**: if the editor store leaks the synthetic key into other tab features, gate it inside a small `useReviewEditorKey()` adapter and revert call sites in `ReviewView` to it.
+- **Risk — index drop+create migration on Postgres**: `DROP INDEX` is fast but locks briefly. Acceptable on Atmos's local-first deployment; would warrant `CREATE INDEX CONCURRENTLY` on a hosted Postgres but is out of scope here.
+- **Rollback plan**: revert PR. The migration's `down()` re-tightens `workspace_guid` to `NOT NULL`, which is safe because no project-scoped rows exist on user machines until they exercise the new flow. Document this in the PR description.
+
+## Dependencies & compatibility
+
+- **Depends on spec**: none.
+- **Blocks spec**: a future "aggregated project review" spec can layer on top by adding a third `ReviewTarget::AggregatedProject` variant without touching the schema again.
+- **Minimum Atmos version**: ships with the next release; older clients without the WS payload reshape will fail on `handle_review_session_list` validation if they happen to send neither field — but no current client does, since today's clients always send `workspace_guid`.
+- **External services**: none.
+
+## Open questions
+
+- [ ] **Telemetry**: where do we emit the `scope=project|workspace` dimension? Need to confirm the existing analytics sink in `apps/web` (if any). If none exists, defer to the implementation skill — TECH-recommended is to log via `tracing::info!(scope = ?…, "review.session.created")` at the service layer and surface in any future analytics plumbing.
+- [ ] **Editor synthetic key**: confirm during impl that no other feature in `useEditorStore` assumes `workspaceId` is non-empty; if it does, route project-scoped review file opens through a dedicated viewer instead of the workspace-keyed editor.

--- a/specs/APP/APP-013_project-level-review-session/TEST.md
+++ b/specs/APP/APP-013_project-level-review-session/TEST.md
@@ -1,0 +1,241 @@
+# TEST · APP-013: Project-Level Review Session
+
+> Test Plan · how we verify that a user on a Project route can create, view, comment on, and AI-fix a review session against the Project's main checkout, while the existing Workspace flow stays untouched. References PRD APP-013 and TECH APP-013.
+
+## Test strategy
+
+The feature is mostly a **shape-change** (new schema nullability + new `ReviewTarget` plumbing) wrapped around already-tested review logic. Most coverage lives in cheap layers; only the glue gets E2E:
+
+- **Unit / integration (Rust)** — `resolve_repo_context` (workspace branch, project happy, project fallback, project hard-fail), the new repo method `list_sessions_by_project`, and the WS handler validator `parse_target`. Run via `cargo test -p infra` and `cargo test -p core-service`.
+- **Migration test** — verify the new migration applies on a freshly seeded DB (with both empty and pre-existing review_session rows) and that `down()` is safe. Run via `cargo test -p infra`.
+- **Frontend unit (Vitest / `bun test`)** — `RightSidebar`'s `reviewTarget` derivation from URL params, `ReviewContextProvider` accepting `target` instead of `workspaceId`, `ReviewView` empty-state copy, N2 badge rendering. Avoid full UI mounts; prefer hook-level tests.
+- **Manual end-to-end smoke** — a single scripted run on a real local Atmos instance covering the full happy path on both project and workspace scopes, plus the coexistence and `target_branch=NULL` edge cases. No Playwright needed; the surface is small and the cost of authoring a Playwright spec for one feature exceeds the value here.
+
+## Coverage map
+
+| PRD item | Scenario IDs |
+|----------|--------------|
+| M1 — Create project session | S1, S10 |
+| M2 — base_ref resolution with fallback | S2, S3, S4 |
+| M3 — Empty-changeset error | S5 |
+| M4 — Full review surface for project sessions | S6 |
+| M5 — Project route lists only project sessions | S7 |
+| M6 — Workspace flow unchanged | S8 |
+| M7 — Coexistence | S9 |
+| M8 — AI fix write-back parity | S6 (signal: working-tree mutation observed) |
+| N2 — Scope badge | S11 |
+| Migration | S12 |
+| WS payload validation | S10 |
+
+## Scenarios
+
+### S1 — Happy path: user creates a project-scoped review session
+
+- **Level**: Manual E2E + Service-level integration test backing it.
+- **Given**: a Project whose `main_file_path` is a clean git repo on branch `main` with `target_branch="main"` set in the DB. The user has made one uncommitted edit to a tracked file. The user is on the project route in the web app, with no workspace selected.
+- **When**: the user opens the right sidebar's Review tab and clicks "New Review Session".
+- **Then**:
+  - A new `review_session` row is inserted with `workspace_guid IS NULL`, `project_guid = <project>`, `repo_path = project.main_file_path`, `base_ref = "main"`.
+  - The Review tab UI replaces the empty state with the session header, "Changed Files" group containing the edited file, and an empty "Comments" group.
+  - Identical "New Review Session" flow on the workspace route still creates a `workspace_guid`-set session (regression covered by S8).
+- **Signals**: DB row inspection, WS frame `review_session_create` request + response payload, DOM has `[data-test=review-session-header]` (or equivalent), no error toast.
+
+### S2 — base_ref happy: target_branch is set on the project
+
+- **Level**: Service-level Rust test on `resolve_repo_context(ReviewTarget::Project { ... })`.
+- **Given**: a project row with `target_branch = Some("main")` and a git repo at its `main_file_path`.
+- **When**: `resolve_repo_context` is called.
+- **Then**: returns `RepoContext { base_ref: Some("main"), base_ref_origin: ProjectTargetBranch, workspace_guid: None, project_guid, repo_path }`.
+- **Signals**: returned struct fields; no `tracing::warn!` line emitted with `target = "review"`.
+
+### S3 — base_ref fallback: target_branch is NULL, origin/HEAD resolves
+
+- **Level**: Service-level Rust test (with a fixture git repo).
+- **Given**: a project row with `target_branch = None` and a git repo whose `origin/HEAD` resolves to `main` (use `core_engine::GitEngine::get_default_branch` against a real test-fixture repo).
+- **When**: `resolve_repo_context` is called.
+- **Then**: returns `base_ref: Some("main"), base_ref_origin: DefaultBranchFallback`. A `tracing::warn!` event with target `"review"` and `project_guid = <id>` is emitted.
+- **Signals**: returned struct fields; captured tracing event via `tracing-test` or equivalent.
+
+### S4 — base_ref hard failure: both target_branch and origin/HEAD missing
+
+- **Level**: Service-level Rust test.
+- **Given**: a project row with `target_branch = None` and a git repo with no `origin` remote (or use a temp directory with `git init` and no remote).
+- **When**: `resolve_repo_context` is called.
+- **Then**: returns `Err(ServiceError::Validation(msg))` where `msg` contains a hint pointing the user at the topbar.
+- **Signals**: error variant + error message substring assertion.
+
+### S5 — Empty changeset: working tree has no diff vs base_ref
+
+- **Level**: Service-level integration test.
+- **Given**: a project on `main` with `target_branch="main"`, no `staged + unstaged + untracked` changes vs `main`.
+- **When**: `create_session(ReviewTarget::Project { ... })` is called.
+- **Then**: returns `Err(ServiceError::Validation("Cannot create a review session with no changed files"))` — same error string as the existing workspace path.
+- **Signals**: error message string match (parity with workspace flow).
+
+### S6 — Full review surface on a project session
+
+- **Level**: Manual E2E (single happy-path run).
+- **Given**: an active project-scoped session created via S1.
+- **When**: the user (1) leaves an inline comment on a changed file, (2) replies to it, (3) marks the file as reviewed, (4) starts an AI fix run via the existing CodeReview dialog, (5) waits for the run to finalize.
+- **Then**:
+  - All four review WS messages succeed: `review_comment_create`, `review_message_add`, `review_file_set_reviewed`, `review_agent_run_create` → `review_agent_run_finalize`.
+  - The AI fix run mutates files inside `project.main_file_path` (the working tree on the current branch is modified — same behavior as the workspace flow). PRD M8.
+  - A new `review_revision` row is created on finalize and the session UI shows the new revision selectable.
+- **Signals**: DB rows for `review_comment`, `review_message`, `review_file_state.reviewed=true`, `review_agent_run.status="finalized"`, `review_revision` count incremented; `git status` inside `main_file_path` shows new modifications after the fix run.
+
+### S7 — Project route lists only project-scoped sessions
+
+- **Level**: Service-level Rust test on `list_sessions_by_project`.
+- **Given**: a project with one project-scoped session AND two workspace-scoped sessions belonging to workspaces of the same project (all `is_deleted = false`, `status = "active"`).
+- **When**: `list_sessions_by_project(project_guid, false)` is called.
+- **Then**: returns exactly one DTO — the project-scoped session. Workspace-scoped sessions are not included.
+- **Signals**: returned vector length and `workspace_guid` field check.
+
+### S8 — Regression: workspace flow unchanged
+
+- **Level**: Service-level integration test + manual smoke.
+- **Given**: a workspace with one uncommitted change in its worktree.
+- **When**: `create_session(ReviewTarget::Workspace { ... })` is called and then `list_sessions_by_workspace(...)`.
+- **Then**:
+  - Created session has `workspace_guid = Some(<ws>)`, `project_guid = <pj>`, `repo_path = <worktree path>`, `base_ref = workspace.base_branch`.
+  - `list_sessions_by_workspace` returns the session (existing behavior preserved).
+  - On the workspace route, the right-sidebar Review tab renders identically to today (no scope badge unless N2 is enabled, no changed copy, no extra UI).
+- **Signals**: DB row shape, list method return, manual UI inspection in dark + light mode (per `apps/web/AGENTS.md`).
+
+### S9 — Coexistence: project session + workspace session active simultaneously
+
+- **Level**: Service-level integration test + manual confirmation.
+- **Given**: a project with one active project-scoped session, AND a workspace under the same project with its own active workspace-scoped session, both with comments and an open AI fix run.
+- **When**: the user performs operations on each session in any order — add comments, finalize fix runs, mark files reviewed.
+- **Then**:
+  - Operations on one session never mutate the other (verified by DB row counts before/after).
+  - AI fix runs touch only their respective `repo_path` (project session writes to `project.main_file_path`, workspace session writes to its worktree path).
+  - Both `list_sessions_by_project(project_guid, _)` and `list_sessions_by_workspace(workspace_guid, _)` continue to return their own session unchanged.
+- **Signals**: DB row counts per session, `git status` in both repo paths, no cross-session WS notifications received.
+
+### S10 — Failure: WS payload validation in `parse_target`
+
+- **Level**: Unit test on `parse_target` in `crates/core-service/src/service/ws_message.rs`.
+- **Given**: four payload variants for `ReviewSessionCreateRequest` / `ReviewSessionListRequest`:
+  1. `{ workspace_guid: "ws-1" }` — workspace-only.
+  2. `{ project_guid: "pj-1" }` — project-only.
+  3. `{ workspace_guid: "ws-1", project_guid: "pj-1" }` — both set.
+  4. `{}` — neither set.
+- **When**: `parse_target` is called on each.
+- **Then**:
+  - (1) returns `Ok(ReviewTarget::Workspace { workspace_guid: "ws-1" })`.
+  - (2) returns `Ok(ReviewTarget::Project { project_guid: "pj-1" })`.
+  - (3) returns `Err(ServiceError::Validation("Specify exactly one of workspace_guid or project_guid"))`.
+  - (4) returns `Err(ServiceError::Validation("workspace_guid or project_guid is required"))`.
+- **Signals**: enum variant assertion, error message substring.
+
+### S11 — N2: scope badge in session header
+
+- **Level**: Frontend unit test (Vitest) on the session header sub-component.
+- **Given**: two `ReviewSessionDto` fixtures — one with `workspace_guid: null` (project), one with `workspace_guid: "ws-1"` (workspace).
+- **When**: the session header renders with each fixture as `currentSession`.
+- **Then**: project fixture renders a badge containing the text `Project`; workspace fixture renders a badge containing `Workspace`. Verify both render correctly in `dark` and `light` data-attribute modes (per `apps/web/AGENTS.md` theme rule).
+- **Signals**: rendered DOM text and `data-theme` attribute walk-through.
+
+### S12 — Migration: applies on fresh and seeded DB
+
+- **Level**: Integration test in `crates/infra` migration test harness.
+- **Given**:
+  1. A fresh in-memory SQLite DB.
+  2. A DB seeded with one `review_session` row produced by the existing `m20260422_000019` migration (`workspace_guid` non-null, all indices in place).
+- **When**: `m20260507_000023_make_review_session_workspace_optional::up()` runs against each.
+- **Then**:
+  - On both DBs the column is now nullable; indices `idx-review_session-workspace-status-updated` and `idx-review_session-project-status-updated` exist; old `idx-review_session-workspace-updated` is gone.
+  - Existing seeded row is unchanged (`workspace_guid` value preserved, `project_guid` preserved).
+  - `down()` then `up()` round-trip is idempotent (no error, no duplicate-index error).
+- **Signals**: `sea-orm` schema introspection, row equality.
+
+## Performance & load budgets
+
+This change is not on a hot path — review sessions are created/listed at human cadence. Two soft budgets reused from existing review behavior:
+
+- `list_sessions_by_project` returns within 200ms p95 for a project with up to 100 sessions (parity with `list_sessions_by_workspace`).
+- `create_session` for a project with ≤ 200 changed files completes within 2s p95 (matches existing workspace-flow expectation; the bottleneck is `git_engine.get_changed_files`, not the new code).
+
+## Regression checklist
+
+Things that have broken near this surface before, or are fragile in this change:
+
+- [ ] **Migration safety**: existing user DBs (with all `workspace_guid` non-null) survive `up()` and don't choke on the index swap. Verify on both SQLite (default) and Postgres if the project supports it.
+- [ ] **No leak of NULL `workspace_guid` into workspace routes**: `RightSidebar` on a workspace URL never derives `target.kind = "project"`. If `workspaceId` is set, that wins.
+- [ ] **CodeReviewDialog**: the auto-create flow still picks the right `ReviewTarget` based on the surrounding context; doesn't accidentally create a project-scoped session when invoked from a workspace.
+- [ ] **Editor synthetic key**: opening a project-scoped review file via `EDITOR_REVIEW_DIFF_PREFIX` doesn't pollute regular tab listings or break tab restoration after refresh (per TECH risk).
+- [ ] **`session.repo_path` is the source of truth** for downstream code; no path is rebuilt from `workspace.name` when it should be read directly from `session.repo_path`.
+- [ ] **WS payload backward compatibility**: a payload sent with only `workspace_guid` (the shape used by today's clients before this change ships) still works. Even though we ship client+server together, this protects against any cached or stale frontend bundle in dev.
+- [ ] **Theme**: scope badge (N2) rendered correctly in both light and dark modes (per `apps/web/AGENTS.md`).
+
+## Acceptance criteria
+
+Binary. Merge-blocking.
+
+- [ ] Every PRD Must Have (M1–M8) and the chosen Nice to Have (N2) is covered by at least one passing scenario in this plan.
+- [ ] All Rust scenarios (S2, S3, S4, S5, S7, S8, S9, S10, S12) pass via `cargo test --workspace` (or scoped `cargo test -p infra` / `cargo test -p core-service`).
+- [ ] All frontend scenarios (S11) pass via `bun test`.
+- [ ] Manual smoke (S1, S6, S8 visual side, S9 visual side) executed once on the developer's local Atmos against a real git project, with results recorded in the PR description.
+- [ ] `just lint` passes on every changed crate and on `apps/web`.
+- [ ] No new REST endpoints — review continues to be 100% WebSocket (per root `AGENTS.md` Transport Rules).
+- [ ] No tracing log line at level `error` from review-session creation in the smoke run; the `DefaultBranchFallback` path emits exactly one `warn` line per occurrence.
+
+## Manual verification steps
+
+Automation can't reasonably mock a real git repo + AI fix run + UI workflow at the cost-effective level for this single feature, so the following are manual:
+
+1. **Project happy path (S1, S6)**: open Atmos web, navigate to a project route (no workspace selected), edit a file, open the right-sidebar Review tab, click "New Review Session". Verify the session appears and contains the changed file. Add a comment, run an AI fix via the CodeReview dialog, and verify the working tree on the project's current branch is mutated by the fix run.
+2. **Coexistence (S9)**: with the project session from step 1 still active, switch to a workspace under the same project, repeat the happy path on the workspace route. Verify (a) workspace Review tab shows ONLY the workspace session — no project session leaks here, and (b) project Review tab shows ONLY the project session.
+3. **target_branch=NULL fallback (S3)**: in the dev DB, manually `UPDATE project SET target_branch = NULL WHERE guid = '<test-project>';` and try to create a project session. Verify the session creates successfully and a `tracing::warn!` line with `target="review"` appears in `./logs/debug/`.
+4. **target_branch=NULL hard fail (S4)**: on a project whose git repo has no `origin` remote AND `target_branch = NULL`, attempt to create a project session. Verify a user-visible validation error explains the fix.
+5. **Workspace regression (S8 visual)**: run through your normal workspace review flow once and confirm zero observable change in behavior.
+6. **Theme (regression checklist)**: toggle between light and dark mode while a project session is open; the new scope badge and any modified empty-state copy must render legibly in both.
+
+## Non-coverage
+
+Deliberately out of scope for this round; will need their own scenarios when added later.
+
+- **Aggregated project review** (showing a roll-up of workspace sessions on the project route) — explicitly out of PRD scope.
+- **Cross-scope hints** in the workspace Review tab — explicitly out of PRD scope.
+- **Protected-branch guard** preventing AI fix runs from writing to `main` — listed as a future enhancement (N1, deferred).
+- **Multi-tenant authorization** — Atmos is single-user / local-first today; adding scope visibility checks across users is a separate concern.
+- **Hosted Postgres `CREATE INDEX CONCURRENTLY`** — TECH calls this out as out of scope; verified only against the local SQLite path.
+
+---
+
+## Coverage Status
+
+> Appended after implementation run on 2026-05-07.
+
+| Scenario | Level | Test file / name | Status |
+|----------|-------|-----------------|--------|
+| S1 — Happy path: user creates a project-scoped review session | Manual E2E | — | **Manual** — requires a running Atmos instance with a real git project. See "Manual verification steps" §1. |
+| S2 — base_ref happy: target_branch is set | Rust unit | `crates/core-service/src/service/review.rs` → `tests::s2_resolve_repo_context_project_target_branch` | ✅ Automated |
+| S3 — base_ref fallback: target_branch NULL, origin/HEAD resolves | Rust unit | `crates/core-service/src/service/review.rs` → `tests::s3_resolve_repo_context_fallback_to_default_branch` | ✅ Automated |
+| S4 — base_ref hard failure: both missing | Rust unit | `crates/core-service/src/service/review.rs` → `tests::s4_resolve_repo_context_hard_fail` | ✅ Automated |
+| S5 — Empty changeset error | Rust integration | `crates/core-service/src/service/review.rs` → `tests::s5_create_session_empty_changeset` | ✅ Automated |
+| S6 — Full review surface on a project session | Manual E2E | — | **Manual** — requires a running Atmos instance. See "Manual verification steps" §1. |
+| S7 — Project route lists only project-scoped sessions | Rust unit | `crates/core-service/src/service/review.rs` → `tests::s7_list_sessions_by_project_excludes_workspace_sessions` | ✅ Automated |
+| S8 — Regression: workspace flow unchanged | Rust unit + Manual | `crates/core-service/src/service/review.rs` → `tests::s8_workspace_session_has_workspace_guid` (automated); visual side requires running instance | ✅ Automated (logic) / **Manual** (visual) |
+| S9 — Coexistence: project + workspace sessions active simultaneously | Rust unit + Manual | `crates/core-service/src/service/review.rs` → `tests::s9_project_and_workspace_sessions_coexist` (automated); visual side requires running instance | ✅ Automated (logic) / **Manual** (visual) |
+| S10 — WS payload validation in `parse_target` | Rust unit | `crates/core-service/src/service/ws_message.rs` → `tests::s10_parse_target_*` (4 tests) | ✅ Automated |
+| S11 — N2: scope badge in session header | Frontend unit | `apps/web/src/components/diff/__tests__/ReviewView.scope-badge.test.ts` | ✅ Automated |
+| S12 — Migration: applies on fresh and seeded DB | Rust integration | `crates/infra/src/db/migration/mod.rs` → `tests::s12_migration_applies_on_fresh_db`, `tests::s12_migration_applies_on_seeded_db_preserves_existing_rows` | ✅ Automated |
+
+### Test commands
+
+```bash
+# Rust tests (all scenarios except S1, S6, S8 visual, S9 visual)
+cargo test -p infra -p core-service
+
+# Frontend tests (S11)
+bun test
+```
+
+### Manual scenarios pending human smoke-test
+
+- **S1** — Create a project-scoped session from the project route in a real Atmos instance.
+- **S6** — Full review surface: comment, reply, mark reviewed, AI fix run, verify working tree mutation.
+- **S8 (visual)** — Workspace Review tab renders identically to before; no scope badge regression; test in both light and dark mode.
+- **S9 (visual)** — Project and workspace sessions coexist; each route shows only its own session.

--- a/specs/README.md
+++ b/specs/README.md
@@ -72,6 +72,7 @@ All four files are always present. Missing content stays as a **template placeho
 | **APP-010** | Preview Element Select (Same-Origin) | `TECH.md` |
 | **APP-011** | Preview Cross-Origin Extension (Browser Ext + Desktop) | `TECH.md` |
 | **APP-012** | Remote Access | `TECH.md` |
+| **APP-013** | Project-Level Review Session | `BRAINSTORM.md` |
 
 ### Landing
 


### PR DESCRIPTION
## Summary

Make `review_session.workspace_guid` nullable and introduce a `ReviewTarget` enum (`Workspace | Project`) at the service boundary. Users on a project route (no workspace selected) can now create, view, comment on, and AI-fix a review session against the project's main checkout — the same right-sidebar Review tab as today. The existing workspace flow is byte-for-byte unchanged.

Includes a DB migration, repo/service/WS-handler updates, full frontend wiring (`RightSidebar` → `ReviewContextProvider` → `useReviewContext`), a synthetic editor key for project-scoped review diffs, and an N2 scope badge ("Project" / "Workspace") in the session header.

## Related Issue

Implements spec APP-013 (`specs/APP/APP-013_project-level-review-session/`)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [x] `just lint` — 0 errors in modified files (pre-existing errors in SettingsModal.tsx / LeftSidebar.tsx)
- [x] `just test` — `cargo test -p infra -p core-service` all green (70 tests); `bun test` green (2 tests). Pre-existing failures in `llm` crate and `atmos-desktop` build unrelated.
- [ ] `just fmt`
- [x] Additional checks: `bun typecheck` clean, `cargo clippy --workspace --exclude atmos-desktop` clean

### Manual smoke-test pending

- **S1** — Create project-scoped session from project route
- **S6** — Full review surface (comment, reply, AI fix run)
- **S8 visual** — Workspace Review tab unchanged (light + dark)
- **S9 visual** — Project and workspace sessions coexist without leakage

## Checklist

- [ ] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable project-level code review sessions so users can start and manage reviews from the project route without selecting a workspace. Implements APP-013; the existing workspace review flow is unchanged.

- **New Features**
  - Added `ReviewTarget` at the service and WS API boundary; handlers accept and trim/validate `project_guid` or `workspace_guid`.
  - Made `ReviewSessionDto.workspace_guid` nullable; list/create support project scope and added repo `list_sessions_by_project`.
  - Frontend wiring: `reviewWsApi.listSessions` and `CodeReviewDialog` accept `ReviewTarget`; `RightSidebar` → `ReviewContextProvider` → `useReviewContext` use `ReviewTarget`; editor uses workspace key or synthetic `project:${projectId}` and `effectiveContextId` for review tabs and file paths.
  - UI: scope badge via shared `getScopeBadgeText`; neutral ReviewView empty state; updated create-session toast; fixed base ref selection for new sessions.
  - Service fix: prioritize the workspace worktree for legacy sessions when finalizing agent runs.

- **Migration**
  - DB migration makes `review_session.workspace_guid` nullable and updates indexes; `down()` prunes NULL rows before ALTER and guards with `PRAGMA foreign_keys = OFF`. Run migrations before deploy.

<sup>Written for commit 255ea10c7cc53e84c485b60cb159f912a94577b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project-scoped review sessions supported alongside workspace sessions
  * UI now shows scope badge and updated empty-state wording for workspace vs project
  * Review actions (create/list, comments, revisions, AI fixes) work for project-scoped sessions with base-branch resolution and fallback

* **Chores / Migration**
  * DB migration makes session workspace optional and adds project-aware indexes

* **Tests**
  * Added unit and migration tests for project-scoped behavior

* **Documentation**
  * New PRD/TECH/TEST/brainstorm docs for project-level review sessions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->