### PR TITLE
feat(web): CodeMirror Git 集成对接 git_file_diff

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,6 +32,7 @@
     "@codemirror/lang-yaml": "^6",
     "@codemirror/language": "^6",
     "@codemirror/legacy-modes": "^6",
+    "@codemirror/merge": "^6.12.1",
     "@codemirror/search": "^6",
     "@codemirror/state": "^6",
     "@codemirror/theme-one-dark": "^6",

--- a/apps/web/src/components/editor/BaseCodeMirrorEditor.tsx
+++ b/apps/web/src/components/editor/BaseCodeMirrorEditor.tsx
@@ -45,8 +45,16 @@ import { showMinimap } from '@replit/codemirror-minimap';
 import { ArrowLeftRight, CaseSensitive, ChevronLeft, ChevronRight, Regex, Replace, ReplaceAll, WholeWord, X } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { cn } from '@workspace/ui';
+import { gitApi } from '@/api/ws-api';
 import { loadCodeLanguageSupport } from '@/lib/code-language';
 import { isTauriRuntime } from '@/lib/desktop-runtime';
+import { createGitUnifiedMergeExtensions } from '@/lib/codemirror-git-unified-merge';
+
+/** 用于在启用 Git 集成时拉取 `git_file_diff`（仓库根路径 + 相对路径）。 */
+export interface BaseCodeMirrorEditorGitDiffSource {
+  repoPath: string;
+  fileRelativePath: string;
+}
 
 export interface BaseCodeMirrorEditorProps {
   className?: string;
@@ -60,6 +68,8 @@ export interface BaseCodeMirrorEditorProps {
   breadcrumbs?: boolean;
   lineHighlight?: boolean;
   gitIntegration?: boolean;
+  /** 提供仓库与文件相对路径时才可显示与 HEAD/比较基 的差异；缺省则仅关闭合并视图。 */
+  gitDiffSource?: BaseCodeMirrorEditorGitDiffSource | null;
   navigationTarget?: { line: number; column?: number } | null;
   onChange?: (value: string) => void;
   onCreateEditor?: (view: EditorView) => void;
@@ -876,6 +886,7 @@ export const BaseCodeMirrorEditor: React.FC<BaseCodeMirrorEditorProps> = ({
   breadcrumbs = true,
   lineHighlight = true,
   gitIntegration = false,
+  gitDiffSource = null,
   navigationTarget,
   onChange,
   onCreateEditor,
@@ -954,6 +965,7 @@ export const BaseCodeMirrorEditor: React.FC<BaseCodeMirrorEditorProps> = ({
           rectangularSelection(),
           crosshairCursor(),
           lineHighlightCompartment.of(initialState.lineHighlight ? [highlightActiveLine(), highlightSelectionMatches()] : []),
+          gitIntegrationCompartment.of([]),
           EditorState.tabSize.of(2),
           lineWrapCompartment.of(initialState.lineWrap ? EditorView.lineWrapping : []),
           searchCompartment.of(createSearchExtension()),
@@ -1110,16 +1122,49 @@ export const BaseCodeMirrorEditor: React.FC<BaseCodeMirrorEditorProps> = ({
     });
   }, [breadcrumbs, breadcrumbsCompartment]);
 
-  // Git integration - placeholder for now, requires backend API
   useEffect(() => {
     const view = editorRef.current;
     if (!view) return;
 
-    // TODO: Implement git integration when backend API is available
-    view.dispatch({
-      effects: gitIntegrationCompartment.reconfigure([]),
-    });
-  }, [gitIntegration, gitIntegrationCompartment]);
+    if (!gitIntegration || !gitDiffSource?.repoPath || !gitDiffSource?.fileRelativePath) {
+      view.dispatch({
+        effects: gitIntegrationCompartment.reconfigure([]),
+      });
+      return;
+    }
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const diff = await gitApi.getFileDiff(
+          gitDiffSource.repoPath,
+          gitDiffSource.fileRelativePath,
+        );
+        if (cancelled || editorRef.current !== view) return;
+
+        view.dispatch({
+          effects: gitIntegrationCompartment.reconfigure(
+            createGitUnifiedMergeExtensions(diff.old_content),
+          ),
+        });
+      } catch {
+        if (cancelled || editorRef.current !== view) return;
+        view.dispatch({
+          effects: gitIntegrationCompartment.reconfigure([]),
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    gitIntegration,
+    gitDiffSource?.repoPath,
+    gitDiffSource?.fileRelativePath,
+    gitIntegrationCompartment,
+  ]);
 
   useEffect(() => {
     const view = editorRef.current;

--- a/apps/web/src/components/editor/CodeMirrorEditor.tsx
+++ b/apps/web/src/components/editor/CodeMirrorEditor.tsx
@@ -32,6 +32,7 @@ import { ReviewReportMetadataCard } from '@/components/code-review/ReviewReportM
 import { useProjectStore } from '@/hooks/use-project-store';
 import { type FileTreeNode } from '@/api/ws-api';
 import { FileTree } from '@/components/files/FileTree';
+import { tryRelativePathUnderRoot } from '@/lib/path-under-root';
 
 interface CodeMirrorEditorProps {
   file: OpenFile;
@@ -76,29 +77,39 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({ file, classN
   const fileTreeRootPath = useFileTreeStore((s) => s.rootPath);
   const editorViewRef = useRef<EditorView | null>(null);
 
-  // Get relative path for breadcrumbs
+  // Get relative path for breadcrumbs (strict root boundary + longest project prefix)
   const { relativePath, projectRoot } = useMemo(() => {
     const fullPath = file.path;
 
-    // Use currentProjectPath from editor store as the project root
-    if (currentProjectPath && fullPath.startsWith(currentProjectPath)) {
-      return {
-        relativePath: fullPath.slice(currentProjectPath.length).replace(/^\//, ''),
-        projectRoot: currentProjectPath,
-      };
-    }
-
-    // Fallback: find the project that contains this file
-    for (const project of projects) {
-      if (fullPath.startsWith(project.mainFilePath)) {
+    if (currentProjectPath) {
+      const rel = tryRelativePathUnderRoot(fullPath, currentProjectPath);
+      if (rel !== null) {
         return {
-          relativePath: fullPath.slice(project.mainFilePath.length).replace(/^\//, ''),
-          projectRoot: project.mainFilePath,
+          relativePath: rel,
+          projectRoot: currentProjectPath,
         };
       }
     }
 
-    // If no project found, return full path
+    let bestRoot: string | null = null;
+    let bestRel: string | null = null;
+    for (const project of projects) {
+      const rel = tryRelativePathUnderRoot(fullPath, project.mainFilePath);
+      if (rel !== null) {
+        const root = project.mainFilePath;
+        if (!bestRoot || root.length > bestRoot.length) {
+          bestRoot = root;
+          bestRel = rel;
+        }
+      }
+    }
+    if (bestRoot !== null && bestRel !== null) {
+      return {
+        relativePath: bestRel,
+        projectRoot: bestRoot,
+      };
+    }
+
     return {
       relativePath: fullPath,
       projectRoot: '',

--- a/apps/web/src/components/editor/CodeMirrorEditor.tsx
+++ b/apps/web/src/components/editor/CodeMirrorEditor.tsx
@@ -109,6 +109,14 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({ file, classN
     return relativePath.split('/').filter(Boolean);
   }, [relativePath]);
 
+  const editorGitDiffSource = useMemo(
+    () =>
+      projectRoot && relativePath
+        ? { repoPath: projectRoot, fileRelativePath: relativePath }
+        : null,
+    [projectRoot, relativePath],
+  );
+
   // Get the full path for a breadcrumb part at a given index
   const getBreadcrumbPath = useCallback((index: number) => {
     const parts = relativePath.split('/').filter(Boolean);
@@ -631,6 +639,7 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({ file, classN
                 breadcrumbs={breadcrumbs}
                 lineHighlight={lineHighlight}
                 gitIntegration={gitIntegration}
+                gitDiffSource={editorGitDiffSource}
                 navigationTarget={navigationTarget}
                 onChange={handleEditorChange}
                 onCreateEditor={handleEditorCreate}

--- a/apps/web/src/lib/__tests__/path-under-root.test.ts
+++ b/apps/web/src/lib/__tests__/path-under-root.test.ts
@@ -1,0 +1,29 @@
+// @ts-expect-error bun:test is available at runtime but not in tsconfig types
+import { describe, it, expect } from 'bun:test';
+import { tryRelativePathUnderRoot } from '@/lib/path-under-root';
+
+describe('tryRelativePathUnderRoot', () => {
+  it('rejects prefix collision: /repo must not match /repo2/...', () => {
+    expect(tryRelativePathUnderRoot('/repo2/foo', '/repo')).toBeNull();
+  });
+
+  it('accepts proper descendants with segment boundary', () => {
+    expect(tryRelativePathUnderRoot('/repo/foo', '/repo')).toBe('foo');
+    expect(tryRelativePathUnderRoot('/repo/foo/bar', '/repo')).toBe('foo/bar');
+  });
+
+  it('returns empty string when file equals root', () => {
+    expect(tryRelativePathUnderRoot('/repo', '/repo')).toBe('');
+    expect(tryRelativePathUnderRoot('/repo/', '/repo')).toBe('');
+  });
+
+  it('handles filesystem root', () => {
+    expect(tryRelativePathUnderRoot('/home/x', '/')).toBe('home/x');
+    expect(tryRelativePathUnderRoot('/', '/')).toBe('');
+  });
+
+  it('returns null for unrelated paths', () => {
+    expect(tryRelativePathUnderRoot('/other/x', '/repo')).toBeNull();
+    expect(tryRelativePathUnderRoot('relative-only', '/repo')).toBeNull();
+  });
+});

--- a/apps/web/src/lib/codemirror-git-unified-merge.ts
+++ b/apps/web/src/lib/codemirror-git-unified-merge.ts
@@ -1,0 +1,19 @@
+import { unifiedMergeView } from '@codemirror/merge';
+import type { Extension } from '@codemirror/state';
+
+/**
+ * CodeMirror 6 unified diff：将当前文档与 Git 基准版本（如 HEAD）对比。
+ * 与后端 `git_file_diff` 返回的 `old_content` 对齐。
+ */
+export function createGitUnifiedMergeExtensions(original: string): Extension[] {
+  return [
+    unifiedMergeView({
+      original,
+      highlightChanges: true,
+      gutter: true,
+      mergeControls: false,
+      allowInlineDiffs: true,
+      diffConfig: { scanLimit: 3000, timeout: 400 },
+    }),
+  ];
+}

--- a/apps/web/src/lib/path-under-root.ts
+++ b/apps/web/src/lib/path-under-root.ts
@@ -1,0 +1,30 @@
+/**
+ * Normalize a directory root for prefix checks (trim trailing slashes).
+ * A lone "/" stays as "/" so we can treat filesystem root explicitly.
+ */
+function normalizeDirectoryRoot(rootPath: string): string | null {
+  if (!rootPath) return null;
+  const trimmed = rootPath.replace(/\/+$/, '');
+  if (trimmed === '' && rootPath.startsWith('/')) return '/';
+  return trimmed || null;
+}
+
+/**
+ * If `filePath` is exactly `rootPath` or a proper descendant (next segment boundary),
+ * return the relative path under that root; otherwise `null`.
+ * Avoids treating `/repo` as an ancestor of `/repo2/...`.
+ */
+export function tryRelativePathUnderRoot(filePath: string, rootPath: string): string | null {
+  const root = normalizeDirectoryRoot(rootPath);
+  if (root == null) return null;
+
+  if (root === '/') {
+    if (!filePath.startsWith('/')) return null;
+    if (filePath === '/' || filePath === '') return '';
+    return filePath.replace(/^\/+/, '');
+  }
+
+  if (filePath === root) return '';
+  if (!filePath.startsWith(`${root}/`)) return null;
+  return filePath.slice(root.length + 1);
+}

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "atmos",
@@ -109,6 +108,7 @@
         "@codemirror/lang-yaml": "^6",
         "@codemirror/language": "^6",
         "@codemirror/legacy-modes": "^6",
+        "@codemirror/merge": "^6.12.1",
         "@codemirror/search": "^6",
         "@codemirror/state": "^6",
         "@codemirror/theme-one-dark": "^6",
@@ -302,23 +302,6 @@
     "sharp",
     "unrs-resolver",
   ],
-  "catalog": {
-    "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
-    "comment": "Unified management of core dependent versions of all front-end projects",
-    "eslint": "^9",
-    "eslint-config-next": "16.2.0",
-    "next": "16.2.0",
-    "next-intl": "^4.7.0",
-    "next-themes": "^0.4.6",
-    "react": "19.2.3",
-    "react-dom": "19.2.3",
-    "tailwindcss": "^4",
-    "tw-animate-css": "^1.4.0",
-    "typescript": "^5",
-  },
   "packages": {
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.46", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-zH1UbNRjG5woOXXFOrVCZraqZuFTtmPvLardMGcgLkzpxKV0U3tAGoyWKSZ862H+eBJfI/Hf2yj/zzGJcCkycg=="],
 
@@ -431,6 +414,8 @@
     "@codemirror/legacy-modes": ["@codemirror/legacy-modes@6.5.2", "", { "dependencies": { "@codemirror/language": "^6.0.0" } }, "sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q=="],
 
     "@codemirror/lint": ["@codemirror/lint@6.9.5", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.35.0", "crelt": "^1.0.5" } }, "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA=="],
+
+    "@codemirror/merge": ["@codemirror/merge@6.12.1", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/highlight": "^1.0.0", "style-mod": "^4.1.0" } }, "sha512-GA8hBq2T+IFM0sb5fk8CunTrqOulA3zurJmHtzcU15EMnL8aYpVINfJ5bkfd53M4ikwoew4Y1ydtSaAlk6+B1w=="],
 
     "@codemirror/search": ["@codemirror/search@6.6.0", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.37.0", "crelt": "^1.0.5" } }, "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw=="],
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

在 `BaseCodeMirrorEditor` 中实现 Git 集成：复用已有 WebSocket `git_file_diff`（`gitApi.getFileDiff`）获取相对 HEAD/比较基的 `old_content`，通过 `@codemirror/merge` 的 `unifiedMergeView` 在单编辑器内展示删除块、插入高亮与变更行 gutter。

## 实现要点

- 将 `gitIntegrationCompartment` 加入初始 `EditorState` 扩展列表（此前仅 `dispatch(reconfigure)` 而未挂载 compartment，重配置不会生效）。
- 新增可选 prop `gitDiffSource`（`repoPath` + `fileRelativePath`）；`CodeMirrorEditor` 用与面包屑相同的项目根与相对路径组装并传入。
- **路径解析**：使用 `tryRelativePathUnderRoot` 做段边界匹配，避免 `/repo` 误判包含 `/repo2/...`；多项目时取 **最长** `mainFilePath` 前缀，保证嵌套仓库时 Git/breadcrumb 指向正确仓库。
- 关闭 merge 的 accept/reject 控件（`mergeControls: false`），避免在普通文件编辑中误触块级回滚；保留行内/块级 diff 展示与 `diffConfig` 扫描上限以控制大文件成本。

## 依赖

- `apps/web` 增加 `@codemirror/merge`；根目录 `bun.lock` 已更新。

## 测试

- `bun test apps/web/src/lib/__tests__/path-under-root.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e68f520a-6d26-463f-9f30-c5180f74177c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e68f520a-6d26-463f-9f30-c5180f74177c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Git diffs to CodeMirror using the existing `git_file_diff` API. Also fixes project root detection so `/repo` doesn’t match `/repo2`, and nested repos choose the longest root.

- **New Features**
  - Integrate `gitApi.getFileDiff` with `@codemirror/merge` `unifiedMergeView` (inline highlights, gutter; accept/reject off; scanLimit/timeout set).
  - Add optional `gitDiffSource` (`repoPath`, `fileRelativePath`); `CodeMirrorEditor` computes it; mount `gitIntegrationCompartment` in initial `EditorState`.
  - Add `@codemirror/merge` to `apps/web`.

- **Bug Fixes**
  - Use `tryRelativePathUnderRoot` for segment-boundary checks and choose the longest matching project root; fixes breadcrumbs and Git diff source. Tests added.

<sup>Written for commit 4eb0de74d7bbd2dacb5d1a961f02bbe7362c6ea5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Git diff & merge visualization added to the code editor with inline diffs and change highlighting.
* **Improvements**
  * More accurate project root / file path detection for editor breadcrumbs and diff sourcing.
* **Tests**
  * Added tests covering path-under-root behavior.
* **Chores**
  * Updated editor dependencies to support merge/diff features.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AruNi-01/atmos/pull/105)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->