### PR TITLE
fix(terminal-canvas): review fixes for layout migration, overview enrichment, canvas persistence, and tldraw theme

### DIFF
--- a/apps/api/src/api/system/handlers.rs
+++ b/apps/api/src/api/system/handlers.rs
@@ -5,10 +5,11 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use core_service::build_terminal_overview_active_sessions_json;
 use infra::utils::debug_logging::DebugLogger;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::process::Command;
 use std::time::Duration;
 use tokio_util::io::ReaderStream;
@@ -639,63 +640,9 @@ pub async fn get_terminal_overview(
     let terminal_service = &state.terminal_service;
     let tmux_engine = terminal_service.tmux_engine();
 
-    let active_sessions = terminal_service.list_session_details().await;
-    let mut tmux_window_names_by_session: HashMap<String, HashMap<u32, String>> = HashMap::new();
-    let mut active_sessions_json = Vec::with_capacity(active_sessions.len());
-
-    for s in &active_sessions {
-        let context_scope = if state
-            .project_service
-            .get_project(s.workspace_id.clone())
-            .await?
-            .is_some()
-        {
-            "project"
-        } else {
-            "workspace"
-        };
-
-        let tmux_window_name = if let Some(name) = s.terminal_name.clone() {
-            Some(name)
-        } else if let (Some(session_name), Some(window_index)) =
-            (s.tmux_session.as_ref(), s.tmux_window_index)
-        {
-            let session_windows = tmux_window_names_by_session
-                .entry(session_name.clone())
-                .or_insert_with(|| {
-                    tmux_engine
-                    .list_windows(session_name)
-                    .map(|windows| {
-                        windows
-                            .into_iter()
-                            .map(|window| (window.index, window.name))
-                            .collect::<HashMap<_, _>>()
-                    })
-                    .unwrap_or_default()
-                });
-
-            session_windows.get(&window_index).cloned()
-        } else {
-            None
-        };
-
-        active_sessions_json.push(
-            json!({
-                "session_id": s.session_id,
-                "workspace_id": s.workspace_id,
-                "context_scope": context_scope,
-                "session_type": s.session_type,
-                "project_name": s.project_name,
-                "workspace_name": s.workspace_name,
-                "terminal_name": s.terminal_name,
-                "tmux_session": s.tmux_session,
-                "tmux_window_index": s.tmux_window_index,
-                "tmux_window_name": tmux_window_name,
-                "cwd": s.cwd,
-                "uptime_secs": s.uptime_secs,
-            }),
-        );
-    }
+    let (active_sessions_json, active_session_count) =
+        build_terminal_overview_active_sessions_json(terminal_service, &state.project_service)
+            .await?;
 
     let tmux_installed = terminal_service.is_tmux_available();
     let tmux_version = if tmux_installed {
@@ -771,7 +718,7 @@ pub async fn get_terminal_overview(
 
     Ok(Json(ApiResponse::success(json!({
         "active_sessions": active_sessions_json,
-        "active_session_count": active_sessions.len(),
+        "active_session_count": active_session_count,
         "tmux": {
             "installed": tmux_installed,
             "version": tmux_version,

--- a/apps/web/src/components/terminal/TerminalCanvasView.tsx
+++ b/apps/web/src/components/terminal/TerminalCanvasView.tsx
@@ -14,6 +14,8 @@ import {
   type TLUiOverrides,
   type Editor,
   type TLEditorSnapshot,
+  type TLBaseShape,
+  type TLShapeId,
 } from "tldraw";
 import "tldraw/tldraw.css";
 import "./tldraw-theme.css";
@@ -23,7 +25,7 @@ import {
   Loader2,
   LoaderCircle,
   Map,
-  RefreshCcw,
+  RotateCw,
   SquareTerminal,
   ArrowUpRight,
   Plus,
@@ -60,10 +62,9 @@ const TERMINAL_CANVAS_BLOCKED_ACTION_IDS = new Set([
 ]);
 const TERMINAL_CANVAS_EXTERNAL_CONTENT_TYPES = ["embed", "excalidraw", "file-replace", "files", "svg-text", "tldraw", "url"] as const;
 
-type TerminalCanvasTerminalShape = {
-  id: string;
-  type: typeof TERMINAL_CARD_SHAPE_TYPE;
-  props: {
+type TerminalCanvasTerminalShape = TLBaseShape<
+  typeof TERMINAL_CARD_SHAPE_TYPE,
+  {
     w: number;
     h: number;
     contextScope: TerminalContextScope;
@@ -74,8 +75,8 @@ type TerminalCanvasTerminalShape = {
     terminalName: string;
     tmuxWindowName: string;
     isNewTerminal: boolean;
-  };
-};
+  }
+>;
 
 type WorkspaceImportItem = {
   scope: "project" | "workspace";
@@ -107,7 +108,7 @@ type ContextPaneState = {
   error: string | null;
 };
 
-class TerminalCanvasTerminalShapeUtil extends BaseBoxShapeUtil<any> {
+class TerminalCanvasTerminalShapeUtil extends BaseBoxShapeUtil<TerminalCanvasTerminalShape> {
   static override type = TERMINAL_CARD_SHAPE_TYPE;
 
   static override props = {
@@ -319,7 +320,7 @@ function TerminalCanvasTerminalCardInner({ shape }: { shape: TerminalCanvasTermi
   const router = useAppRouter();
   const activeShapeId = useTerminalCanvasRuntime((state) => state.activeShapeId);
   const setActiveShapeId = useTerminalCanvasRuntime((state) => state.setActiveShapeId);
-  const isSelected = useValue("terminal-canvas-card-selected", () => editor.getSelectedShapeIds().includes(shape.id as any), [
+  const isSelected = useValue("terminal-canvas-card-selected", () => editor.getSelectedShapeIds().includes(shape.id as TLShapeId), [
     editor,
     shape.id,
   ]);
@@ -337,7 +338,7 @@ function TerminalCanvasTerminalCardInner({ shape }: { shape: TerminalCanvasTermi
         ...shape.props,
         isNewTerminal: false,
       },
-    } as any);
+    });
   }, [editor, shape]);
 
   const handleRevealSource = React.useCallback(
@@ -385,13 +386,10 @@ function TerminalCanvasTerminalCardInner({ shape }: { shape: TerminalCanvasTermi
       <div
         className="min-h-0 flex-1 bg-background"
         onPointerDown={(event) => {
-          // When card is inactive, clicking activates it
-          // When card is active, clicking doesn't re-activate (to avoid focus loss)
-          if (!isActive) {
-            setActiveShapeId(shape.id);
+          // Let tldraw handle selection / transforms when the live terminal is not mounted.
+          if (isActive) {
+            event.stopPropagation();
           }
-          // Always prevent propagation to tldraw
-          event.stopPropagation();
         }}
         onWheel={(event) => {
           // Prevent scroll propagation to tldraw when scrolling inside the terminal
@@ -508,14 +506,6 @@ export const TerminalCanvasView: React.FC = () => {
     setSelectedContextKey(null);
   }, [board?.guid, resetRuntime]);
 
-  React.useEffect(() => {
-    return () => {
-      if (saveTimeoutRef.current) {
-        clearTimeout(saveTimeoutRef.current);
-      }
-    };
-  }, []);
-
   const flushSnapshotSave = React.useCallback(async () => {
     if (saveInFlightRef.current) {
       needsResaveRef.current = true;
@@ -539,6 +529,19 @@ export const TerminalCanvasView: React.FC = () => {
       }
     }
   }, [saveDocument]);
+
+  const flushSnapshotSaveRef = React.useRef(flushSnapshotSave);
+  flushSnapshotSaveRef.current = flushSnapshotSave;
+
+  React.useEffect(() => {
+    return () => {
+      if (saveTimeoutRef.current !== null) {
+        clearTimeout(saveTimeoutRef.current);
+        saveTimeoutRef.current = null;
+      }
+      void flushSnapshotSaveRef.current();
+    };
+  }, []);
 
   const scheduleSnapshotSave = React.useCallback(
     (snapshot: TLEditorSnapshot) => {
@@ -579,16 +582,16 @@ export const TerminalCanvasView: React.FC = () => {
       spawnIndexRef.current += 1;
       const offset = (spawnIndexRef.current - 1) % 8;
 
-      const shapeId = `shape:${crypto.randomUUID()}`;
+      const shapeId = `shape:${crypto.randomUUID()}` as TLShapeId;
 
-      editor.createShape({
+      editor.createShape<TerminalCanvasTerminalShape>({
         id: shapeId,
         type: TERMINAL_CARD_SHAPE_TYPE,
         x: 120 + offset * 44,
         y: 120 + offset * 44,
         props,
-      } as any);
-      editor.select(shapeId as any);
+      });
+      editor.select(shapeId);
       setActiveShapeId(shapeId);
 
       scheduleSnapshotSave(getSnapshot(editor.store) as TLEditorSnapshot);
@@ -679,7 +682,7 @@ export const TerminalCanvasView: React.FC = () => {
   if (error || !document) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-3 bg-background px-6 text-center">
-        <AlertTriangle className="size-12 text-amber-500" />
+        <AlertTriangle className="size-12 text-warning" />
         <div>
           <div className="text-base font-semibold text-foreground">Failed to load Terminal Canvas</div>
           <div className="text-sm text-muted-foreground">{error}</div>
@@ -748,7 +751,7 @@ export const TerminalCanvasView: React.FC = () => {
                               <DefaultSpinner />
                             </div>
                           ) : contextPaneState[selectedContextKey]?.status === "error" ? (
-                            <div className="rounded-lg border border-dashed border-amber-500/30 bg-amber-500/5 px-3 py-3 text-sm text-amber-700 dark:text-amber-300">
+                            <div className="rounded-lg border border-dashed border-warning/30 bg-warning/5 px-3 py-3 text-sm text-warning">
                               {contextPaneState[selectedContextKey]?.error}
                             </div>
                           ) : contextPaneState[selectedContextKey]?.panes.length ? (
@@ -823,11 +826,11 @@ export const TerminalCanvasView: React.FC = () => {
 
                     <section className="space-y-3">
                       <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
-                        <RefreshCcw className="size-4" />
+                        <RotateCw className="size-4" />
                         Attach active tmux sessions
                       </div>
                       {overviewError ? (
-                        <div className="rounded-xl border border-dashed border-amber-500/30 bg-amber-500/5 px-3 py-4 text-sm text-amber-700 dark:text-amber-300">
+                        <div className="rounded-xl border border-dashed border-warning/30 bg-warning/5 px-3 py-4 text-sm text-warning">
                           {overviewError}
                         </div>
                       ) : isOverviewLoading && !overview ? (
@@ -875,7 +878,7 @@ export const TerminalCanvasView: React.FC = () => {
               className="h-10 w-10 rounded-xl bg-muted/20 shadow-sm"
               title="Refresh active sessions"
             >
-              {isOverviewLoading ? <LoaderCircle className="size-4 animate-spin" /> : <RefreshCcw className="size-4" />}
+              {isOverviewLoading ? <LoaderCircle className="size-4 animate-spin" /> : <RotateCw className="size-4" />}
             </Button>
             <div className="rounded-xl border border-border bg-background px-3 py-2 text-xs text-muted-foreground shadow-sm">
               {isSaving ? "Saving…" : error ? "Save failed" : `Saved${board?.updated_at ? ` · ${new Date(board.updated_at).toLocaleTimeString()}` : ""}`}

--- a/apps/web/src/components/terminal/tldraw-theme.css
+++ b/apps/web/src/components/terminal/tldraw-theme.css
@@ -1,67 +1,39 @@
-/* Tldraw dark theme adaptations for Atmos */
+/* Tldraw v5: theme tokens live on `.tl-container` (see tldraw.css / .tl-theme__dark). */
 
-.dark .tl-canvas {
-  background: #09090b;
+.dark .tl-container {
+  --tl-color-background: #09090b;
+  --tl-color-grid: hsl(0, 0%, 40%);
+  --tl-color-low: hsl(260, 4.5%, 10.5%);
+  --tl-color-low-border: hsl(207, 10%, 10%);
+  --tl-color-divider: hsl(240, 9%, 22%);
+  --tl-color-panel: #27272a;
+  --tl-color-panel-contrast: hsl(245, 12%, 23%);
+  --tl-color-panel-overlay: hsl(210, 10%, 24%, 82%);
+  --tl-color-text: #f8f8f8;
+  --tl-color-text-0: hsl(0, 9%, 94%);
+  --tl-color-text-1: hsl(0, 0%, 85%);
+  --tl-color-text-3: #a1a1aa;
+  --tl-color-primary: #58a6ff;
+  --tl-color-selected: hsl(217, 89%, 61%);
+  --tl-color-focus: hsl(217, 76%, 80%);
+  --tl-color-selection-fill: rgba(88, 166, 255, 0.2);
+  --tl-color-selection-stroke: hsl(214, 84%, 56%);
 }
 
-.dark .tl-ui {
-  --tl-ui-panel: #27272a;
-  --tl-ui-panel-hover: #3f3f46;
-  --tl-ui-panel-active: #52525b;
-  --tl-ui-border: #27272a;
-  --tl-ui-text: #f8f8f8;
-  --tl-ui-text-muted: #a1a1aa;
-  --tl-ui-accent: #58a6ff;
-  --tl-ui-accent-hover: #79c0ff;
-  --tl-ui-accent-active: #218bff;
-  --tl-ui-background: #09090b;
-  --tl-ui-selection: rgba(88, 166, 255, 0.2);
-}
-
-.dark .tl-ui-menu {
-  background: #27272a;
-  border-color: #27272a;
-}
-
-.dark .tl-ui-button {
-  color: #f8f8f8;
-}
-
-.dark .tl-ui-button:hover {
-  background: #3f3f46;
-}
-
-.dark .tl-ui-input {
-  background: #18181b;
-  border-color: #27272a;
-  color: #f8f8f8;
-}
-
-.dark .tl-ui-toolbar {
-  background: #27272a;
-  border-color: #27272a;
-}
-
-.dark .tl-ui-panel {
-  background: #27272a;
-  border-color: #27272a;
-}
-
-/* Light theme adjustments */
-.light .tl-canvas {
-  background: #ffffff;
-}
-
-.light .tl-ui {
-  --tl-ui-panel: #f6f8fa;
-  --tl-ui-panel-hover: #eaeef2;
-  --tl-ui-panel-active: #d8dee4;
-  --tl-ui-border: #d0d7de;
-  --tl-ui-text: #24292f;
-  --tl-ui-text-muted: #6e7781;
-  --tl-ui-accent: #0969da;
-  --tl-ui-accent-hover: #218bff;
-  --tl-ui-accent-active: #0550ae;
-  --tl-ui-background: #ffffff;
-  --tl-ui-selection: rgba(9, 105, 218, 0.2);
+.light .tl-container {
+  --tl-color-background: #ffffff;
+  --tl-color-panel: #f6f8fa;
+  --tl-color-panel-contrast: #ffffff;
+  --tl-color-divider: #d0d7de;
+  --tl-color-low: hsl(204, 16%, 94%);
+  --tl-color-low-border: hsl(204, 16%, 92%);
+  --tl-color-text: #24292f;
+  --tl-color-text-0: hsl(0, 9%, 15%);
+  --tl-color-text-1: hsl(0, 0%, 25%);
+  --tl-color-text-3: #6e7781;
+  --tl-color-primary: #0969da;
+  --tl-color-selected: hsl(214, 84%, 56%);
+  --tl-color-focus: hsl(219, 65%, 50%);
+  --tl-color-selection-fill: rgba(9, 105, 218, 0.2);
+  --tl-color-selection-stroke: hsl(214, 84%, 56%);
 }

--- a/apps/web/src/components/terminal/use-terminal-canvas-board.ts
+++ b/apps/web/src/components/terminal/use-terminal-canvas-board.ts
@@ -21,6 +21,24 @@ export function createDefaultDocument(): TerminalCanvasBoardDocument {
   };
 }
 
+function isPlainJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Validates persisted snapshot shape expected by tldraw v5 (`TLEditorSnapshot`). */
+function parseStoredTldrawSnapshot(value: unknown): TLEditorSnapshot | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (!isPlainJsonObject(value)) {
+    throw new Error("Terminal canvas tldraw snapshot must be a JSON object when present");
+  }
+  if (!isPlainJsonObject(value.document) || !isPlainJsonObject(value.session)) {
+    throw new Error("Terminal canvas tldraw snapshot must include document and session objects");
+  }
+  return value as TLEditorSnapshot;
+}
+
 export function parseBoardDocument(documentJson: string): TerminalCanvasBoardDocument {
   let parsed: Partial<TerminalCanvasBoardDocument>;
 
@@ -47,7 +65,7 @@ export function parseBoardDocument(documentJson: string): TerminalCanvasBoardDoc
   return {
     schema: TERMINAL_CANVAS_SCHEMA,
     boardSlug: TERMINAL_CANVAS_BOARD_SLUG,
-    tldrawSnapshot: parsed.tldrawSnapshot ?? null,
+    tldrawSnapshot: parseStoredTldrawSnapshot(parsed.tldrawSnapshot),
   };
 }
 

--- a/apps/web/src/lib/terminal-layout-document.ts
+++ b/apps/web/src/lib/terminal-layout-document.ts
@@ -114,7 +114,7 @@ export function migrateTerminalLayoutDocument(
     layout?: MosaicNode<string> | null;
   } | null;
 
-  if (legacyValue?.panes && legacyValue.layout) {
+  if (legacyValue?.panes) {
     return {
       layout: {
         schema: TERMINAL_LAYOUT_SCHEMA,
@@ -125,7 +125,7 @@ export function migrateTerminalLayoutDocument(
             title: "Term",
             closable: false,
             panes: legacyValue.panes,
-            layout: legacyValue.layout,
+            layout: legacyValue.layout ?? null,
             maximizedTerminalId: null,
           },
         ],

--- a/crates/core-service/src/lib.rs
+++ b/crates/core-service/src/lib.rs
@@ -15,6 +15,7 @@ pub use service::terminal::{
     AttachSessionParams, CreateSessionParams, CreateSimpleSessionParams, SessionDetail,
     SessionType, TerminalMessage, TerminalResponse, TerminalService,
 };
+pub use service::terminal_overview::build_terminal_overview_active_sessions_json;
 pub use service::terminal_canvas::{
     SaveTerminalCanvasBoardReq, TerminalCanvasBoardDto, TerminalCanvasService,
 };

--- a/crates/core-service/src/service/mod.rs
+++ b/crates/core-service/src/service/mod.rs
@@ -10,6 +10,7 @@ pub mod session_title;
 pub mod skill;
 pub mod terminal;
 pub mod terminal_canvas;
+pub mod terminal_overview;
 pub mod test;
 pub mod workspace;
 pub mod ws_message;

--- a/crates/core-service/src/service/project.rs
+++ b/crates/core-service/src/service/project.rs
@@ -3,6 +3,7 @@ use core_engine::GitEngine;
 use infra::db::entities::project;
 use infra::db::repo::{ProjectRepo, WorkspaceRepo};
 use sea_orm::DatabaseConnection;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 pub struct ProjectService {
@@ -168,6 +169,11 @@ impl ProjectService {
     pub async fn get_project(&self, guid: String) -> Result<Option<project::Model>> {
         let repo = ProjectRepo::new(&self.db);
         Ok(repo.find_by_guid(&guid).await?)
+    }
+
+    pub async fn existing_non_deleted_project_guids(&self, candidates: &[String]) -> Result<HashSet<String>> {
+        let repo = ProjectRepo::new(&self.db);
+        Ok(repo.existing_non_deleted_guids(candidates).await?)
     }
 
     pub async fn update_order(&self, guid: String, order: i32) -> Result<()> {

--- a/crates/core-service/src/service/terminal_overview.rs
+++ b/crates/core-service/src/service/terminal_overview.rs
@@ -1,0 +1,82 @@
+//! Terminal overview helpers (diagnostics / manager UI).
+
+use crate::error::Result;
+use crate::service::project::ProjectService;
+use crate::service::terminal::TerminalService;
+use serde_json::{json, Value};
+use std::collections::{HashMap, HashSet};
+
+/// Builds JSON objects for `GET /api/system/terminal-overview` `active_sessions`,
+/// including `context_scope` and resolved `tmux_window_name`, with batched project
+/// existence checks and per-tmux-session window list caching.
+pub async fn build_terminal_overview_active_sessions_json(
+    terminal_service: &TerminalService,
+    project_service: &ProjectService,
+) -> Result<(Vec<Value>, usize)> {
+    let active_sessions = terminal_service.list_session_details().await;
+    let active_session_count = active_sessions.len();
+
+    let mut unique_workspace_ids: Vec<String> = active_sessions
+        .iter()
+        .map(|s| s.workspace_id.clone())
+        .collect();
+    unique_workspace_ids.sort_unstable();
+    unique_workspace_ids.dedup();
+
+    let existing_projects = project_service
+        .existing_non_deleted_project_guids(&unique_workspace_ids)
+        .await?;
+
+    let tmux_engine = terminal_service.tmux_engine();
+    let mut tmux_window_names_by_session: HashMap<String, HashMap<u32, String>> = HashMap::new();
+    let mut active_sessions_json = Vec::with_capacity(active_sessions.len());
+
+    for s in active_sessions {
+        let context_scope = if existing_projects.contains(&s.workspace_id) {
+            "project"
+        } else {
+            "workspace"
+        };
+
+        let tmux_window_name = if let Some(name) = s.terminal_name.clone() {
+            Some(name)
+        } else if let (Some(session_name), Some(window_index)) =
+            (s.tmux_session.as_ref(), s.tmux_window_index)
+        {
+            let session_windows = tmux_window_names_by_session
+                .entry(session_name.clone())
+                .or_insert_with(|| {
+                    tmux_engine
+                        .list_windows(session_name)
+                        .map(|windows| {
+                            windows
+                                .into_iter()
+                                .map(|window| (window.index, window.name))
+                                .collect::<HashMap<_, _>>()
+                        })
+                        .unwrap_or_default()
+                });
+
+            session_windows.get(&window_index).cloned()
+        } else {
+            None
+        };
+
+        active_sessions_json.push(json!({
+            "session_id": s.session_id,
+            "workspace_id": s.workspace_id,
+            "context_scope": context_scope,
+            "session_type": s.session_type,
+            "project_name": s.project_name,
+            "workspace_name": s.workspace_name,
+            "terminal_name": s.terminal_name,
+            "tmux_session": s.tmux_session,
+            "tmux_window_index": s.tmux_window_index,
+            "tmux_window_name": tmux_window_name,
+            "cwd": s.cwd,
+            "uptime_secs": s.uptime_secs,
+        }));
+    }
+
+    Ok((active_sessions_json, active_session_count))
+}

--- a/crates/infra/src/db/repo/project_repo.rs
+++ b/crates/infra/src/db/repo/project_repo.rs
@@ -1,5 +1,6 @@
 use sea_orm::sea_query::Expr;
 use sea_orm::*;
+use std::collections::HashSet;
 
 use crate::db::entities::base::BaseFields;
 use crate::db::entities::project;
@@ -38,6 +39,19 @@ impl<'a> ProjectRepo<'a> {
             .filter(project::Column::IsDeleted.eq(false))
             .one(self.db)
             .await?)
+    }
+
+    /// Returns the subset of `guids` that exist as non-deleted projects (single query).
+    pub async fn existing_non_deleted_guids(&self, guids: &[String]) -> Result<HashSet<String>> {
+        if guids.is_empty() {
+            return Ok(HashSet::new());
+        }
+        let rows = project::Entity::find()
+            .filter(project::Column::IsDeleted.eq(false))
+            .filter(project::Column::Guid.is_in(guids.to_vec()))
+            .all(self.db)
+            .await?;
+        Ok(rows.into_iter().map(|row| row.guid).collect())
     }
 
     /// 创建新项目

--- a/specs/APP/APP-014_terminal-canvas/TECH.md
+++ b/specs/APP/APP-014_terminal-canvas/TECH.md
@@ -27,7 +27,7 @@ The key design choice is:
 
 ## Architecture overview
 
-```
+```text
 apps/web
   ├─ CenterStage.tsx
   ├─ TerminalsView.tsx


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change addresses multiple code review findings around the terminal canvas and terminal overview flows.

### Valid findings fixed

- **Legacy layout migration** (`terminal-layout-document.ts`): the legacy guard required a truthy `layout`, which skipped payloads where `layout` was explicitly `null`. Migration now runs whenever `panes` exist and normalizes `layout` with `?? null`.

- **Terminal overview** (`handlers.rs` + core-service): per-session `get_project` could fail the whole endpoint and caused N+1 queries. Enrichment now lives in `core_service::build_terminal_overview_active_sessions_json`, which batch-loads existing project GUIDs via a new `ProjectRepo::existing_non_deleted_guids` helper and keeps the existing per-tmux-session window map cache.

- **Canvas board JSON** (`use-terminal-canvas-board.ts`): `tldrawSnapshot` is validated at parse time (non-null values must be plain objects with `document` and `session` objects) before being passed to tldraw.

- **Canvas view** (`TerminalCanvasView.tsx`): unmount clears the debounce timer and triggers a best-effort flush of pending saves; pointer propagation is only stopped for the **active** terminal body so tldraw can handle selection/transforms on inactive cards; custom terminal shape uses `TLBaseShape` / `TLShapeId` instead of `any`; warning UI uses theme `warning` tokens; static refresh icons use `RotateCw` per web AGENTS.

- **tldraw theme CSS** (`tldraw-theme.css`): replaced obsolete `.tl-ui-*` / `--tl-ui-*` overrides with tldraw v5-style overrides on `.tl-container` using `--tl-color-*` variables (aligned with published `tldraw.css`).

- **Spec lint** (`TECH.md`): architecture fence tagged as `text` for MD040.

### Finding not applied (already satisfied)

- **`createShape` ID format (P1)**: current code already uses `shape:${crypto.randomUUID()}` as a `TLShapeId`; no change required beyond typing cleanup.

### Validation

- `cargo check` could not be run in this environment (workspace `Cargo.toml` pulls a dependency requiring Cargo `edition2024` / newer toolchain than 1.83). TypeScript edits were checked with workspace diagnostics on the touched files.

## Test plan

- [ ] `cargo check` / `just test` on a toolchain that satisfies workspace manifests
- [ ] `bun run --filter web typecheck` (or project equivalent)
- [ ] Manual: terminal canvas save after quick navigation away; inactive terminal card select / move / resize; light/dark for warning blocks and tldraw chrome
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9429349f-effe-4be0-a2f9-f63c0b70c54b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9429349f-effe-4be0-a2f9-f63c0b70c54b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal canvas and overview: robust legacy layout migration, faster terminal overview with batched lookups, safer canvas saves, and `tldraw` v5 theme alignment.

- **Bug Fixes**
  - Legacy layout migration now runs when panes exist and preserves `layout ?? null`.
  - Terminal overview avoids N+1s and per-session failures by batching non-deleted project GUID checks and caching tmux window lists.
  - Canvas validates stored `tldraw` snapshot, flushes debounced saves on unmount, and only blocks pointer events on the active terminal; warning UI uses theme tokens and `RotateCw`.

- **Refactors**
  - Moved active-session enrichment to core-service (`build_terminal_overview_active_sessions_json`); API handler slimmed and returns `active_session_count`.
  - Added `ProjectRepo::existing_non_deleted_guids` for single-query lookups.
  - Tightened custom shape types with `TLBaseShape`/`TLShapeId`; updated theme CSS to `tldraw` v5 variables on `.tl-container`.

<sup>Written for commit 7ae14954293e9b3a4eb7dbf158cf29a3dd771fe8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

