### PR TITLE
Experiments: gated Management Center, wiki tab, footer ACP Chat

### DIFF
--- a/apps/web/src/api/ws-api.ts
+++ b/apps/web/src/api/ws-api.ts
@@ -2114,6 +2114,12 @@ export interface FunctionSettings {
     kill_tmux_on_archive?: boolean;
     close_acp_on_archive?: boolean;
   };
+  experiments?: {
+    mgmt_terminals?: boolean;
+    mgmt_agents?: boolean;
+    center_wiki_tab?: boolean;
+    [key: string]: unknown;
+  };
   [key: string]: unknown;
 }
 

--- a/apps/web/src/components/dialogs/SettingsModal.tsx
+++ b/apps/web/src/components/dialogs/SettingsModal.tsx
@@ -134,6 +134,8 @@ import { RemoteAccessSection } from '@/components/dialogs/RemoteAccessSection';
 import { useLayoutSettings } from '@/hooks/use-layout-settings';
 import { LabelEditorContent } from '@/components/layout/sidebar/workspace-metadata-controls';
 import { useEditorSettings } from '@/hooks/use-editor-settings';
+import { useExperimentSettings } from '@/hooks/use-experiment-settings';
+import { FlaskIcon, type FlaskIconHandle } from '@/components/ui/flask-icon';
 
 interface ShortcutEntry {
   keys: string[];
@@ -237,6 +239,11 @@ const SETTINGS_SECTIONS = [
     id: 'shortcuts',
     label: 'Shortcuts',
     description: 'Keyboard shortcuts across the application',
+  },
+  {
+    id: 'experiments',
+    label: 'Experiments',
+    description: 'Optional and preview features disabled by default',
   },
   {
     id: 'about',
@@ -611,6 +618,72 @@ function LayoutSettingsSection() {
                 Right Sidebar
               </button>
             </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ExperimentSettingsSection() {
+  const {
+    managementTerminalsEnabled,
+    managementAgentsEnabled,
+    centerWikiTabEnabled,
+    loadSettings,
+    setManagementTerminalsEnabled,
+    setManagementAgentsEnabled,
+    setCenterWikiTabEnabled,
+  } = useExperimentSettings();
+
+  React.useEffect(() => {
+    void loadSettings();
+  }, [loadSettings]);
+
+  return (
+    <div className="space-y-4">
+      <div className="overflow-hidden rounded-2xl border border-border">
+        <div className="grid grid-cols-[minmax(0,1fr)_100px] gap-8 border-b border-border px-6 py-4">
+          <div>
+            <p className="text-sm font-medium text-foreground">Terminals (Management Center)</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Show the Terminals tile in the left sidebar Management Center. Workspaces still have terminal tabs.
+            </p>
+          </div>
+          <div className="flex items-center justify-end">
+            <Switch
+              checked={managementTerminalsEnabled}
+              onCheckedChange={(checked) => void setManagementTerminalsEnabled(checked)}
+            />
+          </div>
+        </div>
+        <div className="grid grid-cols-[minmax(0,1fr)_100px] gap-8 border-b border-border px-6 py-4">
+          <div>
+            <p className="text-sm font-medium text-foreground">Agents (Management Center and footer ACP Chat)</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Show Agents in Management Center, command palette shortcuts, and the ACP Chat control in the footer. ACP Chat
+              inside the wiki flow is unchanged.
+            </p>
+          </div>
+          <div className="flex items-center justify-end">
+            <Switch
+              checked={managementAgentsEnabled}
+              onCheckedChange={(checked) => void setManagementAgentsEnabled(checked)}
+            />
+          </div>
+        </div>
+        <div className="grid grid-cols-[minmax(0,1fr)_100px] gap-8 px-6 py-4">
+          <div>
+            <p className="text-sm font-medium text-foreground">Project Wiki (center tab)</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Show the Project Wiki tab in the center stage tab bar next to Overview and Terminals.
+            </p>
+          </div>
+          <div className="flex items-center justify-end">
+            <Switch
+              checked={centerWikiTabEnabled}
+              onCheckedChange={(checked) => void setCenterWikiTabEnabled(checked)}
+            />
           </div>
         </div>
       </div>
@@ -3042,7 +3115,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
     }
   }, []);
 
-  const sectionIconRefs = React.useRef<Record<string, React.RefObject<AnimatedIconHandle | null>>>({});
+  const sectionIconRefs = React.useRef<Record<string, React.RefObject<AnimatedIconHandle | FlaskIconHandle | null>>>({});
   for (const section of SETTINGS_SECTIONS) {
     if (!sectionIconRefs.current[section.id]) {
       sectionIconRefs.current[section.id] = React.createRef();
@@ -3102,6 +3175,9 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                             {section.id === 'remote-access' && <WorldIcon ref={iconRef} className="shrink-0" size={16} />}
                             {section.id === 'shortcuts' && <KeyboardIcon ref={iconRef} className="shrink-0" size={16} />}
                             {section.id === 'editor' && <CodeXmlIcon ref={iconRef} className="shrink-0" size={16} />}
+                            {section.id === 'experiments' && (
+                              <FlaskIcon ref={iconRef as React.Ref<FlaskIconHandle>} className="shrink-0" size={16} />
+                            )}
                             <span className="min-w-0 truncate text-sm font-medium">{section.label}</span>
                           </MotionSidebarMenuButton>
                         </MotionSidebarMenuItem>
@@ -4206,6 +4282,8 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                       ]}
                     />
                   </div>
+                ) : resolvedActiveSection === 'experiments' ? (
+                  <ExperimentSettingsSection />
                 ) : resolvedActiveSection === 'layout' ? (
                   <LayoutSettingsSection />
                 ) : resolvedActiveSection === 'editor' ? (

--- a/apps/web/src/components/layout/CenterStage.tsx
+++ b/apps/web/src/components/layout/CenterStage.tsx
@@ -485,6 +485,7 @@ const CenterStage: React.FC = () => {
   const previousTerminalContextRef = React.useRef<string | null>(null);
 
   const centerWikiTabEnabled = useExperimentSettings((s) => s.centerWikiTabEnabled);
+  const experimentPrefsLoaded = useExperimentSettings((s) => s.loaded);
   const loadExperimentSettings = useExperimentSettings((s) => s.loadSettings);
   React.useEffect(() => {
     void loadExperimentSettings();
@@ -497,8 +498,16 @@ const CenterStage: React.FC = () => {
   // --- URL-synced tab state ---
   const [{ tab: tabFromUrl, wikiPage: wikiPageFromUrl }, setUrlParams] = useQueryStates(centerStageParams);
 
+  /** Until experiment prefs load, preserve `tab=wiki` from the URL so we do not strip deep links. */
+  const wikiCenterEligible = React.useMemo(() => {
+    if (experimentPrefsLoaded) return centerWikiTabEnabled;
+    return tabFromUrl === "wiki";
+  }, [experimentPrefsLoaded, centerWikiTabEnabled, tabFromUrl]);
+
   const resolvedTab = React.useMemo(() => {
-    if (tabFromUrl === "wiki" && !centerWikiTabEnabled) return FIXED_TERMINAL_TAB_VALUE;
+    if (tabFromUrl === "wiki" && experimentPrefsLoaded && !centerWikiTabEnabled) {
+      return FIXED_TERMINAL_TAB_VALUE;
+    }
     if (tabFromUrl === "project-wiki" && !projectWikiTabVisible) return "terminal";
     if (tabFromUrl === "code-review" && !codeReviewTabVisible) return "terminal";
     if (isTerminalCenterTabValue(tabFromUrl)) {
@@ -507,17 +516,23 @@ const CenterStage: React.FC = () => {
         : FIXED_TERMINAL_TAB_VALUE;
     }
     return tabFromUrl;
-  }, [tabFromUrl, centerWikiTabEnabled, projectWikiTabVisible, codeReviewTabVisible, visibleTerminalTabs]);
+  }, [
+    tabFromUrl,
+    experimentPrefsLoaded,
+    centerWikiTabEnabled,
+    projectWikiTabVisible,
+    codeReviewTabVisible,
+    visibleTerminalTabs,
+  ]);
 
   React.useEffect(() => {
-    if (!centerWikiTabEnabled && tabFromUrl === "wiki") {
-      setUrlParams({ tab: FIXED_TERMINAL_TAB_VALUE, wikiPage: null });
-    }
-  }, [centerWikiTabEnabled, tabFromUrl, setUrlParams]);
+    if (!experimentPrefsLoaded || centerWikiTabEnabled || tabFromUrl !== "wiki") return;
+    setUrlParams({ tab: FIXED_TERMINAL_TAB_VALUE, wikiPage: null });
+  }, [experimentPrefsLoaded, centerWikiTabEnabled, tabFromUrl, setUrlParams]);
 
   const setFixedTab = React.useCallback(
     (tab: FixedTab) => {
-      if (tab === "wiki" && !centerWikiTabEnabled) return;
+      if (tab === "wiki" && experimentPrefsLoaded && !centerWikiTabEnabled) return;
       if (tab === resolvedTab) return;
       const updates: Parameters<typeof setUrlParams>[0] = { tab };
       // Clear wikiPage when leaving wiki tab
@@ -526,15 +541,15 @@ const CenterStage: React.FC = () => {
       }
       setUrlParams(updates);
     },
-    [resolvedTab, setUrlParams, centerWikiTabEnabled]
+    [resolvedTab, setUrlParams, experimentPrefsLoaded, centerWikiTabEnabled]
   );
 
   const setWikiPage = React.useCallback(
     (page: string) => {
-      if (!centerWikiTabEnabled) return;
+      if (experimentPrefsLoaded && !centerWikiTabEnabled) return;
       setUrlParams({ tab: "wiki" as const, wikiPage: page });
     },
-    [setUrlParams, centerWikiTabEnabled]
+    [setUrlParams, experimentPrefsLoaded, centerWikiTabEnabled]
   );
 
   // Check Project Wiki window on mount and when workspace changes. Redirect to terminal only when window doesn't exist.
@@ -1159,7 +1174,7 @@ const CenterStage: React.FC = () => {
   }, [activeValue, closeTerminalTab, effectiveContextId, setUrlParams]);
 
   const handleCenterStageTabChange = React.useCallback((val: string) => {
-    if (val === "wiki" && !centerWikiTabEnabled) {
+    if (val === "wiki" && experimentPrefsLoaded && !centerWikiTabEnabled) {
       setUrlParams({ tab: FIXED_TERMINAL_TAB_VALUE, wikiPage: null });
       setActiveFile(null, effectiveContextId || undefined);
       return;
@@ -1184,7 +1199,15 @@ const CenterStage: React.FC = () => {
       // Clear tab param when opening a file
       setUrlParams({ tab: null, wikiPage: null });
     }
-  }, [centerWikiTabEnabled, effectiveContextId, setActiveFile, setActiveTerminalTab, setFixedTab, setUrlParams]);
+  }, [
+    centerWikiTabEnabled,
+    experimentPrefsLoaded,
+    effectiveContextId,
+    setActiveFile,
+    setActiveTerminalTab,
+    setFixedTab,
+    setUrlParams,
+  ]);
 
   // Additional terminal tabs (excluding the fixed Term tab), in display order.
   // Used to map ⌘2..⌘5 onto the first 4 of these tabs.
@@ -1565,7 +1588,7 @@ const CenterStage: React.FC = () => {
               </TooltipContent>
             </Tooltip>
           )}
-          {effectiveContextId && centerWikiTabEnabled && (
+          {effectiveContextId && wikiCenterEligible && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <TabsTab
@@ -2230,7 +2253,7 @@ const CenterStage: React.FC = () => {
         )}
 
         {/* Wiki Tab Content */}
-        {effectiveContextId && centerWikiTabEnabled && (
+        {effectiveContextId && wikiCenterEligible && (
           <div
             className={cn(
               "flex-1 min-h-0 min-w-0 overflow-hidden",

--- a/apps/web/src/components/layout/CenterStage.tsx
+++ b/apps/web/src/components/layout/CenterStage.tsx
@@ -110,6 +110,7 @@ import { useReviewSnapshotStore } from "@/hooks/use-review-snapshot-store";
 import { usePrewarmCodeLanguages } from "@/hooks/use-prewarm-code-languages";
 import { useAppRouter } from "@/hooks/use-app-router";
 import { useWorkspaceCreationStore } from "@/hooks/use-workspace-creation-store";
+import { useExperimentSettings } from "@/hooks/use-experiment-settings";
 
 const WikiTab = dynamic(
   () => import("@/components/wiki").then((m) => m.WikiTab),
@@ -483,6 +484,12 @@ const CenterStage: React.FC = () => {
   );
   const previousTerminalContextRef = React.useRef<string | null>(null);
 
+  const centerWikiTabEnabled = useExperimentSettings((s) => s.centerWikiTabEnabled);
+  const loadExperimentSettings = useExperimentSettings((s) => s.loadSettings);
+  React.useEffect(() => {
+    void loadExperimentSettings();
+  }, [loadExperimentSettings]);
+
   // Derive per-workspace visibility (default false for unseen workspaces)
   const projectWikiTabVisible = effectiveContextId ? (projectWikiVisibleMap[effectiveContextId] ?? false) : false;
   const codeReviewTabVisible = effectiveContextId ? (codeReviewVisibleMap[effectiveContextId] ?? false) : false;
@@ -491,6 +498,7 @@ const CenterStage: React.FC = () => {
   const [{ tab: tabFromUrl, wikiPage: wikiPageFromUrl }, setUrlParams] = useQueryStates(centerStageParams);
 
   const resolvedTab = React.useMemo(() => {
+    if (tabFromUrl === "wiki" && !centerWikiTabEnabled) return FIXED_TERMINAL_TAB_VALUE;
     if (tabFromUrl === "project-wiki" && !projectWikiTabVisible) return "terminal";
     if (tabFromUrl === "code-review" && !codeReviewTabVisible) return "terminal";
     if (isTerminalCenterTabValue(tabFromUrl)) {
@@ -499,10 +507,17 @@ const CenterStage: React.FC = () => {
         : FIXED_TERMINAL_TAB_VALUE;
     }
     return tabFromUrl;
-  }, [tabFromUrl, projectWikiTabVisible, codeReviewTabVisible, visibleTerminalTabs]);
+  }, [tabFromUrl, centerWikiTabEnabled, projectWikiTabVisible, codeReviewTabVisible, visibleTerminalTabs]);
+
+  React.useEffect(() => {
+    if (!centerWikiTabEnabled && tabFromUrl === "wiki") {
+      setUrlParams({ tab: FIXED_TERMINAL_TAB_VALUE, wikiPage: null });
+    }
+  }, [centerWikiTabEnabled, tabFromUrl, setUrlParams]);
 
   const setFixedTab = React.useCallback(
     (tab: FixedTab) => {
+      if (tab === "wiki" && !centerWikiTabEnabled) return;
       if (tab === resolvedTab) return;
       const updates: Parameters<typeof setUrlParams>[0] = { tab };
       // Clear wikiPage when leaving wiki tab
@@ -511,14 +526,15 @@ const CenterStage: React.FC = () => {
       }
       setUrlParams(updates);
     },
-    [resolvedTab, setUrlParams]
+    [resolvedTab, setUrlParams, centerWikiTabEnabled]
   );
 
   const setWikiPage = React.useCallback(
     (page: string) => {
+      if (!centerWikiTabEnabled) return;
       setUrlParams({ tab: "wiki" as const, wikiPage: page });
     },
-    [setUrlParams]
+    [setUrlParams, centerWikiTabEnabled]
   );
 
   // Check Project Wiki window on mount and when workspace changes. Redirect to terminal only when window doesn't exist.
@@ -1143,6 +1159,11 @@ const CenterStage: React.FC = () => {
   }, [activeValue, closeTerminalTab, effectiveContextId, setUrlParams]);
 
   const handleCenterStageTabChange = React.useCallback((val: string) => {
+    if (val === "wiki" && !centerWikiTabEnabled) {
+      setUrlParams({ tab: FIXED_TERMINAL_TAB_VALUE, wikiPage: null });
+      setActiveFile(null, effectiveContextId || undefined);
+      return;
+    }
     if (isTerminalCenterTabValue(val)) {
       if (effectiveContextId) {
         setActiveTerminalTab(effectiveContextId, val);
@@ -1163,7 +1184,7 @@ const CenterStage: React.FC = () => {
       // Clear tab param when opening a file
       setUrlParams({ tab: null, wikiPage: null });
     }
-  }, [effectiveContextId, setActiveFile, setActiveTerminalTab, setFixedTab, setUrlParams]);
+  }, [centerWikiTabEnabled, effectiveContextId, setActiveFile, setActiveTerminalTab, setFixedTab, setUrlParams]);
 
   // Additional terminal tabs (excluding the fixed Term tab), in display order.
   // Used to map ⌘2..⌘5 onto the first 4 of these tabs.
@@ -1544,7 +1565,7 @@ const CenterStage: React.FC = () => {
               </TooltipContent>
             </Tooltip>
           )}
-          {effectiveContextId && (
+          {effectiveContextId && centerWikiTabEnabled && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <TabsTab
@@ -2209,7 +2230,7 @@ const CenterStage: React.FC = () => {
         )}
 
         {/* Wiki Tab Content */}
-        {effectiveContextId && (
+        {effectiveContextId && centerWikiTabEnabled && (
           <div
             className={cn(
               "flex-1 min-h-0 min-w-0 overflow-hidden",

--- a/apps/web/src/components/layout/Footer.tsx
+++ b/apps/web/src/components/layout/Footer.tsx
@@ -30,6 +30,7 @@ import { ProviderGlyph } from '@/components/layout/UsagePopover';
 import { BotMessageSquareIcon, type BotMessageSquareHandle, TextShimmer, FilledBellIcon } from '@workspace/ui';
 import type { AnimatedIconHandle } from '@workspace/ui';
 import { NappingBotIcon } from '@/components/layout/NappingBotIcon';
+import { useExperimentSettings } from '@/hooks/use-experiment-settings';
 
 const CLIENT_TYPE_LABELS: Record<string, string> = {
   web: 'WEB',
@@ -362,6 +363,8 @@ function HoverScrollText({ text, active }: { text: string; active: boolean }) {
 const Footer: React.FC = () => {
   const connectionState = useWebSocketStore(s => s.connectionState);
   const [, setAgentChatOpen] = useAgentChatUrl();
+  const managementAgentsEnabled = useExperimentSettings((s) => s.managementAgentsEnabled);
+  const loadExperimentSettings = useExperimentSettings((s) => s.loadSettings);
   const [connections, setConnections] = useState<WsConnectionInfo[]>([]);
   const [usageOverview, setUsageOverview] = useState<UsageOverviewResponse | null>(null);
   const [usageIndex, setUsageIndex] = useState(0);
@@ -383,6 +386,10 @@ const Footer: React.FC = () => {
   const usageCarouselItem = usageCarouselItems.length > 0
     ? usageCarouselItems[usageIndex % usageCarouselItems.length]
     : null;
+
+  useEffect(() => {
+    void loadExperimentSettings();
+  }, [loadExperimentSettings]);
 
   useEffect(() => {
     if (connectionState !== 'connected') return;
@@ -621,8 +628,12 @@ const Footer: React.FC = () => {
             <AgentStatusPopoverContent />
           </PopoverContent>
         </Popover>
-        <div className="h-3 w-px bg-border"></div>
-        <AcpChatButton onClick={() => setAgentChatOpen(true)} />
+        {managementAgentsEnabled ? (
+          <>
+            <div className="h-3 w-px bg-border"></div>
+            <AcpChatButton onClick={() => setAgentChatOpen(true)} />
+          </>
+        ) : null}
       </div>
     </footer>
   );

--- a/apps/web/src/components/layout/GlobalSearch.tsx
+++ b/apps/web/src/components/layout/GlobalSearch.tsx
@@ -65,6 +65,7 @@ import { useWorkspaceContext } from '@/hooks/use-workspace-context';
 import { TaskListPanel } from '@/components/workspace/TaskListPanel';
 import { useSidebarLayout } from '@/components/layout/SidebarLayoutContext';
 import { UsagePopover } from '@/components/layout/UsagePopover';
+import { useExperimentSettings } from '@/hooks/use-experiment-settings';
 
 
 
@@ -143,6 +144,14 @@ export function GlobalSearch() {
   const [, setLeftSidebarTab] = useQueryState("lsTab", leftSidebarParams.lsTab);
   const [, setKanbanExpanded] = useQueryState("lsKanban", leftSidebarParams.lsKanban);
   const { isLeftCollapsed, setIsLeftCollapsed } = useSidebarLayout();
+
+  const managementTerminalsEnabled = useExperimentSettings((s) => s.managementTerminalsEnabled);
+  const managementAgentsEnabled = useExperimentSettings((s) => s.managementAgentsEnabled);
+  const loadExperimentSettings = useExperimentSettings((s) => s.loadSettings);
+
+  useEffect(() => {
+    void loadExperimentSettings();
+  }, [loadExperimentSettings]);
 
   // Sub-view state (null = search, inline panels reuse the command dialog shell)
   const [subView, setSubView] = useState<'todo' | 'usage' | null>(null);
@@ -442,46 +451,51 @@ export function GlobalSearch() {
       },
     });
 
-    items.push({
-      id: 'management-terminals',
-      type: 'management',
-      title: 'Management Center: Terminals',
-      description: 'Open terminal management',
-      keywords: ['management', 'center', 'terminals', 'terminal', 'sessions'],
-      icon: <Terminal className="size-4 text-muted-foreground" />,
-      action: () => {
-        router.push('/terminals');
-        setGlobalSearchOpen(false);
-      },
-    });
+    if (managementTerminalsEnabled) {
+      items.push({
+        id: 'management-terminals',
+        type: 'management',
+        title: 'Management Center: Terminals',
+        description: 'Open terminal management',
+        keywords: ['management', 'center', 'terminals', 'terminal', 'sessions'],
+        icon: <Terminal className="size-4 text-muted-foreground" />,
+        action: () => {
+          router.push('/terminals');
+          setGlobalSearchOpen(false);
+        },
+      });
+    }
 
-    // Management Center: Agents
-    items.push({
-      id: 'management-agents',
-      type: 'management',
-      title: 'Management Center: Agents',
-      description: 'Open agent management',
-      keywords: ['management', 'center', 'agents', 'agent', 'bot', 'ai', 'chat'],
-      icon: <Bot className="size-4 text-muted-foreground" />,
-      action: () => {
-        router.push('/agents');
-        setGlobalSearchOpen(false);
-      },
-    });
+    if (managementAgentsEnabled) {
+      items.push({
+        id: 'management-agents',
+        type: 'management',
+        title: 'Management Center: Agents',
+        description: 'Open agent management',
+        keywords: ['management', 'center', 'agents', 'agent', 'bot', 'ai', 'chat'],
+        icon: <Bot className="size-4 text-muted-foreground" />,
+        action: () => {
+          router.push('/agents');
+          setGlobalSearchOpen(false);
+        },
+      });
+    }
 
     // Quick Open Modals
-    items.push({
-      id: 'modal-chat-panel',
-      type: 'modal',
-      title: 'Open ACP Chat',
-      description: 'Toggle the ACP Chat panel',
-      keywords: ['chat', 'agent', 'panel', 'ai', 'assistant', 'message', 'conversation', 'open', 'acp'],
-      icon: <Bot className="size-4 text-muted-foreground" />,
-      action: () => {
-        setAgentChatOpen(true);
-        setGlobalSearchOpen(false);
-      },
-    });
+    if (managementAgentsEnabled) {
+      items.push({
+        id: 'modal-chat-panel',
+        type: 'modal',
+        title: 'Open ACP Chat',
+        description: 'Toggle the ACP Chat panel',
+        keywords: ['chat', 'agent', 'panel', 'ai', 'assistant', 'message', 'conversation', 'open', 'acp'],
+        icon: <Bot className="size-4 text-muted-foreground" />,
+        action: () => {
+          setAgentChatOpen(true);
+          setGlobalSearchOpen(false);
+        },
+      });
+    }
 
     items.push({
       id: 'modal-llm-providers',
@@ -657,7 +671,7 @@ export function GlobalSearch() {
     }
 
     return items;
-  }, [projects, router, setTheme, setGlobalSearchOpen, setCreateProjectOpen, setSelectedProjectId, setCreateWorkspaceOpen, quickAddWorkspace, isFullScreen, currentProject, setLlmProvidersOpen, setAgentChatOpen, setTokenUsageOpen, setLeftSidebarTab, setKanbanExpanded, isLeftCollapsed, setIsLeftCollapsed, setActiveSettingTab, setSettingsOpen, currentWorkspaceId, currentWorkspace]);
+  }, [projects, router, setTheme, setGlobalSearchOpen, setCreateProjectOpen, setSelectedProjectId, setCreateWorkspaceOpen, quickAddWorkspace, isFullScreen, currentProject, setLlmProvidersOpen, setAgentChatOpen, setTokenUsageOpen, setLeftSidebarTab, setKanbanExpanded, isLeftCollapsed, setIsLeftCollapsed, setActiveSettingTab, setSettingsOpen, currentWorkspaceId, currentWorkspace, managementTerminalsEnabled, managementAgentsEnabled]);
 
   // Fuse.js instance for app search
   const appFuse = useMemo(() => {

--- a/apps/web/src/components/layout/LeftSidebar.tsx
+++ b/apps/web/src/components/layout/LeftSidebar.tsx
@@ -98,6 +98,7 @@ import {
 import { isWorkspaceSetupBlocking } from '@/utils/workspace-setup';
 import { useWorkspaceCreationStore } from '@/hooks/use-workspace-creation-store';
 import { useLayoutSettings } from '@/hooks/use-layout-settings';
+import { useExperimentSettings } from '@/hooks/use-experiment-settings';
 import { useFileTreeStore } from '@/hooks/use-file-tree-store';
 
 interface LeftSidebarProps {
@@ -195,6 +196,39 @@ const LeftSidebar: React.FC<LeftSidebarProps> = () => {
     const isLoadingFiles = useFileTreeStore((s) => s.isLoading);
     const fetchFileTree = useFileTreeStore((s) => s.fetch);
     const showHiddenFiles = useFileTreeStore((s) => s.showHidden);
+
+    const managementTerminalsEnabled = useExperimentSettings((s) => s.managementTerminalsEnabled);
+    const managementAgentsEnabled = useExperimentSettings((s) => s.managementAgentsEnabled);
+    const loadExperimentSettings = useExperimentSettings((s) => s.loadSettings);
+    useEffect(() => {
+        void loadExperimentSettings();
+    }, [loadExperimentSettings]);
+
+    const managementCenterItems = useMemo(
+        (): Array<{
+            id: string;
+            label: string;
+            icon: typeof FolderKanban;
+            path?: string;
+            kind?: 'kanban' | 'new-workspace' | 'canvas';
+        }> => {
+            const all = [
+                { id: 'workspaces', label: 'Workspaces', icon: FolderKanban, path: '/workspaces' },
+                { id: 'skills', label: 'Skills', icon: Puzzle, path: '/skills' },
+                { id: 'terminals', label: 'Terminals', icon: SquareTerminal, path: '/terminals' },
+                { id: 'agents', label: 'Agents', icon: Bot, path: '/agents' },
+                { id: 'canvas', label: 'Canvas', icon: Frame, kind: 'canvas' as const },
+                { id: 'kanban', label: 'Kanban', icon: SquareKanban, kind: 'kanban' as const },
+                { id: 'new-workspace', label: 'New Workspace', icon: Plus, kind: 'new-workspace' as const },
+            ];
+            return all.filter((item) => {
+                if (item.id === 'terminals' && !managementTerminalsEnabled) return false;
+                if (item.id === 'agents' && !managementAgentsEnabled) return false;
+                return true;
+            });
+        },
+        [managementTerminalsEnabled, managementAgentsEnabled],
+    );
 
     const {
         isCreateProjectOpen,
@@ -743,21 +777,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = () => {
                     )}>
                         <div className="overflow-hidden">
                             {(() => {
-                                const managementItems: Array<{
-                                    id: string;
-                                    label: string;
-                                    icon: typeof FolderKanban;
-                                    path?: string;
-                                    kind?: 'kanban' | 'new-workspace' | 'canvas';
-                                }> = [
-                                    { id: 'workspaces', label: 'Workspaces', icon: FolderKanban, path: '/workspaces' },
-                                    { id: 'skills', label: 'Skills', icon: Puzzle, path: '/skills' },
-                                    { id: 'terminals', label: 'Terminals', icon: SquareTerminal, path: '/terminals' },
-                                    { id: 'agents', label: 'Agents', icon: Bot, path: '/agents' },
-                                    { id: 'canvas', label: 'Canvas', icon: Frame, kind: 'canvas' },
-                                    { id: 'kanban', label: 'Kanban', icon: SquareKanban, kind: 'kanban' },
-                                    { id: 'new-workspace', label: 'New Workspace', icon: Plus, kind: 'new-workspace' },
-                                ];
+                                const managementItems = managementCenterItems;
                                 const totalItems = managementItems.length;
                                 const isOddCount = totalItems % 2 === 1;
                                 return (

--- a/apps/web/src/components/providers/websocket-provider.tsx
+++ b/apps/web/src/components/providers/websocket-provider.tsx
@@ -5,6 +5,7 @@ import { useWebSocketStore } from '@/hooks/use-websocket';
 import { useAgentHooksStore } from '@/hooks/use-agent-hooks-store';
 import { useAgentNotifications } from '@/hooks/use-agent-notifications';
 import { useLayoutSettings } from '@/hooks/use-layout-settings';
+import { useExperimentSettings } from '@/hooks/use-experiment-settings';
 import { subscribeToWorkspaceSetupProgress, subscribeToWorkspaceDeleteProgress } from '@/hooks/use-project-store';
 
 interface WebSocketProviderProps {
@@ -73,6 +74,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     if (connectionState === 'connected') {
       useAgentHooksStore.getState().init();
       useLayoutSettings.getState().loadSettings();
+      void useExperimentSettings.getState().loadSettings();
     }
   }, [connectionState]);
 

--- a/apps/web/src/components/ui/flask-icon.tsx
+++ b/apps/web/src/components/ui/flask-icon.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes, MouseEvent } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface FlaskIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface FlaskIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const FlaskIcon = forwardRef<FlaskIconHandle, FlaskIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="currentColor"
+          height={size}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="5.632"
+          viewBox="0 0 512 512"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.g
+            animate={controls}
+            variants={{
+              normal: { rotate: 0, translateY: 0 },
+              animate: {
+                translateY: -12,
+                rotate: [0, 5, -5, 3, -3, 0],
+                transition: {
+                  ease: "linear",
+                  rotate: { duration: 0.8 },
+                },
+              },
+            }}
+          >
+            <circle cx="151.273" cy="407.273" r="11.636" />
+            <circle cx="244.364" cy="372.364" r="11.636" />
+            <circle cx="290.909" cy="418.909" r="11.636" />
+            <circle cx="221.091" cy="453.818" r="11.636" />
+            <circle cx="372.364" cy="430.545" r="11.636" />
+          </motion.g>
+          <motion.path
+            animate={controls}
+            d="M456.145,436.364l-79.127-124.509c0-2.327-2.327-4.655-3.491-5.818l-34.909-55.855c-8.146-13.964-12.8-29.091-12.8-44.218 V67.491c13.964-4.655,23.273-17.455,23.273-32.582C349.091,15.127,333.964,0,314.182,0H197.818 c-19.782,0-34.909,15.127-34.909,34.909c0,19.782,15.127,34.909,34.909,34.909h69.818c6.982,0,11.636-4.655,11.636-11.636 s-4.655-11.636-11.636-11.636h-69.818c-6.982,0-11.636-4.655-11.636-11.636c0-6.982,4.655-11.636,11.636-11.636h116.364 c6.982,0,11.636,4.655,11.636,11.636c0,6.982-4.655,11.636-11.636,11.636s-11.636,4.655-11.636,11.636v147.782 c0,19.782,5.818,39.564,16.291,55.855l19.782,31.418c-30.255-5.818-64-2.327-88.436,10.473 c-23.273,11.636-60.509,13.964-87.273,4.655l30.255-46.545c10.473-16.291,16.291-36.073,16.291-55.855V104.727 c0-6.982-4.655-11.636-11.636-11.636s-11.636,4.655-11.636,11.636v101.236c0,15.127-4.655,30.255-12.8,43.055l-34.909,55.855 c-1.164,1.164-2.327,2.327-3.491,3.491c0,1.164,0,1.164-1.164,2.327L55.855,436.364c-5.818,9.309-9.309,19.782-9.309,31.418v9.309 c0,19.782,15.127,34.909,34.909,34.909h349.091c19.782,0,34.909-15.127,34.909-34.909v-9.309 C465.455,456.145,461.964,445.673,456.145,436.364z M443.345,477.091h-1.164c0,6.982-4.655,11.636-11.636,11.636H81.455 c-6.982,0-11.636-4.655-11.636-11.636v-9.309c0-6.982,2.327-12.8,5.818-18.618l75.636-119.855 c15.127,5.818,32.582,8.145,50.036,8.145c22.109,0,43.055-4.655,60.509-12.8c25.6-12.8,68.655-13.964,96.582-1.164l79.127,125.673 c3.491,5.818,5.818,11.636,5.818,18.618V477.091z"
+            variants={{
+              normal: { rotate: 0, scale: 1 },
+              animate: {
+                scale: 0.9,
+                rotate: [0, 6, -6, 3, -3, 0],
+                transition: {
+                  duration: 0.8,
+                  scale: {
+                    duration: 0.3,
+                    type: "spring",
+                    bounce: 0.4,
+                    stiffness: 150,
+                    damping: 10,
+                  },
+                },
+              },
+            }}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+FlaskIcon.displayName = "FlaskIcon";
+
+export { FlaskIcon };

--- a/apps/web/src/hooks/use-experiment-settings.ts
+++ b/apps/web/src/hooks/use-experiment-settings.ts
@@ -1,0 +1,83 @@
+'use client';
+
+import { create } from 'zustand';
+import { functionSettingsApi } from '@/api/ws-api';
+import { useFunctionSettingsStore } from '@/hooks/use-function-settings-store';
+
+export interface ExperimentPrefs {
+  managementTerminalsEnabled: boolean;
+  managementAgentsEnabled: boolean;
+  centerWikiTabEnabled: boolean;
+}
+
+interface ExperimentSettingsState extends ExperimentPrefs {
+  loaded: boolean;
+  loadSettings: () => Promise<void>;
+  setManagementTerminalsEnabled: (value: boolean) => Promise<void>;
+  setManagementAgentsEnabled: (value: boolean) => Promise<void>;
+  setCenterWikiTabEnabled: (value: boolean) => Promise<void>;
+}
+
+function readExperiments(raw: unknown): ExperimentPrefs {
+  const section =
+    raw && typeof raw === 'object' && 'experiments' in raw
+      ? (raw as { experiments?: unknown }).experiments
+      : undefined;
+  const ex = section && typeof section === 'object' ? (section as Record<string, unknown>) : undefined;
+  return {
+    managementTerminalsEnabled: ex?.mgmt_terminals === true,
+    managementAgentsEnabled: ex?.mgmt_agents === true,
+    centerWikiTabEnabled: ex?.center_wiki_tab === true,
+  };
+}
+
+export const useExperimentSettings = create<ExperimentSettingsState>((set, get) => ({
+  managementTerminalsEnabled: false,
+  managementAgentsEnabled: false,
+  centerWikiTabEnabled: false,
+  loaded: false,
+
+  loadSettings: async () => {
+    if (get().loaded) return;
+    try {
+      const settings = await useFunctionSettingsStore.getState().load();
+      const prefs = readExperiments(settings);
+      set({ ...prefs, loaded: true });
+    } catch {
+      set({ loaded: true });
+    }
+  },
+
+  setManagementTerminalsEnabled: async (value) => {
+    const prev = get().managementTerminalsEnabled;
+    set({ managementTerminalsEnabled: value });
+    try {
+      await functionSettingsApi.update('experiments', 'mgmt_terminals', value);
+      useFunctionSettingsStore.getState().invalidate();
+    } catch {
+      set({ managementTerminalsEnabled: prev });
+    }
+  },
+
+  setManagementAgentsEnabled: async (value) => {
+    const prev = get().managementAgentsEnabled;
+    set({ managementAgentsEnabled: value });
+    try {
+      await functionSettingsApi.update('experiments', 'mgmt_agents', value);
+      useFunctionSettingsStore.getState().invalidate();
+    } catch {
+      set({ managementAgentsEnabled: prev });
+    }
+  },
+
+  setCenterWikiTabEnabled: async (value) => {
+    const prev = get().centerWikiTabEnabled;
+    set({ centerWikiTabEnabled: value });
+    try {
+      await functionSettingsApi.update('experiments', 'center_wiki_tab', value);
+      useFunctionSettingsStore.getState().invalidate();
+    } catch {
+      set({ centerWikiTabEnabled: prev });
+    }
+  },
+}));

--- a/apps/web/src/hooks/use-experiment-settings.ts
+++ b/apps/web/src/hooks/use-experiment-settings.ts
@@ -18,6 +18,8 @@ interface ExperimentSettingsState extends ExperimentPrefs {
   setCenterWikiTabEnabled: (value: boolean) => Promise<void>;
 }
 
+let loadInflight: Promise<void> | null = null;
+
 function readExperiments(raw: unknown): ExperimentPrefs {
   const section =
     raw && typeof raw === 'object' && 'experiments' in raw
@@ -39,13 +41,22 @@ export const useExperimentSettings = create<ExperimentSettingsState>((set, get) 
 
   loadSettings: async () => {
     if (get().loaded) return;
-    try {
-      const settings = await useFunctionSettingsStore.getState().load();
-      const prefs = readExperiments(settings);
-      set({ ...prefs, loaded: true });
-    } catch {
-      set({ loaded: true });
-    }
+
+    if (loadInflight) return loadInflight;
+
+    loadInflight = (async () => {
+      try {
+        const settings = await useFunctionSettingsStore.getState().load();
+        const prefs = readExperiments(settings);
+        set({ ...prefs, loaded: true });
+      } catch {
+        // Keep loaded false so callers can retry (e.g. after WS reconnect).
+      } finally {
+        loadInflight = null;
+      }
+    })();
+
+    return loadInflight;
   },
 
   setManagementTerminalsEnabled: async (value) => {

--- a/apps/web/src/lib/nuqs/searchParams.ts
+++ b/apps/web/src/lib/nuqs/searchParams.ts
@@ -88,11 +88,38 @@ export const tokenUsageParams = {
   tokenUsage: parseAsBoolean.withDefault(false),
 };
 
-export type SettingsModalTab = "about" | "terminal" | "code-agent" | "workspace" | "labels" | "integrations" | "ai" | "notify" | "remote-access" | "layout" | "shortcuts" | "editor";
+export type SettingsModalTab =
+  | "about"
+  | "terminal"
+  | "code-agent"
+  | "workspace"
+  | "labels"
+  | "integrations"
+  | "ai"
+  | "notify"
+  | "remote-access"
+  | "layout"
+  | "shortcuts"
+  | "editor"
+  | "experiments";
 
 export const settingsModalParams = {
   settingsModal: parseAsBoolean.withDefault(false),
-  activeSettingTab: parseAsStringEnum<SettingsModalTab>(["about", "terminal", "code-agent", "workspace", "labels", "integrations", "ai", "notify", "remote-access", "layout", "shortcuts", "editor"]).withDefault("layout"),
+  activeSettingTab: parseAsStringEnum<SettingsModalTab>([
+    "about",
+    "terminal",
+    "code-agent",
+    "workspace",
+    "labels",
+    "integrations",
+    "ai",
+    "notify",
+    "remote-access",
+    "layout",
+    "shortcuts",
+    "editor",
+    "experiments",
+  ]).withDefault("layout"),
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
Adds an **Experiments** area in Settings (flask icon) with three toggles, all **off by default**, persisted in `~/.atmos/function_settings.json` under `experiments`:

- **Terminals** — shows the Terminals tile in the left sidebar Management Center (workspace terminal tabs are unchanged).
- **Agents** — shows the Agents tile in Management Center, matching command-palette entries for terminals/agents and **Open ACP Chat**, and the **footer ACP Chat** control. ACP Chat embedded in the wiki flow is not tied to this toggle.
- **Project Wiki (center tab)** — shows the Project Wiki tab in the center tab bar; disables navigation to `wiki` when off and normalizes the URL.

### Follow-up fixes
- **Wiki deep link + load order:** wiki tab gating and URL cleanup now wait until experiment prefs have loaded; until then, `tab=wiki` is preserved and the wiki tab/surface can show when the URL requests it.
- **Failed experiment load:** `loadSettings` no longer sets `loaded` on error (allows retry); concurrent loads deduped via an inflight promise.

### Implementation notes
- New `useExperimentSettings` zustand hook + `FlaskIcon` component (`motion/react`).
- Loads once on WebSocket connect alongside layout settings; components also call load where needed.
- `functionSettingsApi.update('experiments', key, value)` merges keys; `FunctionSettings` type documents the section.

### Verification
- `bun typecheck` in `apps/web` still reports existing unrelated errors (CanvasView, proxy); changed files pass IDE diagnostics.



SetActiveBranch
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-707f2770-58d7-4018-8da7-62ce7b18ac5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-707f2770-58d7-4018-8da7-62ce7b18ac5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Experiments section in Settings with toggles for Management Center Terminals, Agents, and the center Project Wiki tab. All toggles are off by default and gate the sidebar, global search, center tabs, and the footer ACP Chat; wiki deep links are preserved until preferences load.

- **New Features**
  - Settings > Experiments (flask icon). Values persist in `~/.atmos/function_settings.json` under `experiments` (`mgmt_terminals`, `mgmt_agents`, `center_wiki_tab`). Settings load on WebSocket connect.
  - Management Center: show/hide Terminals and Agents tiles; global search items and “Open ACP Chat” follow the gates; footer ACP Chat appears only when Agents is on.
  - Center stage: Project Wiki tab shows only when enabled; navigation to `tab=wiki` is blocked and normalized when off.

- **Bug Fixes**
  - Avoid redirecting `tab=wiki` before experiment prefs load; keep deep links until prefs resolve. Deduplicate loads and allow retries after reconnect.

<sup>Written for commit 7b6005f2bca397333947843213a04a7cfcdd71b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

