### PR TITLE
ci: add deploy-relay workflow

### DIFF
--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -1,0 +1,32 @@
+name: Deploy relay
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "packages/relay/**"
+      - ".github/workflows/deploy-relay.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-relay-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Deploy Worker
+        working-directory: packages/relay
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # Optional: set repo secret CLOUDFLARE_ACCOUNT_ID if the token spans multiple accounts
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bunx wrangler deploy


### PR DESCRIPTION
Adds `.github/workflows/deploy-relay.yml` on `main` so we can `workflow_dispatch` relay deploys with repo Cloudflare secrets before APP-016 merges.

No runtime code changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow to deploy `packages/relay` to Cloudflare Workers via `wrangler`. It can run manually or on `main` pushes that touch `packages/relay`, uses repo secrets (`CLOUDFLARE_API_TOKEN`, optional `CLOUDFLARE_ACCOUNT_ID`), and cancels in-progress runs; supports APP-016 by enabling deploys before that branch merges.

<sup>Written for commit 20a388ee3ca256c94831bc242e3ec7c3917159d9. Summary will update on new commits. <a href="https://cubic.dev/pr/AruNi-01/atmos/pull/116?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

