### PR TITLE
ci(relay): require Node 22 for wrangler deploy

### DIFF
--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - uses: ./.github/actions/setup-bun
 
       - name: Deploy Worker


### PR DESCRIPTION
Wrangler 4.92+ requires Node 22; relay deploy failed on ubuntu-latest Node 20.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update relay deploy workflow to use Node 22 for `wrangler` deploys, fixing failures on ubuntu-latest where Node 20 was default. Adds `actions/setup-node@v4` with `node-version: 22` before the deploy step.

<sup>Written for commit 2debd88fa1f97931929b3d8bcc8f4a784532e5bc. Summary will update on new commits. <a href="https://cubic.dev/pr/AruNi-01/atmos/pull/117?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

