### PR TITLE
ci: bump GitHub Actions to Node 24–compatible versions

### DIFF
--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -21,9 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
+          package-manager-cache: false
 
       - uses: ./.github/actions/setup-bun
 

--- a/.github/workflows/release-local-model-runtime.yml
+++ b/.github/workflows/release-local-model-runtime.yml
@@ -199,7 +199,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Download checksums artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           pattern: checksums-*
           merge-multiple: false

--- a/.github/workflows/sync-r2.yml
+++ b/.github/workflows/sync-r2.yml
@@ -20,7 +20,7 @@ jobs:
   sync-install-scripts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Configure AWS CLI for R2
         env:
@@ -59,7 +59,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.release_tag, 'desktop-v'))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check if release is stable
         if: github.event_name == 'release'
@@ -139,7 +139,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.release_tag, 'local-web-runtime-v'))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check if release is stable
         if: github.event_name == 'release'


### PR DESCRIPTION
- setup-node@v5 + package-manager-cache: false (deploy-relay)\n- checkout@v5 (sync-r2)\n- download-artifact@v6 (local-model release)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CI workflows to use GitHub Actions that are compatible with Node 24 to prevent deprecation warnings and keep builds stable. Also disable `setup-node` package manager caching in deploy-relay.

- **Dependencies**
  - `.github/workflows/deploy-relay.yml`: bump to `actions/setup-node@v5` and set `package-manager-cache: false`
  - `.github/workflows/sync-r2.yml`: bump to `actions/checkout@v5`
  - `.github/workflows/release-local-model-runtime.yml`: bump to `actions/download-artifact@v6`

<sup>Written for commit ec135a266fc279a1627952a7555d3085b52ef2e6. Summary will update on new commits. <a href="https://cubic.dev/pr/AruNi-01/atmos/pull/118?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

