### PR TITLE
Align review and changes diff code views

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,6 +44,7 @@
     "@headless-tree/core": "^1.6.2",
     "@headless-tree/react": "^1.6.2",
     "@pierre/diffs": "^1.2.1",
+    "@pierre/icons": "^0.5.0",
     "@pierre/trees": "1.0.0-beta.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@replit/codemirror-lang-svelte": "^6.0.0",

--- a/apps/web/src/components/diff/ChangesCodeView.tsx
+++ b/apps/web/src/components/diff/ChangesCodeView.tsx
@@ -6,7 +6,6 @@ import type { CodeViewItem, DiffLineAnnotation, SelectedLineRange } from '@pierr
 import { parseDiffFromFile } from '@pierre/diffs';
 import { Loader2 } from 'lucide-react';
 import { toastManager } from '@workspace/ui';
-import { useTheme } from 'next-themes';
 import { gitApi } from '@/api/ws-api';
 import { useGitStore } from '@/hooks/use-git-store';
 import { useEditorStore } from '@/hooks/use-editor-store';
@@ -32,6 +31,7 @@ import {
   updateViewerDiffItem,
 } from '@/components/diff/diff-code-view-shared';
 import {
+  ATMOS_DIFF_THEME,
   buildSharedDiffViewOptions,
   CODE_VIEW_HOST_CLASS,
 } from '@/components/diff/diff-view-constants';
@@ -56,7 +56,6 @@ interface ChangesCodeViewProps {
 export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
   const groupKind = getDiffGroupKind(groupPath);
   const { effectiveContextId } = useContextParams();
-  const { resolvedTheme } = useTheme();
   const compareRef = useGitStore((s) => s.compareRef);
   const stagedFiles = useGitStore((s) => s.stagedFiles);
   const unstagedFiles = useGitStore((s) => s.unstagedFiles);
@@ -405,7 +404,7 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
   const codeViewOptions = useMemo(
     () => ({
       ...buildSharedDiffViewOptions({
-        theme: resolvedTheme === 'dark' ? 'pierre-dark' : 'pierre-light',
+        theme: ATMOS_DIFF_THEME,
         diffStyle,
         wordWrap,
         disableBackground: !showBackgrounds,
@@ -430,7 +429,6 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
       },
     }),
     [
-      resolvedTheme,
       diffStyle,
       wordWrap,
       showBackgrounds,

--- a/apps/web/src/components/diff/ChangesCodeView.tsx
+++ b/apps/web/src/components/diff/ChangesCodeView.tsx
@@ -19,9 +19,13 @@ import {
 } from '@/lib/diff-editor-paths';
 import { useDiffWorkerPoolReady } from '@/components/diff/DiffWorkerPoolProvider';
 import { DiffCodeViewSettingsMenu } from '@/components/diff/DiffCodeViewSettingsMenu';
+import { DiffCodeViewScaffold } from '@/components/diff/DiffCodeViewScaffold';
 import { DiffCopyAnnotation } from '@/components/diff/DiffCopyAnnotation';
+import { sortByDiffTreePath } from '@/components/diff/diff-file-order';
 import {
   applyCollapseModeToItems,
+  buildDiffSelectionInfo,
+  formatSelectedRangeLabel,
   getTextForRange,
   isCopyAnnotation,
   type CopyAnnotationMeta,
@@ -33,9 +37,10 @@ import {
 } from '@/components/diff/diff-view-constants';
 import {
   createDiffHeaderPrefixRenderer,
-  findDiffItemIdAtScrollTop,
+  findDiffItemIdForViewport,
   scrollCodeViewToItem,
 } from '@/components/diff/code-view-ui';
+import { formatDiffSelectionForAI } from '@/lib/format-selection-for-ai';
 
 const CODE_VIEW_BATCH_SIZE = 25;
 
@@ -60,6 +65,9 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
 
   const clearNavigationTarget = useEditorStore((s) => s.clearNavigationTarget);
   const setDiffGroupActiveFile = useEditorStore((s) => s.setDiffGroupActiveFile);
+  const selectedPath = useEditorStore((s) =>
+    effectiveContextId ? s.diffGroupActiveFiles[effectiveContextId]?.[groupPath] : undefined,
+  );
   const navigationTarget = useEditorStore((s) =>
     effectiveContextId
       ? s.navigationTargets[effectiveContextId]?.[groupPath] ?? null
@@ -74,8 +82,8 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
   );
   const [viewerKey, setViewerKey] = useState(0);
   const [viewerMounted, setViewerMounted] = useState(false);
-  const [diffStyle, setDiffStyle] = useState<'split' | 'unified'>('split');
-  const [wordWrap, setWordWrap] = useState(false);
+  const [diffStyle, setDiffStyle] = useState<'split' | 'unified'>('unified');
+  const [wordWrap, setWordWrap] = useState(true);
   const [showBackgrounds, setShowBackgrounds] = useState(true);
   const [lineNumbers, setLineNumbers] = useState(true);
   const [diffIndicators, setDiffIndicators] =
@@ -97,13 +105,15 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
 
   const groupFiles = useMemo(() => {
     if (!groupKind) return [];
-    return getFilesForDiffGroup(groupKind, {
-      stagedFiles,
-      unstagedFiles,
-      untrackedFiles,
-      compareFiles,
-      compareRef,
-    });
+    return sortByDiffTreePath(
+      getFilesForDiffGroup(groupKind, {
+        stagedFiles,
+        unstagedFiles,
+        untrackedFiles,
+        compareFiles,
+        compareRef,
+      }),
+    );
   }, [
     groupKind,
     stagedFiles,
@@ -120,6 +130,16 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
     }),
     [groupFiles],
   );
+  const treeItems = useMemo(
+    () =>
+      groupFiles.map((file) => ({
+        path: file.path,
+        additions: file.additions,
+        deletions: file.deletions,
+      })),
+    [groupFiles],
+  );
+  const groupLabel = getDiffGroupTabLabel(groupPath);
 
   const renderHeaderPrefix = useMemo(
     () =>
@@ -141,7 +161,7 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
   }, []);
 
   const handleCopyAnnotation = useCallback(
-    (itemId: string, key: string) => {
+    (itemId: string, key: string, note: string) => {
       const viewer = codeViewRef.current;
       const item = viewer?.getItem(itemId);
       const contents = loadedContentsRef.current.get(itemId);
@@ -152,8 +172,17 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
       );
       if (!annotation || !isCopyAnnotation(annotation)) return;
 
-      const text = getTextForRange(contents, annotation.metadata.range);
-      if (!text) {
+      const selectionInfo = buildDiffSelectionInfo({
+        filePath: annotation.metadata.filePath,
+        fileDiff: item.fileDiff,
+        contents,
+        range: annotation.metadata.range,
+      });
+      const prompt = selectionInfo
+        ? formatDiffSelectionForAI(selectionInfo, note)
+        : null;
+
+      if (!prompt) {
         toastManager.add({
           title: 'Nothing to copy',
           type: 'error',
@@ -161,15 +190,15 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
         return;
       }
 
-      void navigator.clipboard.writeText(text).then(
+      void navigator.clipboard.writeText(prompt).then(
         () =>
           toastManager.add({
-            title: 'Copied to clipboard',
+            title: 'Prompt copied',
             type: 'success',
           }),
         () =>
           toastManager.add({
-            title: 'Failed to copy',
+            title: 'Failed to copy prompt',
             type: 'error',
           }),
       );
@@ -214,6 +243,7 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
           itemId={annotation.metadata.filePath}
           onCopy={handleCopyAnnotation}
           onDismiss={removeCopyAnnotation}
+          lineLabel={formatSelectedRangeLabel(annotation.metadata.range)}
         />
       );
     },
@@ -235,6 +265,7 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
     pathByFileNameRef.current = new Map();
     loadedContentsRef.current = new Map();
     lastHandledNavRef.current = null;
+    scrollActiveIdRef.current = null;
 
     const loadFile = async (file: (typeof groupFiles)[number]) => {
       const diff = await gitApi.getFileDiff(repoPath, file.path);
@@ -338,6 +369,21 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
     codeViewRef.current?.addItems(pending);
   }, [viewerMounted, initialItems]);
 
+  useEffect(() => {
+    if (!effectiveContextId || itemIdsRef.current.length === 0) return;
+    const currentSelectedPath =
+      selectedPath && itemIdsRef.current.includes(selectedPath) ? selectedPath : null;
+    if (currentSelectedPath) return;
+    setDiffGroupActiveFile(groupPath, itemIdsRef.current[0], effectiveContextId);
+  }, [
+    effectiveContextId,
+    groupPath,
+    initialItems,
+    selectedPath,
+    setDiffGroupActiveFile,
+    viewerKey,
+  ]);
+
   const codeViewOptions = useMemo(
     () => ({
       ...buildSharedDiffViewOptions({
@@ -347,9 +393,16 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
         disableBackground: !showBackgrounds,
         lineNumbers,
         diffIndicators,
-        enableLineSelection: false,
+        enableLineSelection: true,
         enableGutterUtility: true,
       }),
+      onLineSelectionEnd(
+        range: SelectedLineRange | null,
+        context: { item: CodeViewItem<CopyAnnotationMeta> },
+      ) {
+        if (!range || context.item.type !== 'diff') return;
+        openCopyAnnotation(context.item.id, range);
+      },
       onGutterUtilityClick(
         range: SelectedLineRange,
         context: { item: CodeViewItem<CopyAnnotationMeta> },
@@ -389,9 +442,8 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
 
     return instance.subscribeToScroll((scrollTop, viewer) => {
       if (itemIdsRef.current.length === 0) return;
-      const activeId = findDiffItemIdAtScrollTop(
+      const activeId = findDiffItemIdForViewport(
         viewer,
-        scrollTop,
         itemIdsRef.current,
       );
       if (activeId == null || activeId === scrollActiveIdRef.current) return;
@@ -461,8 +513,26 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
 
   if (isLoading || !workerPoolReady) {
     return (
-      <div className="flex h-full items-center justify-center bg-background">
-        <Loader2 className="size-8 animate-spin text-muted-foreground" />
+      <div className="flex h-full flex-col overflow-hidden bg-background">
+        <DiffCodeViewScaffold
+          items={treeItems}
+          selectedPath={selectedPath}
+          ariaLabel={`${groupLabel} files`}
+          loading
+          loadingTreeLabel={groupLabel}
+          defaultTreeVisible={false}
+          toolbar={
+            <div className="flex items-center gap-2">
+              <div className="flex min-w-0 flex-1 items-center gap-3">
+                <span className="truncate text-sm font-medium text-foreground">{groupLabel}</span>
+              </div>
+              <Loader2 className="size-4 animate-spin text-muted-foreground" />
+            </div>
+          }
+          onSelectFile={() => {}}
+        >
+          <div />
+        </DiffCodeViewScaffold>
       </div>
     );
   }
@@ -486,50 +556,56 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
     );
   }
 
-  const groupLabel = getDiffGroupTabLabel(groupPath);
+  const handleSelectFile = (path: string) => {
+    if (effectiveContextId) {
+      setDiffGroupActiveFile(groupPath, path, effectiveContextId);
+    }
+    scrollCodeViewToItem(codeViewRef.current, path, { behavior: 'smooth' });
+  };
+  const toolbar = (
+    <div className="flex items-center gap-2">
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <span className="truncate text-sm font-medium text-foreground">{groupLabel}</span>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {treeItems.length} file{treeItems.length === 1 ? '' : 's'}
+        </span>
+        {compareRef ? (
+          <span className="shrink-0 text-xs text-muted-foreground">vs {compareRef}</span>
+        ) : null}
+      </div>
+      {(totalStats.additions > 0 || totalStats.deletions > 0) && (
+        <div className="flex shrink-0 items-center gap-2 text-[11px] font-mono font-medium">
+          <span className="text-emerald-500">+{totalStats.additions}</span>
+          <span className="text-red-500">-{totalStats.deletions}</span>
+        </div>
+      )}
+      <DiffCodeViewSettingsMenu
+        diffStyle={diffStyle}
+        onDiffStyleChange={setDiffStyle}
+        showBackgrounds={showBackgrounds}
+        onShowBackgroundsChange={setShowBackgrounds}
+        lineNumbers={lineNumbers}
+        onLineNumbersChange={setLineNumbers}
+        wordWrap={wordWrap}
+        onWordWrapChange={setWordWrap}
+        diffIndicators={diffIndicators}
+        onDiffIndicatorsChange={setDiffIndicators}
+        collapseMode={collapseMode}
+        onToggleCollapseMode={handleToggleCollapseMode}
+      />
+    </div>
+  );
 
   return (
     <div className="flex h-full flex-col overflow-hidden bg-background">
-      <div className="flex h-10 shrink-0 items-center justify-between border-b border-sidebar-border bg-muted/30 px-4">
-        <div className="flex min-w-0 flex-1 items-center gap-3">
-          <span className="truncate text-sm font-medium text-foreground">{groupLabel}</span>
-          <span className="text-xs text-muted-foreground shrink-0">
-            {initialItems.length} file{initialItems.length === 1 ? '' : 's'}
-          </span>
-          {compareRef ? (
-            <span className="text-xs text-muted-foreground shrink-0">vs {compareRef}</span>
-          ) : null}
-          {(totalStats.additions > 0 || totalStats.deletions > 0) && (
-            <span className="shrink-0 font-mono text-xs">
-              {totalStats.additions > 0 && (
-                <span className="text-green-500">+{totalStats.additions}</span>
-              )}
-              {totalStats.additions > 0 && totalStats.deletions > 0 && (
-                <span className="mx-1 text-muted-foreground">/</span>
-              )}
-              {totalStats.deletions > 0 && (
-                <span className="text-red-500">-{totalStats.deletions}</span>
-              )}
-            </span>
-          )}
-        </div>
-        <DiffCodeViewSettingsMenu
-          diffStyle={diffStyle}
-          onDiffStyleChange={setDiffStyle}
-          showBackgrounds={showBackgrounds}
-          onShowBackgroundsChange={setShowBackgrounds}
-          lineNumbers={lineNumbers}
-          onLineNumbersChange={setLineNumbers}
-          wordWrap={wordWrap}
-          onWordWrapChange={setWordWrap}
-          diffIndicators={diffIndicators}
-          onDiffIndicatorsChange={setDiffIndicators}
-          collapseMode={collapseMode}
-          onToggleCollapseMode={handleToggleCollapseMode}
-        />
-      </div>
-
-      <div className="relative flex min-h-0 flex-1 flex-col">
+      <DiffCodeViewScaffold
+        items={treeItems}
+        selectedPath={selectedPath}
+        ariaLabel={`${groupLabel} files`}
+        toolbar={toolbar}
+        defaultTreeVisible={false}
+        onSelectFile={handleSelectFile}
+      >
         <CodeView
           key={`${groupPath}:${viewerKey}`}
           ref={handleViewerRef}
@@ -539,7 +615,7 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
           renderAnnotation={renderAnnotation}
           className={CODE_VIEW_HOST_CLASS}
         />
-      </div>
+      </DiffCodeViewScaffold>
     </div>
   );
 }

--- a/apps/web/src/components/diff/ChangesCodeView.tsx
+++ b/apps/web/src/components/diff/ChangesCodeView.tsx
@@ -76,6 +76,8 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
 
   const workerPoolReady = useDiffWorkerPoolReady();
   const [isLoading, setIsLoading] = useState(true);
+  const [hasLoadedAllItems, setHasLoadedAllItems] = useState(false);
+  const [loadedItemVersion, setLoadedItemVersion] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [initialItems, setInitialItems] = useState<CodeViewItem<CopyAnnotationMeta>[]>(
     [],
@@ -261,6 +263,8 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
     setViewerKey((key) => key + 1);
     setViewerMounted(false);
     setInitialItems([]);
+    setHasLoadedAllItems(false);
+    setLoadedItemVersion(0);
     pendingAppendRef.current = [];
     pathByFileNameRef.current = new Map();
     loadedContentsRef.current = new Map();
@@ -317,6 +321,7 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
               id: result.id,
               type: 'diff',
               fileDiff: result.fileDiff,
+              collapsed: collapseMode === 'collapsed',
             });
           }
 
@@ -326,6 +331,7 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
             hasPublishedInitial = true;
             itemIdsRef.current = codeItems.map((item) => item.id);
             setInitialItems(codeItems);
+            setLoadedItemVersion((value) => value + 1);
             setIsLoading(false);
             await yieldToBrowser();
           } else {
@@ -336,6 +342,7 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
             const viewer = codeViewRef.current;
             if (viewer != null) {
               viewer.addItems(codeItems);
+              setLoadedItemVersion((value) => value + 1);
               await yieldToBrowser();
             } else {
               pendingAppendRef.current.push(...codeItems);
@@ -346,6 +353,9 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
         if (!cancelled && !hasPublishedInitial) {
           itemIdsRef.current = [];
           setIsLoading(false);
+        }
+        if (!cancelled) {
+          setHasLoadedAllItems(true);
         }
       } catch (err) {
         if (!cancelled) {
@@ -360,25 +370,28 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
     return () => {
       cancelled = true;
     };
-  }, [groupFiles, groupKind, repoPath]);
+  }, [collapseMode, groupFiles, groupKind, repoPath]);
 
   useEffect(() => {
     if (!viewerMounted || pendingAppendRef.current.length === 0) return;
     const pending = pendingAppendRef.current;
     pendingAppendRef.current = [];
     codeViewRef.current?.addItems(pending);
+    setLoadedItemVersion((value) => value + 1);
   }, [viewerMounted, initialItems]);
 
   useEffect(() => {
     if (!effectiveContextId || itemIdsRef.current.length === 0) return;
-    const currentSelectedPath =
-      selectedPath && itemIdsRef.current.includes(selectedPath) ? selectedPath : null;
-    if (currentSelectedPath) return;
+    if (selectedPath && !hasLoadedAllItems) return;
+    if (selectedPath && itemIdsRef.current.includes(selectedPath)) return;
+    if (selectedPath && navigationTarget?.diffFilePath === selectedPath) return;
     setDiffGroupActiveFile(groupPath, itemIdsRef.current[0], effectiveContextId);
   }, [
     effectiveContextId,
     groupPath,
+    hasLoadedAllItems,
     initialItems,
+    navigationTarget?.diffFilePath,
     selectedPath,
     setDiffGroupActiveFile,
     viewerKey,
@@ -470,15 +483,18 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
     ) {
       return;
     }
-    if (lastHandledNavRef.current === navigationScrollKey) return;
-    lastHandledNavRef.current = navigationScrollKey;
-
     const fileId = navigationTarget.diffFilePath;
+    if (!itemIdsRef.current.includes(fileId)) return;
+    if (lastHandledNavRef.current === navigationScrollKey) return;
     if (effectiveContextId) {
       setDiffGroupActiveFile(groupPath, fileId, effectiveContextId);
     }
 
     requestAnimationFrame(() => {
+      if (!codeViewRef.current?.getItem(fileId)) {
+        return;
+      }
+      lastHandledNavRef.current = navigationScrollKey;
       scrollCodeViewToItem(codeViewRef.current, fileId, {
         line: navigationTarget.line,
         behavior: 'smooth',
@@ -495,6 +511,7 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
   }, [
     navigationTarget,
     navigationScrollKey,
+    loadedItemVersion,
     isLoading,
     viewerMounted,
     groupPath,

--- a/apps/web/src/components/diff/ChangesCodeView.tsx
+++ b/apps/web/src/components/diff/ChangesCodeView.tsx
@@ -104,6 +104,11 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
     Map<string, { oldContent: string; newContent: string }>
   >(new Map());
   const copyKeyRef = useRef(0);
+  const collapseModeRef = useRef(collapseMode);
+
+  useEffect(() => {
+    collapseModeRef.current = collapseMode;
+  }, [collapseMode]);
 
   const groupFiles = useMemo(() => {
     if (!groupKind) return [];
@@ -321,7 +326,7 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
               id: result.id,
               type: 'diff',
               fileDiff: result.fileDiff,
-              collapsed: collapseMode === 'collapsed',
+              collapsed: collapseModeRef.current === 'collapsed',
             });
           }
 
@@ -370,7 +375,7 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
     return () => {
       cancelled = true;
     };
-  }, [collapseMode, groupFiles, groupKind, repoPath]);
+  }, [groupFiles, groupKind, repoPath]);
 
   useEffect(() => {
     if (!viewerMounted || pendingAppendRef.current.length === 0) return;

--- a/apps/web/src/components/diff/DiffCodeViewScaffold.tsx
+++ b/apps/web/src/components/diff/DiffCodeViewScaffold.tsx
@@ -40,6 +40,8 @@ export function DiffCodeViewScaffold({
     <div className="flex h-full min-h-0 flex-col">
       <div className="flex items-center gap-2 border-b border-border/40 px-2 py-1.5 shrink-0">
         <button
+          type="button"
+          aria-label={treeVisible ? "Hide file tree" : "Show file tree"}
           className="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
           onClick={() => setTreeVisible((value) => !value)}
           title={treeVisible ? "Hide file tree" : "Show file tree"}

--- a/apps/web/src/components/diff/DiffCodeViewScaffold.tsx
+++ b/apps/web/src/components/diff/DiffCodeViewScaffold.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
+import { ScrollArea, Skeleton } from "@workspace/ui";
+import { AnimatePresence, motion } from "motion/react";
+import { DiffFileTree, type DiffFileTreeItem } from "@/components/diff/DiffFileTree";
+
+interface DiffCodeViewScaffoldProps {
+  items: DiffFileTreeItem[];
+  selectedPath?: string;
+  ariaLabel: string;
+  toolbar: ReactNode;
+  renderFileInlineDecoration?: (item: DiffFileTreeItem) => ReactNode;
+  onSelectFile: (path: string) => void;
+  children: ReactNode;
+  loading?: boolean;
+  loadingTreeLabel?: string;
+  defaultTreeVisible?: boolean;
+}
+
+export function DiffCodeViewScaffold({
+  items,
+  selectedPath,
+  ariaLabel,
+  toolbar,
+  renderFileInlineDecoration,
+  onSelectFile,
+  children,
+  loading = false,
+  loadingTreeLabel,
+  defaultTreeVisible = true,
+}: DiffCodeViewScaffoldProps) {
+  const [treeVisible, setTreeVisible] = useState(defaultTreeVisible);
+  const [treeWidth, setTreeWidth] = useState(224);
+  const [isResizing, setIsResizing] = useState(false);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex items-center gap-2 border-b border-border/40 px-2 py-1.5 shrink-0">
+        <button
+          className="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+          onClick={() => setTreeVisible((value) => !value)}
+          title={treeVisible ? "Hide file tree" : "Show file tree"}
+        >
+          {treeVisible ? (
+            <PanelLeftClose className="size-3.5" />
+          ) : (
+            <PanelLeftOpen className="size-3.5" />
+          )}
+        </button>
+        <div className="flex-1 min-w-0">{toolbar}</div>
+      </div>
+
+      <div className="flex flex-1 min-h-0">
+        <AnimatePresence initial={false}>
+          {treeVisible ? (
+            <motion.div
+              key="tree"
+              initial={{ width: 0, opacity: 0 }}
+              animate={{ width: treeWidth, opacity: 1 }}
+              exit={{ width: 0, opacity: 0 }}
+              transition={
+                isResizing
+                  ? { duration: 0 }
+                  : { duration: 0.2, ease: "easeInOut" }
+              }
+              className="shrink-0 overflow-hidden"
+            >
+              {loading ? (
+                <div
+                  className="flex h-full flex-col gap-1.5 overflow-hidden border-r border-border/40 p-2"
+                  style={{ width: treeWidth }}
+                >
+                  {loadingTreeLabel ? (
+                    <div className="px-1 pb-1 text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground/70">
+                      {loadingTreeLabel}
+                    </div>
+                  ) : null}
+                  {[...Array(16)].map((_, index) => (
+                    <Skeleton
+                      key={index}
+                      className="h-4 rounded shrink-0"
+                      style={{
+                        width: `${40 + (index % 5) * 10}%`,
+                        marginLeft: index % 3 !== 0 ? "12px" : "0",
+                      }}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <ScrollArea
+                  className="h-full border-r border-border/40 py-1"
+                  style={{ width: treeWidth }}
+                >
+                  <DiffFileTree
+                    items={items}
+                    selectedPath={selectedPath}
+                    ariaLabel={ariaLabel}
+                    renderFileInlineDecoration={renderFileInlineDecoration}
+                    onSelectFile={onSelectFile}
+                  />
+                </ScrollArea>
+              )}
+            </motion.div>
+          ) : null}
+        </AnimatePresence>
+
+        {treeVisible ? (
+          <div
+            className="relative w-px shrink-0 cursor-col-resize bg-border/40 transition-colors before:absolute before:-inset-x-2 before:h-full before:transition-colors before:hover:bg-primary/40"
+            onMouseDown={(event) => {
+              event.preventDefault();
+              setIsResizing(true);
+              const startX = event.clientX;
+              const startWidth = treeWidth;
+              const onMove = (moveEvent: MouseEvent) => {
+                setTreeWidth(
+                  Math.max(140, Math.min(480, startWidth + moveEvent.clientX - startX)),
+                );
+              };
+              const onUp = () => {
+                setIsResizing(false);
+                window.removeEventListener("mousemove", onMove);
+                window.removeEventListener("mouseup", onUp);
+              };
+              window.addEventListener("mousemove", onMove);
+              window.addEventListener("mouseup", onUp);
+            }}
+          />
+        ) : null}
+
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+          {loading ? (
+            <div className="flex flex-1 flex-col gap-3 p-2">
+              {[...Array(4)].map((_, index) => (
+                <Skeleton key={index} className="h-28 rounded-lg" />
+              ))}
+            </div>
+          ) : (
+            children
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/diff/DiffCodeViewSettingsMenu.tsx
+++ b/apps/web/src/components/diff/DiffCodeViewSettingsMenu.tsx
@@ -2,14 +2,15 @@
 
 import type { DiffIndicators } from '@pierre/diffs';
 import {
-  Columns2,
-  EyeOff,
-  Minus,
-  MoreHorizontal,
-  Plus,
-  Rows3,
-  Settings2,
-} from 'lucide-react';
+  IconCodeStyleBars,
+  IconCollapsedRow,
+  IconDiffSplit,
+  IconDiffUnified,
+  IconExpandAll,
+  IconEyeSlash,
+  IconGearFill,
+  IconSymbolDiffstat,
+} from '@pierre/icons';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -66,9 +67,9 @@ export function DiffCodeViewSettingsMenu({
         }
       >
         {diffStyle === 'split' ? (
-          <Columns2 className="size-3.5" />
+          <IconDiffSplit className="size-3.5" />
         ) : (
-          <Rows3 className="size-3.5" />
+          <IconDiffUnified className="size-3.5" />
         )}
       </button>
       <button
@@ -80,9 +81,9 @@ export function DiffCodeViewSettingsMenu({
         onClick={onToggleCollapseMode}
       >
         {collapseMode === 'expanded' ? (
-          <Minus className="size-3.5 rotate-90" />
+          <IconExpandAll className="size-3.5" />
         ) : (
-          <Plus className="size-3.5 rotate-90" />
+          <IconCollapsedRow className="size-3.5" />
         )}
       </button>
       <DropdownMenu>
@@ -92,7 +93,7 @@ export function DiffCodeViewSettingsMenu({
             title="View options"
             className="flex size-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-foreground"
           >
-            <Settings2 className="size-3.5" />
+            <IconGearFill className="size-3.5" />
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-52">
@@ -148,21 +149,21 @@ export function DiffCodeViewSettingsMenu({
                   className="size-7 p-0"
                   aria-label="Bar indicators"
                 >
-                  <MoreHorizontal className="size-3" />
+                  <IconCodeStyleBars className="size-3" />
                 </ToggleGroupItem>
                 <ToggleGroupItem
                   value="classic"
                   className="size-7 p-0"
                   aria-label="Classic indicators"
                 >
-                  <span className="font-mono text-[10px] leading-none">±</span>
+                  <IconSymbolDiffstat className="size-3" />
                 </ToggleGroupItem>
                 <ToggleGroupItem
                   value="none"
                   className="size-7 p-0"
                   aria-label="No indicators"
                 >
-                  <EyeOff className="size-3" />
+                  <IconEyeSlash className="size-3" />
                 </ToggleGroupItem>
               </ToggleGroup>
             </div>

--- a/apps/web/src/components/diff/DiffCopyAnnotation.tsx
+++ b/apps/web/src/components/diff/DiffCopyAnnotation.tsx
@@ -1,16 +1,18 @@
 'use client';
 
+import { useState } from 'react';
 import type { DiffLineAnnotation } from '@pierre/diffs';
 import { Copy, X } from 'lucide-react';
-import { Button, toastManager } from '@workspace/ui';
+import { Button, Textarea } from '@workspace/ui';
 import { cn } from '@/lib/utils';
 import type { CopyAnnotationMeta } from '@/components/diff/diff-code-view-shared';
 
 interface DiffCopyAnnotationProps {
   annotation: DiffLineAnnotation<CopyAnnotationMeta>;
   itemId: string;
-  onCopy: (itemId: string, key: string) => void;
+  onCopy: (itemId: string, key: string, note: string) => void;
   onDismiss: (itemId: string, key: string) => void;
+  lineLabel: string;
 }
 
 export function DiffCopyAnnotation({
@@ -18,40 +20,57 @@ export function DiffCopyAnnotation({
   itemId,
   onCopy,
   onDismiss,
+  lineLabel,
 }: DiffCopyAnnotationProps) {
   const { key } = annotation.metadata;
-  const lineLabel =
-    annotation.lineNumber === annotation.lineNumber
-      ? `Line ${annotation.lineNumber}`
-      : 'Selection';
+  const [note, setNote] = useState('');
 
   return (
     <div
       className={cn(
-        'my-1 mx-2 flex items-center gap-2 rounded-lg border border-border/50 bg-background px-3 py-2 text-xs shadow-sm',
+        'mx-3 my-2 rounded-lg border border-primary/20 bg-background/95 p-3 shadow-sm',
       )}
     >
-      <span className="min-w-0 flex-1 truncate text-muted-foreground">
-        {lineLabel}
-      </span>
-      <Button
-        type="button"
-        size="sm"
-        variant="secondary"
-        className="h-7 shrink-0 gap-1.5 px-2.5"
-        onClick={() => onCopy(itemId, key)}
-      >
-        <Copy className="size-3.5" />
-        Copy
-      </Button>
-      <button
-        type="button"
-        className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        aria-label="Dismiss"
-        onClick={() => onDismiss(itemId, key)}
-      >
-        <X className="size-3.5" />
-      </button>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-medium text-foreground">{lineLabel}</p>
+          <p className="text-xs text-muted-foreground">
+            Add context for the prompt before copying it.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          aria-label="Dismiss"
+          onClick={() => onDismiss(itemId, key)}
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+      <Textarea
+        value={note}
+        onChange={(event) => setNote(event.target.value)}
+        placeholder="What should the prompt focus on?"
+        className="mt-3 min-h-24 bg-background"
+      />
+      <div className="mt-3 flex items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => onCopy(itemId, key, note)}
+        >
+          <Copy className="mr-1.5 size-3.5" />
+          Copy Prompt
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={() => onDismiss(itemId, key)}
+        >
+          Cancel
+        </Button>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/diff/DiffFileTree.tsx
+++ b/apps/web/src/components/diff/DiffFileTree.tsx
@@ -129,10 +129,7 @@ function buildRows(
   depth = 0,
 ): TreeRow[] {
   const rows: TreeRow[] = [];
-  const children = Array.from(node.children.values()).sort((a, b) => {
-    if (!!a.file !== !!b.file) return a.file ? 1 : -1;
-    return a.name.localeCompare(b.name);
-  });
+  const children = Array.from(node.children.values());
 
   for (const child of children) {
     if (child.file) {

--- a/apps/web/src/components/diff/DiffViewer.tsx
+++ b/apps/web/src/components/diff/DiffViewer.tsx
@@ -194,6 +194,25 @@ export const DiffViewer = ({
     return { oldMap, newMap };
   }, [diffMeta]);
 
+  const getMappedContextRange = useCallback((
+    lineMap: Map<number, LineTypeInfo>,
+    startLine: number,
+    endLine: number,
+  ) => {
+    const mapped: LineTypeInfo[] = [];
+    for (let line = startLine; line <= endLine; line++) {
+      const info = lineMap.get(line);
+      if (info) mapped.push(info);
+    }
+
+    return {
+      oldStart: mapped[0]?.oldLine ?? startLine,
+      oldEnd: mapped[mapped.length - 1]?.oldLine ?? endLine,
+      newStart: mapped[0]?.newLine ?? startLine,
+      newEnd: mapped[mapped.length - 1]?.newLine ?? endLine,
+    };
+  }, []);
+
   const [popoverPosition, setPopoverPosition] = useState({ x: 0, y: 0 });
   const [isPopoverVisible, setIsPopoverVisible] = useState(false);
   const [isPopoverExpanded, setIsPopoverExpanded] = useState(false);
@@ -253,8 +272,9 @@ export const DiffViewer = ({
 
     if (onlyContext) {
       changeType = 'context';
-      beforeText = oldLines.slice(normalizedStart - 1, normalizedEnd).join('\n');
-      afterText = newLines.slice(normalizedStart - 1, normalizedEnd).join('\n');
+      const mapped = getMappedContextRange(sideMap, normalizedStart, normalizedEnd);
+      beforeText = oldLines.slice(mapped.oldStart - 1, mapped.oldEnd).join('\n');
+      afterText = newLines.slice(mapped.newStart - 1, mapped.newEnd).join('\n');
     } else if (onlyPureAddition) {
       changeType = 'addition';
       beforeText = undefined;
@@ -300,7 +320,7 @@ export const DiffViewer = ({
       beforeText,
       afterText,
     };
-  }, [filePath, lineTypeMap, newFile?.contents, oldFile?.contents]);
+  }, [filePath, getMappedContextRange, lineTypeMap, newFile?.contents, oldFile?.contents]);
 
   const openInlineCommentDraft = useCallback((draft: InlineCommentDraft) => {
     dismissPopover();
@@ -347,8 +367,8 @@ export const DiffViewer = ({
         startLine: selection.startLine,
         endLine: selection.endLine,
         selectedText: selection.selectedText,
-        beforeContext: [],
-        afterContext: [],
+        beforeContext: selection.beforeText ? selection.beforeText.split('\n') : [],
+        afterContext: selection.afterText ? selection.afterText.split('\n') : [],
       });
       return;
     }

--- a/apps/web/src/components/diff/DiffViewer.tsx
+++ b/apps/web/src/components/diff/DiffViewer.tsx
@@ -13,7 +13,7 @@ import type {
 import { parseDiffFromFile } from '@pierre/diffs';
 import { gitApi, reviewWsApi } from '@/api/ws-api';
 import type { ReviewMessageDto, ReviewCommentDto } from '@/api/ws-api';
-import { Button, Loader2, Textarea, toastManager, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, Tooltip, TooltipContent, TooltipTrigger } from '@workspace/ui';
+import { Button, Loader2, Textarea, toastManager, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, Tooltip, TooltipContent, TooltipTrigger, Switch } from '@workspace/ui';
 import { useTheme } from 'next-themes';
 import { useGitStore } from '@/hooks/use-git-store';
 import { useEditorStore } from '@/hooks/use-editor-store';
@@ -24,11 +24,12 @@ import { ReviewMessageActionsMenu } from '@/components/diff/review/ReviewMessage
 import type { SelectionInfo } from '@/lib/format-selection-for-ai';
 import { useContextParams } from '@/hooks/use-context-params';
 import { cn } from '@/lib/utils';
-import { ChevronRight, Command, CornerDownLeft, MessageSquareReply, SendHorizontal, X, MoreHorizontal } from 'lucide-react';
+import { ChevronRight, Columns2, Command, CornerDownLeft, MessageSquareReply, Minus, Rows3, SendHorizontal, Settings2, X } from 'lucide-react';
 import {
   reviewCommentStatusLabel,
   statusTone,
 } from '@/components/diff/review/utils';
+import { buildSharedDiffViewOptions } from '@/components/diff/diff-view-constants';
 
 interface DiffViewerProps {
   repoPath: string;
@@ -60,25 +61,8 @@ function getDiffScrollRoot(container: HTMLElement | null): HTMLElement | null {
   return codePanel ?? container;
 }
 
-const SCROLLBAR_CSS = `
-  ::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
-  }
-  ::-webkit-scrollbar-track {
-    background: transparent;
-  }
-  ::-webkit-scrollbar-thumb {
-    background: rgba(128, 128, 128, 0.2);
-    border-radius: 9999px;
-  }
-  ::-webkit-scrollbar-thumb:hover {
-    background: rgba(128, 128, 128, 0.4);
-  }
-  ::-webkit-scrollbar-corner {
-    background: transparent;
-  }
-`;
+const SETTING_ROW_CLASS =
+  'flex w-full cursor-pointer items-center justify-between gap-4 px-2 py-1.5 text-sm';
 
 export const DiffViewer = ({
   repoPath,
@@ -351,9 +335,25 @@ export const DiffViewer = ({
 
     const startLine = Math.min(range.start, range.end);
     const endLine = Math.max(range.start, range.end);
-    const side = range.side;
+    const side = range.endSide ?? range.side;
     if (!side) return;
-    setSelectionInfo(buildSelectionInfo(startLine, endLine, side));
+    const selection = buildSelectionInfo(startLine, endLine, side);
+
+    if (isReviewDiff) {
+      if (!reviewContext.canEdit || !reviewContext.file) return;
+      openInlineCommentDraft({
+        side: selection.diffSide === 'old' ? 'old' : 'new',
+        diffSide: selection.diffSide === 'old' ? 'old' : 'new',
+        startLine: selection.startLine,
+        endLine: selection.endLine,
+        selectedText: selection.selectedText,
+        beforeContext: [],
+        afterContext: [],
+      });
+      return;
+    }
+
+    setSelectionInfo(selection);
 
     const container = containerRef.current;
     const containerRect = container.getBoundingClientRect();
@@ -379,7 +379,7 @@ export const DiffViewer = ({
     setPopoverPosition({ x: popX, y: popY });
     setIsPopoverVisible(true);
     setIsPopoverExpanded(false);
-  }, [buildSelectionInfo]);
+  }, [buildSelectionInfo, isReviewDiff, openInlineCommentDraft, reviewContext.canEdit, reviewContext.file]);
 
   useEffect(() => {
     if (!isPopoverVisible) return;
@@ -466,22 +466,28 @@ export const DiffViewer = ({
     loadDiff();
   }, [repoPath, filePath, compareMode, snapshotGuidFromPath]);
 
-  const diffOptions = useMemo(() => ({
-    theme: resolvedTheme === 'dark' ? 'pierre-dark' : 'pierre-light' as const,
-    diffStyle: diffStyle,
-    disableBackground: disableBackground,
-    disableFileHeader: true,
-    overflow: (wordWrap ? 'wrap' : 'scroll') as 'wrap' | 'scroll',
-    unsafeCSS: SCROLLBAR_CSS,
-    enableGutterUtility: true,
-    enableLineSelection: !isReviewDiff,
-    onLineSelectionEnd: isReviewDiff ? undefined : handleLineSelectionEnd,
-  }) satisfies FileDiffOptions<{
+  const diffOptions = useMemo(() => {
+    const sharedOptions = buildSharedDiffViewOptions({
+      theme: resolvedTheme === 'dark' ? 'pierre-dark' : 'pierre-light',
+      diffStyle,
+      wordWrap,
+      disableBackground,
+      enableGutterUtility: true,
+      enableLineSelection: true,
+    });
+
+    return {
+      ...sharedOptions,
+      disableFileHeader: true,
+      unsafeCSS: sharedOptions.unsafeCSS,
+      onLineSelectionEnd: handleLineSelectionEnd,
+    } satisfies FileDiffOptions<{
     kind: 'comment';
     comment: ReviewCommentDto;
   } | {
     kind: 'composer';
-  }>, [resolvedTheme, diffStyle, disableBackground, wordWrap, handleLineSelectionEnd, isReviewDiff]);
+    }>;
+  }, [resolvedTheme, diffStyle, disableBackground, wordWrap, handleLineSelectionEnd, isReviewDiff]);
 
   const commentAnnotations = useMemo(() => {
     if (!isReviewDiff || !reviewContext.file) return [];
@@ -1114,24 +1120,8 @@ export const DiffViewer = ({
   return (
     <div className="h-full flex flex-col bg-background overflow-hidden">
       <div className="h-10 flex items-center justify-between px-4 border-b border-sidebar-border bg-muted/30 shrink-0">
-        <button
-          type="button"
-          onClick={() => setFileCollapsed(!fileCollapsed)}
-          className="flex items-center justify-center w-5 h-5 rounded text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors cursor-pointer shrink-0 mr-2"
-          aria-label={fileCollapsed ? 'Expand file' : 'Collapse file'}
-        >
-          {fileCollapsed ? (
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-              <path d="M6 4L10 8L6 12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-            </svg>
-          ) : (
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-              <path d="M4 6L8 10L12 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-            </svg>
-          )}
-        </button>
         <div
-          className="relative h-5 flex-1 min-w-0 overflow-hidden mr-3"
+          className="relative h-5 flex-1 min-w-0 overflow-hidden pr-3"
           onMouseEnter={() => setTipPaused(true)}
           onMouseLeave={() => setTipPaused(false)}
         >
@@ -1175,7 +1165,7 @@ export const DiffViewer = ({
             </div>
           )}
         </div>
-        <div className="flex items-center gap-1.5">
+        <div className="flex items-center gap-1">
           {(() => {
             if (!snapshotGuidFromPath) return null;
             const file = reviewContext.file;
@@ -1206,37 +1196,67 @@ export const DiffViewer = ({
               </button>
             );
           })()}
+          <button
+            type="button"
+            title={diffStyle === 'split' ? 'Switch to unified view' : 'Switch to split view'}
+            className="flex size-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-foreground"
+            onClick={() =>
+              setDiffStyle(diffStyle === 'split' ? 'unified' : 'split')
+            }
+          >
+            {diffStyle === 'split' ? (
+              <Columns2 className="size-3.5" />
+            ) : (
+              <Rows3 className="size-3.5" />
+            )}
+          </button>
+          <button
+            type="button"
+            title={fileCollapsed ? 'Expand file' : 'Collapse file'}
+            className="flex size-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-foreground"
+            onClick={() => setFileCollapsed(!fileCollapsed)}
+          >
+            <Minus
+              className={cn(
+                'size-3.5 rotate-90 transition-transform',
+                fileCollapsed && 'rotate-0',
+              )}
+            />
+          </button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
-                className="flex items-center justify-center size-6 rounded-md text-muted-foreground hover:text-foreground hover:bg-sidebar-accent transition-colors cursor-pointer"
-                title="More actions"
+                className="flex size-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-foreground"
+                title="View options"
               >
-                <MoreHorizontal className="size-3.5" />
+                <Settings2 className="size-3.5" />
               </button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="min-w-[10rem]">
+            <DropdownMenuContent align="end" className="w-52">
               <DropdownMenuItem
+                className="cursor-default p-0"
                 onSelect={(e) => e.preventDefault()}
-                onClick={() => setWordWrap(!wordWrap)}
-                className="text-xs"
               >
-                {wordWrap ? "Scroll" : "Wrap"}
+                <label className={SETTING_ROW_CLASS}>
+                  <span className="min-w-0 flex-1">Backgrounds</span>
+                  <Switch
+                    checked={!disableBackground}
+                    onCheckedChange={(checked) => setDisableBackground(!checked)}
+                  />
+                </label>
               </DropdownMenuItem>
               <DropdownMenuItem
+                className="cursor-default p-0"
                 onSelect={(e) => e.preventDefault()}
-                onClick={() => setDiffStyle(diffStyle === 'unified' ? 'split' : 'unified')}
-                className="text-xs"
               >
-                {diffStyle === 'unified' ? "Split" : "Unified"}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={(e) => e.preventDefault()}
-                onClick={() => setDisableBackground(!disableBackground)}
-                className="text-xs"
-              >
-                {disableBackground ? "Show BG" : "No BG"}
+                <label className={SETTING_ROW_CLASS}>
+                  <span className="min-w-0 flex-1">Word wrap</span>
+                  <Switch
+                    checked={wordWrap}
+                    onCheckedChange={setWordWrap}
+                  />
+                </label>
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/apps/web/src/components/diff/DiffViewer.tsx
+++ b/apps/web/src/components/diff/DiffViewer.tsx
@@ -2,6 +2,13 @@
 
 import { useEffect, useState, useMemo, useRef, useCallback } from 'react';
 import { FileDiff, Virtualizer } from '@pierre/diffs/react';
+import {
+  IconCollapsedRow,
+  IconDiffSplit,
+  IconDiffUnified,
+  IconExpandAll,
+  IconGearFill,
+} from '@pierre/icons';
 import type {
   DiffLineAnnotation,
   FileContents,
@@ -24,7 +31,7 @@ import { ReviewMessageActionsMenu } from '@/components/diff/review/ReviewMessage
 import type { SelectionInfo } from '@/lib/format-selection-for-ai';
 import { useContextParams } from '@/hooks/use-context-params';
 import { cn } from '@/lib/utils';
-import { ChevronRight, Columns2, Command, CornerDownLeft, MessageSquareReply, Minus, Rows3, SendHorizontal, Settings2, X } from 'lucide-react';
+import { ChevronRight, Command, CornerDownLeft, MessageSquareReply, SendHorizontal, X } from 'lucide-react';
 import {
   reviewCommentStatusLabel,
   statusTone,
@@ -1225,9 +1232,9 @@ export const DiffViewer = ({
             }
           >
             {diffStyle === 'split' ? (
-              <Columns2 className="size-3.5" />
+              <IconDiffSplit className="size-3.5" />
             ) : (
-              <Rows3 className="size-3.5" />
+              <IconDiffUnified className="size-3.5" />
             )}
           </button>
           <button
@@ -1236,12 +1243,11 @@ export const DiffViewer = ({
             className="flex size-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-foreground"
             onClick={() => setFileCollapsed(!fileCollapsed)}
           >
-            <Minus
-              className={cn(
-                'size-3.5 rotate-90 transition-transform',
-                fileCollapsed && 'rotate-0',
-              )}
-            />
+            {fileCollapsed ? (
+              <IconCollapsedRow className="size-3.5" />
+            ) : (
+              <IconExpandAll className="size-3.5" />
+            )}
           </button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -1250,7 +1256,7 @@ export const DiffViewer = ({
                 className="flex size-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-foreground"
                 title="View options"
               >
-                <Settings2 className="size-3.5" />
+                <IconGearFill className="size-3.5" />
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-52">

--- a/apps/web/src/components/diff/DiffViewer.tsx
+++ b/apps/web/src/components/diff/DiffViewer.tsx
@@ -21,7 +21,6 @@ import { parseDiffFromFile } from '@pierre/diffs';
 import { gitApi, reviewWsApi } from '@/api/ws-api';
 import type { ReviewMessageDto, ReviewCommentDto } from '@/api/ws-api';
 import { Button, Loader2, Textarea, toastManager, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, Tooltip, TooltipContent, TooltipTrigger, Switch } from '@workspace/ui';
-import { useTheme } from 'next-themes';
 import { useGitStore } from '@/hooks/use-git-store';
 import { useEditorStore } from '@/hooks/use-editor-store';
 import { SelectionPopover } from '@/components/selection/SelectionPopover';
@@ -36,7 +35,7 @@ import {
   reviewCommentStatusLabel,
   statusTone,
 } from '@/components/diff/review/utils';
-import { buildSharedDiffViewOptions } from '@/components/diff/diff-view-constants';
+import { ATMOS_DIFF_THEME, buildSharedDiffViewOptions } from '@/components/diff/diff-view-constants';
 
 interface DiffViewerProps {
   repoPath: string;
@@ -125,7 +124,6 @@ export const DiffViewer = ({
   const [showTip, setShowTip] = useState(false);
   const [tipPaused, setTipPaused] = useState(false);
   const [fileCollapsed, setFileCollapsed] = useState(false);
-  const { resolvedTheme } = useTheme();
   const containerRef = useRef<HTMLDivElement>(null);
   const clearNavigationTarget = useEditorStore((state) => state.clearNavigationTarget);
   const navigationTarget = useEditorStore((state) =>
@@ -495,7 +493,7 @@ export const DiffViewer = ({
 
   const diffOptions = useMemo(() => {
     const sharedOptions = buildSharedDiffViewOptions({
-      theme: resolvedTheme === 'dark' ? 'pierre-dark' : 'pierre-light',
+      theme: ATMOS_DIFF_THEME,
       diffStyle,
       wordWrap,
       disableBackground,
@@ -514,7 +512,7 @@ export const DiffViewer = ({
   } | {
     kind: 'composer';
     }>;
-  }, [resolvedTheme, diffStyle, disableBackground, wordWrap, handleLineSelectionEnd, isReviewDiff]);
+  }, [diffStyle, disableBackground, wordWrap, handleLineSelectionEnd, isReviewDiff]);
 
   const commentAnnotations = useMemo(() => {
     if (!isReviewDiff || !reviewContext.file) return [];

--- a/apps/web/src/components/diff/ReviewCodeView.tsx
+++ b/apps/web/src/components/diff/ReviewCodeView.tsx
@@ -1,0 +1,1104 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { CodeView, type CodeViewHandle } from '@pierre/diffs/react';
+import type {
+  CodeViewItem,
+  DiffLineAnnotation,
+  SelectedLineRange,
+} from '@pierre/diffs';
+import { parseDiffFromFile } from '@pierre/diffs';
+import type { ReviewCommentDto, ReviewFileDto, ReviewMessageDto } from '@/api/ws-api';
+import { reviewWsApi } from '@/api/ws-api';
+import { useReviewCtx } from '@/components/diff/review/ReviewContextProvider';
+import { useEditorStore } from '@/hooks/use-editor-store';
+import { useContextParams } from '@/hooks/use-context-params';
+import { useTheme } from 'next-themes';
+import { useDiffWorkerPoolReady } from '@/components/diff/DiffWorkerPoolProvider';
+import { DiffCodeViewScaffold } from '@/components/diff/DiffCodeViewScaffold';
+import { DiffCodeViewSettingsMenu } from '@/components/diff/DiffCodeViewSettingsMenu';
+import { sortByDiffTreePath } from '@/components/diff/diff-file-order';
+import {
+  buildDiffSelectionInfo,
+  formatSelectedRangeLabel,
+  getNextItemVersion,
+  updateViewerDiffItem,
+} from '@/components/diff/diff-code-view-shared';
+import {
+  buildSharedDiffViewOptions,
+  CODE_VIEW_HOST_CLASS,
+} from '@/components/diff/diff-view-constants';
+import {
+  createDiffHeaderPrefixRenderer,
+  findDiffItemIdForViewport,
+  scrollCodeViewToItem,
+} from '@/components/diff/code-view-ui';
+import { MessageBubble } from '@/components/diff/review/MessageBubble';
+import { ReviewMessageActionsMenu } from '@/components/diff/review/ReviewMessageActionsMenu';
+import {
+  reviewCommentStatusLabel,
+  statusTone,
+} from '@/components/diff/review/utils';
+import { cn } from '@/lib/utils';
+import {
+  Button,
+  Loader2,
+  Textarea,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  toastManager,
+} from '@workspace/ui';
+import {
+  ChevronRight,
+  Command,
+  CornerDownLeft,
+  X,
+} from 'lucide-react';
+
+const CODE_VIEW_BATCH_SIZE = 25;
+
+function yieldToBrowser(): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, 0));
+}
+
+type ReviewAnnotationMeta =
+  | {
+      kind: 'comment';
+      comment: ReviewCommentDto;
+    }
+  | {
+      kind: 'composer';
+    };
+
+interface InlineCommentDraft {
+  itemId: string;
+  filePath: string;
+  fileSnapshotGuid: string;
+  diffSide: 'old' | 'new';
+  startLine: number;
+  endLine: number;
+  selectedText: string;
+  beforeContext: string[];
+  afterContext: string[];
+}
+
+interface ReviewCodeViewProps {
+  groupPath: string;
+}
+
+export function ReviewCodeView({ groupPath }: ReviewCodeViewProps) {
+  const { effectiveContextId } = useContextParams();
+  const { resolvedTheme } = useTheme();
+  const workerPoolReady = useDiffWorkerPoolReady();
+  const reviewCtx = useReviewCtx();
+  const clearNavigationTarget = useEditorStore((s) => s.clearNavigationTarget);
+  const setDiffGroupActiveFile = useEditorStore((s) => s.setDiffGroupActiveFile);
+  const selectedPath = useEditorStore((s) =>
+    effectiveContextId ? s.diffGroupActiveFiles[effectiveContextId]?.[groupPath] : undefined,
+  );
+  const navigationTarget = useEditorStore((s) =>
+    effectiveContextId ? s.navigationTargets[effectiveContextId]?.[groupPath] ?? null : null,
+  );
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [initialItems, setInitialItems] = useState<CodeViewItem<ReviewAnnotationMeta>[]>([]);
+  const [annotationVersion, setAnnotationVersion] = useState(0);
+  const [viewerKey, setViewerKey] = useState(0);
+  const [viewerMounted, setViewerMounted] = useState(false);
+  const [diffStyle, setDiffStyle] = useState<'split' | 'unified'>('split');
+  const [wordWrap, setWordWrap] = useState(false);
+  const [showBackgrounds, setShowBackgrounds] = useState(true);
+  const [lineNumbers, setLineNumbers] = useState(true);
+  const [diffIndicators, setDiffIndicators] =
+    useState<'bars' | 'classic' | 'none'>('bars');
+  const [collapseMode, setCollapseMode] = useState<'expanded' | 'collapsed'>(
+    'expanded',
+  );
+  const [inlineCommentDraft, setInlineCommentDraft] =
+    useState<InlineCommentDraft | null>(null);
+  const [inlineCommentBody, setInlineCommentBody] = useState('');
+  const [isSubmittingInlineComment, setIsSubmittingInlineComment] = useState(false);
+  const [replyDraftCommentGuid, setReplyDraftCommentGuid] = useState<string | null>(null);
+  const [replyBody, setReplyBody] = useState('');
+  const [isSubmittingReply, setIsSubmittingReply] = useState(false);
+  const [deletingMessageGuid, setDeletingMessageGuid] = useState<string | null>(null);
+  const [collapsedInlineCommentGuids, setCollapsedInlineCommentGuids] =
+    useState<Set<string>>(() => new Set());
+  const [highlightedInlineCommentGuid, setHighlightedInlineCommentGuid] =
+    useState<string | null>(null);
+  const [highlightedInlineMessageGuid, setHighlightedInlineMessageGuid] =
+    useState<string | null>(null);
+
+  const codeViewRef = useRef<CodeViewHandle<ReviewAnnotationMeta>>(null);
+  const itemIdsRef = useRef<string[]>([]);
+  const pendingAppendRef = useRef<CodeViewItem<ReviewAnnotationMeta>[]>([]);
+  const scrollActiveIdRef = useRef<string | null>(null);
+  const pathByFileNameRef = useRef<Map<string, string>>(new Map());
+  const loadedContentsRef = useRef<
+    Map<string, { oldContent: string; newContent: string }>
+  >(new Map());
+  const fileSnapshotByPathRef = useRef<Map<string, ReviewFileDto>>(new Map());
+  const lastHandledNavRef = useRef<string | null>(null);
+  const inlineCommentTextareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const orderedFiles = useMemo(
+    () =>
+      sortByDiffTreePath(
+        (reviewCtx.currentRevision?.files ?? []).map((file) => ({
+          path: file.snapshot.file_path,
+          file,
+        })),
+      ).map((entry) => entry.file),
+    [reviewCtx.currentRevision?.files],
+  );
+
+  const treeItems = useMemo(
+    () =>
+      orderedFiles.map((file) => ({
+        path: file.snapshot.file_path,
+        gitStatus: file.snapshot.git_status,
+        additions: file.additions,
+        deletions: file.deletions,
+      })),
+    [orderedFiles],
+  );
+
+  const totalStats = useMemo(
+    () => ({
+      additions: orderedFiles.reduce((sum, file) => sum + file.additions, 0),
+      deletions: orderedFiles.reduce((sum, file) => sum + file.deletions, 0),
+    }),
+    [orderedFiles],
+  );
+
+  const revisionLabel = useMemo(() => {
+    if (!reviewCtx.currentSession || !reviewCtx.currentRevision) return 'Review';
+    const sorted = [...reviewCtx.currentSession.revisions].sort((a, b) =>
+      a.created_at.localeCompare(b.created_at),
+    );
+    const index = sorted.findIndex((r) => r.guid === reviewCtx.currentRevision?.guid);
+    return index >= 0 ? `Review v${index + 1}` : 'Review';
+  }, [reviewCtx.currentRevision, reviewCtx.currentSession]);
+
+  const renderHeaderPrefix = useMemo(
+    () =>
+      createDiffHeaderPrefixRenderer({
+        viewerRef: codeViewRef,
+        pathByFileName: pathByFileNameRef.current,
+      }),
+    [viewerMounted, viewerKey],
+  );
+
+  useEffect(() => {
+    if (!inlineCommentDraft) return;
+    let cancelled = false;
+    const tryFocus = () => {
+      if (cancelled) return;
+      const el = inlineCommentTextareaRef.current;
+      if (el) {
+        el.focus();
+        return;
+      }
+      requestAnimationFrame(tryFocus);
+    };
+    requestAnimationFrame(tryFocus);
+    return () => {
+      cancelled = true;
+    };
+  }, [inlineCommentDraft]);
+
+  useEffect(() => {
+    if (!highlightedInlineCommentGuid) return;
+    const timer = window.setTimeout(() => {
+      setHighlightedInlineCommentGuid(null);
+    }, 2000);
+    return () => window.clearTimeout(timer);
+  }, [highlightedInlineCommentGuid]);
+
+  useEffect(() => {
+    if (!highlightedInlineMessageGuid) return;
+    const timer = window.setTimeout(() => {
+      setHighlightedInlineMessageGuid(null);
+    }, 2000);
+    return () => window.clearTimeout(timer);
+  }, [highlightedInlineMessageGuid]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setViewerKey((key) => key + 1);
+    setViewerMounted(false);
+    setInitialItems([]);
+    pendingAppendRef.current = [];
+    pathByFileNameRef.current = new Map();
+    loadedContentsRef.current = new Map();
+    fileSnapshotByPathRef.current = new Map();
+    itemIdsRef.current = [];
+    scrollActiveIdRef.current = null;
+    lastHandledNavRef.current = null;
+
+    if (!reviewCtx.currentRevision) {
+      setIsLoading(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const load = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        let hasPublishedInitial = false;
+
+        for (
+          let offset = 0;
+          offset < orderedFiles.length;
+          offset += CODE_VIEW_BATCH_SIZE
+        ) {
+          if (cancelled) return;
+
+          const batch = orderedFiles.slice(offset, offset + CODE_VIEW_BATCH_SIZE);
+          const results = await Promise.all(
+            batch.map(async (file) => {
+              try {
+                const diff = await reviewWsApi.getFileContent(file.snapshot.guid);
+                const fileDiff = parseDiffFromFile(
+                  {
+                    name: file.snapshot.file_path,
+                    contents: diff.old_content,
+                  },
+                  {
+                    name: file.snapshot.file_path,
+                    contents: diff.new_content,
+                  },
+                );
+                pathByFileNameRef.current.set(fileDiff.name, file.snapshot.file_path);
+                fileSnapshotByPathRef.current.set(file.snapshot.file_path, file);
+                loadedContentsRef.current.set(file.snapshot.file_path, {
+                  oldContent: diff.old_content,
+                  newContent: diff.new_content,
+                });
+                return {
+                  id: file.snapshot.file_path,
+                  type: 'diff' as const,
+                  fileDiff,
+                };
+              } catch (loadError) {
+                console.error(
+                  `Failed to load review diff for ${file.snapshot.file_path}:`,
+                  loadError,
+                );
+                return null;
+              }
+            }),
+          );
+
+          if (cancelled) return;
+
+          const codeItems: CodeViewItem<ReviewAnnotationMeta>[] = [];
+          for (const item of results) {
+            if (!item) continue;
+            codeItems.push(item);
+          }
+          if (codeItems.length === 0) continue;
+
+          if (!hasPublishedInitial) {
+            hasPublishedInitial = true;
+            itemIdsRef.current = codeItems.map((item) => item.id);
+            setInitialItems(codeItems);
+            setAnnotationVersion((value) => value + 1);
+            setIsLoading(false);
+            await yieldToBrowser();
+          } else {
+            itemIdsRef.current = [
+              ...itemIdsRef.current,
+              ...codeItems.map((item) => item.id),
+            ];
+            const viewer = codeViewRef.current;
+            if (viewer) {
+              viewer.addItems(codeItems);
+              setAnnotationVersion((value) => value + 1);
+              await yieldToBrowser();
+            } else {
+              pendingAppendRef.current.push(...codeItems);
+            }
+          }
+        }
+
+        if (!cancelled && !hasPublishedInitial) {
+          setIsLoading(false);
+        }
+      } catch (loadError) {
+        if (!cancelled) {
+          setError(
+            loadError instanceof Error
+              ? loadError.message
+              : 'Failed to load review changes',
+          );
+          setInitialItems([]);
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [orderedFiles, reviewCtx.currentRevision]);
+
+  useEffect(() => {
+    if (!viewerMounted || pendingAppendRef.current.length === 0) return;
+    const pending = pendingAppendRef.current;
+    pendingAppendRef.current = [];
+    codeViewRef.current?.addItems(pending);
+    setAnnotationVersion((value) => value + 1);
+  }, [initialItems, viewerMounted]);
+
+  useEffect(() => {
+    if (!effectiveContextId || itemIdsRef.current.length === 0) return;
+    const currentSelectedPath =
+      selectedPath && itemIdsRef.current.includes(selectedPath) ? selectedPath : null;
+    if (currentSelectedPath) return;
+    setDiffGroupActiveFile(groupPath, itemIdsRef.current[0], effectiveContextId);
+  }, [
+    effectiveContextId,
+    groupPath,
+    initialItems,
+    selectedPath,
+    setDiffGroupActiveFile,
+    viewerKey,
+  ]);
+
+  useEffect(() => {
+    const commentsByPath = new Map<string, ReviewCommentDto[]>();
+    for (const comment of reviewCtx.comments) {
+      const file = reviewCtx.currentRevision?.files.find(
+        (entry) => entry.snapshot.guid === comment.file_snapshot_guid,
+      );
+      const filePath = file?.snapshot.file_path ?? comment.anchor.file_path;
+      if (!filePath) continue;
+      const list = commentsByPath.get(filePath) ?? [];
+      list.push(comment);
+      commentsByPath.set(filePath, list);
+    }
+
+    for (const itemId of itemIdsRef.current) {
+      updateViewerDiffItem(codeViewRef.current, itemId, (item) => {
+        const commentAnnotations: DiffLineAnnotation<ReviewAnnotationMeta>[] = (
+          commentsByPath.get(itemId) ?? []
+        ).map((comment) => ({
+          side: comment.anchor_side === 'old' ? 'deletions' : 'additions',
+          lineNumber: comment.anchor_start_line,
+          metadata: {
+            kind: 'comment',
+            comment,
+          },
+        }));
+
+        const composerAnnotation =
+          inlineCommentDraft?.itemId === itemId
+            ? [
+                {
+                  side:
+                    inlineCommentDraft.diffSide === 'old'
+                      ? 'deletions'
+                      : 'additions',
+                  lineNumber: inlineCommentDraft.startLine,
+                  metadata: { kind: 'composer' as const },
+                } satisfies DiffLineAnnotation<ReviewAnnotationMeta>,
+              ]
+            : [];
+
+        item.annotations = [...commentAnnotations, ...composerAnnotation];
+        item.version = getNextItemVersion(item);
+        return true;
+      });
+    }
+  }, [
+    annotationVersion,
+    inlineCommentDraft,
+    reviewCtx.comments,
+    reviewCtx.currentRevision?.files,
+    viewerMounted,
+  ]);
+
+  const openInlineCommentDraft = useCallback(
+    (itemId: string, range: SelectedLineRange) => {
+      if (!reviewCtx.canEdit) return;
+      const viewer = codeViewRef.current;
+      const item = viewer?.getItem(itemId);
+      const contents = loadedContentsRef.current.get(itemId);
+      const file = fileSnapshotByPathRef.current.get(itemId);
+      if (item?.type !== 'diff' || !contents || !file) return;
+
+      const selectionInfo = buildDiffSelectionInfo({
+        filePath: itemId,
+        fileDiff: item.fileDiff,
+        contents,
+        range,
+      });
+      if (!selectionInfo) return;
+
+      setInlineCommentBody('');
+      setInlineCommentDraft({
+        itemId,
+        filePath: itemId,
+        fileSnapshotGuid: file.snapshot.guid,
+        diffSide: selectionInfo.diffSide === 'old' ? 'old' : 'new',
+        startLine: selectionInfo.startLine,
+        endLine: selectionInfo.endLine,
+        selectedText: selectionInfo.selectedText,
+        beforeContext: selectionInfo.beforeText
+          ? selectionInfo.beforeText.split('\n')
+          : [],
+        afterContext: selectionInfo.afterText ? selectionInfo.afterText.split('\n') : [],
+      });
+    },
+    [reviewCtx.canEdit],
+  );
+
+  const handleInlineCommentSubmit = useCallback(async () => {
+    if (!reviewCtx.currentSession || !reviewCtx.currentRevision || !inlineCommentDraft) {
+      return;
+    }
+
+    const body = inlineCommentBody.trim();
+    if (!body) {
+      toastManager.add({
+        title: 'Comment is empty',
+        description: 'Write a short review note before creating a comment.',
+        type: 'error',
+      });
+      return;
+    }
+
+    setIsSubmittingInlineComment(true);
+    try {
+      await reviewWsApi.createComment({
+        sessionGuid: reviewCtx.currentSession.guid,
+        revisionGuid: reviewCtx.currentRevision.guid,
+        fileSnapshotGuid: inlineCommentDraft.fileSnapshotGuid,
+        anchor: {
+          file_path: inlineCommentDraft.filePath,
+          side: inlineCommentDraft.diffSide,
+          start_line: inlineCommentDraft.startLine,
+          end_line: inlineCommentDraft.endLine,
+          line_range_kind:
+            inlineCommentDraft.startLine === inlineCommentDraft.endLine
+              ? 'single'
+              : 'range',
+          selected_text: inlineCommentDraft.selectedText,
+          before_context: inlineCommentDraft.beforeContext,
+          after_context: inlineCommentDraft.afterContext,
+          hunk_header: null,
+        },
+        body,
+      });
+      setInlineCommentBody('');
+      setInlineCommentDraft(null);
+    } catch (submitError) {
+      toastManager.add({
+        title: 'Failed to create review comment',
+        description:
+          submitError instanceof Error
+            ? submitError.message
+            : 'Unknown review comment error',
+        type: 'error',
+      });
+    } finally {
+      setIsSubmittingInlineComment(false);
+    }
+  }, [
+    inlineCommentBody,
+    inlineCommentDraft,
+    reviewCtx.currentRevision,
+    reviewCtx.currentSession,
+  ]);
+
+  const handleCommentReplySubmit = useCallback(
+    async (comment: ReviewCommentDto) => {
+      const body = replyBody.trim();
+      if (!body) {
+        toastManager.add({
+          title: 'Reply is empty',
+          description: 'Write a short reply before sending.',
+          type: 'error',
+        });
+        return;
+      }
+
+      setIsSubmittingReply(true);
+      try {
+        await reviewCtx.handleReplyToComment(comment, body);
+        setReplyBody('');
+        setReplyDraftCommentGuid(null);
+      } catch {
+        // Shared review hook already reports failures.
+      } finally {
+        setIsSubmittingReply(false);
+      }
+    },
+    [replyBody, reviewCtx],
+  );
+
+  const handleDeleteMessage = useCallback(
+    async (comment: ReviewCommentDto, message: ReviewMessageDto) => {
+      setDeletingMessageGuid(message.guid);
+      try {
+        await reviewCtx.handleDeleteMessage(comment, message);
+      } catch {
+        // Shared review hook already reports failures.
+      } finally {
+        setDeletingMessageGuid(null);
+      }
+    },
+    [reviewCtx],
+  );
+
+  const toggleInlineCommentExpanded = useCallback((commentGuid: string) => {
+    setCollapsedInlineCommentGuids((prev) => {
+      const next = new Set(prev);
+      if (next.has(commentGuid)) {
+        next.delete(commentGuid);
+      } else {
+        next.add(commentGuid);
+      }
+      return next;
+    });
+  }, []);
+
+  const renderAnnotation = useCallback(
+    (annotation: DiffLineAnnotation<ReviewAnnotationMeta>) => {
+      if (annotation.metadata?.kind === 'composer') {
+        if (!inlineCommentDraft) return null;
+        return (
+          <div className="mx-3 my-2 rounded-lg border border-primary/20 bg-background/95 p-3 shadow-sm">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-sm font-medium text-foreground">
+                  Comment on{' '}
+                  {inlineCommentDraft.startLine === inlineCommentDraft.endLine
+                    ? `L${inlineCommentDraft.startLine}`
+                    : `L${inlineCommentDraft.startLine}-L${inlineCommentDraft.endLine}`}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Add a review comment directly on this diff.
+                </p>
+              </div>
+              <button
+                type="button"
+                className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                onClick={() => {
+                  setInlineCommentDraft(null);
+                  setInlineCommentBody('');
+                }}
+                aria-label="Cancel comment"
+              >
+                <X className="size-4" />
+              </button>
+            </div>
+            <Textarea
+              ref={inlineCommentTextareaRef}
+              value={inlineCommentBody}
+              onChange={(event) => setInlineCommentBody(event.target.value)}
+              onKeyDown={(event) => {
+                if (
+                  event.key === 'Enter' &&
+                  (event.metaKey || event.ctrlKey) &&
+                  inlineCommentBody.trim() &&
+                  !isSubmittingInlineComment
+                ) {
+                  event.preventDefault();
+                  void handleInlineCommentSubmit();
+                }
+              }}
+              placeholder="Describe the issue or expected change..."
+              className="mt-3 min-h-24 bg-background"
+            />
+            <div className="mt-3 flex items-center gap-2">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="sm"
+                    onClick={() => void handleInlineCommentSubmit()}
+                    disabled={isSubmittingInlineComment}
+                  >
+                    {isSubmittingInlineComment ? (
+                      <Loader2 className="mr-2 size-4 animate-spin" />
+                    ) : null}
+                    Add Comment
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <div className="flex items-center gap-2">
+                    <span>Add comment</span>
+                    <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border border-border bg-muted px-1.5 font-mono text-[10px] font-medium text-foreground/90">
+                      <Command className="size-3" />
+                      <CornerDownLeft className="size-3" />
+                    </kbd>
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setInlineCommentDraft(null);
+                  setInlineCommentBody('');
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        );
+      }
+
+      const comment = annotation.metadata?.comment;
+      if (!comment) return null;
+      const expanded =
+        !collapsedInlineCommentGuids.has(comment.guid) ||
+        replyDraftCommentGuid === comment.guid;
+      const title =
+        comment.title?.trim() ||
+        `Comment on L${comment.anchor_start_line}${
+          comment.anchor_start_line === comment.anchor_end_line
+            ? ''
+            : `-${comment.anchor_end_line}`
+        }`;
+
+      return (
+        <div
+          className={cn(
+            'mx-3 my-2 rounded-lg border p-3 shadow-sm',
+            comment.status === 'fixed'
+              ? 'border-emerald-500/25 bg-emerald-500/5'
+              : comment.status === 'agent_fixed'
+                ? 'border-amber-500/25 bg-amber-500/5'
+                : comment.status === 'dismissed'
+                  ? 'border-muted-foreground/15 bg-muted/30'
+                  : 'border-blue-500/25 bg-blue-500/5',
+            highlightedInlineCommentGuid === comment.guid &&
+              'animate-pulse ring-2 ring-primary/60 ring-offset-2 ring-offset-background',
+          )}
+          data-review-comment-guid={comment.guid}
+          data-review-anchor-line={comment.anchor_start_line}
+        >
+          <button
+            type="button"
+            onClick={() => toggleInlineCommentExpanded(comment.guid)}
+            className="grid w-full cursor-pointer grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 text-left"
+            aria-label={expanded ? 'Collapse comment' : 'Expand comment'}
+          >
+            <ChevronRight
+              className={cn(
+                'size-3.5 shrink-0 text-muted-foreground transition-transform',
+                expanded && 'rotate-90',
+              )}
+            />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-foreground">{title}</p>
+            </div>
+            <span
+              className={cn(
+                'shrink-0 rounded-full border px-2 py-0.5 text-[11px] font-medium',
+                statusTone(comment.status),
+              )}
+            >
+              {reviewCommentStatusLabel(comment.status)}
+            </span>
+          </button>
+
+          {expanded ? (
+            <>
+              <div className="mt-3 space-y-2">
+                {comment.messages.map((message) => (
+                  <div
+                    key={message.guid}
+                    data-review-message-guid={message.guid}
+                    className={cn(
+                      'group/message rounded-md',
+                      highlightedInlineMessageGuid === message.guid &&
+                        'animate-pulse ring-2 ring-primary/60 ring-offset-2 ring-offset-background',
+                    )}
+                  >
+                    <MessageBubble
+                      message={message}
+                      onEdit={reviewCtx.handleUpdateMessage}
+                      action={
+                        reviewCtx.canEdit
+                          ? ({ startEdit }) => (
+                              <ReviewMessageActionsMenu
+                                message={message}
+                                disabled={deletingMessageGuid === message.guid}
+                                onEdit={startEdit}
+                                onDelete={() => void handleDeleteMessage(comment, message)}
+                              />
+                            )
+                          : undefined
+                      }
+                    />
+                  </div>
+                ))}
+              </div>
+
+              <div className="mt-3 flex items-center gap-2">
+                {reviewCtx.canEdit ? (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() =>
+                      setReplyDraftCommentGuid((current) =>
+                        current === comment.guid ? null : comment.guid,
+                      )
+                    }
+                  >
+                    Reply
+                  </Button>
+                ) : null}
+                {reviewCtx.canEdit ? (
+                  <>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() =>
+                        void reviewCtx.handleUpdateCommentStatus(
+                          comment.guid,
+                          comment.status === 'open' ? 'fixed' : 'open',
+                        )
+                      }
+                    >
+                      {comment.status === 'open' ? 'Mark Fixed' : 'Reopen'}
+                    </Button>
+                    {comment.status !== 'dismissed' ? (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() =>
+                          void reviewCtx.handleUpdateCommentStatus(
+                            comment.guid,
+                            'dismissed',
+                          )
+                        }
+                      >
+                        Dismiss
+                      </Button>
+                    ) : null}
+                  </>
+                ) : null}
+              </div>
+
+              {replyDraftCommentGuid === comment.guid ? (
+                <div className="mt-3 rounded-md border border-border/60 bg-background/80 p-3">
+                  <Textarea
+                    value={replyBody}
+                    onChange={(event) => setReplyBody(event.target.value)}
+                    placeholder="Write a reply..."
+                    className="min-h-20 bg-background"
+                  />
+                  <div className="mt-3 flex items-center gap-2">
+                    <Button
+                      size="sm"
+                      onClick={() => void handleCommentReplySubmit(comment)}
+                      disabled={isSubmittingReply}
+                    >
+                      {isSubmittingReply ? (
+                        <Loader2 className="mr-2 size-4 animate-spin" />
+                      ) : null}
+                      Send Reply
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        setReplyDraftCommentGuid(null);
+                        setReplyBody('');
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
+            </>
+          ) : null}
+        </div>
+      );
+    },
+    [
+      collapsedInlineCommentGuids,
+      deletingMessageGuid,
+      handleCommentReplySubmit,
+      handleDeleteMessage,
+      handleInlineCommentSubmit,
+      highlightedInlineCommentGuid,
+      highlightedInlineMessageGuid,
+      inlineCommentBody,
+      inlineCommentDraft,
+      isSubmittingInlineComment,
+      isSubmittingReply,
+      replyBody,
+      replyDraftCommentGuid,
+      reviewCtx,
+      toggleInlineCommentExpanded,
+    ],
+  );
+
+  const codeViewOptions = useMemo(
+    () => ({
+      ...buildSharedDiffViewOptions({
+        theme: resolvedTheme === 'dark' ? 'pierre-dark' : 'pierre-light',
+        diffStyle,
+        wordWrap,
+        disableBackground: !showBackgrounds,
+        lineNumbers,
+        diffIndicators,
+        enableLineSelection: reviewCtx.canEdit,
+        enableGutterUtility: reviewCtx.canEdit,
+      }),
+      onLineSelectionEnd(
+        range: SelectedLineRange | null,
+        context: { item: CodeViewItem<ReviewAnnotationMeta> },
+      ) {
+        if (!range || context.item.type !== 'diff') return;
+        openInlineCommentDraft(context.item.id, range);
+      },
+      onGutterUtilityClick(
+        range: SelectedLineRange,
+        context: { item: CodeViewItem<ReviewAnnotationMeta> },
+      ) {
+        if (context.item.type !== 'diff') return;
+        openInlineCommentDraft(context.item.id, range);
+      },
+      gutterUtilityAriaLabel: reviewCtx.canEdit ? 'Add review comment' : undefined,
+    }),
+    [
+      diffIndicators,
+      diffStyle,
+      lineNumbers,
+      openInlineCommentDraft,
+      resolvedTheme,
+      reviewCtx.canEdit,
+      showBackgrounds,
+      wordWrap,
+    ],
+  );
+
+  const handleViewerRef = useCallback(
+    (handle: CodeViewHandle<ReviewAnnotationMeta> | null) => {
+      codeViewRef.current = handle;
+      setViewerMounted(handle != null);
+    },
+    [],
+  );
+
+  const handleToggleCollapseMode = useCallback(() => {
+    const viewer = codeViewRef.current;
+    if (!viewer) return;
+    const next = collapseMode === 'expanded' ? 'collapsed' : 'expanded';
+    setCollapseMode(next);
+
+    for (const itemId of itemIdsRef.current) {
+      updateViewerDiffItem(viewer, itemId, (item) => {
+        item.collapsed = next === 'collapsed';
+        return true;
+      });
+    }
+  }, [collapseMode]);
+
+  useEffect(() => {
+    const instance = codeViewRef.current?.getInstance();
+    if (!instance || !effectiveContextId) return;
+
+    return instance.subscribeToScroll((_scrollTop, viewer) => {
+      if (itemIdsRef.current.length === 0) return;
+      const activeId = findDiffItemIdForViewport(viewer, itemIdsRef.current);
+      if (!activeId || activeId === scrollActiveIdRef.current) return;
+      scrollActiveIdRef.current = activeId;
+      setDiffGroupActiveFile(groupPath, activeId, effectiveContextId);
+    });
+  }, [effectiveContextId, groupPath, setDiffGroupActiveFile, viewerKey, viewerMounted]);
+
+  const navigationScrollKey = navigationTarget?.diffFilePath
+    ? [
+        navigationTarget.diffFilePath,
+        navigationTarget.line ?? '',
+        navigationTarget.reviewCommentGuid ?? '',
+        navigationTarget.reviewMessageGuid ?? '',
+      ].join(':')
+    : null;
+
+  useEffect(() => {
+    if (
+      !navigationTarget?.diffFilePath ||
+      isLoading ||
+      !navigationScrollKey ||
+      !viewerMounted
+    ) {
+      return;
+    }
+    if (lastHandledNavRef.current === navigationScrollKey) return;
+    lastHandledNavRef.current = navigationScrollKey;
+
+    if (navigationTarget.reviewCommentGuid) {
+      setCollapsedInlineCommentGuids((prev) => {
+        if (!prev.has(navigationTarget.reviewCommentGuid!)) return prev;
+        const next = new Set(prev);
+        next.delete(navigationTarget.reviewCommentGuid!);
+        return next;
+      });
+      if (navigationTarget.reviewMessageGuid) {
+        setHighlightedInlineMessageGuid(navigationTarget.reviewMessageGuid);
+      } else {
+        setHighlightedInlineCommentGuid(navigationTarget.reviewCommentGuid);
+      }
+    }
+
+    if (effectiveContextId) {
+      setDiffGroupActiveFile(groupPath, navigationTarget.diffFilePath, effectiveContextId);
+    }
+
+    requestAnimationFrame(() => {
+      scrollCodeViewToItem(codeViewRef.current, navigationTarget.diffFilePath!, {
+        line: navigationTarget.line,
+        behavior: 'smooth',
+      });
+      if (effectiveContextId) {
+        clearNavigationTarget(groupPath, effectiveContextId);
+      }
+    });
+  }, [
+    clearNavigationTarget,
+    effectiveContextId,
+    groupPath,
+    isLoading,
+    navigationScrollKey,
+    navigationTarget,
+    setDiffGroupActiveFile,
+    viewerMounted,
+  ]);
+
+  const handleSelectFile = useCallback(
+    (path: string) => {
+      if (effectiveContextId) {
+        setDiffGroupActiveFile(groupPath, path, effectiveContextId);
+      }
+      scrollCodeViewToItem(codeViewRef.current, path, { behavior: 'smooth' });
+    },
+    [effectiveContextId, groupPath, setDiffGroupActiveFile],
+  );
+
+  const toolbar = (
+    <div className="flex items-center gap-2">
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <span className="truncate text-sm font-medium text-foreground">
+          {revisionLabel}
+        </span>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {treeItems.length} file{treeItems.length === 1 ? '' : 's'}
+        </span>
+      </div>
+      {(totalStats.additions > 0 || totalStats.deletions > 0) && (
+        <div className="flex shrink-0 items-center gap-2 text-[11px] font-mono font-medium">
+          <span className="text-emerald-500">+{totalStats.additions}</span>
+          <span className="text-red-500">-{totalStats.deletions}</span>
+        </div>
+      )}
+      <DiffCodeViewSettingsMenu
+        diffStyle={diffStyle}
+        onDiffStyleChange={setDiffStyle}
+        showBackgrounds={showBackgrounds}
+        onShowBackgroundsChange={setShowBackgrounds}
+        lineNumbers={lineNumbers}
+        onLineNumbersChange={setLineNumbers}
+        wordWrap={wordWrap}
+        onWordWrapChange={setWordWrap}
+        diffIndicators={diffIndicators}
+        onDiffIndicatorsChange={setDiffIndicators}
+        collapseMode={collapseMode}
+        onToggleCollapseMode={handleToggleCollapseMode}
+      />
+    </div>
+  );
+
+  if (!reviewCtx.currentSession || !reviewCtx.currentRevision) {
+    return (
+      <div className="flex h-full items-center justify-center bg-background text-sm text-muted-foreground">
+        No review revision selected
+      </div>
+    );
+  }
+
+  if (isLoading || !workerPoolReady) {
+    return (
+      <div className="flex h-full flex-col overflow-hidden bg-background">
+        <DiffCodeViewScaffold
+          items={treeItems}
+          selectedPath={selectedPath}
+          ariaLabel="Review files"
+          loading
+          loadingTreeLabel={revisionLabel}
+          defaultTreeVisible={false}
+          toolbar={
+            <div className="flex items-center gap-2">
+              <div className="flex min-w-0 flex-1 items-center gap-3">
+                <span className="truncate text-sm font-medium text-foreground">
+                  {revisionLabel}
+                </span>
+              </div>
+              <Loader2 className="size-4 animate-spin text-muted-foreground" />
+            </div>
+          }
+          onSelectFile={() => {}}
+        >
+          <div />
+        </DiffCodeViewScaffold>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full items-center justify-center bg-background">
+        <div className="text-center">
+          <p className="mb-2 text-red-500">Error loading review diff</p>
+          <p className="text-sm text-muted-foreground">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (initialItems.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center bg-background text-sm text-muted-foreground">
+        No files in this revision
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-background">
+      <DiffCodeViewScaffold
+        items={treeItems}
+        selectedPath={selectedPath}
+        ariaLabel="Review files"
+        toolbar={toolbar}
+        defaultTreeVisible={false}
+        onSelectFile={handleSelectFile}
+      >
+        <CodeView
+          key={`${groupPath}:${viewerKey}`}
+          ref={handleViewerRef}
+          initialItems={initialItems}
+          options={codeViewOptions}
+          renderHeaderPrefix={renderHeaderPrefix}
+          renderAnnotation={renderAnnotation}
+          className={CODE_VIEW_HOST_CLASS}
+        />
+      </DiffCodeViewScaffold>
+    </div>
+  );
+}

--- a/apps/web/src/components/diff/ReviewCodeView.tsx
+++ b/apps/web/src/components/diff/ReviewCodeView.tsx
@@ -13,7 +13,6 @@ import { reviewWsApi } from '@/api/ws-api';
 import { useReviewCtx } from '@/components/diff/review/ReviewContextProvider';
 import { useEditorStore } from '@/hooks/use-editor-store';
 import { useContextParams } from '@/hooks/use-context-params';
-import { useTheme } from 'next-themes';
 import { useDiffWorkerPoolReady } from '@/components/diff/DiffWorkerPoolProvider';
 import { DiffCodeViewScaffold } from '@/components/diff/DiffCodeViewScaffold';
 import { DiffCodeViewSettingsMenu } from '@/components/diff/DiffCodeViewSettingsMenu';
@@ -25,6 +24,7 @@ import {
   updateViewerDiffItem,
 } from '@/components/diff/diff-code-view-shared';
 import {
+  ATMOS_DIFF_THEME,
   buildSharedDiffViewOptions,
   CODE_VIEW_HOST_CLASS,
 } from '@/components/diff/diff-view-constants';
@@ -89,7 +89,6 @@ interface ReviewCodeViewProps {
 
 export function ReviewCodeView({ groupPath }: ReviewCodeViewProps) {
   const { effectiveContextId } = useContextParams();
-  const { resolvedTheme } = useTheme();
   const workerPoolReady = useDiffWorkerPoolReady();
   const reviewCtx = useReviewCtx();
   const clearNavigationTarget = useEditorStore((s) => s.clearNavigationTarget);
@@ -867,7 +866,7 @@ export function ReviewCodeView({ groupPath }: ReviewCodeViewProps) {
   const codeViewOptions = useMemo(
     () => ({
       ...buildSharedDiffViewOptions({
-        theme: resolvedTheme === 'dark' ? 'pierre-dark' : 'pierre-light',
+        theme: ATMOS_DIFF_THEME,
         diffStyle,
         wordWrap,
         disableBackground: !showBackgrounds,
@@ -897,7 +896,6 @@ export function ReviewCodeView({ groupPath }: ReviewCodeViewProps) {
       diffStyle,
       lineNumbers,
       openInlineCommentDraft,
-      resolvedTheme,
       reviewCtx.canEdit,
       showBackgrounds,
       wordWrap,

--- a/apps/web/src/components/diff/ReviewCodeView.tsx
+++ b/apps/web/src/components/diff/ReviewCodeView.tsx
@@ -102,6 +102,7 @@ export function ReviewCodeView({ groupPath }: ReviewCodeViewProps) {
   );
 
   const [isLoading, setIsLoading] = useState(true);
+  const [hasLoadedAllItems, setHasLoadedAllItems] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [initialItems, setInitialItems] = useState<CodeViewItem<ReviewAnnotationMeta>[]>([]);
   const [annotationVersion, setAnnotationVersion] = useState(0);
@@ -142,6 +143,7 @@ export function ReviewCodeView({ groupPath }: ReviewCodeViewProps) {
   const fileSnapshotByPathRef = useRef<Map<string, ReviewFileDto>>(new Map());
   const lastHandledNavRef = useRef<string | null>(null);
   const inlineCommentTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const loadErrorRef = useRef<Error | null>(null);
 
   const orderedFiles = useMemo(
     () =>
@@ -230,6 +232,7 @@ export function ReviewCodeView({ groupPath }: ReviewCodeViewProps) {
     setViewerKey((key) => key + 1);
     setViewerMounted(false);
     setInitialItems([]);
+    setHasLoadedAllItems(false);
     pendingAppendRef.current = [];
     pathByFileNameRef.current = new Map();
     loadedContentsRef.current = new Map();
@@ -237,6 +240,7 @@ export function ReviewCodeView({ groupPath }: ReviewCodeViewProps) {
     itemIdsRef.current = [];
     scrollActiveIdRef.current = null;
     lastHandledNavRef.current = null;
+    loadErrorRef.current = null;
 
     if (!reviewCtx.currentRevision) {
       setIsLoading(false);
@@ -284,12 +288,19 @@ export function ReviewCodeView({ groupPath }: ReviewCodeViewProps) {
                   id: file.snapshot.file_path,
                   type: 'diff' as const,
                   fileDiff,
+                  collapsed: collapseMode === 'collapsed',
                 };
               } catch (loadError) {
                 console.error(
                   `Failed to load review diff for ${file.snapshot.file_path}:`,
                   loadError,
                 );
+                if (loadErrorRef.current == null) {
+                  loadErrorRef.current =
+                    loadError instanceof Error
+                      ? loadError
+                      : new Error('Failed to load review diff');
+                }
                 return null;
               }
             }),
@@ -327,7 +338,11 @@ export function ReviewCodeView({ groupPath }: ReviewCodeViewProps) {
           }
         }
 
-        if (!cancelled && !hasPublishedInitial) {
+        if (!cancelled) {
+          setHasLoadedAllItems(true);
+          if (!hasPublishedInitial && loadErrorRef.current) {
+            setError(loadErrorRef.current.message);
+          }
           setIsLoading(false);
         }
       } catch (loadError) {
@@ -347,7 +362,7 @@ export function ReviewCodeView({ groupPath }: ReviewCodeViewProps) {
     return () => {
       cancelled = true;
     };
-  }, [orderedFiles, reviewCtx.currentRevision]);
+  }, [collapseMode, orderedFiles, reviewCtx.currentRevision]);
 
   useEffect(() => {
     if (!viewerMounted || pendingAppendRef.current.length === 0) return;
@@ -359,14 +374,16 @@ export function ReviewCodeView({ groupPath }: ReviewCodeViewProps) {
 
   useEffect(() => {
     if (!effectiveContextId || itemIdsRef.current.length === 0) return;
-    const currentSelectedPath =
-      selectedPath && itemIdsRef.current.includes(selectedPath) ? selectedPath : null;
-    if (currentSelectedPath) return;
+    if (selectedPath && !hasLoadedAllItems) return;
+    if (selectedPath && itemIdsRef.current.includes(selectedPath)) return;
+    if (selectedPath && navigationTarget?.diffFilePath === selectedPath) return;
     setDiffGroupActiveFile(groupPath, itemIdsRef.current[0], effectiveContextId);
   }, [
     effectiveContextId,
     groupPath,
+    hasLoadedAllItems,
     initialItems,
+    navigationTarget?.diffFilePath,
     selectedPath,
     setDiffGroupActiveFile,
     viewerKey,
@@ -940,8 +957,9 @@ export function ReviewCodeView({ groupPath }: ReviewCodeViewProps) {
     ) {
       return;
     }
+    const targetPath = navigationTarget.diffFilePath;
+    if (!itemIdsRef.current.includes(targetPath)) return;
     if (lastHandledNavRef.current === navigationScrollKey) return;
-    lastHandledNavRef.current = navigationScrollKey;
 
     if (navigationTarget.reviewCommentGuid) {
       setCollapsedInlineCommentGuids((prev) => {
@@ -958,11 +976,15 @@ export function ReviewCodeView({ groupPath }: ReviewCodeViewProps) {
     }
 
     if (effectiveContextId) {
-      setDiffGroupActiveFile(groupPath, navigationTarget.diffFilePath, effectiveContextId);
+      setDiffGroupActiveFile(groupPath, targetPath, effectiveContextId);
     }
 
     requestAnimationFrame(() => {
-      scrollCodeViewToItem(codeViewRef.current, navigationTarget.diffFilePath!, {
+      if (!codeViewRef.current?.getItem(targetPath)) {
+        return;
+      }
+      lastHandledNavRef.current = navigationScrollKey;
+      scrollCodeViewToItem(codeViewRef.current, targetPath, {
         line: navigationTarget.line,
         behavior: 'smooth',
       });
@@ -971,6 +993,7 @@ export function ReviewCodeView({ groupPath }: ReviewCodeViewProps) {
       }
     });
   }, [
+    annotationVersion,
     clearNavigationTarget,
     effectiveContextId,
     groupPath,

--- a/apps/web/src/components/diff/ReviewView.tsx
+++ b/apps/web/src/components/diff/ReviewView.tsx
@@ -13,7 +13,13 @@ import { cn } from "@/lib/utils";
 import { useReviewCtx } from "@/components/diff/review/ReviewContextProvider";
 import { useReviewSnapshotStore } from "@/hooks/use-review-snapshot-store";
 import { useContextParams } from "@/hooks/use-context-params";
-import { useEditorStore, EDITOR_REVIEW_DIFF_PREFIX, getEditorSourcePath } from "@/hooks/use-editor-store";
+import {
+  useEditorStore,
+  EDITOR_REVIEW_DIFF_PREFIX,
+  EDITOR_REVIEW_GROUP_PREFIX,
+  isReviewGroupEditorPath,
+  getEditorSourcePath,
+} from "@/hooks/use-editor-store";
 import { DiffFilePathLabel } from "@/components/diff/DiffFilePathLabel";
 import { CommentCard } from "@/components/diff/review/CommentCard";
 import { FrozenFileList } from "@/components/diff/review/FrozenFileList";
@@ -30,14 +36,17 @@ import { useSidebarUiPrefs } from "@/hooks/use-ui-pref-hooks";
 
 const ReviewView: React.FC = () => {
   const { effectiveContextId } = useContextParams();
-  // For review-diff editor tabs, use the same context key as the main editor
-  // to ensure file/comment navigation opens in the correct tab namespace.
   const reviewEditorKey = effectiveContextId;
   const getActiveFilePath = useEditorStore((s) => s.getActiveFilePath);
   const rawFilePath = (reviewEditorKey && getActiveFilePath(reviewEditorKey)) || "";
-  const filePath = rawFilePath.startsWith(EDITOR_REVIEW_DIFF_PREFIX)
-    ? getEditorSourcePath(rawFilePath)
-    : "";
+  const activeGroupedFilePath = useEditorStore((s) =>
+    reviewEditorKey ? s.diffGroupActiveFiles[reviewEditorKey]?.[rawFilePath] ?? "" : "",
+  );
+  const filePath = isReviewGroupEditorPath(rawFilePath)
+    ? activeGroupedFilePath
+    : rawFilePath.startsWith(EDITOR_REVIEW_DIFF_PREFIX)
+      ? getEditorSourcePath(rawFilePath)
+      : "";
 
   const {
     currentSession,
@@ -57,7 +66,6 @@ const ReviewView: React.FC = () => {
     artifactLoading,
   } = useReviewCtx();
 
-  const setSnapshot = useReviewSnapshotStore((s) => s.setSnapshot);
   const setSessionDisplay = useReviewSnapshotStore((s) => s.setSessionDisplay);
   const openFile = useEditorStore((s) => s.openFile);
   const pinFile = useEditorStore((s) => s.pinFile);
@@ -101,6 +109,9 @@ const ReviewView: React.FC = () => {
 
   const summaryRunGuid = latestSummaryRun?.guid ?? null;
   const hasLoadedSummary = artifactPreview?.kind === "summary" && artifactPreview?.runGuid === summaryRunGuid;
+  const reviewGroupPath = currentRevision
+    ? `${EDITOR_REVIEW_GROUP_PREFIX}${currentRevision.guid}`
+    : null;
 
   useEffect(() => {
     if (summaryRunGuid && !hasLoadedSummary && !artifactLoading) {
@@ -210,23 +221,20 @@ const ReviewView: React.FC = () => {
                   revision={currentRevision}
                   currentFilePath={filePath}
                   canEdit={canEdit}
-                  onSelectFile={(snapshotGuid, snapFilePath, label) => {
-                    setSnapshot({
-                      snapshotGuid,
-                      label,
-                      filePath: snapFilePath,
+                  onSelectFile={(_snapshotGuid, snapFilePath) => {
+                    if (!reviewGroupPath) return;
+                    void openFile(reviewGroupPath, reviewEditorKey, {
+                      preview: true,
+                      diffFilePath: snapFilePath,
                     });
-                    void openFile(`${EDITOR_REVIEW_DIFF_PREFIX}${snapshotGuid}/${snapFilePath}`, reviewEditorKey, { preview: true });
                   }}
-                  onDoubleClickFile={(snapshotGuid, snapFilePath) => {
-                    const tabPath = `${EDITOR_REVIEW_DIFF_PREFIX}${snapshotGuid}/${snapFilePath}`;
-                    setSnapshot({
-                      snapshotGuid,
-                      label: revisionLabel,
-                      filePath: snapFilePath,
+                  onDoubleClickFile={(_snapshotGuid, snapFilePath) => {
+                    if (!reviewGroupPath) return;
+                    void openFile(reviewGroupPath, reviewEditorKey, {
+                      preview: false,
+                      diffFilePath: snapFilePath,
                     });
-                    void openFile(tabPath, reviewEditorKey, { preview: false });
-                    pinFile(tabPath, reviewEditorKey ?? undefined);
+                    pinFile(reviewGroupPath, reviewEditorKey ?? undefined);
                   }}
                   onToggleReviewed={handleToggleReviewed}
                   revisionLabel={revisionLabel}
@@ -299,14 +307,10 @@ const ReviewView: React.FC = () => {
                           onNavigate={(targetComment, targetMessage) => {
                             const snapFilePath =
                               targetComment.anchor.file_path || file;
-                            const tabPath = `${EDITOR_REVIEW_DIFF_PREFIX}${targetComment.file_snapshot_guid}/${snapFilePath}`;
-                            setSnapshot({
-                              snapshotGuid: targetComment.file_snapshot_guid,
-                              label: revisionLabel,
-                              filePath: snapFilePath,
-                            });
-                            void openFile(tabPath, reviewEditorKey, {
+                            if (!reviewGroupPath) return;
+                            void openFile(reviewGroupPath, reviewEditorKey, {
                               preview: true,
+                              diffFilePath: snapFilePath,
                               line: targetComment.anchor_start_line,
                               reviewCommentGuid: targetComment.guid,
                               reviewMessageGuid: targetMessage?.guid,

--- a/apps/web/src/components/diff/code-view-ui.tsx
+++ b/apps/web/src/components/diff/code-view-ui.tsx
@@ -1,11 +1,7 @@
 'use client';
 
 import type { MutableRefObject } from 'react';
-import type {
-  CodeViewItem,
-  CodeViewScrollBehavior,
-  CodeViewScrollListener,
-} from '@pierre/diffs';
+import type { CodeViewItem, CodeViewScrollBehavior } from '@pierre/diffs';
 import type { CodeViewHandle } from '@pierre/diffs/react';
 import { ChevronRight } from 'lucide-react';
 import { getFileIconProps } from '@workspace/ui';
@@ -96,24 +92,49 @@ export function scrollCodeViewToItem<LAnnotation = undefined>(
   }
 }
 
-/** File whose header is closest to (but not below) the viewport top. */
-export function findDiffItemIdAtScrollTop<LAnnotation>(
-  viewer: Parameters<CodeViewScrollListener<LAnnotation>>[1],
-  scrollTop: number,
+/** File whose diff occupies the viewport center, with a top-of-viewport fallback. */
+export function findDiffItemIdForViewport<LAnnotation>(
+  viewer: {
+    getTopForItem(id: string): number | undefined;
+    getWindowSpecs(): { top: number; bottom: number };
+  },
   itemIds: readonly string[],
 ): string | undefined {
+  const windowSpecs = viewer.getWindowSpecs();
+  const viewportTop = windowSpecs.top;
+  const viewportMidpoint = viewportTop + (windowSpecs.bottom - viewportTop) / 2;
   let activeId: string | undefined;
   let activeTop = -Infinity;
   const viewportOffset = 4;
 
-  for (const id of itemIds) {
+  for (let index = 0; index < itemIds.length; index += 1) {
+    const id = itemIds[index];
     const top = viewer.getTopForItem(id);
     if (top == null) continue;
-    if (top <= scrollTop + viewportOffset && top > activeTop) {
+    const nextTop = itemIds[index + 1]
+      ? viewer.getTopForItem(itemIds[index + 1])
+      : undefined;
+
+    if (viewportMidpoint >= top && (nextTop == null || viewportMidpoint < nextTop)) {
+      return id;
+    }
+
+    if (top <= viewportTop + viewportOffset && top > activeTop) {
       activeTop = top;
       activeId = id;
     }
   }
 
   return activeId ?? itemIds[0];
+}
+
+export function findDiffItemIdAtScrollTop<LAnnotation>(
+  viewer: {
+    getTopForItem(id: string): number | undefined;
+    getWindowSpecs(): { top: number; bottom: number };
+  },
+  _scrollTop: number,
+  itemIds: readonly string[],
+): string | undefined {
+  return findDiffItemIdForViewport(viewer, itemIds);
 }

--- a/apps/web/src/components/diff/code-view-ui.tsx
+++ b/apps/web/src/components/diff/code-view-ui.tsx
@@ -59,7 +59,7 @@ export function createDiffHeaderPrefixRenderer<LAnnotation>(args: {
           <ChevronRight
             className={cn(
               'size-4 transition-transform',
-              (isEmptyDiff || collapsed) && '-rotate-90',
+              !isEmptyDiff && !collapsed && 'rotate-90',
             )}
           />
         </button>

--- a/apps/web/src/components/diff/diff-code-view-shared.ts
+++ b/apps/web/src/components/diff/diff-code-view-shared.ts
@@ -108,6 +108,25 @@ function buildLineTypeMaps(fileDiff: FileDiffMetadata) {
   return { oldMap, newMap };
 }
 
+function getMappedContextRange(
+  lineMap: Map<number, LineTypeInfo>,
+  startLine: number,
+  endLine: number,
+) {
+  const mapped: LineTypeInfo[] = [];
+  for (let line = startLine; line <= endLine; line += 1) {
+    const info = lineMap.get(line);
+    if (info) mapped.push(info);
+  }
+
+  return {
+    oldStart: mapped[0]?.oldLine ?? startLine,
+    oldEnd: mapped[mapped.length - 1]?.oldLine ?? endLine,
+    newStart: mapped[0]?.newLine ?? startLine,
+    newEnd: mapped[mapped.length - 1]?.newLine ?? endLine,
+  };
+}
+
 export function formatSelectedRangeLabel(range: SelectedLineRange): string {
   const start = Math.min(range.start, range.end);
   const end = Math.max(range.start, range.end);
@@ -151,8 +170,9 @@ export function buildDiffSelectionInfo(args: {
 
   if (onlyContext) {
     changeType = 'context';
-    beforeText = oldLines.slice(startLine - 1, endLine).join('\n');
-    afterText = newLines.slice(startLine - 1, endLine).join('\n');
+    const mapped = getMappedContextRange(lineMap, startLine, endLine);
+    beforeText = oldLines.slice(mapped.oldStart - 1, mapped.oldEnd).join('\n');
+    afterText = newLines.slice(mapped.newStart - 1, mapped.newEnd).join('\n');
   } else if (onlyAddition) {
     changeType = 'addition';
     afterText = newLines.slice(startLine - 1, endLine).join('\n');

--- a/apps/web/src/components/diff/diff-code-view-shared.ts
+++ b/apps/web/src/components/diff/diff-code-view-shared.ts
@@ -2,6 +2,7 @@
 
 import type { MutableRefObject } from 'react';
 import type {
+  ChangeContent,
   CodeViewDiffItem,
   CodeViewItem,
   DiffLineAnnotation,
@@ -9,6 +10,7 @@ import type {
   SelectedLineRange,
 } from '@pierre/diffs';
 import type { CodeViewHandle } from '@pierre/diffs/react';
+import type { SelectionInfo } from '@/lib/format-selection-for-ai';
 
 export type CopyAnnotationMeta = {
   kind: 'copy';
@@ -43,6 +45,160 @@ export function getTextForRange(
     side === 'deletions' ? contents.oldContent : contents.newContent;
   const lines = source.split('\n');
   return lines.slice(start - 1, end).join('\n');
+}
+
+type LineTypeInfo = {
+  type: 'context' | 'addition' | 'deletion' | 'mixed';
+  oldLine?: number;
+  newLine?: number;
+};
+
+function buildLineTypeMaps(fileDiff: FileDiffMetadata) {
+  const oldMap = new Map<number, LineTypeInfo>();
+  const newMap = new Map<number, LineTypeInfo>();
+
+  for (const hunk of fileDiff.hunks) {
+    let oldLine = hunk.deletionStart;
+    let newLine = hunk.additionStart;
+
+    for (const content of hunk.hunkContent) {
+      if (content.type === 'context') {
+        const lineCount = Array.isArray(content.lines)
+          ? content.lines.length
+          : content.lines;
+
+        for (let index = 0; index < lineCount; index += 1) {
+          const info: LineTypeInfo = { type: 'context', oldLine, newLine };
+          oldMap.set(oldLine, info);
+          newMap.set(newLine, info);
+          oldLine += 1;
+          newLine += 1;
+        }
+        continue;
+      }
+
+      const change = content as ChangeContent;
+      const deletionCount = Array.isArray(change.deletions)
+        ? change.deletions.length
+        : change.deletions;
+      const additionCount = Array.isArray(change.additions)
+        ? change.additions.length
+        : change.additions;
+      const hasBoth = deletionCount > 0 && additionCount > 0;
+      const lineType: LineTypeInfo['type'] = hasBoth
+        ? 'mixed'
+        : deletionCount > 0
+          ? 'deletion'
+          : 'addition';
+      const deletionStart = oldLine;
+      const additionStart = newLine;
+
+      for (let index = 0; index < deletionCount; index += 1) {
+        oldMap.set(oldLine, { type: lineType, oldLine, newLine: additionStart });
+        oldLine += 1;
+      }
+
+      for (let index = 0; index < additionCount; index += 1) {
+        newMap.set(newLine, { type: lineType, oldLine: deletionStart, newLine });
+        newLine += 1;
+      }
+    }
+  }
+
+  return { oldMap, newMap };
+}
+
+export function formatSelectedRangeLabel(range: SelectedLineRange): string {
+  const start = Math.min(range.start, range.end);
+  const end = Math.max(range.start, range.end);
+  return start === end ? `Line ${start}` : `Lines ${start}-${end}`;
+}
+
+export function buildDiffSelectionInfo(args: {
+  filePath: string;
+  fileDiff: FileDiffMetadata;
+  contents: { oldContent: string; newContent: string };
+  range: SelectedLineRange;
+}): SelectionInfo | null {
+  const side = args.range.endSide ?? args.range.side;
+  if (!side) return null;
+
+  const startLine = Math.min(args.range.start, args.range.end);
+  const endLine = Math.max(args.range.start, args.range.end);
+  const oldLines = args.contents.oldContent.split('\n');
+  const newLines = args.contents.newContent.split('\n');
+  const sourceLines = side === 'deletions' ? oldLines : newLines;
+  const selectedText = sourceLines.slice(startLine - 1, endLine).join('\n');
+  const { oldMap, newMap } = buildLineTypeMaps(args.fileDiff);
+  const lineMap = side === 'deletions' ? oldMap : newMap;
+  const lineTypes = new Set<LineTypeInfo['type']>();
+
+  for (let line = startLine; line <= endLine; line += 1) {
+    lineTypes.add(lineMap.get(line)?.type ?? 'context');
+  }
+
+  const hasMixed = lineTypes.has('mixed');
+  const hasAddition = lineTypes.has('addition');
+  const hasDeletion = lineTypes.has('deletion');
+  const hasContext = lineTypes.has('context');
+  const onlyContext = lineTypes.size === 1 && hasContext;
+  const onlyAddition = !hasMixed && !hasDeletion && hasAddition;
+  const onlyDeletion = !hasMixed && !hasAddition && hasDeletion;
+
+  let changeType: SelectionInfo['changeType'];
+  let beforeText: string | undefined;
+  let afterText: string | undefined;
+
+  if (onlyContext) {
+    changeType = 'context';
+    beforeText = oldLines.slice(startLine - 1, endLine).join('\n');
+    afterText = newLines.slice(startLine - 1, endLine).join('\n');
+  } else if (onlyAddition) {
+    changeType = 'addition';
+    afterText = newLines.slice(startLine - 1, endLine).join('\n');
+  } else if (onlyDeletion) {
+    changeType = 'deletion';
+    beforeText = oldLines.slice(startLine - 1, endLine).join('\n');
+  } else {
+    changeType = 'mixed';
+    let minOtherLine = Infinity;
+    let maxOtherLine = -Infinity;
+
+    for (let line = startLine; line <= endLine; line += 1) {
+      const info = lineMap.get(line);
+      if (!info) continue;
+      const otherLine = side === 'deletions' ? info.newLine : info.oldLine;
+      if (otherLine == null) continue;
+      minOtherLine = Math.min(minOtherLine, otherLine);
+      maxOtherLine = Math.max(maxOtherLine, otherLine);
+    }
+
+    if (side === 'deletions') {
+      beforeText = oldLines.slice(startLine - 1, endLine).join('\n');
+      afterText =
+        minOtherLine <= maxOtherLine
+          ? newLines.slice(minOtherLine - 1, maxOtherLine).join('\n')
+          : undefined;
+    } else {
+      afterText = newLines.slice(startLine - 1, endLine).join('\n');
+      beforeText =
+        minOtherLine <= maxOtherLine
+          ? oldLines.slice(minOtherLine - 1, maxOtherLine).join('\n')
+          : undefined;
+    }
+  }
+
+  return {
+    filePath: args.filePath,
+    startLine,
+    endLine,
+    selectedText:
+      selectedText || `Lines ${startLine}${startLine === endLine ? '' : `-${endLine}`}`,
+    changeType,
+    diffSide: side === 'deletions' ? 'old' : 'new',
+    beforeText,
+    afterText,
+  };
 }
 
 export function updateViewerDiffItem<LAnnotation>(

--- a/apps/web/src/components/diff/diff-file-order.ts
+++ b/apps/web/src/components/diff/diff-file-order.ts
@@ -1,0 +1,31 @@
+"use client";
+
+export function compareDiffTreePaths(leftPath: string, rightPath: string): number {
+  const leftParts = leftPath.split("/").filter(Boolean);
+  const rightParts = rightPath.split("/").filter(Boolean);
+  const sharedLength = Math.min(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < sharedLength; index += 1) {
+    const leftPart = leftParts[index];
+    const rightPart = rightParts[index];
+
+    if (leftPart === rightPart) continue;
+
+    const leftIsLeaf = index === leftParts.length - 1;
+    const rightIsLeaf = index === rightParts.length - 1;
+
+    if (leftIsLeaf !== rightIsLeaf) {
+      return leftIsLeaf ? 1 : -1;
+    }
+
+    return leftPart.localeCompare(rightPart);
+  }
+
+  return leftParts.length - rightParts.length;
+}
+
+export function sortByDiffTreePath<T extends { path: string }>(items: readonly T[]): T[] {
+  return [...items].sort((left, right) =>
+    compareDiffTreePaths(left.path, right.path),
+  );
+}

--- a/apps/web/src/components/diff/diff-file-order.ts
+++ b/apps/web/src/components/diff/diff-file-order.ts
@@ -11,13 +11,6 @@ export function compareDiffTreePaths(leftPath: string, rightPath: string): numbe
 
     if (leftPart === rightPart) continue;
 
-    const leftIsLeaf = index === leftParts.length - 1;
-    const rightIsLeaf = index === rightParts.length - 1;
-
-    if (leftIsLeaf !== rightIsLeaf) {
-      return leftIsLeaf ? 1 : -1;
-    }
-
     return leftPart.localeCompare(rightPart);
   }
 

--- a/apps/web/src/components/diff/diff-view-constants.ts
+++ b/apps/web/src/components/diff/diff-view-constants.ts
@@ -1,4 +1,4 @@
-import type { CodeViewLayout, DiffIndicators } from '@pierre/diffs';
+import type { CodeViewLayout, DiffIndicators, ThemesType } from '@pierre/diffs';
 
 /** Matches diffshub CodeView layout — tight gaps reduce scroll height churn. */
 export const CODE_VIEW_LAYOUT: CodeViewLayout = {
@@ -41,7 +41,7 @@ export const DIFF_VIEW_SEPARATOR_CSS = `
     display: block !important;
   }
 
-  [data-diff-type=split] [data-additions] [data-content]
+  [data-diff-type=split] :is([data-deletions] [data-content], [data-additions] [data-content])
     :is([data-separator=line-info], [data-separator=line-info-basic])
     [data-separator-content] {
     visibility: hidden !important;
@@ -76,8 +76,13 @@ export const DIFF_VIEW_SCROLLBAR_CSS = `
   }
 `;
 
+export const ATMOS_DIFF_THEME: ThemesType = {
+  dark: 'pierre-dark-soft',
+  light: 'pierre-light-soft',
+};
+
 export function buildSharedDiffViewOptions(args: {
-  theme: 'pierre-dark' | 'pierre-light';
+  theme: ThemesType;
   diffStyle: 'split' | 'unified';
   wordWrap: boolean;
   disableBackground?: boolean;
@@ -86,7 +91,7 @@ export function buildSharedDiffViewOptions(args: {
   enableLineSelection?: boolean;
   enableGutterUtility?: boolean;
 }): {
-  theme: 'pierre-dark' | 'pierre-light';
+  theme: ThemesType;
   diffStyle: 'split' | 'unified';
   disableBackground: boolean;
   disableLineNumbers: boolean;

--- a/apps/web/src/components/diff/diff-view-constants.ts
+++ b/apps/web/src/components/diff/diff-view-constants.ts
@@ -31,9 +31,20 @@ export const DIFF_VIEW_SEPARATOR_CSS = `
     white-space: nowrap;
   }
 
-  /* Undo mistaken override: keep Pierre's content-column separators hidden in split */
-  [data-diff-type=split] [data-additions] [data-content] [data-separator-wrapper] {
-    display: none !important;
+  /* Keep unchanged separators visually spanning both split panes. */
+  [data-diff-type=split]
+    :is([data-deletions] [data-content], [data-additions] [data-content])
+    [data-separator=line-info] [data-separator-wrapper],
+  [data-diff-type=split]
+    :is([data-deletions] [data-content], [data-additions] [data-content])
+    [data-separator=line-info-basic] [data-separator-wrapper] {
+    display: block !important;
+  }
+
+  [data-diff-type=split] [data-additions] [data-content]
+    :is([data-separator=line-info], [data-separator=line-info-basic])
+    [data-separator-content] {
+    visibility: hidden !important;
   }
 
   /* Left/unified: ensure label stays visible in gutter */

--- a/apps/web/src/components/diff/review/FrozenFileList.tsx
+++ b/apps/web/src/components/diff/review/FrozenFileList.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import type { ReviewFileDto, ReviewSessionDto } from "@/api/ws-api";
 import { DiffFileTree } from "@/components/diff/DiffFileTree";
 import { DiffFilePathLabel } from "@/components/diff/DiffFilePathLabel";
+import { sortByDiffTreePath } from "@/components/diff/diff-file-order";
 
 interface FrozenFileListProps {
   revision: ReviewSessionDto["revisions"][number] | null;
@@ -66,8 +67,14 @@ export const FrozenFileList: React.FC<FrozenFileListProps> = ({
   viewMode = "list",
 }) => {
   const clickTimers = useRef<Record<string, number>>({});
+  const orderedFiles = sortByDiffTreePath(
+    revision?.files.map((file) => ({
+      path: file.snapshot.file_path,
+      file,
+    })) ?? [],
+  ).map((entry) => entry.file);
 
-  if (!revision || revision.files.length === 0) {
+  if (!revision || orderedFiles.length === 0) {
     return (
       <p className="text-xs text-muted-foreground px-1">
         No files in this revision.
@@ -77,12 +84,12 @@ export const FrozenFileList: React.FC<FrozenFileListProps> = ({
 
   if (viewMode === "tree") {
     const fileByPath = new Map(
-      revision.files.map((file) => [file.snapshot.file_path, file]),
+      orderedFiles.map((file) => [file.snapshot.file_path, file]),
     );
 
     return (
       <DiffFileTree
-        items={revision.files.map((file) => {
+        items={orderedFiles.map((file) => {
           const annotations = [
             file.state.reviewed ? "reviewed" : null,
             file.open_comment_count > 0 ? `${file.open_comment_count}` : null,
@@ -220,7 +227,7 @@ export const FrozenFileList: React.FC<FrozenFileListProps> = ({
 
   return (
     <div className="space-y-1">
-      {revision.files.map((file) => {
+      {orderedFiles.map((file) => {
         const path = file.snapshot.file_path;
         const isCurrent = path === currentFilePath;
         const status = file.snapshot.git_status;

--- a/apps/web/src/components/diff/review/ReviewContextProvider.tsx
+++ b/apps/web/src/components/diff/review/ReviewContextProvider.tsx
@@ -10,6 +10,7 @@ interface ReviewContextProviderProps {
   target: ReviewTarget | null;
   filePath: string;
   fileSnapshotGuid?: string | null;
+  revisionGuid?: string | null;
   children: React.ReactNode;
 }
 
@@ -17,9 +18,10 @@ export const ReviewContextProvider: React.FC<ReviewContextProviderProps> = ({
   target,
   filePath,
   fileSnapshotGuid,
+  revisionGuid,
   children,
 }) => {
-  const ctx = useReviewContext({ target, filePath, fileSnapshotGuid });
+  const ctx = useReviewContext({ target, filePath, fileSnapshotGuid, revisionGuid });
 
   // Memoize context value to avoid unnecessary re-renders
   const contextValue = useMemo(() => ctx, [

--- a/apps/web/src/components/github/PRDetailModal.tsx
+++ b/apps/web/src/components/github/PRDetailModal.tsx
@@ -30,9 +30,9 @@ import {
 } from '@workspace/ui';
 import { MultiFileDiff } from '@pierre/diffs/react';
 import type { FileContents } from '@pierre/diffs';
-import { useTheme } from 'next-themes';
 import { useGithubPRDetail, useGithubPRDetailSidebar, useGithubPRTimeline, useGithubPRFiles } from '@/hooks/use-github';
 import { useWebSocketStore } from '@/hooks/use-websocket';
+import { ATMOS_DIFF_THEME } from '@/components/diff/diff-view-constants';
 import {
   Github,
   ExternalLink,
@@ -396,7 +396,6 @@ function SidebarSection({ title, icon, children }: { title: string; icon: React.
 
 const ReviewCommentThreadView = React.memo(function ReviewCommentThreadView({ thread }: { thread: ReviewCommentThread }) {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const { resolvedTheme } = useTheme();
   const isMounted = React.useSyncExternalStore(
     () => () => { },
     () => true,
@@ -409,15 +408,14 @@ const ReviewCommentThreadView = React.memo(function ReviewCommentThreadView({ th
   }, [thread.diffHunk, thread.path]);
 
   const diffOptions = useMemo(() => {
-    const isDark = resolvedTheme === 'dark' || (!resolvedTheme && typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches);
     return {
-      theme: (isDark ? 'pierre-dark' : 'pierre-light') as 'pierre-dark' | 'pierre-light',
+      theme: ATMOS_DIFF_THEME,
       diffStyle: 'unified' as const,
       overflow: 'wrap' as const,
       disableLineNumbers: false,
       disableFileHeader: true,
     };
-  }, [resolvedTheme]);
+  }, []);
 
   return (
     <div className="ml-12 mt-2 border border-border/60 rounded-lg overflow-hidden bg-muted/10 shadow-sm">

--- a/apps/web/src/components/github/PRDetailModal.tsx
+++ b/apps/web/src/components/github/PRDetailModal.tsx
@@ -808,7 +808,7 @@ export function PRDetailModal({ owner, repo, branch, prNumber, isOpen, onOpenCha
         showCloseButton={false}
         className={cn(
           "transition-all duration-200 flex flex-col gap-0 overflow-hidden",
-          isFullscreen ? "max-w-none sm:max-w-none w-screen sm:w-screen h-screen max-h-screen px-6 pb-6 pt-0 m-0 border-none rounded-none" : "max-w-6xl sm:max-w-6xl w-full max-h-[90vh] px-6 pb-6 pt-0"
+          isFullscreen ? "max-w-none sm:max-w-none w-screen sm:w-screen h-screen max-h-screen px-6 pb-6 pt-0 m-0 border-none rounded-none" : "max-w-6xl sm:max-w-6xl w-full h-[80vh] px-6 pb-6 pt-0"
         )}
       >
         <div className="flex flex-col flex-1 min-h-0 min-h-[600px]">

--- a/apps/web/src/components/github/PRFilesTab.tsx
+++ b/apps/web/src/components/github/PRFilesTab.tsx
@@ -5,13 +5,12 @@ import { CodeView, type CodeViewHandle } from '@pierre/diffs/react';
 import type { CodeViewItem, DiffLineAnnotation } from '@pierre/diffs';
 import { processFile } from '@pierre/diffs';
 import { useTheme } from 'next-themes';
-import { Avatar, AvatarImage, AvatarFallback, Skeleton, ScrollArea, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@workspace/ui';
-import { MessageSquare, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { Avatar, AvatarImage, AvatarFallback, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@workspace/ui';
+import { MessageSquare } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { MarkdownRenderer } from '@/components/markdown/MarkdownRenderer';
-import { DiffFileTree } from '@/components/diff/DiffFileTree';
-import { motion, AnimatePresence } from 'motion/react';
+import { DiffCodeViewScaffold } from '@/components/diff/DiffCodeViewScaffold';
+import { sortByDiffTreePath } from '@/components/diff/diff-file-order';
 import type { PrFile } from '@/hooks/use-github';
 import { useDiffWorkerPoolReady } from '@/components/diff/DiffWorkerPoolProvider';
 import { DiffCodeViewSettingsMenu } from '@/components/diff/DiffCodeViewSettingsMenu';
@@ -114,24 +113,6 @@ export function PRFilesTab({ files, loading, reviewComments = [], owner, repo }:
   const workerPoolReady = useDiffWorkerPoolReady();
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [viewerMounted, setViewerMounted] = useState(false);
-  const [treeVisible, setTreeVisible] = useState(true);
-  const [treeWidth, setTreeWidth] = useState(224);
-  const [isResizing, setIsResizing] = useState(false);
-  const onResizeDragStart = (e: React.MouseEvent) => {
-    e.preventDefault();
-    setIsResizing(true);
-    const startX = e.clientX;
-    const startW = treeWidth;
-    const onMove = (ev: MouseEvent) =>
-      setTreeWidth(Math.max(140, Math.min(480, startW + ev.clientX - startX)));
-    const onUp = () => {
-      setIsResizing(false);
-      window.removeEventListener('mousemove', onMove);
-      window.removeEventListener('mouseup', onUp);
-    };
-    window.addEventListener('mousemove', onMove);
-    window.addEventListener('mouseup', onUp);
-  };
   const [diffStyle, setDiffStyle] = useState<'unified' | 'split'>('unified');
   const [wordWrap, setWordWrap] = useState(true);
   const [showBackgrounds, setShowBackgrounds] = useState(true);
@@ -151,16 +132,31 @@ export function PRFilesTab({ files, loading, reviewComments = [], owner, repo }:
     [files],
   );
 
+  const orderedFiles = useMemo(
+    () => sortByDiffTreePath(files.map((file) => ({ path: file.filename, file }))).map((entry) => entry.file),
+    [files],
+  );
   const commentsByPath = useMemo(
     () => groupCommentsByPath(reviewComments),
     [reviewComments],
+  );
+  const treeItems = useMemo(
+    () =>
+      orderedFiles
+        .filter((file) => Boolean(file.patch))
+        .map((file) => ({
+          path: file.filename,
+          additions: file.additions,
+          deletions: file.deletions,
+        })),
+    [orderedFiles],
   );
 
   const { codeViewItems, fileLevelThreads } = useMemo(() => {
     const items: CodeViewItem<PrAnnotationMeta>[] = [];
     const fileThreads = new Map<string, ReviewComment[][]>();
 
-    for (const file of files) {
+    for (const file of orderedFiles) {
       const threads = commentsByPath.get(file.filename) ?? [];
       const lineThreads = threads.filter(
         (t) => t[0]?.line != null || t[0]?.original_line != null,
@@ -205,7 +201,7 @@ export function PRFilesTab({ files, loading, reviewComments = [], owner, repo }:
     }
 
     return { codeViewItems: items, fileLevelThreads: fileThreads };
-  }, [files, commentsByPath]);
+  }, [orderedFiles, commentsByPath]);
 
   const renderHeaderPrefix = useMemo(
     () =>
@@ -253,6 +249,18 @@ export function PRFilesTab({ files, loading, reviewComments = [], owner, repo }:
 
   itemIdsRef.current = codeViewItems.map((item) => item.id);
 
+  useEffect(() => {
+    if (codeViewItems.length === 0) {
+      setSelectedPath(null);
+      return;
+    }
+    setSelectedPath((current) =>
+      current && codeViewItems.some((item) => item.id === current)
+        ? current
+        : codeViewItems[0]?.id ?? null,
+    );
+  }, [codeViewItems]);
+
   const handleViewerRef = useCallback(
     (handle: CodeViewHandle<PrAnnotationMeta | undefined> | null) => {
       codeViewRef.current = handle;
@@ -280,11 +288,11 @@ export function PRFilesTab({ files, loading, reviewComments = [], owner, repo }:
 
   const totalStats = useMemo(
     () => ({
-      additions: files.reduce((s, f) => s + f.additions, 0),
-      deletions: files.reduce((s, f) => s + f.deletions, 0),
-      changed: files.length,
+      additions: orderedFiles.reduce((s, f) => s + f.additions, 0),
+      deletions: orderedFiles.reduce((s, f) => s + f.deletions, 0),
+      changed: orderedFiles.length,
     }),
-    [files],
+    [orderedFiles],
   );
 
   const handleSelect = (path: string) => {
@@ -293,17 +301,10 @@ export function PRFilesTab({ files, loading, reviewComments = [], owner, repo }:
   };
 
   const toolbar = (
-    <div className="flex items-center gap-2 px-2 py-1.5 border-b border-border/40 shrink-0">
-      <button
-        className="flex items-center justify-center size-6 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-        onClick={() => setTreeVisible((v) => !v)}
-        title={treeVisible ? 'Hide file tree' : 'Show file tree'}
-      >
-        {treeVisible ? <PanelLeftClose className="size-3.5" /> : <PanelLeftOpen className="size-3.5" />}
-      </button>
+    <div className="flex items-center gap-2">
       <div className="flex-1" />
-      {files.length > 0 && (
-        <div className="flex items-center gap-2 text-[11px] font-mono font-medium">
+      {orderedFiles.length > 0 && (
+        <div className="flex items-center gap-2 shrink-0 text-[11px] font-mono font-medium">
           <span className="text-emerald-500">+{totalStats.additions}</span>
           <span className="text-red-500">-{totalStats.deletions}</span>
         </div>
@@ -328,69 +329,40 @@ export function PRFilesTab({ files, loading, reviewComments = [], owner, repo }:
   if (loading) {
     return (
       <div className="flex flex-col h-full min-h-0">
-        {toolbar}
-        <div className="flex flex-1 min-h-0 gap-0">
-          <div className="w-56 shrink-0 border-r border-border/40 p-2 flex flex-col gap-1.5 overflow-hidden">
-            {[...Array(16)].map((_, i) => (
-              <Skeleton key={i} className="h-4 rounded shrink-0" style={{ width: `${40 + (i % 5) * 10}%`, marginLeft: i % 3 !== 0 ? '12px' : '0' }} />
-            ))}
-          </div>
-          <div className="flex-1 p-2 flex flex-col gap-3">
-            {[...Array(4)].map((_, i) => <Skeleton key={i} className="h-28 rounded-lg" />)}
-          </div>
-        </div>
+        <DiffCodeViewScaffold
+          items={treeItems}
+          selectedPath={selectedPath ?? undefined}
+          ariaLabel="PR changed files"
+          toolbar={toolbar}
+          loading
+          loadingTreeLabel="Files"
+          onSelectFile={() => {}}
+        >
+          <div />
+        </DiffCodeViewScaffold>
       </div>
     );
   }
 
   return (
     <div className="flex flex-col h-full min-h-0">
-      {toolbar}
-
-      <div className="flex flex-1 min-h-0">
-        <AnimatePresence initial={false}>
-          {treeVisible && (
-            <motion.div
-              key="tree"
-              initial={{ width: 0, opacity: 0 }}
-              animate={{ width: treeWidth, opacity: 1 }}
-              exit={{ width: 0, opacity: 0 }}
-              transition={isResizing ? { duration: 0 } : { duration: 0.2, ease: 'easeInOut' }}
-              className="shrink-0 overflow-hidden"
-            >
-              <ScrollArea className="h-full py-1 border-r border-border/40" style={{ width: treeWidth }}>
-                <DiffFileTree
-                  items={files.map((f) => ({
-                    path: f.filename,
-                    additions: f.additions,
-                    deletions: f.deletions,
-                  }))}
-                  selectedPath={selectedPath ?? undefined}
-                  ariaLabel="PR changed files"
-                  renderFileInlineDecoration={(item) => {
-                    const count = commentsByPath.get(item.path)?.length ?? 0;
-                    if (!count) return null;
-                    return (
-                      <span className="ml-1 flex items-center gap-0.5 text-[11px] text-muted-foreground shrink-0">
-                        <MessageSquare className="size-3" />{count}
-                      </span>
-                    );
-                  }}
-                  onSelectFile={handleSelect}
-                />
-              </ScrollArea>
-            </motion.div>
-          )}
-        </AnimatePresence>
-
-        {treeVisible && (
-          <div
-            className="w-px shrink-0 cursor-col-resize bg-border/40 transition-colors relative before:absolute before:-inset-x-2 before:h-full before:hover:bg-primary/40 before:transition-colors"
-            onMouseDown={onResizeDragStart}
-          />
-        )}
-
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+      <DiffCodeViewScaffold
+        items={treeItems}
+        selectedPath={selectedPath ?? undefined}
+        ariaLabel="PR changed files"
+        toolbar={toolbar}
+        renderFileInlineDecoration={(item) => {
+          const count = commentsByPath.get(item.path)?.length ?? 0;
+          if (!count) return null;
+          return (
+            <span className="ml-1 flex items-center gap-0.5 text-[11px] text-muted-foreground shrink-0">
+              <MessageSquare className="size-3" />
+              {count}
+            </span>
+          );
+        }}
+        onSelectFile={handleSelect}
+      >
           {workerPoolReady && codeViewItems.length > 0 ? (
           <CodeView
             key={codeViewMountKey}
@@ -414,8 +386,7 @@ export function PRFilesTab({ files, loading, reviewComments = [], owner, repo }:
               ))}
             </div>
           ))}
-        </div>
-      </div>
+      </DiffCodeViewScaffold>
     </div>
   );
 }

--- a/apps/web/src/components/github/PRFilesTab.tsx
+++ b/apps/web/src/components/github/PRFilesTab.tsx
@@ -152,9 +152,10 @@ export function PRFilesTab({ files, loading, reviewComments = [], owner, repo }:
     [orderedFiles],
   );
 
-  const { codeViewItems, fileLevelThreads } = useMemo(() => {
+  const { codeViewItems, fileLevelThreads, pathByFileName, itemIds } = useMemo(() => {
     const items: CodeViewItem<PrAnnotationMeta>[] = [];
     const fileThreads = new Map<string, ReviewComment[][]>();
+    const nextPathByFileName = new Map<string, string>();
 
     for (const file of orderedFiles) {
       const threads = commentsByPath.get(file.filename) ?? [];
@@ -191,7 +192,7 @@ export function PRFilesTab({ files, loading, reviewComments = [], owner, repo }:
         },
       );
 
-      pathByFileNameRef.current.set(fileDiff.name, file.filename);
+      nextPathByFileName.set(fileDiff.name, file.filename);
       items.push({
         id: file.filename,
         type: 'diff',
@@ -200,16 +201,21 @@ export function PRFilesTab({ files, loading, reviewComments = [], owner, repo }:
       });
     }
 
-    return { codeViewItems: items, fileLevelThreads: fileThreads };
+    return {
+      codeViewItems: items,
+      fileLevelThreads: fileThreads,
+      pathByFileName: nextPathByFileName,
+      itemIds: items.map((item) => item.id),
+    };
   }, [orderedFiles, commentsByPath]);
 
   const renderHeaderPrefix = useMemo(
     () =>
       createDiffHeaderPrefixRenderer({
         viewerRef: codeViewRef,
-        pathByFileName: pathByFileNameRef.current,
+        pathByFileName,
       }),
-    [codeViewMountKey, viewerMounted],
+    [codeViewMountKey, pathByFileName, viewerMounted],
   );
 
   const codeViewOptions = useMemo(
@@ -247,7 +253,10 @@ export function PRFilesTab({ files, loading, reviewComments = [], owner, repo }:
     [commentsByPath],
   );
 
-  itemIdsRef.current = codeViewItems.map((item) => item.id);
+  useEffect(() => {
+    pathByFileNameRef.current = pathByFileName;
+    itemIdsRef.current = itemIds;
+  }, [itemIds, pathByFileName]);
 
   useEffect(() => {
     if (codeViewItems.length === 0) {

--- a/apps/web/src/components/github/PRFilesTab.tsx
+++ b/apps/web/src/components/github/PRFilesTab.tsx
@@ -4,7 +4,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { CodeView, type CodeViewHandle } from '@pierre/diffs/react';
 import type { CodeViewItem, DiffLineAnnotation } from '@pierre/diffs';
 import { processFile } from '@pierre/diffs';
-import { useTheme } from 'next-themes';
 import { Avatar, AvatarImage, AvatarFallback, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@workspace/ui';
 import { MessageSquare } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
@@ -15,7 +14,7 @@ import type { PrFile } from '@/hooks/use-github';
 import { useDiffWorkerPoolReady } from '@/components/diff/DiffWorkerPoolProvider';
 import { DiffCodeViewSettingsMenu } from '@/components/diff/DiffCodeViewSettingsMenu';
 import { applyCollapseModeToItems } from '@/components/diff/diff-code-view-shared';
-import { buildSharedDiffViewOptions, CODE_VIEW_HOST_CLASS } from '@/components/diff/diff-view-constants';
+import { ATMOS_DIFF_THEME, buildSharedDiffViewOptions, CODE_VIEW_HOST_CLASS } from '@/components/diff/diff-view-constants';
 import {
   createDiffHeaderPrefixRenderer,
   findDiffItemIdAtScrollTop,
@@ -109,7 +108,6 @@ type PrAnnotationMeta = {
 };
 
 export function PRFilesTab({ files, loading, reviewComments = [], owner, repo }: PRFilesTabProps) {
-  const { resolvedTheme } = useTheme();
   const workerPoolReady = useDiffWorkerPoolReady();
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [viewerMounted, setViewerMounted] = useState(false);
@@ -221,7 +219,7 @@ export function PRFilesTab({ files, loading, reviewComments = [], owner, repo }:
   const codeViewOptions = useMemo(
     () => ({
       ...buildSharedDiffViewOptions({
-        theme: resolvedTheme === 'dark' ? 'pierre-dark' : 'pierre-light',
+        theme: ATMOS_DIFF_THEME,
         diffStyle,
         wordWrap,
         disableBackground: !showBackgrounds,
@@ -230,7 +228,7 @@ export function PRFilesTab({ files, loading, reviewComments = [], owner, repo }:
         enableLineSelection: false,
       }),
     }),
-    [resolvedTheme, diffStyle, wordWrap, showBackgrounds, lineNumbers, diffIndicators],
+    [diffStyle, wordWrap, showBackgrounds, lineNumbers, diffIndicators],
   );
 
   const handleToggleCollapseMode = useCallback(() => {

--- a/apps/web/src/components/layout/CenterStage.tsx
+++ b/apps/web/src/components/layout/CenterStage.tsx
@@ -58,6 +58,8 @@ import {
   getEditorSourcePath,
   isConflictResolveEditorPath,
   isDiffEditorPath,
+  isReviewGroupEditorPath,
+  getReviewGroupRevisionGuid,
   EDITOR_REVIEW_DIFF_PREFIX,
 } from "@/hooks/use-editor-store";
 import { isDiffGroupEditorPath } from "@/lib/diff-editor-paths";
@@ -129,6 +131,10 @@ const ChangesCodeView = dynamic(
 );
 const DiffViewer = dynamic(
   () => import("@/components/diff/DiffViewer").then((m) => m.DiffViewer),
+  { ssr: false },
+);
+const ReviewCodeView = dynamic(
+  () => import("@/components/diff/ReviewCodeView").then((m) => m.ReviewCodeView),
   { ssr: false },
 );
 
@@ -1275,7 +1281,7 @@ const CenterStage: React.FC = () => {
     }
 
     const reviewTabsGroup = openFiles
-      .filter((file) => file.path.startsWith(EDITOR_REVIEW_DIFF_PREFIX))
+      .filter((file) => file.path.startsWith(EDITOR_REVIEW_DIFF_PREFIX) || isReviewGroupEditorPath(file.path))
       .map((file) => ({
         id: file.path,
         label: file.name,
@@ -1846,7 +1852,9 @@ const CenterStage: React.FC = () => {
           {/* Open File Tabs */}
           {openFiles.map((file) => {
             const isDiffGroup = isDiffGroupEditorPath(file.path);
-            const isReviewDiff = file.path.startsWith(EDITOR_REVIEW_DIFF_PREFIX);
+            const isReviewDiff =
+              file.path.startsWith(EDITOR_REVIEW_DIFF_PREFIX) ||
+              isReviewGroupEditorPath(file.path);
             const isDiff = isDiffGroup || isReviewDiff;
             const isConflictResolver = isConflictResolveEditorPath(file.path);
             const displayPath = getEditorSourcePath(file.path);
@@ -2174,6 +2182,15 @@ const CenterStage: React.FC = () => {
                   repoPath={currentRepoPath}
                   groupPath={file.path}
                 />
+              ) : isReviewGroupEditorPath(file.path) ? (
+                <ReviewContextProvider
+                  target={reviewTarget}
+                  filePath=""
+                  fileSnapshotGuid={null}
+                  revisionGuid={getReviewGroupRevisionGuid(file.path)}
+                >
+                  <ReviewCodeView groupPath={file.path} />
+                </ReviewContextProvider>
               ) : file.path.startsWith(EDITOR_REVIEW_DIFF_PREFIX) && currentRepoPath ? (
                 <ReviewContextProvider
                   target={reviewTarget}

--- a/apps/web/src/components/layout/sidebar/ChangeSection.tsx
+++ b/apps/web/src/components/layout/sidebar/ChangeSection.tsx
@@ -20,6 +20,7 @@ import type { GitChangedFile } from "@/api/ws-api";
 import { buildDiffGroupPath, type DiffChangeGroupKind } from "@/lib/diff-editor-paths";
 import { DiffFileTree } from "@/components/diff/DiffFileTree";
 import { DiffFilePathLabel } from "@/components/diff/DiffFilePathLabel";
+import { sortByDiffTreePath } from "@/components/diff/diff-file-order";
 
 function stopActionEvent(
   event:
@@ -74,8 +75,9 @@ export const ChangeSection = React.memo<ChangeSectionProps>(function ChangeSecti
   });
   const openFile = useEditorStore((s) => s.openFile);
   const pinFile = useEditorStore((s) => s.pinFile);
+  const orderedFiles = sortByDiffTreePath(files);
 
-  if (files.length === 0) return null;
+  if (orderedFiles.length === 0) return null;
 
   const isDestructiveSection = kind === "unstaged" || kind === "untracked";
 
@@ -204,7 +206,7 @@ export const ChangeSection = React.memo<ChangeSectionProps>(function ChangeSecti
           />
           <span>{title}</span>
           <span className="text-[10px] ml-1 px-1.5 rounded-full bg-sidebar-accent text-muted-foreground tabular-nums">
-            {files.length}
+            {orderedFiles.length}
           </span>
         </CollapsibleTrigger>
 
@@ -266,7 +268,7 @@ export const ChangeSection = React.memo<ChangeSectionProps>(function ChangeSecti
         {viewMode === "tree" ? (
           <div className="mt-0.5 overflow-hidden pb-2">
             <DiffFileTree
-              items={files.map((file) => ({
+              items={orderedFiles.map((file) => ({
                 path: file.path,
                 gitStatus: file.status,
                 additions: file.additions,
@@ -420,7 +422,7 @@ export const ChangeSection = React.memo<ChangeSectionProps>(function ChangeSecti
           </div>
         ) : (
           <div className="flex flex-col gap-0.5 mt-0.5 overflow-hidden pb-2">
-            {files.map((file) => {
+            {orderedFiles.map((file) => {
             const fileName = file.path.split("/").pop() || file.path;
             const hasActiveRowAction =
               confirmingActionKey?.includes(`:${file.path}:`) ||

--- a/apps/web/src/hooks/use-editor-store.ts
+++ b/apps/web/src/hooks/use-editor-store.ts
@@ -108,11 +108,23 @@ interface EditorStore {
 /** @deprecated Per-file diff tabs — use `diff-group://` instead */
 export const EDITOR_DIFF_PREFIX = 'diff://';
 export const EDITOR_REVIEW_DIFF_PREFIX = 'review-diff://';
+export const EDITOR_REVIEW_GROUP_PREFIX = 'review-group://';
 export const EDITOR_CONFLICT_RESOLVE_PREFIX = 'git-conflict-resolve://';
 export const EDITOR_CONFLICT_RESOLVE_ALL_PATH = `${EDITOR_CONFLICT_RESOLVE_PREFIX}merge-conflicts`;
 
+export function isReviewGroupEditorPath(path: string): boolean {
+  return path.startsWith(EDITOR_REVIEW_GROUP_PREFIX);
+}
+
+function isGroupedDiffEditorPath(path: string): boolean {
+  return isDiffGroupEditorPath(path) || isReviewGroupEditorPath(path);
+}
+
 export function isDiffEditorPath(path: string): boolean {
-  return isDiffGroupEditorPath(path) || path.startsWith(EDITOR_REVIEW_DIFF_PREFIX);
+  return (
+    isGroupedDiffEditorPath(path) ||
+    path.startsWith(EDITOR_REVIEW_DIFF_PREFIX)
+  );
 }
 
 export function isConflictResolveEditorPath(path: string): boolean {
@@ -120,6 +132,10 @@ export function isConflictResolveEditorPath(path: string): boolean {
 }
 
 export function getEditorSourcePath(path: string): string {
+  if (path.startsWith(EDITOR_REVIEW_GROUP_PREFIX)) {
+    return path.slice(EDITOR_REVIEW_GROUP_PREFIX.length);
+  }
+
   if (path.startsWith(EDITOR_REVIEW_DIFF_PREFIX)) {
     const rest = path.slice(EDITOR_REVIEW_DIFF_PREFIX.length);
     const slashIdx = rest.indexOf('/');
@@ -144,6 +160,12 @@ export function getReviewDiffSnapshotGuid(path: string): string | null {
   return slashIdx >= 0 ? rest.slice(0, slashIdx) : null;
 }
 
+export function getReviewGroupRevisionGuid(path: string): string | null {
+  if (!path.startsWith(EDITOR_REVIEW_GROUP_PREFIX)) return null;
+  const revisionGuid = path.slice(EDITOR_REVIEW_GROUP_PREFIX.length);
+  return revisionGuid || null;
+}
+
 function getLanguageFromPath(path: string): string {
   return detectCodeLanguage(getEditorSourcePath(path));
 }
@@ -162,6 +184,10 @@ function isBinaryFile(path: string): boolean {
 }
 
 function getFileNameFromPath(path: string): string {
+  if (isReviewGroupEditorPath(path)) {
+    return 'Review';
+  }
+
   if (isDiffGroupEditorPath(path)) {
     return getDiffGroupTabLabel(path);
   }
@@ -192,6 +218,10 @@ function getReviewDiffTabName(name: string): string {
 }
 
 function getSpecialTabName(path: string, name: string): string {
+  if (isReviewGroupEditorPath(path)) {
+    return 'Review';
+  }
+
   if (path.startsWith(EDITOR_REVIEW_DIFF_PREFIX)) {
     return getReviewDiffTabName(name);
   }
@@ -500,7 +530,7 @@ export const useEditorStore = create<EditorStore>()((set, get) => ({
                 }
               : removeNavigationTargetForPath(state.navigationTargets, id, path),
             diffGroupActiveFiles:
-              hasDiffFilePath && isDiffGroupEditorPath(path)
+              hasDiffFilePath && isGroupedDiffEditorPath(path)
                 ? applyDiffGroupActiveFile(
                     state.diffGroupActiveFiles,
                     id,
@@ -563,7 +593,7 @@ export const useEditorStore = create<EditorStore>()((set, get) => ({
               }
             : removeNavigationTargetForPath(state.navigationTargets, id, path),
           diffGroupActiveFiles:
-            hasDiffFilePath && isDiffGroupEditorPath(path)
+            hasDiffFilePath && isGroupedDiffEditorPath(path)
               ? applyDiffGroupActiveFile(
                   state.diffGroupActiveFiles,
                   id,

--- a/apps/web/src/hooks/use-editor-store.ts
+++ b/apps/web/src/hooks/use-editor-store.ts
@@ -122,6 +122,7 @@ function isGroupedDiffEditorPath(path: string): boolean {
 
 export function isDiffEditorPath(path: string): boolean {
   return (
+    path.startsWith(EDITOR_DIFF_PREFIX) ||
     isGroupedDiffEditorPath(path) ||
     path.startsWith(EDITOR_REVIEW_DIFF_PREFIX)
   );

--- a/apps/web/src/hooks/use-review-context.ts
+++ b/apps/web/src/hooks/use-review-context.ts
@@ -36,9 +36,15 @@ interface UseReviewContextArgs {
   target: ReviewTarget | null;
   filePath: string;
   fileSnapshotGuid?: string | null;
+  revisionGuid?: string | null;
 }
 
-export function useReviewContext({ target, filePath, fileSnapshotGuid }: UseReviewContextArgs) {
+export function useReviewContext({
+  target,
+  filePath,
+  fileSnapshotGuid,
+  revisionGuid,
+}: UseReviewContextArgs) {
   const [storedReviewAgentId, setStoredReviewAgentId] = useReviewDefaultAgentId();
   const onWsEvent = useWebSocketStore((state) => state.onEvent);
   const enqueueAgentChatPrompt = useDialogStore((state) => state.enqueueAgentChatPrompt);
@@ -113,6 +119,12 @@ export function useReviewContext({ target, filePath, fileSnapshotGuid }: UseRevi
 
   const currentSession = useMemo(() => {
     if (sessions.length === 0) return null;
+    if (revisionGuid) {
+      const revisionSession = sessions.find((session) =>
+        session.revisions.some((revision) => revision.guid === revisionGuid),
+      );
+      if (revisionSession) return revisionSession;
+    }
     if (fileSnapshotGuid) {
       const snapshotSession = sessions.find((session) =>
         session.revisions.some((revision) =>
@@ -128,7 +140,7 @@ export function useReviewContext({ target, filePath, fileSnapshotGuid }: UseRevi
       sessions.find((session) => session.status === "active") ??
       sortReviewSessions(sessions)[0]
     );
-  }, [fileSnapshotGuid, selectedSessionGuid, sessions]);
+  }, [fileSnapshotGuid, revisionGuid, selectedSessionGuid, sessions]);
 
   // Note: We intentionally do NOT sync currentSession back to URL here.
   // The URL is the source of truth for user selection; currentSession
@@ -136,6 +148,11 @@ export function useReviewContext({ target, filePath, fileSnapshotGuid }: UseRevi
 
   const currentRevision = useMemo(() => {
     if (!currentSession) return null;
+    if (revisionGuid) {
+      const explicitRevision =
+        currentSession.revisions.find((revision) => revision.guid === revisionGuid) ?? null;
+      if (explicitRevision) return explicitRevision;
+    }
     if (fileSnapshotGuid) {
       const snapshotRevision = currentSession.revisions.find((revision) =>
         revision.files.some((file) => file.snapshot.guid === fileSnapshotGuid),
@@ -148,7 +165,7 @@ export function useReviewContext({ target, filePath, fileSnapshotGuid }: UseRevi
           revision.guid === (selectedRevisionGuid ?? currentSession.current_revision_guid),
       ) ?? currentSession.revisions[0] ?? null
     );
-  }, [currentSession, fileSnapshotGuid, selectedRevisionGuid]);
+  }, [currentSession, fileSnapshotGuid, revisionGuid, selectedRevisionGuid]);
 
   // Auto-switch to latest revision when session creates a new one (e.g., after finalize)
   const prevLatestRevisionGuidRef = useRef<string | null>(null);

--- a/bun.lock
+++ b/bun.lock
@@ -118,6 +118,7 @@
         "@headless-tree/core": "^1.6.2",
         "@headless-tree/react": "^1.6.2",
         "@pierre/diffs": "^1.2.1",
+        "@pierre/icons": "^0.5.0",
         "@pierre/trees": "1.0.0-beta.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@replit/codemirror-lang-svelte": "^6.0.0",
@@ -781,6 +782,8 @@
     "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-3A6efb6BOKwyw7yk9ro2vus2YTt2nvcd56AuzxdMiVOxL9umDyN5PKkKfZ/gZ9row41SjVmTVQNWQhaRRGpOKw=="],
 
     "@pierre/diffs": ["@pierre/diffs@1.2.1", "", { "dependencies": { "@pierre/theme": "1.0.3", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-T9pYhh1KeaYLTwL1HMiAkeETj9CPjiKq6pqiUWRVJXvIkIvYutMrYyr3kN07cFWX2XPM8eqe6l2dknezs6K2AA=="],
+
+    "@pierre/icons": ["@pierre/icons@0.5.0", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-c46ZiKK8Vh3fhJM7Ci9jKW36UKsD+DTxVnr91liX0bgpc2jkwICW9bx9XTQsETpLR9CnoLSA/4ZQyLrb5HO0GA=="],
 
     "@pierre/theme": ["@pierre/theme@1.0.3", "", {}, "sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA=="],
 


### PR DESCRIPTION
## Summary

- align changes and PR diff views onto a shared CodeView scaffold that matches the official diffs.com example more closely
- add a revision-level `review-group://` combined review diff view and route review file/comment navigation to it
- unify diff file ordering, active-file sidebar sync, multiline selection, and prompt/comment composition behaviors across diff surfaces

## Related Issue

<!-- e.g. Closes #123 -->

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] Additional checks (describe below)

Ran `bun x tsc --noEmit --pretty false -p apps/web/tsconfig.json`.

## Checklist

- [ ] I updated documentation if behavior changed
- [ ] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the Changes, PR Files, and Review diff views on a shared CodeView scaffold and adds a revision-level combined review diff (`review-group://`). Also fixes split diff separators and theme colors for a consistent, readable UI.

- **New Features**
  - Added `review-group://` combined review diff with inline commenting and routing.
  - Introduced shared `DiffCodeViewScaffold` (collapsible file tree + toolbar) across Changes, PR Files, and Review.
  - Unified path-aware file ordering and viewport-center active-file tracking across diff views and sidebars.
  - Consistent multiline selection labels and AI-formatted copy prompts with optional note and `lineLabel`.

- **Refactors**
  - Extracted shared diff utilities (selection info, labels, file ordering); moved sorting out of `DiffFileTree`.
  - Switched PR Files and Review to the shared scaffold; added `review-group` tabs and `revisionGuid` support in context.
  - UI polish: toolbar now uses `@pierre/icons` to match diffshub; fixed split-diff separators to span both panes; applied consistent theme colors in CodeView and PR modal; steadier PR modal height; more predictable scroll-to-file behavior.

<sup>Written for commit 869f4b81d80e62ee66e5cd2e5d200ba0bdbb15eb. Summary will update on new commits. <a href="https://cubic.dev/pr/AruNi-01/atmos/pull/120?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Copy annotations now produce AI-formatted prompts with editable context and a “Copy Prompt” action.
  * Resizable file-tree scaffold for a consistent diff layout and toolbar.
  * Review-group view: grouped-diff editor with full inline commenting, navigation, and pinned/open behavior.

* **Improvements**
  * Files consistently sorted for predictable ordering across views.
  * Viewport-driven active-file detection, smoother scroll/navigation and auto-selection.
  * Default unified-diff style with word-wrap; updated display and header controls.

* **Bug Fixes**
  * Copy action reports “Nothing to copy” when appropriate; dialog sizing adjusted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AruNi-01/atmos/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->