### PR TITLE
feat: add cross-app appshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,6 +530,8 @@ name = "atmos-desktop"
 version = "1.2.0-beta.10"
 dependencies = [
  "chrono",
+ "core-foundation 0.10.1",
+ "core-graphics",
  "dirs 5.0.1",
  "keyring",
  "objc2-app-kit",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -31,4 +31,6 @@ remote-access = { path = "../../../crates/remote-access" }
 keyring = "3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.10"
+core-graphics = "0.24"
 objc2-app-kit = "0.3.2"

--- a/apps/desktop/src-tauri/src/appshot/capture_animation.rs
+++ b/apps/desktop/src-tauri/src/appshot/capture_animation.rs
@@ -1,0 +1,52 @@
+use crate::appshot::types::AppshotWindowBounds;
+use std::path::PathBuf;
+use tauri::utils::config::Color;
+use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
+use tokio::time::{sleep, Duration};
+
+const OVERLAY_LABEL: &str = "appshot-capture-overlay";
+const OVERLAY_PADDING: f64 = 14.0;
+const OVERLAY_DURATION_MS: u64 = 720;
+
+pub async fn play(app: AppHandle, bounds: AppshotWindowBounds) -> Result<(), String> {
+    if bounds.width < 32 || bounds.height < 32 {
+        return Ok(());
+    }
+
+    if let Some(existing) = app.get_webview_window(OVERLAY_LABEL) {
+        let _ = existing.close();
+    }
+
+    let x = bounds.x as f64 - OVERLAY_PADDING;
+    let y = bounds.y as f64 - OVERLAY_PADDING;
+    let width = bounds.width as f64 + OVERLAY_PADDING * 2.0;
+    let height = bounds.height as f64 + OVERLAY_PADDING * 2.0;
+
+    let overlay = WebviewWindowBuilder::new(
+        &app,
+        OVERLAY_LABEL,
+        WebviewUrl::App(PathBuf::from("appshot-capture-overlay.html")),
+    )
+    .title("Appshot Capture")
+    .position(x, y)
+    .inner_size(width, height)
+    .resizable(false)
+    .decorations(false)
+    .transparent(true)
+    .shadow(false)
+    .always_on_top(true)
+    .visible_on_all_workspaces(true)
+    .skip_taskbar(true)
+    .focusable(false)
+    .focused(false)
+    .visible(true)
+    .build()
+    .map_err(|error| format!("failed to show appshot capture overlay: {error}"))?;
+
+    let _ = overlay.set_background_color(Some(Color(0, 0, 0, 0)));
+    let _ = overlay.set_ignore_cursor_events(true);
+
+    sleep(Duration::from_millis(OVERLAY_DURATION_MS)).await;
+    let _ = overlay.close();
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/appshot/clipboard.rs
+++ b/apps/desktop/src-tauri/src/appshot/clipboard.rs
@@ -43,9 +43,14 @@ pub fn copy_text(text: &str) -> Result<(), String> {
 
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        let helpers = ["wl-copy", "xclip"];
-        for helper in helpers {
-            if let Ok(mut child) = Command::new(helper).stdin(Stdio::piped()).spawn() {
+        let helpers: [(&str, &[&str]); 2] =
+            [("wl-copy", &[]), ("xclip", &["-selection", "clipboard"])];
+        for (helper, args) in helpers {
+            if let Ok(mut child) = Command::new(helper)
+                .args(args)
+                .stdin(Stdio::piped())
+                .spawn()
+            {
                 if let Some(stdin) = child.stdin.as_mut() {
                     if stdin.write_all(text.as_bytes()).is_ok() {
                         if let Ok(status) = child.wait() {

--- a/apps/desktop/src-tauri/src/appshot/clipboard.rs
+++ b/apps/desktop/src-tauri/src/appshot/clipboard.rs
@@ -1,0 +1,62 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+pub fn copy_text(text: &str) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let mut child = Command::new("pbcopy")
+            .stdin(Stdio::piped())
+            .spawn()
+            .map_err(|error| format!("failed to start pbcopy: {error}"))?;
+        let stdin = child
+            .stdin
+            .as_mut()
+            .ok_or_else(|| "failed to open pbcopy stdin".to_string())?;
+        stdin
+            .write_all(text.as_bytes())
+            .map_err(|error| format!("failed to write clipboard text: {error}"))?;
+        let status = child
+            .wait()
+            .map_err(|error| format!("failed to wait for pbcopy: {error}"))?;
+        if status.success() {
+            return Ok(());
+        }
+        return Err(format!("pbcopy exited with status {status}"));
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let escaped = text.replace('\'', "''");
+        let status = Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-Command",
+                &format!("Set-Clipboard -Value '{escaped}'"),
+            ])
+            .status()
+            .map_err(|error| format!("failed to start powershell clipboard: {error}"))?;
+        if status.success() {
+            return Ok(());
+        }
+        return Err(format!("Set-Clipboard exited with status {status}"));
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        let helpers = ["wl-copy", "xclip"];
+        for helper in helpers {
+            if let Ok(mut child) = Command::new(helper).stdin(Stdio::piped()).spawn() {
+                if let Some(stdin) = child.stdin.as_mut() {
+                    if stdin.write_all(text.as_bytes()).is_ok() {
+                        if let Ok(status) = child.wait() {
+                            if status.success() {
+                                return Ok(());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Err("no supported clipboard helper found".to_string())
+    }
+}

--- a/apps/desktop/src-tauri/src/appshot/encoding.rs
+++ b/apps/desktop/src-tauri/src/appshot/encoding.rs
@@ -1,7 +1,16 @@
 const BASE64_TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+pub const DATA_URL_PREFIX: &str = "data:image/png;base64,";
 pub const MAX_INLINE_SNAPSHOT_BYTES: usize = 384 * 1024;
 pub const OVERSIZED_SNAPSHOT_WARNING: &str =
     "Screenshot preview was hidden because the inline image payload is too large.";
+
+pub fn png_data_url_len(byte_len: u64) -> u64 {
+    DATA_URL_PREFIX.len() as u64 + byte_len.div_ceil(3) * 4
+}
+
+pub fn fits_inline_png_data_url(byte_len: u64) -> bool {
+    png_data_url_len(byte_len) <= MAX_INLINE_SNAPSHOT_BYTES as u64
+}
 
 pub fn base64_encode(bytes: &[u8]) -> String {
     let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);

--- a/apps/desktop/src-tauri/src/appshot/encoding.rs
+++ b/apps/desktop/src-tauri/src/appshot/encoding.rs
@@ -1,0 +1,57 @@
+const BASE64_TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+pub const MAX_INLINE_SNAPSHOT_BYTES: usize = 384 * 1024;
+pub const OVERSIZED_SNAPSHOT_WARNING: &str =
+    "Screenshot preview was hidden because the inline image payload is too large.";
+
+pub fn base64_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    let mut index = 0;
+
+    while index + 3 <= bytes.len() {
+        let chunk = &bytes[index..index + 3];
+        out.push(BASE64_TABLE[(chunk[0] >> 2) as usize] as char);
+        out.push(
+            BASE64_TABLE[(((chunk[0] & 0b0000_0011) << 4) | (chunk[1] >> 4)) as usize] as char,
+        );
+        out.push(
+            BASE64_TABLE[(((chunk[1] & 0b0000_1111) << 2) | (chunk[2] >> 6)) as usize] as char,
+        );
+        out.push(BASE64_TABLE[(chunk[2] & 0b0011_1111) as usize] as char);
+        index += 3;
+    }
+
+    match bytes.len() - index {
+        1 => {
+            let byte = bytes[index];
+            out.push(BASE64_TABLE[(byte >> 2) as usize] as char);
+            out.push(BASE64_TABLE[((byte & 0b0000_0011) << 4) as usize] as char);
+            out.push('=');
+            out.push('=');
+        }
+        2 => {
+            let first = bytes[index];
+            let second = bytes[index + 1];
+            out.push(BASE64_TABLE[(first >> 2) as usize] as char);
+            out.push(BASE64_TABLE[(((first & 0b0000_0011) << 4) | (second >> 4)) as usize] as char);
+            out.push(BASE64_TABLE[((second & 0b0000_1111) << 2) as usize] as char);
+            out.push('=');
+        }
+        _ => {}
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::base64_encode;
+
+    #[test]
+    fn encodes_base64_padding_cases() {
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"f"), "Zg==");
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+        assert_eq!(base64_encode(b"hello world"), "aGVsbG8gd29ybGQ=");
+    }
+}

--- a/apps/desktop/src-tauri/src/appshot/macos.rs
+++ b/apps/desktop/src-tauri/src/appshot/macos.rs
@@ -1,7 +1,7 @@
 use crate::appshot::types::{
     AppshotPermissionName, AppshotPermissionRecoveryAction, AppshotPermissionState,
     AppshotPlatform, AppshotQuality, AppshotScreenshotMetadata, AppshotSettingsTarget,
-    CapturedAppshot,
+    AppshotWindowBounds, CapturedAppshot,
 };
 use chrono::Utc;
 use core_foundation::array::CFArray;
@@ -150,6 +150,18 @@ pub async fn capture_frontmost() -> Result<CapturedAppshot, String> {
         .map_err(|error| format!("appshot capture task failed: {error}"))?
 }
 
+pub async fn capture_animation_target() -> Option<AppshotWindowBounds> {
+    tauri::async_runtime::spawn_blocking(|| {
+        read_frontmost_window_native()
+            .ok()
+            .filter(|frontmost| frontmost.app_name != "Atmos")
+            .and_then(|frontmost| window_bounds(&frontmost))
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
 fn capture_frontmost_blocking() -> Result<CapturedAppshot, String> {
     let captured_at = Utc::now().to_rfc3339();
     let permissions = permission_states();
@@ -199,12 +211,14 @@ fn capture_frontmost_blocking() -> Result<CapturedAppshot, String> {
                 height: Some(1),
                 media_type: "image/png".to_string(),
             },
+            source_bounds: None,
             context_markdown,
             permissions,
             warnings,
         });
     }
 
+    let source_bounds = window_bounds(&frontmost);
     let (screenshot_png, screenshot_available, mut screenshot_warnings) =
         capture_screenshot(&frontmost);
     warnings.append(&mut screenshot_warnings);
@@ -256,9 +270,27 @@ fn capture_frontmost_blocking() -> Result<CapturedAppshot, String> {
             height: screenshot_dimensions.map(|(_, height)| height),
             media_type: "image/png".to_string(),
         },
+        source_bounds,
         context_markdown,
         permissions,
         warnings,
+    })
+}
+
+fn window_bounds(frontmost: &FrontmostWindow) -> Option<AppshotWindowBounds> {
+    let (Some(x), Some(y), Some(width), Some(height)) =
+        (frontmost.x, frontmost.y, frontmost.width, frontmost.height)
+    else {
+        return None;
+    };
+    if width <= 0 || height <= 0 {
+        return None;
+    }
+    Some(AppshotWindowBounds {
+        x,
+        y,
+        width: u32::try_from(width).ok()?,
+        height: u32::try_from(height).ok()?,
     })
 }
 
@@ -596,6 +628,7 @@ end replaceText
 
 on cleanText(valueText)
   try
+    if valueText is missing value then return ""
     set outputText to valueText as text
     set outputText to my replaceText(linefeed, " ", outputText)
     set outputText to my replaceText(return, " ", outputText)
@@ -619,16 +652,16 @@ on dumpElement(uiElement, depth)
   set descriptionText to ""
   set valueText to ""
   try
-    set roleText to my cleanText(role of uiElement)
+    tell application "System Events" to set roleText to my cleanText(role of uiElement)
   end try
   try
-    set nameText to my cleanText(name of uiElement)
+    tell application "System Events" to set nameText to my cleanText(name of uiElement)
   end try
   try
-    set descriptionText to my cleanText(description of uiElement)
+    tell application "System Events" to set descriptionText to my cleanText(description of uiElement)
   end try
   try
-    set valueText to my cleanText(value of uiElement)
+    tell application "System Events" to set valueText to my cleanText(value of uiElement)
   end try
   if {redaction_condition} then
     set valueText to "[redacted]"
@@ -639,7 +672,7 @@ on dumpElement(uiElement, depth)
   if descriptionText is not "" and descriptionText is not nameText then set lineText to lineText & " (" & descriptionText & ")"
   set outputText to lineText & linefeed
   try
-    set childItems to UI elements of uiElement
+    tell application "System Events" to set childItems to UI elements of uiElement
     repeat with childItem in childItems
       set outputText to outputText & my dumpElement(childItem, depth + 1)
       if nodeCount > nodeLimit then exit repeat

--- a/apps/desktop/src-tauri/src/appshot/macos.rs
+++ b/apps/desktop/src-tauri/src/appshot/macos.rs
@@ -1,0 +1,1071 @@
+use crate::appshot::types::{
+    AppshotPermissionName, AppshotPermissionRecoveryAction, AppshotPermissionState,
+    AppshotPlatform, AppshotQuality, AppshotScreenshotMetadata, AppshotSettingsTarget,
+    CapturedAppshot,
+};
+use chrono::Utc;
+use core_foundation::array::CFArray;
+use core_foundation::base::{CFType, TCFType};
+use core_foundation::dictionary::CFDictionary;
+use core_foundation::number::CFNumber;
+use core_foundation::string::{CFString, CFStringRef};
+use core_graphics::window::{
+    copy_window_info, kCGNullWindowID, kCGWindowAlpha, kCGWindowBounds, kCGWindowIsOnscreen,
+    kCGWindowLayer, kCGWindowListExcludeDesktopElements, kCGWindowListOptionOnScreenOnly,
+    kCGWindowName, kCGWindowNumber, kCGWindowOwnerName, kCGWindowOwnerPID,
+};
+use objc2_app_kit::{NSRunningApplication, NSWorkspace};
+use std::fs;
+use std::io::Read;
+use std::process::{Command, ExitStatus, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const FRONTMOST_WINDOW_TIMEOUT_MS: u64 = 2_500;
+const ACCESSIBILITY_TREE_TIMEOUT_MS: u64 = 3_500;
+const SCREENSHOT_TIMEOUT_MS: u64 = 2_500;
+const PROCESS_POLL_INTERVAL_MS: u64 = 20;
+const MIN_WINDOW_WIDTH: i32 = 32;
+const MIN_WINDOW_HEIGHT: i32 = 32;
+const ACCESSIBILITY_REDACTION_TERMS: &[&str] = &["secure", "Secure", "password", "Password"];
+const ACCESSIBILITY_REDACTION_FIELDS: &[&str] = &["roleText", "nameText", "descriptionText"];
+
+#[link(name = "ApplicationServices", kind = "framework")]
+extern "C" {
+    fn AXIsProcessTrusted() -> bool;
+}
+
+#[link(name = "CoreGraphics", kind = "framework")]
+extern "C" {
+    fn CGPreflightScreenCaptureAccess() -> bool;
+}
+
+struct FrontmostWindow {
+    app_name: String,
+    bundle_id: Option<String>,
+    process_id: Option<u32>,
+    window_title: Option<String>,
+    window_id: Option<String>,
+    x: Option<i32>,
+    y: Option<i32>,
+    width: Option<i32>,
+    height: Option<i32>,
+}
+
+struct FrontmostApp {
+    app_name: String,
+    bundle_id: Option<String>,
+    process_id: Option<u32>,
+}
+
+#[derive(Clone)]
+struct WindowCandidate {
+    app_name: String,
+    process_id: Option<u32>,
+    window_title: Option<String>,
+    window_id: Option<String>,
+    x: Option<i32>,
+    y: Option<i32>,
+    width: Option<i32>,
+    height: Option<i32>,
+}
+
+pub fn accessibility_granted() -> bool {
+    unsafe { AXIsProcessTrusted() }
+}
+
+pub fn screen_recording_granted() -> bool {
+    unsafe { CGPreflightScreenCaptureAccess() }
+}
+
+pub fn permission_states(input_monitoring_granted: bool) -> Vec<AppshotPermissionState> {
+    vec![
+        permission_state(
+            AppshotPermissionName::Accessibility,
+            "Accessibility",
+            accessibility_granted(),
+            vec![
+                "Read the target app's accessibility tree".to_string(),
+                "Detect modifier-only Appshot gestures when required by macOS".to_string(),
+            ],
+            AppshotSettingsTarget::Accessibility,
+            vec![
+                "Open System Settings > Privacy & Security > Accessibility.".to_string(),
+                "Enable Atmos, then return to Atmos.".to_string(),
+            ],
+        ),
+        permission_state(
+            AppshotPermissionName::ScreenRecording,
+            "Screen Recording",
+            screen_recording_granted(),
+            vec!["Capture the focused app window as snapshot.png".to_string()],
+            AppshotSettingsTarget::ScreenRecording,
+            vec![
+                "Open System Settings > Privacy & Security > Screen & System Audio Recording."
+                    .to_string(),
+                "Enable Atmos, then return to Atmos.".to_string(),
+            ],
+        ),
+        permission_state(
+            AppshotPermissionName::InputMonitoring,
+            "Input Monitoring",
+            input_monitoring_granted,
+            vec!["Listen for the Fn + Option + Command Appshot gesture".to_string()],
+            AppshotSettingsTarget::InputMonitoring,
+            vec![
+                "Open System Settings > Privacy & Security > Input Monitoring.".to_string(),
+                "Enable Atmos if it appears in the list, then return to Atmos.".to_string(),
+            ],
+        ),
+    ]
+}
+
+pub fn open_settings(target: AppshotSettingsTarget) -> Result<(), String> {
+    let url = match target {
+        AppshotSettingsTarget::Accessibility => {
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+        }
+        AppshotSettingsTarget::ScreenRecording => {
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+        }
+        AppshotSettingsTarget::InputMonitoring => {
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
+        }
+        AppshotSettingsTarget::PrivacySecurity => {
+            "x-apple.systempreferences:com.apple.preference.security"
+        }
+    };
+
+    let status = Command::new("open")
+        .arg(url)
+        .status()
+        .map_err(|error| format!("failed to open System Settings: {error}"))?;
+    if status.success() {
+        return Ok(());
+    }
+
+    let fallback = Command::new("open")
+        .arg("x-apple.systempreferences:com.apple.preference.security")
+        .status()
+        .map_err(|error| format!("failed to open Privacy & Security settings: {error}"))?;
+    if fallback.success() {
+        Ok(())
+    } else {
+        Err("Open System Settings > Privacy & Security manually.".to_string())
+    }
+}
+
+pub async fn capture_frontmost(input_monitoring_granted: bool) -> Result<CapturedAppshot, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        capture_frontmost_blocking(input_monitoring_granted)
+    })
+    .await
+    .map_err(|error| format!("appshot capture task failed: {error}"))?
+}
+
+fn capture_frontmost_blocking(input_monitoring_granted: bool) -> Result<CapturedAppshot, String> {
+    let captured_at = Utc::now().to_rfc3339();
+    let permissions = permission_states(input_monitoring_granted);
+    let mut warnings = Vec::new();
+    let frontmost = match read_frontmost_window() {
+        Ok(info) => info,
+        Err(error) => {
+            warnings.push(error);
+            FrontmostWindow {
+                app_name: "Unknown App".to_string(),
+                bundle_id: None,
+                process_id: None,
+                window_title: None,
+                window_id: None,
+                x: None,
+                y: None,
+                width: None,
+                height: None,
+            }
+        }
+    };
+
+    if frontmost.app_name == "Atmos" {
+        warnings
+            .push("Atmos is frontmost; focus another app and trigger Appshots again.".to_string());
+        let screenshot_png = placeholder_png();
+        let context_markdown = build_context_markdown(
+            &frontmost,
+            &captured_at,
+            AppshotQuality::MetadataOnly,
+            "No external target was captured.",
+            &warnings,
+        );
+        return Ok(CapturedAppshot {
+            app_name: "No external app".to_string(),
+            bundle_id: None,
+            process_id: None,
+            window_title: None,
+            window_id: None,
+            captured_at,
+            platform: AppshotPlatform::Macos,
+            quality: AppshotQuality::MetadataOnly,
+            screenshot_png,
+            screenshot: AppshotScreenshotMetadata {
+                available: false,
+                width: Some(1),
+                height: Some(1),
+                media_type: "image/png".to_string(),
+            },
+            context_markdown,
+            permissions,
+            warnings,
+        });
+    }
+
+    let (screenshot_png, screenshot_available, mut screenshot_warnings) =
+        capture_screenshot(&frontmost);
+    warnings.append(&mut screenshot_warnings);
+    let screenshot_dimensions = png_dimensions(&screenshot_png);
+    let accessibility_tree = match read_accessibility_tree() {
+        Ok(tree) if !tree.trim().is_empty() => tree,
+        Ok(_) => {
+            warnings.push("Accessibility tree was empty.".to_string());
+            String::new()
+        }
+        Err(error) => {
+            warnings.push(error);
+            String::new()
+        }
+    };
+
+    let has_accessibility = !accessibility_tree.trim().is_empty();
+    let quality = match (screenshot_available, has_accessibility) {
+        (true, true) => AppshotQuality::ScreenshotAndAccessibility,
+        (true, false) => AppshotQuality::ScreenshotOnly,
+        (false, true) => AppshotQuality::AccessibilityOnly,
+        (false, false) => AppshotQuality::MetadataOnly,
+    };
+    let context_markdown = build_context_markdown(
+        &frontmost,
+        &captured_at,
+        quality.clone(),
+        if has_accessibility {
+            accessibility_tree.as_str()
+        } else {
+            "Accessibility tree unavailable."
+        },
+        &warnings,
+    );
+
+    Ok(CapturedAppshot {
+        app_name: frontmost.app_name,
+        bundle_id: frontmost.bundle_id,
+        process_id: frontmost.process_id,
+        window_title: frontmost.window_title,
+        window_id: frontmost.window_id,
+        captured_at,
+        platform: AppshotPlatform::Macos,
+        quality,
+        screenshot_png,
+        screenshot: AppshotScreenshotMetadata {
+            available: screenshot_available,
+            width: screenshot_dimensions.map(|(width, _)| width),
+            height: screenshot_dimensions.map(|(_, height)| height),
+            media_type: "image/png".to_string(),
+        },
+        context_markdown,
+        permissions,
+        warnings,
+    })
+}
+
+fn permission_state(
+    name: AppshotPermissionName,
+    display_name: &str,
+    granted: bool,
+    required_for: Vec<String>,
+    target: AppshotSettingsTarget,
+    manual_steps: Vec<String>,
+) -> AppshotPermissionState {
+    AppshotPermissionState {
+        name,
+        display_name: display_name.to_string(),
+        granted,
+        required_for,
+        recovery_action: if granted {
+            None
+        } else {
+            Some(AppshotPermissionRecoveryAction {
+                label: "Open System Settings".to_string(),
+                target,
+                manual_steps,
+            })
+        },
+    }
+}
+
+fn read_frontmost_window() -> Result<FrontmostWindow, String> {
+    read_frontmost_window_native().or_else(|native_error| {
+        read_frontmost_window_with_system_events().map_err(|script_error| {
+            format!("{native_error}; System Events fallback failed: {script_error}")
+        })
+    })
+}
+
+fn read_frontmost_window_native() -> Result<FrontmostWindow, String> {
+    let front_app = read_frontmost_app();
+    let candidates = read_window_candidates()?;
+    select_frontmost_window(front_app, candidates)
+}
+
+fn select_frontmost_window(
+    front_app: Option<FrontmostApp>,
+    candidates: Vec<WindowCandidate>,
+) -> Result<FrontmostWindow, String> {
+    if candidates.is_empty() && front_app.is_none() {
+        return Err("Unable to identify the frontmost app or any visible window.".to_string());
+    }
+
+    if let Some(app) = front_app {
+        if let Some(window) = app
+            .process_id
+            .and_then(|process_id| {
+                candidates
+                    .iter()
+                    .find(|window| window.process_id == Some(process_id))
+            })
+            .cloned()
+        {
+            return Ok(merge_app_and_window(app, Some(window)));
+        }
+
+        if app.app_name == "Atmos" {
+            return Ok(merge_app_and_window(app, None));
+        }
+
+        if let Some(window) = candidates
+            .iter()
+            .find(|window| window.app_name == app.app_name)
+            .cloned()
+        {
+            return Ok(merge_app_and_window(app, Some(window)));
+        }
+
+        return Ok(merge_app_and_window(app, None));
+    }
+
+    candidates
+        .into_iter()
+        .find(|window| window.app_name != "Atmos")
+        .map(window_candidate_to_frontmost)
+        .ok_or_else(|| "Unable to identify a non-Atmos visible window.".to_string())
+}
+
+fn read_frontmost_app() -> Option<FrontmostApp> {
+    let workspace = NSWorkspace::sharedWorkspace();
+    let app = workspace.frontmostApplication()?;
+    let app_name = app
+        .localizedName()
+        .map(|name| name.to_string())
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or_else(|| "Unknown App".to_string());
+    let bundle_id = app
+        .bundleIdentifier()
+        .map(|bundle_id| bundle_id.to_string())
+        .filter(|bundle_id| !bundle_id.trim().is_empty());
+    let process_id = {
+        let pid = app.processIdentifier();
+        u32::try_from(pid).ok()
+    };
+
+    Some(FrontmostApp {
+        app_name,
+        bundle_id,
+        process_id,
+    })
+}
+
+fn merge_app_and_window(app: FrontmostApp, window: Option<WindowCandidate>) -> FrontmostWindow {
+    FrontmostWindow {
+        app_name: app.app_name,
+        bundle_id: app.bundle_id,
+        process_id: app
+            .process_id
+            .or_else(|| window.as_ref().and_then(|window| window.process_id)),
+        window_title: window
+            .as_ref()
+            .and_then(|window| window.window_title.clone()),
+        window_id: window.as_ref().and_then(|window| window.window_id.clone()),
+        x: window.as_ref().and_then(|window| window.x),
+        y: window.as_ref().and_then(|window| window.y),
+        width: window.as_ref().and_then(|window| window.width),
+        height: window.as_ref().and_then(|window| window.height),
+    }
+}
+
+fn window_candidate_to_frontmost(window: WindowCandidate) -> FrontmostWindow {
+    let bundle_id = window.process_id.and_then(bundle_id_for_pid);
+    FrontmostWindow {
+        app_name: window.app_name,
+        bundle_id,
+        process_id: window.process_id,
+        window_title: window.window_title,
+        window_id: window.window_id,
+        x: window.x,
+        y: window.y,
+        width: window.width,
+        height: window.height,
+    }
+}
+
+fn bundle_id_for_pid(process_id: u32) -> Option<String> {
+    let pid = i32::try_from(process_id).ok()?;
+    let app = NSRunningApplication::runningApplicationWithProcessIdentifier(pid)?;
+    app.bundleIdentifier()
+        .map(|bundle_id| bundle_id.to_string())
+        .filter(|bundle_id| !bundle_id.trim().is_empty())
+}
+
+fn read_window_candidates() -> Result<Vec<WindowCandidate>, String> {
+    let options = kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements;
+    let raw_windows = copy_window_info(options, kCGNullWindowID)
+        .ok_or_else(|| "CoreGraphics window list was unavailable.".to_string())?;
+    let windows: CFArray<CFDictionary<CFType, CFType>> =
+        unsafe { TCFType::wrap_under_get_rule(raw_windows.as_concrete_TypeRef()) };
+
+    let mut candidates = Vec::new();
+    for window in windows.iter() {
+        if cf_number_i32(&window, unsafe { kCGWindowLayer }).unwrap_or_default() != 0 {
+            continue;
+        }
+        if cf_number_i32(&window, unsafe { kCGWindowIsOnscreen }) == Some(0) {
+            continue;
+        }
+        if cf_number_f64(&window, unsafe { kCGWindowAlpha })
+            .map(|alpha| alpha <= 0.01)
+            .unwrap_or(false)
+        {
+            continue;
+        }
+
+        let bounds = cg_window_bounds(&window);
+        if !usable_bounds(bounds) {
+            continue;
+        }
+
+        let app_name = cf_string(&window, unsafe { kCGWindowOwnerName })
+            .filter(|name| !name.trim().is_empty())
+            .unwrap_or_else(|| "Unknown App".to_string());
+        candidates.push(WindowCandidate {
+            app_name,
+            process_id: cf_number_u32(&window, unsafe { kCGWindowOwnerPID }),
+            window_title: cf_string(&window, unsafe { kCGWindowName })
+                .filter(|title| !title.trim().is_empty()),
+            window_id: cf_number_u32(&window, unsafe { kCGWindowNumber })
+                .map(|window_id| window_id.to_string()),
+            x: bounds.map(|bounds| bounds.0),
+            y: bounds.map(|bounds| bounds.1),
+            width: bounds.map(|bounds| bounds.2),
+            height: bounds.map(|bounds| bounds.3),
+        });
+    }
+
+    Ok(candidates)
+}
+
+fn usable_bounds(bounds: Option<(i32, i32, i32, i32)>) -> bool {
+    matches!(
+        bounds,
+        Some((_, _, width, height)) if width >= MIN_WINDOW_WIDTH && height >= MIN_WINDOW_HEIGHT
+    )
+}
+
+fn cg_window_bounds(window: &CFDictionary<CFType, CFType>) -> Option<(i32, i32, i32, i32)> {
+    let bounds = cf_value(window, unsafe { kCGWindowBounds })?;
+    let untyped_bounds = bounds.downcast::<CFDictionary>()?;
+    let bounds: CFDictionary<CFType, CFType> =
+        unsafe { TCFType::wrap_under_get_rule(untyped_bounds.as_concrete_TypeRef()) };
+
+    let x = cf_number_i32_for_name(&bounds, "X")?;
+    let y = cf_number_i32_for_name(&bounds, "Y")?;
+    let width = cf_number_i32_for_name(&bounds, "Width")?;
+    let height = cf_number_i32_for_name(&bounds, "Height")?;
+    Some((x, y, width, height))
+}
+
+fn cf_number_i32_for_name(dictionary: &CFDictionary<CFType, CFType>, name: &str) -> Option<i32> {
+    let key = CFString::new(name);
+    dictionary
+        .find(&key.as_CFType())
+        .and_then(|value| value.downcast::<CFNumber>())
+        .and_then(|number| number.to_i32())
+}
+
+fn cf_string(dictionary: &CFDictionary<CFType, CFType>, key: CFStringRef) -> Option<String> {
+    cf_value(dictionary, key)
+        .and_then(|value| value.downcast::<CFString>().map(|text| text.to_string()))
+}
+
+fn cf_number_i32(dictionary: &CFDictionary<CFType, CFType>, key: CFStringRef) -> Option<i32> {
+    cf_value(dictionary, key)
+        .and_then(|value| value.downcast::<CFNumber>())
+        .and_then(|number| number.to_i32())
+}
+
+fn cf_number_u32(dictionary: &CFDictionary<CFType, CFType>, key: CFStringRef) -> Option<u32> {
+    cf_number_i32(dictionary, key).and_then(|value| u32::try_from(value).ok())
+}
+
+fn cf_number_f64(dictionary: &CFDictionary<CFType, CFType>, key: CFStringRef) -> Option<f64> {
+    cf_value(dictionary, key)
+        .and_then(|value| value.downcast::<CFNumber>())
+        .and_then(|number| number.to_f64())
+}
+
+fn cf_value(dictionary: &CFDictionary<CFType, CFType>, key: CFStringRef) -> Option<CFType> {
+    let key = unsafe { CFString::wrap_under_get_rule(key) };
+    dictionary.find(&key.as_CFType()).map(|value| value.clone())
+}
+
+fn read_frontmost_window_with_system_events() -> Result<FrontmostWindow, String> {
+    let script = r#"
+tell application "System Events"
+  set frontApp to first application process whose frontmost is true
+  set appName to name of frontApp as text
+  set bundleId to ""
+  set pidValue to ""
+  set windowTitle to ""
+  set posX to ""
+  set posY to ""
+  set winW to ""
+  set winH to ""
+  try
+    set bundleId to bundle identifier of frontApp as text
+  end try
+  try
+    set pidValue to unix id of frontApp as text
+  end try
+  try
+    set frontWindow to front window of frontApp
+    set windowTitle to name of frontWindow as text
+    set windowPosition to position of frontWindow
+    set windowSize to size of frontWindow
+    set posX to item 1 of windowPosition as text
+    set posY to item 2 of windowPosition as text
+    set winW to item 1 of windowSize as text
+    set winH to item 2 of windowSize as text
+  end try
+  return appName & linefeed & bundleId & linefeed & pidValue & linefeed & windowTitle & linefeed & posX & linefeed & posY & linefeed & winW & linefeed & winH
+end tell
+"#;
+    let raw = run_osascript(
+        script,
+        Duration::from_millis(FRONTMOST_WINDOW_TIMEOUT_MS),
+        "frontmost window lookup",
+    )?;
+    let mut lines = raw.lines();
+    let app_name = lines.next().unwrap_or("").trim().to_string();
+    if app_name.is_empty() {
+        return Err("Unable to identify the frontmost app.".to_string());
+    }
+    let bundle_id = non_empty(lines.next());
+    let process_id = non_empty(lines.next()).and_then(|value| value.parse::<u32>().ok());
+    let window_title = non_empty(lines.next());
+    let x = non_empty(lines.next()).and_then(|value| value.parse::<i32>().ok());
+    let y = non_empty(lines.next()).and_then(|value| value.parse::<i32>().ok());
+    let width = non_empty(lines.next()).and_then(|value| value.parse::<i32>().ok());
+    let height = non_empty(lines.next()).and_then(|value| value.parse::<i32>().ok());
+    Ok(FrontmostWindow {
+        app_name,
+        bundle_id,
+        process_id,
+        window_title,
+        window_id: None,
+        x,
+        y,
+        width,
+        height,
+    })
+}
+
+fn read_accessibility_tree() -> Result<String, String> {
+    if !accessibility_granted() {
+        return Err("Accessibility permission is required to read UI structure.".to_string());
+    }
+    let redaction_condition = accessibility_redaction_condition();
+    let script = format!(
+        r#"
+property nodeCount : 0
+property nodeLimit : 420
+property depthLimit : 8
+
+on replaceText(findText, replaceTextValue, inputText)
+  set oldDelimiters to AppleScript's text item delimiters
+  set AppleScript's text item delimiters to findText
+  set textItems to text items of inputText
+  set AppleScript's text item delimiters to replaceTextValue
+  set outputText to textItems as text
+  set AppleScript's text item delimiters to oldDelimiters
+  return outputText
+end replaceText
+
+on cleanText(valueText)
+  try
+    set outputText to valueText as text
+    set outputText to my replaceText(linefeed, " ", outputText)
+    set outputText to my replaceText(return, " ", outputText)
+    if length of outputText > 140 then set outputText to text 1 thru 140 of outputText
+    return outputText
+  on error
+    return ""
+  end try
+end cleanText
+
+on dumpElement(uiElement, depth)
+  if depth > depthLimit then return ""
+  if nodeCount > nodeLimit then return ""
+  set nodeCount to nodeCount + 1
+  set indent to ""
+  repeat depth times
+    set indent to indent & "  "
+  end repeat
+  set roleText to ""
+  set nameText to ""
+  set descriptionText to ""
+  set valueText to ""
+  try
+    set roleText to my cleanText(role of uiElement)
+  end try
+  try
+    set nameText to my cleanText(name of uiElement)
+  end try
+  try
+    set descriptionText to my cleanText(description of uiElement)
+  end try
+  if {redaction_condition} then
+    set valueText to "[redacted]"
+  else
+    try
+      set valueText to my cleanText(value of uiElement)
+    end try
+  end if
+  set lineText to indent & "- " & roleText
+  if nameText is not "" then set lineText to lineText & " \"" & nameText & "\""
+  if valueText is not "" and valueText is not nameText then set lineText to lineText & " = " & valueText
+  if descriptionText is not "" and descriptionText is not nameText then set lineText to lineText & " (" & descriptionText & ")"
+  set outputText to lineText & linefeed
+  try
+    set childItems to UI elements of uiElement
+    repeat with childItem in childItems
+      set outputText to outputText & my dumpElement(childItem, depth + 1)
+      if nodeCount > nodeLimit then exit repeat
+    end repeat
+  end try
+  return outputText
+end dumpElement
+
+tell application "System Events"
+  set frontApp to first application process whose frontmost is true
+  try
+    return my dumpElement(front window of frontApp, 0)
+  on error
+    return my dumpElement(frontApp, 0)
+  end try
+end tell
+"#
+    );
+    let raw = run_osascript(
+        &script,
+        Duration::from_millis(ACCESSIBILITY_TREE_TIMEOUT_MS),
+        "accessibility tree capture",
+    )?;
+    Ok(truncate_bytes(&raw, 24 * 1024))
+}
+
+fn accessibility_redaction_condition() -> String {
+    let mut clauses = Vec::new();
+    for field in ACCESSIBILITY_REDACTION_FIELDS {
+        for term in ACCESSIBILITY_REDACTION_TERMS {
+            clauses.push(format!("({field} contains \"{term}\")"));
+        }
+    }
+    clauses.join(" or ")
+}
+
+fn capture_screenshot(frontmost: &FrontmostWindow) -> (Vec<u8>, bool, Vec<String>) {
+    if !screen_recording_granted() {
+        return (
+            placeholder_png(),
+            false,
+            vec!["Screen Recording permission is required for snapshot.png.".to_string()],
+        );
+    }
+
+    let (x, y, width, height) = match (frontmost.x, frontmost.y, frontmost.width, frontmost.height)
+    {
+        (Some(x), Some(y), Some(width), Some(height)) if width > 0 && height > 0 => {
+            (x, y, width, height)
+        }
+        _ => {
+            return (
+                placeholder_png(),
+                false,
+                vec![
+                    "Unable to determine the focused window bounds; skipped screenshot capture."
+                        .to_string(),
+                ],
+            )
+        }
+    };
+
+    let temp_path = std::env::temp_dir().join(format!(
+        "atmos-appshot-{}.png",
+        Utc::now().timestamp_millis()
+    ));
+    let mut command = Command::new("screencapture");
+    command.arg("-x");
+    command.arg("-R").arg(format!("{x},{y},{width},{height}"));
+    command.arg(&temp_path);
+
+    let output = match run_command_output(
+        command,
+        Duration::from_millis(SCREENSHOT_TIMEOUT_MS),
+        "screencapture",
+    ) {
+        Ok(output) => output,
+        Err(error) => {
+            let _ = fs::remove_file(&temp_path);
+            return (placeholder_png(), false, vec![error]);
+        }
+    };
+    if !output.status.success() {
+        let _ = fs::remove_file(&temp_path);
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return (
+            placeholder_png(),
+            false,
+            vec![if stderr.is_empty() {
+                format!("screencapture exited with status {}", output.status)
+            } else {
+                format!("screencapture failed: {stderr}")
+            }],
+        );
+    }
+
+    let bytes = match fs::read(&temp_path) {
+        Ok(bytes) if !bytes.is_empty() => bytes,
+        Ok(_) => {
+            let _ = fs::remove_file(&temp_path);
+            return (
+                placeholder_png(),
+                false,
+                vec!["screencapture produced an empty file.".to_string()],
+            );
+        }
+        Err(error) => {
+            let _ = fs::remove_file(&temp_path);
+            return (
+                placeholder_png(),
+                false,
+                vec![format!("Failed to read screencapture output: {error}")],
+            );
+        }
+    };
+    let _ = fs::remove_file(temp_path);
+    (bytes, true, Vec::new())
+}
+
+fn build_context_markdown(
+    frontmost: &FrontmostWindow,
+    captured_at: &str,
+    quality: AppshotQuality,
+    accessibility_tree: &str,
+    warnings: &[String],
+) -> String {
+    let mut out = String::new();
+    out.push_str("# Appshot Context\n\n");
+    out.push_str(&format!("- App: {}\n", frontmost.app_name));
+    if let Some(title) = &frontmost.window_title {
+        out.push_str(&format!("- Window: {}\n", title));
+    }
+    if let Some(bundle_id) = &frontmost.bundle_id {
+        out.push_str(&format!("- Bundle ID: {}\n", bundle_id));
+    }
+    if let Some(process_id) = frontmost.process_id {
+        out.push_str(&format!("- Process ID: {}\n", process_id));
+    }
+    if let Some(window_id) = &frontmost.window_id {
+        out.push_str(&format!("- Window ID: {}\n", window_id));
+    }
+    out.push_str(&format!("- Captured at: {}\n", captured_at));
+    out.push_str(&format!("- Quality: {:?}\n\n", quality));
+    out.push_str("## Accessibility Tree\n\n");
+    out.push_str(accessibility_tree.trim());
+    out.push_str("\n\n## Warnings\n\n");
+    if warnings.is_empty() {
+        out.push_str("- None\n");
+    } else {
+        for warning in warnings {
+            out.push_str("- ");
+            out.push_str(warning);
+            out.push('\n');
+        }
+    }
+    truncate_bytes(&out, 28 * 1024)
+}
+
+fn run_osascript(script: &str, timeout: Duration, label: &str) -> Result<String, String> {
+    let mut command = Command::new("osascript");
+    command.arg("-e").arg(script);
+    let output = run_command_output(command, timeout, label)?;
+    if output.status.success() {
+        return String::from_utf8(output.stdout)
+            .map(|text| text.trim_end().to_string())
+            .map_err(|error| format!("osascript returned invalid utf8: {error}"));
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if stderr.is_empty() {
+        Err(format!("osascript exited with status {}", output.status))
+    } else {
+        Err(stderr)
+    }
+}
+
+#[derive(Debug)]
+struct CommandOutput {
+    status: ExitStatus,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+fn run_command_output(
+    mut command: Command,
+    timeout: Duration,
+    label: &str,
+) -> Result<CommandOutput, String> {
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| format!("failed to start {label}: {error}"))?;
+    let started_at = Instant::now();
+
+    loop {
+        match child
+            .try_wait()
+            .map_err(|error| format!("failed to wait for {label}: {error}"))?
+        {
+            Some(status) => {
+                let stdout = read_child_pipe(child.stdout.take(), label, "stdout")?;
+                let stderr = read_child_pipe(child.stderr.take(), label, "stderr")?;
+                return Ok(CommandOutput {
+                    status,
+                    stdout,
+                    stderr,
+                });
+            }
+            None if started_at.elapsed() >= timeout => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!(
+                    "{label} timed out after {} ms",
+                    timeout.as_millis()
+                ));
+            }
+            None => thread::sleep(Duration::from_millis(PROCESS_POLL_INTERVAL_MS)),
+        }
+    }
+}
+
+fn read_child_pipe<R: Read>(
+    pipe: Option<R>,
+    label: &str,
+    stream_name: &str,
+) -> Result<Vec<u8>, String> {
+    let Some(mut pipe) = pipe else {
+        return Ok(Vec::new());
+    };
+    let mut bytes = Vec::new();
+    pipe.read_to_end(&mut bytes)
+        .map_err(|error| format!("failed to read {label} {stream_name}: {error}"))?;
+    Ok(bytes)
+}
+
+fn non_empty(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn png_dimensions(bytes: &[u8]) -> Option<(u32, u32)> {
+    const PNG_SIG: &[u8; 8] = b"\x89PNG\r\n\x1a\n";
+    if bytes.len() < 24 || &bytes[0..8] != PNG_SIG {
+        return None;
+    }
+    let width = u32::from_be_bytes(bytes[16..20].try_into().ok()?);
+    let height = u32::from_be_bytes(bytes[20..24].try_into().ok()?);
+    Some((width, height))
+}
+
+fn truncate_bytes(text: &str, limit: usize) -> String {
+    if text.len() <= limit {
+        return text.to_string();
+    }
+    let mut end = 0;
+    for (idx, ch) in text.char_indices() {
+        if idx + ch.len_utf8() > limit {
+            break;
+        }
+        end = idx + ch.len_utf8();
+    }
+    format!("{}...", &text[..end])
+}
+
+fn placeholder_png() -> Vec<u8> {
+    vec![
+        137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 6,
+        0, 0, 0, 31, 21, 196, 137, 0, 0, 0, 13, 73, 68, 65, 84, 120, 156, 99, 248, 255, 255, 63, 0,
+        5, 254, 2, 254, 167, 69, 129, 132, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        accessibility_redaction_condition, run_command_output, select_frontmost_window,
+        truncate_bytes, FrontmostApp, WindowCandidate,
+    };
+    use std::process::Command;
+    use std::time::Duration;
+
+    #[test]
+    fn command_runner_times_out_hung_process() {
+        let mut command = Command::new("sh");
+        command.arg("-c").arg("sleep 2");
+
+        let error = run_command_output(command, Duration::from_millis(50), "test command")
+            .expect_err("command should time out");
+
+        assert!(error.contains("test command timed out after"));
+    }
+
+    #[test]
+    fn command_runner_returns_stdout_and_stderr() {
+        let mut command = Command::new("sh");
+        command.arg("-c").arg("printf 'hello'; printf 'warn' >&2");
+
+        let output = run_command_output(command, Duration::from_secs(1), "test command")
+            .expect("command output");
+
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"hello");
+        assert_eq!(output.stderr, b"warn");
+    }
+
+    #[test]
+    fn truncate_bytes_keeps_utf8_boundary() {
+        assert_eq!(truncate_bytes("hello", 20), "hello");
+        assert_eq!(truncate_bytes("你好世界", 7), "你好...");
+    }
+
+    #[test]
+    fn accessibility_redaction_condition_covers_secure_fields_before_values() {
+        let condition = accessibility_redaction_condition();
+
+        assert!(condition.contains("(roleText contains \"secure\")"));
+        assert!(condition.contains("(roleText contains \"password\")"));
+        assert!(condition.contains("(nameText contains \"password\")"));
+        assert!(condition.contains("(descriptionText contains \"password\")"));
+        assert!(condition.contains(") or ("));
+        assert!(!condition.contains("valueText contains"));
+    }
+
+    #[test]
+    fn native_frontmost_selection_uses_pid_matched_window_bounds() {
+        let selected = select_frontmost_window(
+            Some(frontmost_app("Cursor", Some(42))),
+            vec![
+                window_candidate("Atmos", Some(7), Some((0, 0, 300, 200))),
+                window_candidate("Cursor", Some(42), Some((10, 20, 1200, 800))),
+            ],
+        )
+        .expect("selected window");
+
+        assert_eq!(selected.app_name, "Cursor");
+        assert_eq!(selected.process_id, Some(42));
+        assert_eq!(selected.window_title.as_deref(), Some("Cursor Window"));
+        assert_eq!(selected.window_id.as_deref(), Some("9001"));
+        assert_eq!(selected.x, Some(10));
+        assert_eq!(selected.y, Some(20));
+        assert_eq!(selected.width, Some(1200));
+        assert_eq!(selected.height, Some(800));
+    }
+
+    #[test]
+    fn native_frontmost_selection_falls_back_to_visible_non_atmos_window() {
+        let selected = select_frontmost_window(
+            None,
+            vec![
+                window_candidate("Atmos", Some(7), Some((0, 0, 300, 200))),
+                window_candidate("WeChat", Some(88), Some((30, 40, 900, 700))),
+            ],
+        )
+        .expect("selected window");
+
+        assert_eq!(selected.app_name, "WeChat");
+        assert_eq!(selected.process_id, Some(88));
+        assert_eq!(selected.x, Some(30));
+        assert_eq!(selected.width, Some(900));
+    }
+
+    #[test]
+    fn native_frontmost_selection_uses_name_match_when_pid_differs() {
+        let selected = select_frontmost_window(
+            Some(frontmost_app("Electron App", Some(100))),
+            vec![window_candidate(
+                "Electron App",
+                Some(101),
+                Some((50, 60, 1000, 700)),
+            )],
+        )
+        .expect("selected window");
+
+        assert_eq!(selected.app_name, "Electron App");
+        assert_eq!(selected.process_id, Some(100));
+        assert_eq!(selected.x, Some(50));
+        assert_eq!(selected.height, Some(700));
+    }
+
+    #[test]
+    fn native_frontmost_selection_keeps_app_identity_without_window() {
+        let selected = select_frontmost_window(Some(frontmost_app("Safari", Some(55))), Vec::new())
+            .expect("selected app");
+
+        assert_eq!(selected.app_name, "Safari");
+        assert_eq!(selected.process_id, Some(55));
+        assert_eq!(selected.window_title, None);
+        assert_eq!(selected.width, None);
+    }
+
+    fn frontmost_app(name: &str, process_id: Option<u32>) -> FrontmostApp {
+        FrontmostApp {
+            app_name: name.to_string(),
+            bundle_id: Some(format!("test.{name}")),
+            process_id,
+        }
+    }
+
+    fn window_candidate(
+        app_name: &str,
+        process_id: Option<u32>,
+        bounds: Option<(i32, i32, i32, i32)>,
+    ) -> WindowCandidate {
+        WindowCandidate {
+            app_name: app_name.to_string(),
+            process_id,
+            window_title: Some(format!("{app_name} Window")),
+            window_id: Some("9001".to_string()),
+            x: bounds.map(|bounds| bounds.0),
+            y: bounds.map(|bounds| bounds.1),
+            width: bounds.map(|bounds| bounds.2),
+            height: bounds.map(|bounds| bounds.3),
+        }
+    }
+}

--- a/apps/desktop/src-tauri/src/appshot/macos.rs
+++ b/apps/desktop/src-tauri/src/appshot/macos.rs
@@ -17,8 +17,10 @@ use core_graphics::window::{
 use objc2_app_kit::{NSRunningApplication, NSWorkspace};
 use std::fs;
 use std::io::Read;
+use std::mem;
 use std::process::{Command, ExitStatus, Stdio};
 use std::thread;
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 const FRONTMOST_WINDOW_TIMEOUT_MS: u64 = 2_500;
@@ -28,7 +30,8 @@ const PROCESS_POLL_INTERVAL_MS: u64 = 20;
 const MIN_WINDOW_WIDTH: i32 = 32;
 const MIN_WINDOW_HEIGHT: i32 = 32;
 const ACCESSIBILITY_REDACTION_TERMS: &[&str] = &["secure", "Secure", "password", "Password"];
-const ACCESSIBILITY_REDACTION_FIELDS: &[&str] = &["roleText", "nameText", "descriptionText"];
+const ACCESSIBILITY_REDACTION_FIELDS: &[&str] =
+    &["roleText", "nameText", "descriptionText", "valueText"];
 
 #[link(name = "ApplicationServices", kind = "framework")]
 extern "C" {
@@ -426,8 +429,10 @@ fn read_window_candidates() -> Result<Vec<WindowCandidate>, String> {
     let options = kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements;
     let raw_windows = copy_window_info(options, kCGNullWindowID)
         .ok_or_else(|| "CoreGraphics window list was unavailable.".to_string())?;
+    let raw_windows_ref = raw_windows.as_concrete_TypeRef();
+    mem::forget(raw_windows);
     let windows: CFArray<CFDictionary<CFType, CFType>> =
-        unsafe { TCFType::wrap_under_get_rule(raw_windows.as_concrete_TypeRef()) };
+        unsafe { TCFType::wrap_under_create_rule(raw_windows_ref) };
 
     let mut candidates = Vec::new();
     for window in windows.iter() {
@@ -638,12 +643,11 @@ on dumpElement(uiElement, depth)
   try
     set descriptionText to my cleanText(description of uiElement)
   end try
+  try
+    set valueText to my cleanText(value of uiElement)
+  end try
   if {redaction_condition} then
     set valueText to "[redacted]"
-  else
-    try
-      set valueText to my cleanText(value of uiElement)
-    end try
   end if
   set lineText to indent & "- " & roleText
   if nameText is not "" then set lineText to lineText & " \"" & nameText & "\""
@@ -844,6 +848,8 @@ fn run_command_output(
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|error| format!("failed to start {label}: {error}"))?;
+    let stdout_reader = spawn_child_pipe_reader(child.stdout.take(), label, "stdout");
+    let stderr_reader = spawn_child_pipe_reader(child.stderr.take(), label, "stderr");
     let started_at = Instant::now();
 
     loop {
@@ -852,8 +858,8 @@ fn run_command_output(
             .map_err(|error| format!("failed to wait for {label}: {error}"))?
         {
             Some(status) => {
-                let stdout = read_child_pipe(child.stdout.take(), label, "stdout")?;
-                let stderr = read_child_pipe(child.stderr.take(), label, "stderr")?;
+                let stdout = join_child_pipe_reader(stdout_reader, label, "stdout")?;
+                let stderr = join_child_pipe_reader(stderr_reader, label, "stderr")?;
                 return Ok(CommandOutput {
                     status,
                     stdout,
@@ -863,6 +869,8 @@ fn run_command_output(
             None if started_at.elapsed() >= timeout => {
                 let _ = child.kill();
                 let _ = child.wait();
+                let _ = stdout_reader.join();
+                let _ = stderr_reader.join();
                 return Err(format!(
                     "{label} timed out after {} ms",
                     timeout.as_millis()
@@ -871,6 +879,28 @@ fn run_command_output(
             None => thread::sleep(Duration::from_millis(PROCESS_POLL_INTERVAL_MS)),
         }
     }
+}
+
+fn spawn_child_pipe_reader<R>(
+    pipe: Option<R>,
+    label: &str,
+    stream_name: &'static str,
+) -> JoinHandle<Result<Vec<u8>, String>>
+where
+    R: Read + Send + 'static,
+{
+    let label = label.to_string();
+    thread::spawn(move || read_child_pipe(pipe, &label, stream_name))
+}
+
+fn join_child_pipe_reader(
+    reader: JoinHandle<Result<Vec<u8>, String>>,
+    label: &str,
+    stream_name: &str,
+) -> Result<Vec<u8>, String> {
+    reader
+        .join()
+        .map_err(|_| format!("failed to join {label} {stream_name} reader"))?
 }
 
 fn read_child_pipe<R: Read>(
@@ -973,8 +1003,8 @@ mod tests {
         assert!(condition.contains("(roleText contains \"password\")"));
         assert!(condition.contains("(nameText contains \"password\")"));
         assert!(condition.contains("(descriptionText contains \"password\")"));
+        assert!(condition.contains("(valueText contains \"password\")"));
         assert!(condition.contains(") or ("));
-        assert!(!condition.contains("valueText contains"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/appshot/macos.rs
+++ b/apps/desktop/src-tauri/src/appshot/macos.rs
@@ -95,6 +95,7 @@ pub fn permission_states(input_monitoring_granted: bool) -> Vec<AppshotPermissio
             vec![
                 "Open System Settings > Privacy & Security > Accessibility.".to_string(),
                 "Enable Atmos, then return to Atmos.".to_string(),
+                "If Atmos is already enabled after a local rebuild but still shows as denied, remove the stale Atmos entry with the minus button, add the current Atmos app again, then relaunch Atmos.".to_string(),
             ],
         ),
         permission_state(
@@ -107,6 +108,7 @@ pub fn permission_states(input_monitoring_granted: bool) -> Vec<AppshotPermissio
                 "Open System Settings > Privacy & Security > Screen & System Audio Recording."
                     .to_string(),
                 "Enable Atmos, then return to Atmos.".to_string(),
+                "If Atmos is already enabled after a local rebuild but still shows as denied, remove the stale Atmos entry with the minus button, add the current Atmos app again, then relaunch Atmos.".to_string(),
             ],
         ),
         permission_state(
@@ -118,6 +120,7 @@ pub fn permission_states(input_monitoring_granted: bool) -> Vec<AppshotPermissio
             vec![
                 "Open System Settings > Privacy & Security > Input Monitoring.".to_string(),
                 "Enable Atmos if it appears in the list, then return to Atmos.".to_string(),
+                "If Atmos is already enabled after a local rebuild but the shortcut still does not work, remove the stale Atmos entry, add the current Atmos app again, then relaunch Atmos.".to_string(),
             ],
         ),
     ]

--- a/apps/desktop/src-tauri/src/appshot/macos.rs
+++ b/apps/desktop/src-tauri/src/appshot/macos.rs
@@ -81,7 +81,7 @@ pub fn screen_recording_granted() -> bool {
     unsafe { CGPreflightScreenCaptureAccess() }
 }
 
-pub fn permission_states(input_monitoring_granted: bool) -> Vec<AppshotPermissionState> {
+pub fn permission_states() -> Vec<AppshotPermissionState> {
     vec![
         permission_state(
             AppshotPermissionName::Accessibility,
@@ -95,7 +95,6 @@ pub fn permission_states(input_monitoring_granted: bool) -> Vec<AppshotPermissio
             vec![
                 "Open System Settings > Privacy & Security > Accessibility.".to_string(),
                 "Enable Atmos, then return to Atmos.".to_string(),
-                "If Atmos is already enabled after a local rebuild but still shows as denied, remove the stale Atmos entry with the minus button, add the current Atmos app again, then relaunch Atmos.".to_string(),
             ],
         ),
         permission_state(
@@ -108,19 +107,6 @@ pub fn permission_states(input_monitoring_granted: bool) -> Vec<AppshotPermissio
                 "Open System Settings > Privacy & Security > Screen & System Audio Recording."
                     .to_string(),
                 "Enable Atmos, then return to Atmos.".to_string(),
-                "If Atmos is already enabled after a local rebuild but still shows as denied, remove the stale Atmos entry with the minus button, add the current Atmos app again, then relaunch Atmos.".to_string(),
-            ],
-        ),
-        permission_state(
-            AppshotPermissionName::InputMonitoring,
-            "Input Monitoring",
-            input_monitoring_granted,
-            vec!["Listen for the Fn + Option + Command Appshot gesture".to_string()],
-            AppshotSettingsTarget::InputMonitoring,
-            vec![
-                "Open System Settings > Privacy & Security > Input Monitoring.".to_string(),
-                "Enable Atmos if it appears in the list, then return to Atmos.".to_string(),
-                "If Atmos is already enabled after a local rebuild but the shortcut still does not work, remove the stale Atmos entry, add the current Atmos app again, then relaunch Atmos.".to_string(),
             ],
         ),
     ]
@@ -133,9 +119,6 @@ pub fn open_settings(target: AppshotSettingsTarget) -> Result<(), String> {
         }
         AppshotSettingsTarget::ScreenRecording => {
             "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
-        }
-        AppshotSettingsTarget::InputMonitoring => {
-            "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
         }
         AppshotSettingsTarget::PrivacySecurity => {
             "x-apple.systempreferences:com.apple.preference.security"
@@ -161,17 +144,15 @@ pub fn open_settings(target: AppshotSettingsTarget) -> Result<(), String> {
     }
 }
 
-pub async fn capture_frontmost(input_monitoring_granted: bool) -> Result<CapturedAppshot, String> {
-    tauri::async_runtime::spawn_blocking(move || {
-        capture_frontmost_blocking(input_monitoring_granted)
-    })
-    .await
-    .map_err(|error| format!("appshot capture task failed: {error}"))?
+pub async fn capture_frontmost() -> Result<CapturedAppshot, String> {
+    tauri::async_runtime::spawn_blocking(capture_frontmost_blocking)
+        .await
+        .map_err(|error| format!("appshot capture task failed: {error}"))?
 }
 
-fn capture_frontmost_blocking(input_monitoring_granted: bool) -> Result<CapturedAppshot, String> {
+fn capture_frontmost_blocking() -> Result<CapturedAppshot, String> {
     let captured_at = Utc::now().to_rfc3339();
-    let permissions = permission_states(input_monitoring_granted);
+    let permissions = permission_states();
     let mut warnings = Vec::new();
     let frontmost = match read_frontmost_window() {
         Ok(info) => info,

--- a/apps/desktop/src-tauri/src/appshot/mod.rs
+++ b/apps/desktop/src-tauri/src/appshot/mod.rs
@@ -1,3 +1,4 @@
+mod capture_animation;
 mod clipboard;
 mod encoding;
 #[cfg(target_os = "macos")]
@@ -6,6 +7,7 @@ mod pending;
 pub mod protocol;
 mod records;
 mod shortcut;
+mod thumbnail;
 pub mod types;
 #[cfg(not(target_os = "macos"))]
 mod unsupported;
@@ -13,7 +15,7 @@ mod unsupported;
 use crate::appshot::types::{
     AppshotAcceptResponse, AppshotCopyResponse, AppshotOpenPermissionsRequest,
     AppshotPendingAutoAcceptRequest, AppshotReadRecordsRequest, AppshotRecordDetail,
-    AppshotRecordListItem, AppshotStatus,
+    AppshotRecordListItem, AppshotSnapshotView, AppshotStatus,
 };
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -67,6 +69,10 @@ pub async fn read_records(
     records::read_records(&req.timestamps)
 }
 
+pub async fn read_snapshot(timestamp: String) -> Result<AppshotSnapshotView, String> {
+    records::read_snapshot(&timestamp)
+}
+
 pub async fn copy_record(timestamp: String) -> Result<AppshotCopyResponse, String> {
     records::copy_record(&timestamp)
 }
@@ -89,6 +95,7 @@ pub async fn open_permissions(req: AppshotOpenPermissionsRequest) -> Result<(), 
 }
 
 pub async fn trigger_capture(app: AppHandle) {
+    play_capture_animation(&app).await;
     match capture_current().await {
         Ok(captured) => match pending::insert(captured) {
             Ok(preview) => {
@@ -108,6 +115,20 @@ pub async fn trigger_capture(app: AppHandle) {
         Err(error) => {
             let _ = app.emit("appshot://error", error);
         }
+    }
+}
+
+async fn play_capture_animation(app: &AppHandle) {
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(bounds) = macos::capture_animation_target().await {
+            let _ = capture_animation::play(app.clone(), bounds).await;
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
     }
 }
 

--- a/apps/desktop/src-tauri/src/appshot/mod.rs
+++ b/apps/desktop/src-tauri/src/appshot/mod.rs
@@ -1,0 +1,125 @@
+mod clipboard;
+mod encoding;
+#[cfg(target_os = "macos")]
+mod macos;
+mod pending;
+pub mod protocol;
+mod records;
+mod shortcut;
+pub mod types;
+#[cfg(not(target_os = "macos"))]
+mod unsupported;
+
+use crate::appshot::types::{
+    AppshotAcceptResponse, AppshotCopyResponse, AppshotOpenPermissionsRequest,
+    AppshotPendingAutoAcceptRequest, AppshotReadRecordsRequest, AppshotRecordDetail,
+    AppshotRecordListItem, AppshotStatus,
+};
+use tauri::{AppHandle, Emitter, Manager};
+
+const PREVIEW_EVENT: &str = "appshot://preview";
+
+pub fn init(app: AppHandle) {
+    shortcut::start(app);
+}
+
+pub async fn status(app: AppHandle) -> Result<AppshotStatus, String> {
+    #[cfg(target_os = "macos")]
+    {
+        shortcut::start(app);
+        let permissions = macos::permission_states(shortcut::is_enabled());
+        let trigger = shortcut::trigger_status(permissions.clone());
+        return Ok(AppshotStatus {
+            supported: true,
+            platform: types::AppshotPlatform::Macos,
+            reason: None,
+            trigger,
+            permissions,
+        });
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
+        Ok(unsupported::status())
+    }
+}
+
+pub async fn accept_pending(preview_id: String) -> Result<AppshotAcceptResponse, String> {
+    pending::accept(&preview_id)
+}
+
+pub async fn discard_pending(preview_id: String) -> Result<(), String> {
+    pending::discard(&preview_id)
+}
+
+pub async fn set_pending_auto_accept(req: AppshotPendingAutoAcceptRequest) -> Result<(), String> {
+    pending::set_auto_accept_hold(&req.preview_id, req.held, req.resume_in_ms)
+}
+
+pub async fn list_records() -> Result<Vec<AppshotRecordListItem>, String> {
+    records::list_records()
+}
+
+pub async fn read_records(
+    req: AppshotReadRecordsRequest,
+) -> Result<Vec<AppshotRecordDetail>, String> {
+    records::read_records(&req.timestamps)
+}
+
+pub async fn copy_record(timestamp: String) -> Result<AppshotCopyResponse, String> {
+    records::copy_record(&timestamp)
+}
+
+pub async fn delete_record(timestamp: String) -> Result<(), String> {
+    records::delete_record(&timestamp)
+}
+
+pub async fn open_permissions(req: AppshotOpenPermissionsRequest) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        return macos::open_settings(req.target);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = req;
+        Err("Appshot permissions are only available on macOS desktop builds.".to_string())
+    }
+}
+
+pub async fn trigger_capture(app: AppHandle) {
+    match capture_current(shortcut::is_enabled()).await {
+        Ok(captured) => match pending::insert(captured) {
+            Ok(preview) => {
+                if let Some(main) = app.get_webview_window("main") {
+                    let _ = main.show();
+                    let _ = main.set_focus();
+                }
+                let _ = app.emit(PREVIEW_EVENT, &preview);
+                if preview.expires_in_ms > 0 {
+                    pending::spawn_auto_accept(app, preview.preview_id);
+                }
+            }
+            Err(error) => {
+                let _ = app.emit("appshot://error", error);
+            }
+        },
+        Err(error) => {
+            let _ = app.emit("appshot://error", error);
+        }
+    }
+}
+
+async fn capture_current(input_monitoring_granted: bool) -> Result<types::CapturedAppshot, String> {
+    #[cfg(target_os = "macos")]
+    {
+        return macos::capture_frontmost(input_monitoring_granted).await;
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = input_monitoring_granted;
+        Err("Appshots are currently available on macOS desktop builds only.".to_string())
+    }
+}

--- a/apps/desktop/src-tauri/src/appshot/mod.rs
+++ b/apps/desktop/src-tauri/src/appshot/mod.rs
@@ -26,7 +26,7 @@ pub fn init(app: AppHandle) {
 pub async fn status(app: AppHandle) -> Result<AppshotStatus, String> {
     #[cfg(target_os = "macos")]
     {
-        let _ = app;
+        shortcut::start(app);
         let permissions = macos::permission_states(shortcut::is_enabled());
         let trigger = shortcut::trigger_status(permissions.clone());
         return Ok(AppshotStatus {

--- a/apps/desktop/src-tauri/src/appshot/mod.rs
+++ b/apps/desktop/src-tauri/src/appshot/mod.rs
@@ -27,7 +27,7 @@ pub async fn status(app: AppHandle) -> Result<AppshotStatus, String> {
     #[cfg(target_os = "macos")]
     {
         shortcut::start(app);
-        let permissions = macos::permission_states(shortcut::is_enabled());
+        let permissions = macos::permission_states();
         let trigger = shortcut::trigger_status(permissions.clone());
         return Ok(AppshotStatus {
             supported: true,
@@ -89,7 +89,7 @@ pub async fn open_permissions(req: AppshotOpenPermissionsRequest) -> Result<(), 
 }
 
 pub async fn trigger_capture(app: AppHandle) {
-    match capture_current(shortcut::is_enabled()).await {
+    match capture_current().await {
         Ok(captured) => match pending::insert(captured) {
             Ok(preview) => {
                 if let Some(main) = app.get_webview_window("main") {
@@ -111,15 +111,14 @@ pub async fn trigger_capture(app: AppHandle) {
     }
 }
 
-async fn capture_current(input_monitoring_granted: bool) -> Result<types::CapturedAppshot, String> {
+async fn capture_current() -> Result<types::CapturedAppshot, String> {
     #[cfg(target_os = "macos")]
     {
-        return macos::capture_frontmost(input_monitoring_granted).await;
+        return macos::capture_frontmost().await;
     }
 
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = input_monitoring_granted;
         Err("Appshots are currently available on macOS desktop builds only.".to_string())
     }
 }

--- a/apps/desktop/src-tauri/src/appshot/mod.rs
+++ b/apps/desktop/src-tauri/src/appshot/mod.rs
@@ -26,7 +26,7 @@ pub fn init(app: AppHandle) {
 pub async fn status(app: AppHandle) -> Result<AppshotStatus, String> {
     #[cfg(target_os = "macos")]
     {
-        shortcut::start(app);
+        let _ = app;
         let permissions = macos::permission_states(shortcut::is_enabled());
         let trigger = shortcut::trigger_status(permissions.clone());
         return Ok(AppshotStatus {

--- a/apps/desktop/src-tauri/src/appshot/pending.rs
+++ b/apps/desktop/src-tauri/src/appshot/pending.rs
@@ -1,5 +1,6 @@
 use crate::appshot::encoding;
 use crate::appshot::records;
+use crate::appshot::thumbnail;
 use crate::appshot::types::{AppshotAcceptResponse, AppshotPendingPreview, CapturedAppshot};
 use chrono::Utc;
 use std::collections::HashMap;
@@ -51,6 +52,7 @@ pub fn insert(captured: CapturedAppshot) -> Result<AppshotPendingPreview, String
         captured_at: captured.captured_at.clone(),
         quality: captured.quality.clone(),
         screenshot_preview_base64,
+        source_bounds: captured.source_bounds.clone(),
         permissions: captured.permissions.clone(),
         warnings: preview_warnings,
         expires_in_ms: if has_denied_permissions {
@@ -97,11 +99,18 @@ fn screenshot_preview_base64(
     if !captured.screenshot.available {
         return None;
     }
-    if captured.screenshot_png.len() > encoding::MAX_INLINE_SNAPSHOT_BYTES {
-        append_warning(warnings, encoding::OVERSIZED_SNAPSHOT_WARNING);
-        return None;
+    if encoding::fits_inline_png_data_url(captured.screenshot_png.len() as u64) {
+        return Some(encoding::base64_encode(&captured.screenshot_png));
     }
-    Some(encoding::base64_encode(&captured.screenshot_png))
+
+    if let Ok(thumbnail_png) = thumbnail::thumbnail_png_for_bytes(&captured.screenshot_png) {
+        if encoding::fits_inline_png_data_url(thumbnail_png.len() as u64) {
+            return Some(encoding::base64_encode(&thumbnail_png));
+        }
+    }
+
+    append_warning(warnings, encoding::OVERSIZED_SNAPSHOT_WARNING);
+    None
 }
 
 fn append_warning(warnings: &mut Vec<String>, warning: &str) {
@@ -490,6 +499,12 @@ mod tests {
                 height: Some(10),
                 media_type: "image/png".to_string(),
             },
+            source_bounds: Some(crate::appshot::types::AppshotWindowBounds {
+                x: 100,
+                y: 120,
+                width: 900,
+                height: 600,
+            }),
             context_markdown: "# Appshot Context\n\nbody".to_string(),
             permissions: vec![AppshotPermissionState {
                 name: AppshotPermissionName::Accessibility,

--- a/apps/desktop/src-tauri/src/appshot/pending.rs
+++ b/apps/desktop/src-tauri/src/appshot/pending.rs
@@ -1,0 +1,512 @@
+use crate::appshot::encoding;
+use crate::appshot::records;
+use crate::appshot::types::{AppshotAcceptResponse, AppshotPendingPreview, CapturedAppshot};
+use chrono::Utc;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+use tauri::{AppHandle, Emitter};
+
+const PREVIEW_EXPIRES_IN_MS: u64 = 6_000;
+const NATIVE_AUTO_ACCEPT_GRACE_MS: i64 = 500;
+const RECOVERABLE_PENDING_TTL_MS: i64 = 5 * 60 * 1_000;
+const BLOCKED_PENDING_TTL_MS: i64 = 60 * 1_000;
+const MAX_PENDING_ENTRIES: usize = 16;
+
+#[derive(Clone)]
+struct PendingEntry {
+    state: PendingState,
+    created_at_ms: i64,
+    expires_at_ms: i64,
+    blocked_by_permissions: bool,
+    auto_accept_held: bool,
+    auto_accept_after_ms: Option<i64>,
+}
+
+#[derive(Clone)]
+enum PendingState {
+    Captured(CapturedAppshot),
+    Saved(AppshotAcceptResponse),
+}
+
+static PENDING: OnceLock<Mutex<HashMap<String, PendingEntry>>> = OnceLock::new();
+
+fn pending() -> &'static Mutex<HashMap<String, PendingEntry>> {
+    PENDING.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub fn insert(captured: CapturedAppshot) -> Result<AppshotPendingPreview, String> {
+    let now_ms = Utc::now().timestamp_millis();
+    let preview_id = format!("{}-{}", now_ms, random_suffix());
+    let mut preview_warnings = captured.warnings.clone();
+    let screenshot_preview_base64 = screenshot_preview_base64(&captured, &mut preview_warnings);
+    let has_denied_permissions = captured
+        .permissions
+        .iter()
+        .any(|permission| !permission.granted);
+    let preview = AppshotPendingPreview {
+        preview_id: preview_id.clone(),
+        app_name: captured.app_name.clone(),
+        window_title: captured.window_title.clone(),
+        captured_at: captured.captured_at.clone(),
+        quality: captured.quality.clone(),
+        screenshot_preview_base64,
+        permissions: captured.permissions.clone(),
+        warnings: preview_warnings,
+        expires_in_ms: if has_denied_permissions {
+            0
+        } else {
+            PREVIEW_EXPIRES_IN_MS
+        },
+    };
+    let mut pending = pending()
+        .lock()
+        .map_err(|_| "appshot pending state lock poisoned".to_string())?;
+    prune_locked(&mut pending, now_ms);
+    if has_denied_permissions {
+        pending.retain(|_, entry| !entry.blocked_by_permissions);
+    }
+    enforce_capacity_locked(&mut pending);
+    pending.insert(
+        preview_id,
+        PendingEntry {
+            state: PendingState::Captured(captured),
+            created_at_ms: now_ms,
+            expires_at_ms: now_ms
+                + if has_denied_permissions {
+                    BLOCKED_PENDING_TTL_MS
+                } else {
+                    RECOVERABLE_PENDING_TTL_MS
+                },
+            blocked_by_permissions: has_denied_permissions,
+            auto_accept_held: false,
+            auto_accept_after_ms: if has_denied_permissions {
+                None
+            } else {
+                Some(now_ms + PREVIEW_EXPIRES_IN_MS as i64 + NATIVE_AUTO_ACCEPT_GRACE_MS)
+            },
+        },
+    );
+    Ok(preview)
+}
+
+fn screenshot_preview_base64(
+    captured: &CapturedAppshot,
+    warnings: &mut Vec<String>,
+) -> Option<String> {
+    if !captured.screenshot.available {
+        return None;
+    }
+    if captured.screenshot_png.len() > encoding::MAX_INLINE_SNAPSHOT_BYTES {
+        append_warning(warnings, encoding::OVERSIZED_SNAPSHOT_WARNING);
+        return None;
+    }
+    Some(encoding::base64_encode(&captured.screenshot_png))
+}
+
+fn append_warning(warnings: &mut Vec<String>, warning: &str) {
+    if !warnings.iter().any(|existing| existing == warning) {
+        warnings.push(warning.to_string());
+    }
+}
+
+pub fn accept(preview_id: &str) -> Result<AppshotAcceptResponse, String> {
+    accept_with_clipboard(preview_id, records::copy_protocol_text)
+}
+
+fn accept_with_clipboard(
+    preview_id: &str,
+    copy_protocol_text: impl Fn(&str) -> Result<(), String>,
+) -> Result<AppshotAcceptResponse, String> {
+    let entry = pending()
+        .lock()
+        .map_err(|_| "appshot pending state lock poisoned".to_string())?
+        .remove(preview_id)
+        .ok_or_else(|| "appshot preview is no longer pending".to_string())?;
+    let created_at_ms = entry.created_at_ms;
+    let expires_at_ms = entry.expires_at_ms;
+    let blocked_by_permissions = entry.blocked_by_permissions;
+    let auto_accept_held = entry.auto_accept_held;
+    let auto_accept_after_ms = entry.auto_accept_after_ms;
+
+    match entry.state {
+        PendingState::Captured(captured) => match records::write_record(captured.clone()) {
+            Ok(response) => copy_saved_response(
+                preview_id,
+                response,
+                created_at_ms,
+                blocked_by_permissions,
+                auto_accept_held,
+                auto_accept_after_ms,
+                &copy_protocol_text,
+            ),
+            Err(error) => {
+                restore_entry(
+                    preview_id,
+                    PendingEntry {
+                        state: PendingState::Captured(captured),
+                        created_at_ms,
+                        expires_at_ms,
+                        blocked_by_permissions,
+                        auto_accept_held,
+                        auto_accept_after_ms,
+                    },
+                );
+                Err(error)
+            }
+        },
+        PendingState::Saved(response) => copy_saved_response(
+            preview_id,
+            response,
+            created_at_ms,
+            blocked_by_permissions,
+            auto_accept_held,
+            auto_accept_after_ms,
+            &copy_protocol_text,
+        ),
+    }
+}
+
+fn copy_saved_response(
+    preview_id: &str,
+    response: AppshotAcceptResponse,
+    created_at_ms: i64,
+    blocked_by_permissions: bool,
+    auto_accept_held: bool,
+    auto_accept_after_ms: Option<i64>,
+    copy_protocol_text: &impl Fn(&str) -> Result<(), String>,
+) -> Result<AppshotAcceptResponse, String> {
+    match copy_protocol_text(&response.protocol_text) {
+        Ok(()) => Ok(response),
+        Err(error) => {
+            restore_entry(
+                preview_id,
+                PendingEntry {
+                    state: PendingState::Saved(response),
+                    created_at_ms,
+                    expires_at_ms: Utc::now().timestamp_millis() + RECOVERABLE_PENDING_TTL_MS,
+                    blocked_by_permissions,
+                    auto_accept_held,
+                    auto_accept_after_ms,
+                },
+            );
+            Err(error)
+        }
+    }
+}
+
+pub fn discard(preview_id: &str) -> Result<(), String> {
+    let removed = pending()
+        .lock()
+        .map_err(|_| "appshot pending state lock poisoned".to_string())?
+        .remove(preview_id);
+    if let Some(PendingEntry {
+        state: PendingState::Saved(response),
+        ..
+    }) = removed
+    {
+        records::delete_record(&response.timestamp)?;
+    }
+    Ok(())
+}
+
+pub fn set_auto_accept_hold(
+    preview_id: &str,
+    held: bool,
+    resume_in_ms: Option<u64>,
+) -> Result<(), String> {
+    let mut pending = pending()
+        .lock()
+        .map_err(|_| "appshot pending state lock poisoned".to_string())?;
+    prune_locked(&mut pending, Utc::now().timestamp_millis());
+    let Some(entry) = pending.get_mut(preview_id) else {
+        return Ok(());
+    };
+
+    entry.auto_accept_held = held;
+    if !held {
+        entry.auto_accept_after_ms = resume_in_ms.map(|millis| {
+            Utc::now().timestamp_millis()
+                + i64::try_from(millis.max(500)).unwrap_or(500)
+                + NATIVE_AUTO_ACCEPT_GRACE_MS
+        });
+    }
+    Ok(())
+}
+
+pub fn spawn_auto_accept(app: AppHandle, preview_id: String) {
+    tauri::async_runtime::spawn(async move {
+        loop {
+            match auto_accept_state(&preview_id) {
+                Ok(AutoAcceptState::Missing) => return,
+                Ok(AutoAcceptState::Held) => {
+                    tokio::time::sleep(Duration::from_millis(250)).await;
+                }
+                Ok(AutoAcceptState::Wait(delay_ms)) => {
+                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                }
+                Ok(AutoAcceptState::Ready) => {
+                    if let Err(error) = accept(&preview_id) {
+                        if !error.to_lowercase().contains("no longer pending") {
+                            let _ = app.emit("appshot://error", error.clone());
+                            eprintln!("appshot auto-accept failed: {error}");
+                        }
+                    }
+                    return;
+                }
+                Err(error) => {
+                    let _ = app.emit("appshot://error", error.clone());
+                    eprintln!("appshot auto-accept failed: {error}");
+                    return;
+                }
+            }
+        }
+    });
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum AutoAcceptState {
+    Missing,
+    Held,
+    Wait(u64),
+    Ready,
+}
+
+fn auto_accept_state(preview_id: &str) -> Result<AutoAcceptState, String> {
+    let mut pending = pending()
+        .lock()
+        .map_err(|_| "appshot pending state lock poisoned".to_string())?;
+    let now_ms = Utc::now().timestamp_millis();
+    prune_locked(&mut pending, now_ms);
+    let Some(entry) = pending.get(preview_id) else {
+        return Ok(AutoAcceptState::Missing);
+    };
+    if entry.auto_accept_held {
+        return Ok(AutoAcceptState::Held);
+    }
+    let Some(auto_accept_after_ms) = entry.auto_accept_after_ms else {
+        return Ok(AutoAcceptState::Missing);
+    };
+    if auto_accept_after_ms <= now_ms {
+        return Ok(AutoAcceptState::Ready);
+    }
+    Ok(AutoAcceptState::Wait(
+        (auto_accept_after_ms - now_ms) as u64,
+    ))
+}
+
+fn restore_entry(preview_id: &str, entry: PendingEntry) {
+    if let Ok(mut pending) = pending().lock() {
+        prune_locked(&mut pending, Utc::now().timestamp_millis());
+        enforce_capacity_locked(&mut pending);
+        pending.insert(preview_id.to_string(), entry);
+    }
+}
+
+fn prune_locked(pending: &mut HashMap<String, PendingEntry>, now_ms: i64) {
+    pending.retain(|_, entry| entry.expires_at_ms > now_ms);
+}
+
+fn enforce_capacity_locked(pending: &mut HashMap<String, PendingEntry>) {
+    while pending.len() >= MAX_PENDING_ENTRIES {
+        let Some(oldest_key) = pending
+            .iter()
+            .min_by_key(|(_, entry)| entry.created_at_ms)
+            .map(|(key, _)| key.clone())
+        else {
+            break;
+        };
+        pending.remove(&oldest_key);
+    }
+}
+
+fn random_suffix() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+#[cfg(test)]
+fn pending_count() -> usize {
+    pending().lock().expect("pending lock").len()
+}
+
+#[cfg(test)]
+fn clear_for_tests() {
+    pending().lock().expect("pending lock").clear();
+}
+
+#[cfg(test)]
+fn test_serial_guard() -> std::sync::MutexGuard<'static, ()> {
+    static TEST_SERIAL: OnceLock<Mutex<()>> = OnceLock::new();
+    TEST_SERIAL
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("pending test serial lock")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        accept_with_clipboard, auto_accept_state, clear_for_tests, insert, pending_count,
+        set_auto_accept_hold, test_serial_guard, AutoAcceptState,
+    };
+    use crate::appshot::types::{
+        AppshotPermissionName, AppshotPermissionState, AppshotPlatform, AppshotQuality,
+        AppshotScreenshotMetadata, CapturedAppshot,
+    };
+    use crate::appshot::{encoding, records};
+    use chrono::Utc;
+    use std::cell::{Cell, RefCell};
+    use std::fs;
+    use std::path::PathBuf;
+
+    #[test]
+    fn clipboard_failure_keeps_saved_record_retryable() {
+        let _serial = test_serial_guard();
+        clear_for_tests();
+        let root = unique_test_root("retry");
+        let _root_guard = records::use_test_data_root(root.clone());
+        let preview = insert(sample_capture(true)).expect("insert pending");
+
+        let attempts = Cell::new(0);
+        let copied_text = RefCell::new(None::<String>);
+        let first_error = accept_with_clipboard(&preview.preview_id, |protocol_text| {
+            attempts.set(attempts.get() + 1);
+            if attempts.get() == 1 {
+                Err("clipboard unavailable".to_string())
+            } else {
+                *copied_text.borrow_mut() = Some(protocol_text.to_string());
+                Ok(())
+            }
+        })
+        .expect_err("first copy should fail");
+
+        assert!(first_error.contains("clipboard unavailable"));
+        assert_eq!(pending_count(), 1);
+        let saved_records = records::list_records().expect("list records after failed copy");
+        assert_eq!(saved_records.len(), 1);
+        let saved_timestamp = saved_records[0].timestamp.clone();
+
+        let response = accept_with_clipboard(&preview.preview_id, |protocol_text| {
+            attempts.set(attempts.get() + 1);
+            *copied_text.borrow_mut() = Some(protocol_text.to_string());
+            Ok(())
+        })
+        .expect("retry copy");
+
+        assert_eq!(response.timestamp, saved_timestamp);
+        assert_eq!(pending_count(), 0);
+        assert_eq!(attempts.get(), 2);
+        assert_eq!(
+            copied_text.borrow().as_deref(),
+            Some(response.protocol_text.as_str())
+        );
+        assert_eq!(records::list_records().unwrap().len(), 1);
+
+        clear_for_tests();
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn permission_blocked_pending_entries_are_replaced() {
+        let _serial = test_serial_guard();
+        clear_for_tests();
+
+        let first = insert(sample_capture(false)).expect("first blocked pending");
+        assert_eq!(first.expires_in_ms, 0);
+        assert_eq!(pending_count(), 1);
+
+        let second = insert(sample_capture(false)).expect("second blocked pending");
+        assert_eq!(second.expires_in_ms, 0);
+        assert_eq!(pending_count(), 1);
+        assert!(accept_with_clipboard(&first.preview_id, |_| Ok(())).is_err());
+
+        clear_for_tests();
+    }
+
+    #[test]
+    fn pending_preview_omits_oversized_inline_snapshot() {
+        let _serial = test_serial_guard();
+        clear_for_tests();
+
+        let mut capture = sample_capture(true);
+        capture.screenshot_png = vec![7; encoding::MAX_INLINE_SNAPSHOT_BYTES + 1];
+        let preview = insert(capture).expect("insert oversized pending");
+
+        assert!(preview.screenshot_preview_base64.is_none());
+        assert!(preview
+            .warnings
+            .iter()
+            .any(|warning| warning == encoding::OVERSIZED_SNAPSHOT_WARNING));
+
+        clear_for_tests();
+    }
+
+    #[test]
+    fn pending_auto_accept_can_be_held_and_resumed() {
+        let _serial = test_serial_guard();
+        clear_for_tests();
+
+        let preview = insert(sample_capture(true)).expect("insert pending");
+        assert!(matches!(
+            auto_accept_state(&preview.preview_id).expect("initial auto accept state"),
+            AutoAcceptState::Wait(delay) if delay > 0
+        ));
+
+        set_auto_accept_hold(&preview.preview_id, true, None).expect("hold auto accept");
+        assert_eq!(
+            auto_accept_state(&preview.preview_id).expect("held auto accept state"),
+            AutoAcceptState::Held
+        );
+
+        set_auto_accept_hold(&preview.preview_id, false, Some(1_200)).expect("resume auto accept");
+        assert!(matches!(
+            auto_accept_state(&preview.preview_id).expect("resumed auto accept state"),
+            AutoAcceptState::Wait(delay) if delay > 0 && delay <= 1_700
+        ));
+
+        clear_for_tests();
+    }
+
+    fn sample_capture(granted: bool) -> CapturedAppshot {
+        CapturedAppshot {
+            app_name: "Safari".to_string(),
+            bundle_id: Some("com.apple.Safari".to_string()),
+            process_id: Some(100),
+            window_title: Some("Example".to_string()),
+            window_id: None,
+            captured_at: Utc::now().to_rfc3339(),
+            platform: AppshotPlatform::Macos,
+            quality: if granted {
+                AppshotQuality::ScreenshotAndAccessibility
+            } else {
+                AppshotQuality::MetadataOnly
+            },
+            screenshot_png: b"png-bytes".to_vec(),
+            screenshot: AppshotScreenshotMetadata {
+                available: granted,
+                width: Some(20),
+                height: Some(10),
+                media_type: "image/png".to_string(),
+            },
+            context_markdown: "# Appshot Context\n\nbody".to_string(),
+            permissions: vec![AppshotPermissionState {
+                name: AppshotPermissionName::Accessibility,
+                display_name: "Accessibility".to_string(),
+                granted,
+                required_for: Vec::new(),
+                recovery_action: None,
+            }],
+            warnings: Vec::new(),
+        }
+    }
+
+    fn unique_test_root(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "atmos-appshot-pending-{name}-{}-{}",
+            std::process::id(),
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ))
+    }
+}

--- a/apps/desktop/src-tauri/src/appshot/protocol.rs
+++ b/apps/desktop/src-tauri/src/appshot/protocol.rs
@@ -1,22 +1,37 @@
+use std::path::Path;
+
 const APPSHOT_PROTOCOL_PREFIX: &str = "atmos://appshots/";
 
 pub fn is_valid_timestamp(timestamp: &str) -> bool {
     timestamp.len() == 13 && timestamp.bytes().all(|byte| byte.is_ascii_digit())
 }
 
+#[cfg(test)]
 pub fn format_prompt(timestamp: &str) -> Result<String, String> {
+    let record_dir = dirs::home_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join(".atmos")
+        .join("appshots")
+        .join("records")
+        .join(timestamp);
+    format_prompt_for_record_dir(timestamp, &record_dir)
+}
+
+pub fn format_prompt_for_record_dir(timestamp: &str, record_dir: &Path) -> Result<String, String> {
     if !is_valid_timestamp(timestamp) {
         return Err("invalid appshot timestamp".to_string());
     }
     Ok(format!(
-        "{prefix}{timestamp}\nAppshot record is stored locally at ~/.atmos/appshots/records/{timestamp}/. Read metadata.json, context.md, and snapshot.png in that directory before answering. Inspect snapshot.png when visual context matters.",
+        "{prefix}{timestamp}\nAppshot record is stored locally at {record_dir}/. Read metadata.json, context.md, and snapshot.png in that directory before answering. Inspect snapshot.png when visual context matters.",
         prefix = APPSHOT_PROTOCOL_PREFIX,
+        record_dir = record_dir.display(),
     ))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{format_prompt, is_valid_timestamp};
+    use super::{format_prompt, format_prompt_for_record_dir, is_valid_timestamp};
+    use std::path::Path;
 
     #[test]
     fn validates_timestamp_shape() {
@@ -30,7 +45,18 @@ mod tests {
     fn formats_protocol_prompt() {
         let prompt = format_prompt("1760000000000").unwrap();
         assert!(prompt.starts_with("atmos://appshots/1760000000000\n"));
-        assert!(prompt.contains("~/.atmos/appshots/records/1760000000000/"));
+        assert!(prompt.contains(".atmos/appshots/records/1760000000000/"));
         assert!(prompt.contains("snapshot.png"));
+    }
+
+    #[test]
+    fn formats_protocol_prompt_with_actual_record_dir() {
+        let prompt = format_prompt_for_record_dir(
+            "1760000000000",
+            Path::new("/tmp/atmos-appshots/1760000000000"),
+        )
+        .unwrap();
+
+        assert!(prompt.contains("/tmp/atmos-appshots/1760000000000/"));
     }
 }

--- a/apps/desktop/src-tauri/src/appshot/protocol.rs
+++ b/apps/desktop/src-tauri/src/appshot/protocol.rs
@@ -1,0 +1,36 @@
+const APPSHOT_PROTOCOL_PREFIX: &str = "atmos://appshots/";
+
+pub fn is_valid_timestamp(timestamp: &str) -> bool {
+    timestamp.len() == 13 && timestamp.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+pub fn format_prompt(timestamp: &str) -> Result<String, String> {
+    if !is_valid_timestamp(timestamp) {
+        return Err("invalid appshot timestamp".to_string());
+    }
+    Ok(format!(
+        "{prefix}{timestamp}\nAppshot record is stored locally at ~/.atmos/appshots/records/{timestamp}/. Read metadata.json, context.md, and snapshot.png in that directory before answering. Inspect snapshot.png when visual context matters.",
+        prefix = APPSHOT_PROTOCOL_PREFIX,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_prompt, is_valid_timestamp};
+
+    #[test]
+    fn validates_timestamp_shape() {
+        assert!(is_valid_timestamp("1760000000000"));
+        assert!(!is_valid_timestamp("176000000000"));
+        assert!(!is_valid_timestamp("17600000000000"));
+        assert!(!is_valid_timestamp("17600000000aa"));
+    }
+
+    #[test]
+    fn formats_protocol_prompt() {
+        let prompt = format_prompt("1760000000000").unwrap();
+        assert!(prompt.starts_with("atmos://appshots/1760000000000\n"));
+        assert!(prompt.contains("~/.atmos/appshots/records/1760000000000/"));
+        assert!(prompt.contains("snapshot.png"));
+    }
+}

--- a/apps/desktop/src-tauri/src/appshot/protocol.rs
+++ b/apps/desktop/src-tauri/src/appshot/protocol.rs
@@ -1,37 +1,22 @@
-use std::path::Path;
-
 const APPSHOT_PROTOCOL_PREFIX: &str = "atmos://appshots/";
 
 pub fn is_valid_timestamp(timestamp: &str) -> bool {
     timestamp.len() == 13 && timestamp.bytes().all(|byte| byte.is_ascii_digit())
 }
 
-#[cfg(test)]
 pub fn format_prompt(timestamp: &str) -> Result<String, String> {
-    let record_dir = dirs::home_dir()
-        .unwrap_or_else(std::env::temp_dir)
-        .join(".atmos")
-        .join("appshots")
-        .join("records")
-        .join(timestamp);
-    format_prompt_for_record_dir(timestamp, &record_dir)
-}
-
-pub fn format_prompt_for_record_dir(timestamp: &str, record_dir: &Path) -> Result<String, String> {
     if !is_valid_timestamp(timestamp) {
         return Err("invalid appshot timestamp".to_string());
     }
     Ok(format!(
-        "{prefix}{timestamp}\nAppshot record is stored locally at {record_dir}/. Read metadata.json, context.md, and snapshot.png in that directory before answering. Inspect snapshot.png when visual context matters.",
+        "{prefix}{timestamp}\nAppshot record is stored locally in Atmos appshots records for timestamp {timestamp}. The default location is ~/.atmos/appshots/records/{timestamp}/. Read metadata.json, context.md, and snapshot.png before answering. Inspect snapshot.png when visual context matters.",
         prefix = APPSHOT_PROTOCOL_PREFIX,
-        record_dir = record_dir.display(),
     ))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{format_prompt, format_prompt_for_record_dir, is_valid_timestamp};
-    use std::path::Path;
+    use super::{format_prompt, is_valid_timestamp};
 
     #[test]
     fn validates_timestamp_shape() {
@@ -47,16 +32,7 @@ mod tests {
         assert!(prompt.starts_with("atmos://appshots/1760000000000\n"));
         assert!(prompt.contains(".atmos/appshots/records/1760000000000/"));
         assert!(prompt.contains("snapshot.png"));
-    }
-
-    #[test]
-    fn formats_protocol_prompt_with_actual_record_dir() {
-        let prompt = format_prompt_for_record_dir(
-            "1760000000000",
-            Path::new("/tmp/atmos-appshots/1760000000000"),
-        )
-        .unwrap();
-
-        assert!(prompt.contains("/tmp/atmos-appshots/1760000000000/"));
+        assert!(!prompt.contains("/Users/"));
+        assert!(!prompt.contains("/tmp/"));
     }
 }

--- a/apps/desktop/src-tauri/src/appshot/records.rs
+++ b/apps/desktop/src-tauri/src/appshot/records.rs
@@ -131,7 +131,7 @@ pub fn write_record(captured: CapturedAppshot) -> Result<AppshotAcceptResponse, 
         )
     })?;
 
-    let protocol_text = protocol::format_prompt(&timestamp)?;
+    let protocol_text = protocol::format_prompt_for_record_dir(&timestamp, &final_dir)?;
 
     Ok(AppshotAcceptResponse {
         timestamp,
@@ -187,7 +187,7 @@ pub fn copy_record(timestamp: &str) -> Result<AppshotCopyResponse, String> {
     if !dir.is_dir() {
         return Err(format!("appshot record not found: {timestamp}"));
     }
-    let protocol_text = protocol::format_prompt(timestamp)?;
+    let protocol_text = protocol::format_prompt_for_record_dir(timestamp, &dir)?;
     copy_protocol_text(&protocol_text)?;
     Ok(AppshotCopyResponse {
         timestamp: timestamp.to_string(),
@@ -290,14 +290,17 @@ enum SnapshotDataUrl {
 }
 
 fn read_snapshot_data_url(path: &Path) -> Result<SnapshotDataUrl, String> {
+    const DATA_URL_PREFIX: &str = "data:image/png;base64,";
+
     let metadata =
         fs::metadata(path).map_err(|error| format!("failed to read snapshot metadata: {error}"))?;
-    if metadata.len() > encoding::MAX_INLINE_SNAPSHOT_BYTES as u64 {
+    let encoded_len = DATA_URL_PREFIX.len() as u64 + metadata.len().div_ceil(3) * 4;
+    if encoded_len > encoding::MAX_INLINE_SNAPSHOT_BYTES as u64 {
         return Ok(SnapshotDataUrl::TooLarge);
     }
     let bytes = fs::read(path).map_err(|error| format!("failed to read snapshot: {error}"))?;
     Ok(SnapshotDataUrl::Inline(format!(
-        "data:image/png;base64,{}",
+        "{DATA_URL_PREFIX}{}",
         encoding::base64_encode(&bytes)
     )))
 }
@@ -407,6 +410,9 @@ mod tests {
         assert_eq!(metadata.timestamp, response.timestamp);
         assert_eq!(metadata.record_dir, record_dir.display().to_string());
         assert_eq!(metadata.context_bytes, "# Appshot Context\n\nhello".len());
+        assert!(response
+            .protocol_text
+            .contains(&record_dir.display().to_string()));
 
         let listed = list_records().expect("list records");
         assert_eq!(listed.len(), 1);
@@ -453,6 +459,33 @@ mod tests {
             .len(),
             (encoding::MAX_INLINE_SNAPSHOT_BYTES + 1) as u64
         );
+
+        delete_record(&response.timestamp).expect("delete record");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn read_record_omits_snapshot_when_encoded_data_url_is_too_large() {
+        let root = unique_test_root("encoded-oversized");
+        let _guard = use_test_data_root(root.clone());
+        let mut capture = sample_capture();
+        let raw_len_that_exceeds_after_encoding = encoding::MAX_INLINE_SNAPSHOT_BYTES * 3 / 4;
+        capture.screenshot_png = vec![7; raw_len_that_exceeds_after_encoding];
+        let response = write_record(capture).expect("record write");
+
+        let details = read_records(std::slice::from_ref(&response.timestamp)).expect("read record");
+
+        assert_eq!(details.len(), 1);
+        assert!(details[0].snapshot_url.is_none());
+        assert!(
+            raw_len_that_exceeds_after_encoding <= encoding::MAX_INLINE_SNAPSHOT_BYTES,
+            "test must cover raw bytes below the inline cap"
+        );
+        assert!(details[0]
+            .metadata
+            .warnings
+            .iter()
+            .any(|warning| warning == encoding::OVERSIZED_SNAPSHOT_WARNING));
 
         delete_record(&response.timestamp).expect("delete record");
         let _ = fs::remove_dir_all(root);

--- a/apps/desktop/src-tauri/src/appshot/records.rs
+++ b/apps/desktop/src-tauri/src/appshot/records.rs
@@ -131,7 +131,7 @@ pub fn write_record(captured: CapturedAppshot) -> Result<AppshotAcceptResponse, 
         )
     })?;
 
-    let protocol_text = protocol::format_prompt_for_record_dir(&timestamp, &final_dir)?;
+    let protocol_text = protocol::format_prompt(&timestamp)?;
 
     Ok(AppshotAcceptResponse {
         timestamp,
@@ -187,7 +187,7 @@ pub fn copy_record(timestamp: &str) -> Result<AppshotCopyResponse, String> {
     if !dir.is_dir() {
         return Err(format!("appshot record not found: {timestamp}"));
     }
-    let protocol_text = protocol::format_prompt_for_record_dir(timestamp, &dir)?;
+    let protocol_text = protocol::format_prompt(timestamp)?;
     copy_protocol_text(&protocol_text)?;
     Ok(AppshotCopyResponse {
         timestamp: timestamp.to_string(),
@@ -410,9 +410,13 @@ mod tests {
         assert_eq!(metadata.timestamp, response.timestamp);
         assert_eq!(metadata.record_dir, record_dir.display().to_string());
         assert_eq!(metadata.context_bytes, "# Appshot Context\n\nhello".len());
-        assert!(response
+        assert!(!response
             .protocol_text
             .contains(&record_dir.display().to_string()));
+        assert!(response.protocol_text.contains(&format!(
+            "~/.atmos/appshots/records/{}/",
+            response.timestamp
+        )));
 
         let listed = list_records().expect("list records");
         assert_eq!(listed.len(), 1);

--- a/apps/desktop/src-tauri/src/appshot/records.rs
+++ b/apps/desktop/src-tauri/src/appshot/records.rs
@@ -1,0 +1,497 @@
+use crate::appshot::clipboard;
+use crate::appshot::encoding;
+use crate::appshot::protocol;
+use crate::appshot::types::{
+    AppshotAcceptResponse, AppshotCopyResponse, AppshotRecordDetail, AppshotRecordListItem,
+    AppshotRecordMetadata, CapturedAppshot,
+};
+use chrono::Utc;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicI64, Ordering};
+#[cfg(test)]
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+const APPSHOTS_DIR: &str = ".atmos/appshots";
+const RECORDS_DIR_NAME: &str = "records";
+const TMP_DIR_NAME: &str = "tmp";
+const SNAPSHOT_FILE: &str = "snapshot.png";
+const CONTEXT_FILE: &str = "context.md";
+const METADATA_FILE: &str = "metadata.json";
+
+pub fn records_root() -> PathBuf {
+    appshots_root().join(RECORDS_DIR_NAME)
+}
+
+fn tmp_root() -> PathBuf {
+    appshots_root().join(TMP_DIR_NAME)
+}
+
+fn appshots_root() -> PathBuf {
+    #[cfg(test)]
+    {
+        if let Some(root) = test_data_root()
+            .lock()
+            .expect("test data root lock")
+            .clone()
+        {
+            return root;
+        }
+    }
+
+    home_dir().join(APPSHOTS_DIR)
+}
+
+fn home_dir() -> PathBuf {
+    dirs::home_dir().unwrap_or_else(std::env::temp_dir)
+}
+
+pub fn write_record(captured: CapturedAppshot) -> Result<AppshotAcceptResponse, String> {
+    let records_root = records_root();
+    let tmp_root = tmp_root();
+    fs::create_dir_all(&records_root)
+        .map_err(|error| format!("failed to create appshot records directory: {error}"))?;
+    fs::create_dir_all(&tmp_root)
+        .map_err(|error| format!("failed to create appshot temp directory: {error}"))?;
+
+    let timestamp = allocate_timestamp(&records_root);
+    let tmp_dir = tmp_root.join(&timestamp);
+    if tmp_dir.exists() {
+        fs::remove_dir_all(&tmp_dir)
+            .map_err(|error| format!("failed to clear stale appshot temp directory: {error}"))?;
+    }
+    fs::create_dir_all(&tmp_dir)
+        .map_err(|error| format!("failed to create appshot temp record: {error}"))?;
+
+    let snapshot_path = tmp_dir.join(SNAPSHOT_FILE);
+    let context_path = tmp_dir.join(CONTEXT_FILE);
+    let metadata_path = tmp_dir.join(METADATA_FILE);
+    let snapshot_png = if captured.screenshot_png.is_empty() {
+        placeholder_png().to_vec()
+    } else {
+        captured.screenshot_png
+    };
+
+    fs::write(&snapshot_path, &snapshot_png).map_err(|error| {
+        cleanup_tmp_dir(
+            &tmp_dir,
+            format!("failed to write appshot snapshot: {error}"),
+        )
+    })?;
+    fs::write(&context_path, &captured.context_markdown).map_err(|error| {
+        cleanup_tmp_dir(
+            &tmp_dir,
+            format!("failed to write appshot context: {error}"),
+        )
+    })?;
+
+    let final_dir = records_root.join(&timestamp);
+    let metadata = AppshotRecordMetadata {
+        timestamp: timestamp.clone(),
+        captured_at: captured.captured_at,
+        platform: captured.platform,
+        app_name: captured.app_name,
+        bundle_id: captured.bundle_id,
+        process_id: captured.process_id,
+        window_title: captured.window_title,
+        window_id: captured.window_id,
+        quality: captured.quality,
+        record_dir: final_dir.display().to_string(),
+        snapshot_path: final_dir.join(SNAPSHOT_FILE).display().to_string(),
+        context_path: final_dir.join(CONTEXT_FILE).display().to_string(),
+        metadata_path: final_dir.join(METADATA_FILE).display().to_string(),
+        screenshot: captured.screenshot,
+        warnings: captured.warnings,
+        context_bytes: captured.context_markdown.len(),
+    };
+
+    let raw_metadata = serde_json::to_vec_pretty(&metadata).map_err(|error| {
+        cleanup_tmp_dir(
+            &tmp_dir,
+            format!("failed to serialize appshot metadata: {error}"),
+        )
+    })?;
+    fs::write(&metadata_path, raw_metadata).map_err(|error| {
+        cleanup_tmp_dir(
+            &tmp_dir,
+            format!("failed to write appshot metadata: {error}"),
+        )
+    })?;
+
+    if final_dir.exists() {
+        return Err(cleanup_tmp_dir(
+            &tmp_dir,
+            format!("appshot record already exists: {timestamp}"),
+        ));
+    }
+    fs::rename(&tmp_dir, &final_dir).map_err(|error| {
+        cleanup_tmp_dir(
+            &tmp_dir,
+            format!("failed to finalize appshot record: {error}"),
+        )
+    })?;
+
+    let protocol_text = protocol::format_prompt(&timestamp)?;
+
+    Ok(AppshotAcceptResponse {
+        timestamp,
+        record_dir: final_dir.display().to_string(),
+        protocol_text,
+        metadata,
+    })
+}
+
+pub fn list_records() -> Result<Vec<AppshotRecordListItem>, String> {
+    let root = records_root();
+    let mut items = Vec::new();
+    if !root.exists() {
+        return Ok(items);
+    }
+
+    for entry in fs::read_dir(&root)
+        .map_err(|error| format!("failed to read appshot records directory: {error}"))?
+    {
+        let entry =
+            entry.map_err(|error| format!("failed to read appshot record entry: {error}"))?;
+        let file_type = entry
+            .file_type()
+            .map_err(|error| format!("failed to read appshot record file type: {error}"))?;
+        if !file_type.is_dir() {
+            continue;
+        }
+        let timestamp = entry.file_name().to_string_lossy().to_string();
+        if !protocol::is_valid_timestamp(&timestamp) {
+            continue;
+        }
+        items.push(AppshotRecordListItem {
+            timestamp,
+            record_dir: entry.path().display().to_string(),
+        });
+    }
+
+    items.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    Ok(items)
+}
+
+pub fn read_records(timestamps: &[String]) -> Result<Vec<AppshotRecordDetail>, String> {
+    timestamps
+        .iter()
+        .filter(|timestamp| protocol::is_valid_timestamp(timestamp))
+        .map(|timestamp| read_record(timestamp))
+        .collect()
+}
+
+pub fn copy_record(timestamp: &str) -> Result<AppshotCopyResponse, String> {
+    ensure_timestamp(timestamp)?;
+    let dir = records_root().join(timestamp);
+    if !dir.is_dir() {
+        return Err(format!("appshot record not found: {timestamp}"));
+    }
+    let protocol_text = protocol::format_prompt(timestamp)?;
+    copy_protocol_text(&protocol_text)?;
+    Ok(AppshotCopyResponse {
+        timestamp: timestamp.to_string(),
+        protocol_text,
+        copied: true,
+    })
+}
+
+pub fn copy_protocol_text(protocol_text: &str) -> Result<(), String> {
+    clipboard::copy_text(protocol_text)
+}
+
+pub fn delete_record(timestamp: &str) -> Result<(), String> {
+    ensure_timestamp(timestamp)?;
+    let dir = records_root().join(timestamp);
+    if !dir.exists() {
+        return Ok(());
+    }
+    fs::remove_dir_all(&dir).map_err(|error| format!("failed to delete appshot record: {error}"))
+}
+
+fn read_record(timestamp: &str) -> Result<AppshotRecordDetail, String> {
+    ensure_timestamp(timestamp)?;
+    let dir = records_root().join(timestamp);
+    let metadata_path = dir.join(METADATA_FILE);
+    let context_path = dir.join(CONTEXT_FILE);
+    let snapshot_path = dir.join(SNAPSHOT_FILE);
+
+    let metadata_raw = fs::read_to_string(&metadata_path)
+        .map_err(|error| format!("failed to read appshot metadata: {error}"))?;
+    let mut metadata: AppshotRecordMetadata = serde_json::from_str(&metadata_raw)
+        .map_err(|error| format!("failed to parse appshot metadata: {error}"))?;
+    let context = fs::read_to_string(&context_path)
+        .map_err(|error| format!("failed to read appshot context: {error}"))?;
+    let context_preview = truncate_preview(&context, 900);
+    let snapshot_url = match read_snapshot_data_url(&snapshot_path) {
+        Ok(SnapshotDataUrl::Inline(url)) => Some(url),
+        Ok(SnapshotDataUrl::TooLarge) => {
+            append_warning(&mut metadata.warnings, encoding::OVERSIZED_SNAPSHOT_WARNING);
+            None
+        }
+        Err(_) => None,
+    };
+
+    Ok(AppshotRecordDetail {
+        timestamp: timestamp.to_string(),
+        metadata,
+        context_preview,
+        snapshot_url,
+    })
+}
+
+fn allocate_timestamp(records_root: &Path) -> String {
+    static LAST_TIMESTAMP_MS: AtomicI64 = AtomicI64::new(0);
+
+    let mut millis = Utc::now().timestamp_millis();
+    loop {
+        let last = LAST_TIMESTAMP_MS.load(Ordering::Relaxed);
+        if millis <= last {
+            millis = last + 1;
+        }
+        if LAST_TIMESTAMP_MS
+            .compare_exchange(last, millis, Ordering::SeqCst, Ordering::Relaxed)
+            .is_err()
+        {
+            continue;
+        }
+
+        let timestamp = millis.to_string();
+        if !records_root.join(&timestamp).exists() {
+            return timestamp;
+        }
+        millis += 1;
+    }
+}
+
+fn ensure_timestamp(timestamp: &str) -> Result<(), String> {
+    if protocol::is_valid_timestamp(timestamp) {
+        Ok(())
+    } else {
+        Err("invalid appshot timestamp".to_string())
+    }
+}
+
+fn truncate_preview(text: &str, limit: usize) -> String {
+    let mut out = String::new();
+    for ch in text.chars() {
+        if out.len() + ch.len_utf8() > limit {
+            out.push_str("...");
+            return out;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+enum SnapshotDataUrl {
+    Inline(String),
+    TooLarge,
+}
+
+fn read_snapshot_data_url(path: &Path) -> Result<SnapshotDataUrl, String> {
+    let metadata =
+        fs::metadata(path).map_err(|error| format!("failed to read snapshot metadata: {error}"))?;
+    if metadata.len() > encoding::MAX_INLINE_SNAPSHOT_BYTES as u64 {
+        return Ok(SnapshotDataUrl::TooLarge);
+    }
+    let bytes = fs::read(path).map_err(|error| format!("failed to read snapshot: {error}"))?;
+    Ok(SnapshotDataUrl::Inline(format!(
+        "data:image/png;base64,{}",
+        encoding::base64_encode(&bytes)
+    )))
+}
+
+fn append_warning(warnings: &mut Vec<String>, warning: &str) {
+    if !warnings.iter().any(|existing| existing == warning) {
+        warnings.push(warning.to_string());
+    }
+}
+
+fn cleanup_tmp_dir(tmp_dir: &Path, message: String) -> String {
+    let _ = fs::remove_dir_all(tmp_dir);
+    message
+}
+
+#[cfg(test)]
+static TEST_DATA_ROOT: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
+
+#[cfg(test)]
+static TEST_DATA_ROOT_SERIAL: OnceLock<Mutex<()>> = OnceLock::new();
+
+#[cfg(test)]
+fn test_data_root() -> &'static Mutex<Option<PathBuf>> {
+    TEST_DATA_ROOT.get_or_init(|| Mutex::new(None))
+}
+
+#[cfg(test)]
+pub(crate) struct TestDataRootGuard {
+    _serial_guard: MutexGuard<'static, ()>,
+    previous: Option<PathBuf>,
+}
+
+#[cfg(test)]
+impl Drop for TestDataRootGuard {
+    fn drop(&mut self) {
+        *test_data_root().lock().expect("test data root lock") = self.previous.take();
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn use_test_data_root(root: PathBuf) -> TestDataRootGuard {
+    let serial_guard = TEST_DATA_ROOT_SERIAL
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("test data root serial lock");
+    let mut current = test_data_root().lock().expect("test data root lock");
+    let previous = current.replace(root);
+    drop(current);
+    TestDataRootGuard {
+        _serial_guard: serial_guard,
+        previous,
+    }
+}
+
+fn placeholder_png() -> &'static [u8] {
+    &[
+        137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 6,
+        0, 0, 0, 31, 21, 196, 137, 0, 0, 0, 13, 73, 68, 65, 84, 120, 156, 99, 248, 255, 255, 63, 0,
+        5, 254, 2, 254, 167, 69, 129, 132, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        delete_record, list_records, read_records, truncate_preview, use_test_data_root,
+        write_record, CONTEXT_FILE, METADATA_FILE, RECORDS_DIR_NAME, SNAPSHOT_FILE,
+    };
+    use crate::appshot::encoding;
+    use crate::appshot::types::{
+        AppshotPermissionName, AppshotPermissionState, AppshotPlatform, AppshotQuality,
+        AppshotScreenshotMetadata, CapturedAppshot,
+    };
+    use chrono::Utc;
+    use std::fs;
+    use std::path::PathBuf;
+
+    #[test]
+    fn truncates_preview_on_char_boundary() {
+        assert_eq!(truncate_preview("hello", 10), "hello");
+        assert_eq!(truncate_preview("你好世界", 7), "你好...");
+    }
+
+    #[test]
+    fn writes_record_three_file_layout_under_data_root() {
+        let root = unique_test_root("layout");
+        let _guard = use_test_data_root(root.clone());
+        let response = write_record(sample_capture()).expect("record write");
+
+        let record_dir = root.join(RECORDS_DIR_NAME).join(&response.timestamp);
+        assert!(record_dir.join(SNAPSHOT_FILE).is_file());
+        assert!(record_dir.join(CONTEXT_FILE).is_file());
+        assert!(record_dir.join(METADATA_FILE).is_file());
+        assert_eq!(
+            fs::read(record_dir.join(SNAPSHOT_FILE)).unwrap(),
+            b"png-bytes"
+        );
+        assert_eq!(
+            fs::read_to_string(record_dir.join(CONTEXT_FILE)).unwrap(),
+            "# Appshot Context\n\nhello"
+        );
+
+        let metadata_raw = fs::read_to_string(record_dir.join(METADATA_FILE)).unwrap();
+        assert!(!metadata_raw.contains("\"permissions\""));
+        let metadata: crate::appshot::types::AppshotRecordMetadata =
+            serde_json::from_str(&metadata_raw).unwrap();
+        assert_eq!(metadata.timestamp, response.timestamp);
+        assert_eq!(metadata.record_dir, record_dir.display().to_string());
+        assert_eq!(metadata.context_bytes, "# Appshot Context\n\nhello".len());
+
+        let listed = list_records().expect("list records");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].timestamp, response.timestamp);
+
+        let details = read_records(std::slice::from_ref(&response.timestamp)).expect("read record");
+        assert_eq!(details.len(), 1);
+        assert_eq!(details[0].timestamp, response.timestamp);
+        assert!(details[0]
+            .snapshot_url
+            .as_deref()
+            .unwrap()
+            .starts_with("data:image/png;base64,"));
+
+        delete_record(&response.timestamp).expect("delete record");
+        assert!(!record_dir.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn read_record_omits_oversized_inline_snapshot() {
+        let root = unique_test_root("oversized");
+        let _guard = use_test_data_root(root.clone());
+        let mut capture = sample_capture();
+        capture.screenshot_png = vec![7; encoding::MAX_INLINE_SNAPSHOT_BYTES + 1];
+        let response = write_record(capture).expect("record write");
+
+        let details = read_records(std::slice::from_ref(&response.timestamp)).expect("read record");
+
+        assert_eq!(details.len(), 1);
+        assert!(details[0].snapshot_url.is_none());
+        assert!(details[0]
+            .metadata
+            .warnings
+            .iter()
+            .any(|warning| warning == encoding::OVERSIZED_SNAPSHOT_WARNING));
+        assert_eq!(
+            fs::metadata(
+                root.join(RECORDS_DIR_NAME)
+                    .join(&response.timestamp)
+                    .join(SNAPSHOT_FILE)
+            )
+            .unwrap()
+            .len(),
+            (encoding::MAX_INLINE_SNAPSHOT_BYTES + 1) as u64
+        );
+
+        delete_record(&response.timestamp).expect("delete record");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    fn sample_capture() -> CapturedAppshot {
+        CapturedAppshot {
+            app_name: "Notes".to_string(),
+            bundle_id: Some("com.apple.Notes".to_string()),
+            process_id: Some(42),
+            window_title: Some("Draft".to_string()),
+            window_id: None,
+            captured_at: Utc::now().to_rfc3339(),
+            platform: AppshotPlatform::Macos,
+            quality: AppshotQuality::ScreenshotAndAccessibility,
+            screenshot_png: b"png-bytes".to_vec(),
+            screenshot: AppshotScreenshotMetadata {
+                available: true,
+                width: Some(10),
+                height: Some(10),
+                media_type: "image/png".to_string(),
+            },
+            context_markdown: "# Appshot Context\n\nhello".to_string(),
+            permissions: vec![AppshotPermissionState {
+                name: AppshotPermissionName::Accessibility,
+                display_name: "Accessibility".to_string(),
+                granted: true,
+                required_for: Vec::new(),
+                recovery_action: None,
+            }],
+            warnings: Vec::new(),
+        }
+    }
+
+    fn unique_test_root(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "atmos-appshot-records-{name}-{}-{}",
+            std::process::id(),
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ))
+    }
+}

--- a/apps/desktop/src-tauri/src/appshot/records.rs
+++ b/apps/desktop/src-tauri/src/appshot/records.rs
@@ -1,9 +1,10 @@
 use crate::appshot::clipboard;
 use crate::appshot::encoding;
 use crate::appshot::protocol;
+use crate::appshot::thumbnail;
 use crate::appshot::types::{
     AppshotAcceptResponse, AppshotCopyResponse, AppshotRecordDetail, AppshotRecordListItem,
-    AppshotRecordMetadata, CapturedAppshot,
+    AppshotRecordMetadata, AppshotSnapshotView, CapturedAppshot,
 };
 use chrono::Utc;
 use std::fs;
@@ -46,7 +47,7 @@ fn home_dir() -> PathBuf {
     dirs::home_dir().unwrap_or_else(std::env::temp_dir)
 }
 
-pub fn write_record(captured: CapturedAppshot) -> Result<AppshotAcceptResponse, String> {
+pub fn write_record(mut captured: CapturedAppshot) -> Result<AppshotAcceptResponse, String> {
     let records_root = records_root();
     let tmp_root = tmp_root();
     fs::create_dir_all(&records_root)
@@ -66,11 +67,22 @@ pub fn write_record(captured: CapturedAppshot) -> Result<AppshotAcceptResponse, 
     let snapshot_path = tmp_dir.join(SNAPSHOT_FILE);
     let context_path = tmp_dir.join(CONTEXT_FILE);
     let metadata_path = tmp_dir.join(METADATA_FILE);
-    let snapshot_png = if captured.screenshot_png.is_empty() {
+    let mut snapshot_png = if captured.screenshot_png.is_empty() {
         placeholder_png().to_vec()
     } else {
         captured.screenshot_png
     };
+    if captured.screenshot.available {
+        if let Ok(resized_png) = thumbnail::snapshot_png_for_bytes(&snapshot_png) {
+            if !resized_png.is_empty() && resized_png.len() < snapshot_png.len() {
+                snapshot_png = resized_png;
+                if let Some((width, height)) = png_dimensions(&snapshot_png) {
+                    captured.screenshot.width = Some(width);
+                    captured.screenshot.height = Some(height);
+                }
+            }
+        }
+    }
 
     fs::write(&snapshot_path, &snapshot_png).map_err(|error| {
         cleanup_tmp_dir(
@@ -196,6 +208,23 @@ pub fn copy_record(timestamp: &str) -> Result<AppshotCopyResponse, String> {
     })
 }
 
+pub fn read_snapshot(timestamp: &str) -> Result<AppshotSnapshotView, String> {
+    ensure_timestamp(timestamp)?;
+    let snapshot_path = records_root().join(timestamp).join(SNAPSHOT_FILE);
+    if !snapshot_path.is_file() {
+        return Err(format!("appshot snapshot not found: {timestamp}"));
+    }
+    let snapshot_png = match thumbnail::snapshot_png_for_path(&snapshot_path) {
+        Ok(bytes) => bytes,
+        Err(_) => fs::read(&snapshot_path)
+            .map_err(|error| format!("failed to read appshot snapshot: {error}"))?,
+    };
+    Ok(AppshotSnapshotView {
+        timestamp: timestamp.to_string(),
+        snapshot_url: data_url_for_png(&snapshot_png),
+    })
+}
+
 pub fn copy_protocol_text(protocol_text: &str) -> Result<(), String> {
     clipboard::copy_text(protocol_text)
 }
@@ -290,19 +319,38 @@ enum SnapshotDataUrl {
 }
 
 fn read_snapshot_data_url(path: &Path) -> Result<SnapshotDataUrl, String> {
-    const DATA_URL_PREFIX: &str = "data:image/png;base64,";
-
     let metadata =
         fs::metadata(path).map_err(|error| format!("failed to read snapshot metadata: {error}"))?;
-    let encoded_len = DATA_URL_PREFIX.len() as u64 + metadata.len().div_ceil(3) * 4;
-    if encoded_len > encoding::MAX_INLINE_SNAPSHOT_BYTES as u64 {
-        return Ok(SnapshotDataUrl::TooLarge);
+    if encoding::fits_inline_png_data_url(metadata.len()) {
+        let bytes = fs::read(path).map_err(|error| format!("failed to read snapshot: {error}"))?;
+        return Ok(SnapshotDataUrl::Inline(data_url_for_png(&bytes)));
     }
-    let bytes = fs::read(path).map_err(|error| format!("failed to read snapshot: {error}"))?;
-    Ok(SnapshotDataUrl::Inline(format!(
-        "{DATA_URL_PREFIX}{}",
-        encoding::base64_encode(&bytes)
-    )))
+
+    if let Ok(thumbnail_png) = thumbnail::thumbnail_png_for_path(path) {
+        if encoding::fits_inline_png_data_url(thumbnail_png.len() as u64) {
+            return Ok(SnapshotDataUrl::Inline(data_url_for_png(&thumbnail_png)));
+        }
+    }
+
+    Ok(SnapshotDataUrl::TooLarge)
+}
+
+fn data_url_for_png(bytes: &[u8]) -> String {
+    format!(
+        "{}{}",
+        encoding::DATA_URL_PREFIX,
+        encoding::base64_encode(bytes)
+    )
+}
+
+fn png_dimensions(bytes: &[u8]) -> Option<(u32, u32)> {
+    const PNG_SIG: &[u8; 8] = b"\x89PNG\r\n\x1a\n";
+    if bytes.len() < 24 || &bytes[0..8] != PNG_SIG {
+        return None;
+    }
+    let width = u32::from_be_bytes(bytes[16..20].try_into().ok()?);
+    let height = u32::from_be_bytes(bytes[20..24].try_into().ok()?);
+    Some((width, height))
 }
 
 fn append_warning(warnings: &mut Vec<String>, warning: &str) {
@@ -512,6 +560,7 @@ mod tests {
                 height: Some(10),
                 media_type: "image/png".to_string(),
             },
+            source_bounds: None,
             context_markdown: "# Appshot Context\n\nhello".to_string(),
             permissions: vec![AppshotPermissionState {
                 name: AppshotPermissionName::Accessibility,

--- a/apps/desktop/src-tauri/src/appshot/shortcut.rs
+++ b/apps/desktop/src-tauri/src/appshot/shortcut.rs
@@ -73,13 +73,6 @@ pub fn trigger_status(
     }
 }
 
-pub fn is_enabled() -> bool {
-    status_state()
-        .lock()
-        .map(|status| status.enabled)
-        .unwrap_or(false)
-}
-
 #[cfg(target_os = "macos")]
 fn start_macos(app: AppHandle) {
     use std::thread;
@@ -124,7 +117,7 @@ fn start_macos(app: AppHandle) {
             }
             set_status_error(
                 &status,
-                "Failed to install Appshot modifier listener. Grant Accessibility and Input Monitoring permissions, then restart Atmos if the listener does not recover.",
+                "Failed to install Appshot modifier listener. Grant Accessibility permission, then restart Atmos if the listener does not recover.",
             );
             return;
         }
@@ -275,7 +268,7 @@ fn handle_tap_disabled(context: &TapContext) {
 
     set_status_warning(
         &context.status,
-        "Appshot modifier listener was disabled by macOS. Check Accessibility and Input Monitoring permissions.",
+        "Appshot modifier listener was disabled by macOS. Check Accessibility permission.",
     );
     unsafe {
         CFRunLoopStop(CFRunLoopGetCurrent());

--- a/apps/desktop/src-tauri/src/appshot/shortcut.rs
+++ b/apps/desktop/src-tauri/src/appshot/shortcut.rs
@@ -158,6 +158,10 @@ fn start_macos(app: AppHandle) {
 
         unsafe {
             CFRunLoopRun();
+            if let Ok(mut status) = status.lock() {
+                status.started = false;
+                status.enabled = false;
+            }
             CFRelease(source.cast());
             CFRelease(tap.cast());
             let _ = Box::from_raw(context_ptr);
@@ -273,6 +277,9 @@ fn handle_tap_disabled(context: &TapContext) {
         &context.status,
         "Appshot modifier listener was disabled by macOS. Check Accessibility and Input Monitoring permissions.",
     );
+    unsafe {
+        CFRunLoopStop(CFRunLoopGetCurrent());
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -349,6 +356,7 @@ extern "C" {
         mode: *const std::ffi::c_void,
     );
     fn CFRunLoopRun();
+    fn CFRunLoopStop(run_loop: *mut std::ffi::c_void);
     fn CFMachPortCreateRunLoopSource(
         allocator: *const std::ffi::c_void,
         port: *mut std::ffi::c_void,

--- a/apps/desktop/src-tauri/src/appshot/shortcut.rs
+++ b/apps/desktop/src-tauri/src/appshot/shortcut.rs
@@ -90,7 +90,7 @@ fn start_macos(app: AppHandle) {
             Ok(guard) => guard,
             Err(_) => return,
         };
-        if guard.started && (guard.enabled || guard.last_error.is_none()) {
+        if guard.started {
             return;
         }
         guard.started = true;
@@ -269,7 +269,7 @@ fn handle_tap_disabled(context: &TapContext) {
         }
     }
 
-    set_status_error(
+    set_status_warning(
         &context.status,
         "Appshot modifier listener was disabled by macOS. Check Accessibility and Input Monitoring permissions.",
     );
@@ -279,6 +279,14 @@ fn handle_tap_disabled(context: &TapContext) {
 fn set_status_error(status: &Arc<Mutex<RuntimeStatus>>, message: &str) {
     if let Ok(mut status) = status.lock() {
         status.started = false;
+        status.enabled = false;
+        status.last_error = Some(message.to_string());
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn set_status_warning(status: &Arc<Mutex<RuntimeStatus>>, message: &str) {
+    if let Ok(mut status) = status.lock() {
         status.enabled = false;
         status.last_error = Some(message.to_string());
     }

--- a/apps/desktop/src-tauri/src/appshot/shortcut.rs
+++ b/apps/desktop/src-tauri/src/appshot/shortcut.rs
@@ -1,0 +1,350 @@
+use crate::appshot::types::{AppshotTriggerMode, AppshotTriggerStatus};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+use tauri::AppHandle;
+
+#[derive(Debug)]
+struct RuntimeStatus {
+    started: bool,
+    enabled: bool,
+    last_error: Option<String>,
+}
+
+static STATUS: OnceLock<Arc<Mutex<RuntimeStatus>>> = OnceLock::new();
+
+fn status_state() -> Arc<Mutex<RuntimeStatus>> {
+    STATUS
+        .get_or_init(|| {
+            Arc::new(Mutex::new(RuntimeStatus {
+                started: false,
+                enabled: false,
+                last_error: None,
+            }))
+        })
+        .clone()
+}
+
+pub fn start(app: AppHandle) {
+    #[cfg(target_os = "macos")]
+    start_macos(app);
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let status = status_state();
+        if let Ok(mut status) = status.lock() {
+            status.started = true;
+            status.enabled = false;
+            status.last_error =
+                Some("Appshot trigger is unsupported on this platform.".to_string());
+        }
+        let _ = app;
+    }
+}
+
+pub fn trigger_status(
+    permissions: Vec<crate::appshot::types::AppshotPermissionState>,
+) -> AppshotTriggerStatus {
+    let status = status_state();
+    let status = status.lock().ok();
+    let enabled = status
+        .as_ref()
+        .map(|status| status.enabled)
+        .unwrap_or(false);
+    let last_error = status.as_ref().and_then(|status| status.last_error.clone());
+
+    AppshotTriggerStatus {
+        mode: if cfg!(target_os = "macos") {
+            AppshotTriggerMode::MacosModifierGesture
+        } else {
+            AppshotTriggerMode::Unsupported
+        },
+        enabled,
+        required_modifiers: if cfg!(target_os = "macos") {
+            vec![
+                "function".to_string(),
+                "option".to_string(),
+                "command".to_string(),
+            ]
+        } else {
+            Vec::new()
+        },
+        last_error,
+        permissions,
+    }
+}
+
+pub fn is_enabled() -> bool {
+    status_state()
+        .lock()
+        .map(|status| status.enabled)
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "macos")]
+fn start_macos(app: AppHandle) {
+    use std::thread;
+
+    let status = status_state();
+    {
+        let mut guard = match status.lock() {
+            Ok(guard) => guard,
+            Err(_) => return,
+        };
+        if guard.started && (guard.enabled || guard.last_error.is_none()) {
+            return;
+        }
+        guard.started = true;
+        guard.enabled = false;
+        guard.last_error = None;
+    }
+
+    thread::spawn(move || {
+        let context = Box::new(TapContext {
+            app,
+            status: status.clone(),
+            gesture: Arc::new(Mutex::new(ModifierGestureState::default())),
+            tap_ref: Mutex::new(None),
+            reenable_attempted: Mutex::new(false),
+        });
+        let context_ptr = Box::into_raw(context);
+        let tap = unsafe {
+            CGEventTapCreate(
+                K_CG_HID_EVENT_TAP,
+                K_CG_HEAD_INSERT_EVENT_TAP,
+                K_CG_EVENT_TAP_OPTION_LISTEN_ONLY,
+                event_mask(K_CG_EVENT_FLAGS_CHANGED),
+                appshot_event_tap_callback,
+                context_ptr.cast(),
+            )
+        };
+
+        if tap.is_null() {
+            unsafe {
+                let _ = Box::from_raw(context_ptr);
+            }
+            set_status_error(
+                &status,
+                "Failed to install Appshot modifier listener. Grant Accessibility and Input Monitoring permissions, then restart Atmos if the listener does not recover.",
+            );
+            return;
+        }
+
+        if let Ok(mut tap_ref) = unsafe { &*context_ptr }.tap_ref.lock() {
+            *tap_ref = Some(tap as usize);
+        }
+
+        let source = unsafe { CFMachPortCreateRunLoopSource(std::ptr::null(), tap, 0) };
+        if source.is_null() {
+            set_status_error(
+                &status,
+                "Failed to attach Appshot modifier listener to the run loop.",
+            );
+            unsafe {
+                CFRelease(tap.cast());
+                let _ = Box::from_raw(context_ptr);
+            }
+            return;
+        }
+
+        unsafe {
+            let current_loop = CFRunLoopGetCurrent();
+            CFRunLoopAddSource(current_loop, source, kCFRunLoopCommonModes);
+            CGEventTapEnable(tap, true);
+        }
+        if let Ok(mut status) = status.lock() {
+            status.enabled = true;
+            status.last_error = None;
+        }
+
+        unsafe {
+            CFRunLoopRun();
+            CFRelease(source.cast());
+            CFRelease(tap.cast());
+            let _ = Box::from_raw(context_ptr);
+        }
+    });
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Default)]
+struct ModifierGestureState {
+    fired: bool,
+    last_fire_at: Option<Instant>,
+}
+
+#[cfg(target_os = "macos")]
+struct TapContext {
+    app: AppHandle,
+    status: Arc<Mutex<RuntimeStatus>>,
+    gesture: Arc<Mutex<ModifierGestureState>>,
+    tap_ref: Mutex<Option<usize>>,
+    reenable_attempted: Mutex<bool>,
+}
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" fn appshot_event_tap_callback(
+    _proxy: *mut std::ffi::c_void,
+    event_type: u32,
+    event: *mut std::ffi::c_void,
+    user_info: *mut std::ffi::c_void,
+) -> *mut std::ffi::c_void {
+    if user_info.is_null() {
+        return event;
+    }
+
+    let context = &*(user_info as *const TapContext);
+    match event_type {
+        K_CG_EVENT_FLAGS_CHANGED if !event.is_null() => {
+            let flags = CGEventGetFlags(event);
+            handle_flags_changed(context, flags);
+        }
+        K_CG_EVENT_TAP_DISABLED_BY_TIMEOUT | K_CG_EVENT_TAP_DISABLED_BY_USER_INPUT => {
+            handle_tap_disabled(context);
+        }
+        _ => {}
+    }
+
+    event
+}
+
+#[cfg(target_os = "macos")]
+fn handle_flags_changed(context: &TapContext, flags: u64) {
+    let mut gesture = match context.gesture.lock() {
+        Ok(gesture) => gesture,
+        Err(_) => return,
+    };
+
+    let gesture_down = flags & K_CG_EVENT_FLAG_SECONDARY_FN != 0
+        && flags & K_CG_EVENT_FLAG_ALTERNATE != 0
+        && flags & K_CG_EVENT_FLAG_COMMAND != 0;
+    if !gesture_down {
+        gesture.fired = false;
+        return;
+    }
+
+    let cooldown_elapsed = gesture
+        .last_fire_at
+        .map(|instant| instant.elapsed() >= Duration::from_millis(800))
+        .unwrap_or(true);
+    if gesture.fired || !cooldown_elapsed {
+        return;
+    }
+
+    gesture.fired = true;
+    gesture.last_fire_at = Some(Instant::now());
+    if let Ok(mut status) = context.status.lock() {
+        status.enabled = true;
+        status.last_error = None;
+    }
+
+    let app = context.app.clone();
+    tauri::async_runtime::spawn(async move {
+        crate::appshot::trigger_capture(app).await;
+    });
+}
+
+#[cfg(target_os = "macos")]
+fn handle_tap_disabled(context: &TapContext) {
+    let should_reenable = context
+        .reenable_attempted
+        .lock()
+        .map(|mut attempted| {
+            if *attempted {
+                false
+            } else {
+                *attempted = true;
+                true
+            }
+        })
+        .unwrap_or(false);
+
+    if should_reenable {
+        if let Ok(tap_ref) = context.tap_ref.lock() {
+            if let Some(tap) = *tap_ref {
+                unsafe {
+                    CGEventTapEnable(tap as *mut std::ffi::c_void, true);
+                }
+                return;
+            }
+        }
+    }
+
+    set_status_error(
+        &context.status,
+        "Appshot modifier listener was disabled by macOS. Check Accessibility and Input Monitoring permissions.",
+    );
+}
+
+#[cfg(target_os = "macos")]
+fn set_status_error(status: &Arc<Mutex<RuntimeStatus>>, message: &str) {
+    if let Ok(mut status) = status.lock() {
+        status.started = false;
+        status.enabled = false;
+        status.last_error = Some(message.to_string());
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn event_mask(event_type: u32) -> u64 {
+    1_u64 << event_type
+}
+
+#[cfg(target_os = "macos")]
+const K_CG_HID_EVENT_TAP: u32 = 0;
+#[cfg(target_os = "macos")]
+const K_CG_HEAD_INSERT_EVENT_TAP: u32 = 0;
+#[cfg(target_os = "macos")]
+const K_CG_EVENT_TAP_OPTION_LISTEN_ONLY: u32 = 1;
+#[cfg(target_os = "macos")]
+const K_CG_EVENT_FLAGS_CHANGED: u32 = 12;
+#[cfg(target_os = "macos")]
+const K_CG_EVENT_TAP_DISABLED_BY_TIMEOUT: u32 = 0xFFFF_FFFE;
+#[cfg(target_os = "macos")]
+const K_CG_EVENT_TAP_DISABLED_BY_USER_INPUT: u32 = 0xFFFF_FFFF;
+#[cfg(target_os = "macos")]
+const K_CG_EVENT_FLAG_ALTERNATE: u64 = 0x0008_0000;
+#[cfg(target_os = "macos")]
+const K_CG_EVENT_FLAG_COMMAND: u64 = 0x0010_0000;
+#[cfg(target_os = "macos")]
+const K_CG_EVENT_FLAG_SECONDARY_FN: u64 = 0x0080_0000;
+
+#[cfg(target_os = "macos")]
+#[link(name = "ApplicationServices", kind = "framework")]
+extern "C" {
+    fn CGEventTapCreate(
+        tap: u32,
+        place: u32,
+        options: u32,
+        events_of_interest: u64,
+        callback: unsafe extern "C" fn(
+            proxy: *mut std::ffi::c_void,
+            event_type: u32,
+            event: *mut std::ffi::c_void,
+            user_info: *mut std::ffi::c_void,
+        ) -> *mut std::ffi::c_void,
+        user_info: *mut std::ffi::c_void,
+    ) -> *mut std::ffi::c_void;
+
+    fn CGEventTapEnable(tap: *mut std::ffi::c_void, enable: bool);
+    fn CGEventGetFlags(event: *mut std::ffi::c_void) -> u64;
+}
+
+#[cfg(target_os = "macos")]
+#[link(name = "CoreFoundation", kind = "framework")]
+extern "C" {
+    static kCFRunLoopCommonModes: *const std::ffi::c_void;
+
+    fn CFRunLoopGetCurrent() -> *mut std::ffi::c_void;
+    fn CFRunLoopAddSource(
+        run_loop: *mut std::ffi::c_void,
+        source: *mut std::ffi::c_void,
+        mode: *const std::ffi::c_void,
+    );
+    fn CFRunLoopRun();
+    fn CFMachPortCreateRunLoopSource(
+        allocator: *const std::ffi::c_void,
+        port: *mut std::ffi::c_void,
+        order: isize,
+    ) -> *mut std::ffi::c_void;
+    fn CFRelease(value: *const std::ffi::c_void);
+}

--- a/apps/desktop/src-tauri/src/appshot/thumbnail.rs
+++ b/apps/desktop/src-tauri/src/appshot/thumbnail.rs
@@ -1,0 +1,82 @@
+use chrono::Utc;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const THUMBNAIL_MAX_EDGE: &str = "480";
+const SNAPSHOT_MAX_EDGE: &str = "1600";
+
+pub fn thumbnail_png_for_bytes(bytes: &[u8]) -> Result<Vec<u8>, String> {
+    resize_png_for_bytes(bytes, THUMBNAIL_MAX_EDGE, "thumbnail")
+}
+
+#[cfg(target_os = "macos")]
+pub fn thumbnail_png_for_path(path: &Path) -> Result<Vec<u8>, String> {
+    resize_png_for_path(path, THUMBNAIL_MAX_EDGE, "thumbnail")
+}
+
+pub fn snapshot_png_for_bytes(bytes: &[u8]) -> Result<Vec<u8>, String> {
+    resize_png_for_bytes(bytes, SNAPSHOT_MAX_EDGE, "snapshot")
+}
+
+pub fn snapshot_png_for_path(path: &Path) -> Result<Vec<u8>, String> {
+    resize_png_for_path(path, SNAPSHOT_MAX_EDGE, "snapshot")
+}
+
+fn resize_png_for_bytes(bytes: &[u8], max_edge: &str, label: &str) -> Result<Vec<u8>, String> {
+    let input_path = temp_png_path("input");
+    fs::write(&input_path, bytes)
+        .map_err(|error| format!("failed to stage appshot {label} input: {error}"))?;
+    let result = resize_png_for_path(&input_path, max_edge, label);
+    let _ = fs::remove_file(input_path);
+    result
+}
+
+#[cfg(target_os = "macos")]
+fn resize_png_for_path(path: &Path, max_edge: &str, label: &str) -> Result<Vec<u8>, String> {
+    let output_path = temp_png_path("thumb");
+    let output = Command::new("sips")
+        .arg("-Z")
+        .arg(max_edge)
+        .arg(path)
+        .arg("--out")
+        .arg(&output_path)
+        .output()
+        .map_err(|error| format!("failed to start appshot {label} generator: {error}"))?;
+
+    if !output.status.success() {
+        let _ = fs::remove_file(output_path);
+        return Err(format!(
+            "appshot {label} generator exited with status {}",
+            output.status
+        ));
+    }
+
+    let bytes = fs::read(&output_path)
+        .map_err(|error| format!("failed to read appshot {label}: {error}"))?;
+    let _ = fs::remove_file(output_path);
+    if bytes.is_empty() {
+        return Err(format!("appshot {label} generator produced an empty file"));
+    }
+    Ok(bytes)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn resize_png_for_path(_path: &Path, _max_edge: &str, label: &str) -> Result<Vec<u8>, String> {
+    Err(format!(
+        "appshot {label} generation is unavailable on this platform"
+    ))
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn thumbnail_png_for_path(_path: &Path) -> Result<Vec<u8>, String> {
+    Err("appshot thumbnail generation is unavailable on this platform".to_string())
+}
+
+fn temp_png_path(label: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "atmos-appshot-{label}-{}-{}.png",
+        std::process::id(),
+        Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    ))
+}

--- a/apps/desktop/src-tauri/src/appshot/types.rs
+++ b/apps/desktop/src-tauri/src/appshot/types.rs
@@ -27,6 +27,7 @@ pub struct AppshotPendingPreview {
     pub captured_at: String,
     pub quality: AppshotQuality,
     pub screenshot_preview_base64: Option<String>,
+    pub source_bounds: Option<AppshotWindowBounds>,
     pub permissions: Vec<AppshotPermissionState>,
     pub warnings: Vec<String>,
     pub expires_in_ms: u64,
@@ -83,6 +84,12 @@ pub struct AppshotRecordDetail {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotSnapshotView {
+    pub timestamp: String,
+    pub snapshot_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppshotRecordMetadata {
     pub timestamp: String,
     pub captured_at: String,
@@ -108,6 +115,14 @@ pub struct AppshotScreenshotMetadata {
     pub width: Option<u32>,
     pub height: Option<u32>,
     pub media_type: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotWindowBounds {
+    pub x: i32,
+    pub y: i32,
+    pub width: u32,
+    pub height: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -175,6 +190,7 @@ pub struct CapturedAppshot {
     pub quality: AppshotQuality,
     pub screenshot_png: Vec<u8>,
     pub screenshot: AppshotScreenshotMetadata,
+    pub source_bounds: Option<AppshotWindowBounds>,
     pub context_markdown: String,
     pub permissions: Vec<AppshotPermissionState>,
     pub warnings: Vec<String>,

--- a/apps/desktop/src-tauri/src/appshot/types.rs
+++ b/apps/desktop/src-tauri/src/appshot/types.rs
@@ -115,7 +115,6 @@ pub struct AppshotScreenshotMetadata {
 pub enum AppshotPermissionName {
     Accessibility,
     ScreenRecording,
-    InputMonitoring,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -123,7 +122,6 @@ pub enum AppshotPermissionName {
 pub enum AppshotSettingsTarget {
     Accessibility,
     ScreenRecording,
-    InputMonitoring,
     PrivacySecurity,
 }
 

--- a/apps/desktop/src-tauri/src/appshot/types.rs
+++ b/apps/desktop/src-tauri/src/appshot/types.rs
@@ -1,0 +1,183 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AppshotPlatform {
+    Macos,
+    Windows,
+    Linux,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AppshotQuality {
+    ScreenshotAndAccessibility,
+    ScreenshotOnly,
+    AccessibilityOnly,
+    MetadataOnly,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotPendingPreview {
+    pub preview_id: String,
+    pub app_name: String,
+    pub window_title: Option<String>,
+    pub captured_at: String,
+    pub quality: AppshotQuality,
+    pub screenshot_preview_base64: Option<String>,
+    pub permissions: Vec<AppshotPermissionState>,
+    pub warnings: Vec<String>,
+    pub expires_in_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotStatus {
+    pub supported: bool,
+    pub platform: AppshotPlatform,
+    pub reason: Option<String>,
+    pub trigger: AppshotTriggerStatus,
+    pub permissions: Vec<AppshotPermissionState>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotAcceptResponse {
+    pub timestamp: String,
+    pub record_dir: String,
+    pub protocol_text: String,
+    pub metadata: AppshotRecordMetadata,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotCopyResponse {
+    pub timestamp: String,
+    pub protocol_text: String,
+    pub copied: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotReadRecordsRequest {
+    pub timestamps: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotPendingAutoAcceptRequest {
+    pub preview_id: String,
+    pub held: bool,
+    pub resume_in_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotRecordListItem {
+    pub timestamp: String,
+    pub record_dir: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotRecordDetail {
+    pub timestamp: String,
+    pub metadata: AppshotRecordMetadata,
+    pub context_preview: String,
+    pub snapshot_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotRecordMetadata {
+    pub timestamp: String,
+    pub captured_at: String,
+    pub platform: AppshotPlatform,
+    pub app_name: String,
+    pub bundle_id: Option<String>,
+    pub process_id: Option<u32>,
+    pub window_title: Option<String>,
+    pub window_id: Option<String>,
+    pub quality: AppshotQuality,
+    pub record_dir: String,
+    pub snapshot_path: String,
+    pub context_path: String,
+    pub metadata_path: String,
+    pub screenshot: AppshotScreenshotMetadata,
+    pub warnings: Vec<String>,
+    pub context_bytes: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotScreenshotMetadata {
+    pub available: bool,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub media_type: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AppshotPermissionName {
+    Accessibility,
+    ScreenRecording,
+    InputMonitoring,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AppshotSettingsTarget {
+    Accessibility,
+    ScreenRecording,
+    InputMonitoring,
+    PrivacySecurity,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotPermissionRecoveryAction {
+    pub label: String,
+    pub target: AppshotSettingsTarget,
+    pub manual_steps: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotPermissionState {
+    pub name: AppshotPermissionName,
+    pub display_name: String,
+    pub granted: bool,
+    pub required_for: Vec<String>,
+    pub recovery_action: Option<AppshotPermissionRecoveryAction>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotOpenPermissionsRequest {
+    pub target: AppshotSettingsTarget,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AppshotTriggerMode {
+    MacosModifierGesture,
+    RegularHotkeyFallback,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotTriggerStatus {
+    pub mode: AppshotTriggerMode,
+    pub enabled: bool,
+    pub required_modifiers: Vec<String>,
+    pub last_error: Option<String>,
+    pub permissions: Vec<AppshotPermissionState>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CapturedAppshot {
+    pub app_name: String,
+    pub bundle_id: Option<String>,
+    pub process_id: Option<u32>,
+    pub window_title: Option<String>,
+    pub window_id: Option<String>,
+    pub captured_at: String,
+    pub platform: AppshotPlatform,
+    pub quality: AppshotQuality,
+    pub screenshot_png: Vec<u8>,
+    pub screenshot: AppshotScreenshotMetadata,
+    pub context_markdown: String,
+    pub permissions: Vec<AppshotPermissionState>,
+    pub warnings: Vec<String>,
+}

--- a/apps/desktop/src-tauri/src/appshot/unsupported.rs
+++ b/apps/desktop/src-tauri/src/appshot/unsupported.rs
@@ -1,0 +1,32 @@
+use crate::appshot::types::{
+    AppshotPlatform, AppshotStatus, AppshotTriggerMode, AppshotTriggerStatus,
+};
+
+pub fn status() -> AppshotStatus {
+    AppshotStatus {
+        supported: false,
+        platform: platform(),
+        reason: Some("Appshots are currently available on macOS desktop builds only.".to_string()),
+        trigger: AppshotTriggerStatus {
+            mode: AppshotTriggerMode::Unsupported,
+            enabled: false,
+            required_modifiers: Vec::new(),
+            last_error: Some("No native Appshot backend for this platform.".to_string()),
+            permissions: Vec::new(),
+        },
+        permissions: Vec::new(),
+    }
+}
+
+fn platform() -> AppshotPlatform {
+    #[cfg(target_os = "windows")]
+    {
+        return AppshotPlatform::Windows;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        return AppshotPlatform::Linux;
+    }
+    #[allow(unreachable_code)]
+    AppshotPlatform::Unknown
+}

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -177,3 +177,61 @@ pub async fn preview_bridge_probe_url(url: String) -> Result<(), String> {
 
     Ok(())
 }
+
+#[tauri::command]
+pub async fn appshot_status(
+    app: tauri::AppHandle,
+) -> Result<crate::appshot::types::AppshotStatus, String> {
+    crate::appshot::status(app).await
+}
+
+#[tauri::command]
+pub async fn appshot_accept_pending(
+    preview_id: String,
+) -> Result<crate::appshot::types::AppshotAcceptResponse, String> {
+    crate::appshot::accept_pending(preview_id).await
+}
+
+#[tauri::command]
+pub async fn appshot_discard_pending(preview_id: String) -> Result<(), String> {
+    crate::appshot::discard_pending(preview_id).await
+}
+
+#[tauri::command]
+pub async fn appshot_set_pending_auto_accept(
+    req: crate::appshot::types::AppshotPendingAutoAcceptRequest,
+) -> Result<(), String> {
+    crate::appshot::set_pending_auto_accept(req).await
+}
+
+#[tauri::command]
+pub async fn appshot_list_records(
+) -> Result<Vec<crate::appshot::types::AppshotRecordListItem>, String> {
+    crate::appshot::list_records().await
+}
+
+#[tauri::command]
+pub async fn appshot_read_records(
+    req: crate::appshot::types::AppshotReadRecordsRequest,
+) -> Result<Vec<crate::appshot::types::AppshotRecordDetail>, String> {
+    crate::appshot::read_records(req).await
+}
+
+#[tauri::command]
+pub async fn appshot_copy_record(
+    timestamp: String,
+) -> Result<crate::appshot::types::AppshotCopyResponse, String> {
+    crate::appshot::copy_record(timestamp).await
+}
+
+#[tauri::command]
+pub async fn appshot_delete_record(timestamp: String) -> Result<(), String> {
+    crate::appshot::delete_record(timestamp).await
+}
+
+#[tauri::command]
+pub async fn appshot_open_permissions(
+    req: crate::appshot::types::AppshotOpenPermissionsRequest,
+) -> Result<(), String> {
+    crate::appshot::open_permissions(req).await
+}

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -218,6 +218,13 @@ pub async fn appshot_read_records(
 }
 
 #[tauri::command]
+pub async fn appshot_read_snapshot(
+    timestamp: String,
+) -> Result<crate::appshot::types::AppshotSnapshotView, String> {
+    crate::appshot::read_snapshot(timestamp).await
+}
+
+#[tauri::command]
 pub async fn appshot_copy_record(
     timestamp: String,
 ) -> Result<crate::appshot::types::AppshotCopyResponse, String> {

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -355,6 +355,7 @@ fn main() {
             commands::appshot_set_pending_auto_accept,
             commands::appshot_list_records,
             commands::appshot_read_records,
+            commands::appshot_read_snapshot,
             commands::appshot_copy_record,
             commands::appshot_delete_record,
             commands::appshot_open_permissions,

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,3 +1,4 @@
+mod appshot;
 mod commands;
 mod logging;
 mod preview_bridge;
@@ -68,6 +69,7 @@ fn main() {
                     remote_access_state_path,
                 ),
             });
+            appshot::init(app.handle().clone());
 
             let app_handle = app.handle().clone();
             app.listen("frontend://theme-ready", move |_| {
@@ -347,6 +349,15 @@ fn main() {
             commands::preview_bridge_hide,
             commands::preview_bridge_event,
             commands::preview_bridge_probe_url,
+            commands::appshot_status,
+            commands::appshot_accept_pending,
+            commands::appshot_discard_pending,
+            commands::appshot_set_pending_auto_accept,
+            commands::appshot_list_records,
+            commands::appshot_read_records,
+            commands::appshot_copy_record,
+            commands::appshot_delete_record,
+            commands::appshot_open_permissions,
             remote_access::commands::remote_access_detect,
             remote_access::commands::remote_access_start,
             remote_access::commands::remote_access_stop,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -112,6 +112,7 @@
     "@xterm/addon-unicode11": "^0.9.0",
     "eslint": "^9",
     "eslint-config-next": "16.2.0",
+    "happy-dom": "^20.9.0",
     "shiki": "^3.22.0",
     "tailwindcss": "^4.3.0",
     "tw-animate-css": "^1.4.0",

--- a/apps/web/public/appshot-capture-overlay.html
+++ b/apps/web/public/appshot-capture-overlay.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        overflow: hidden;
+        background: transparent;
+        pointer-events: none;
+      }
+
+      .frame {
+        position: fixed;
+        inset: 12px;
+        border: 3px solid rgba(66, 153, 255, 0.95);
+        border-radius: 14px;
+        box-shadow:
+          0 0 0 1px rgba(255, 255, 255, 0.35),
+          0 0 18px rgba(66, 153, 255, 0.75),
+          0 0 46px rgba(66, 153, 255, 0.36);
+        animation: appshot-border-breathe 720ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+      }
+
+      .flash {
+        position: fixed;
+        inset: 0;
+        background: white;
+        opacity: 0;
+        animation: appshot-camera-flash 520ms cubic-bezier(0.2, 0.8, 0.2, 1) 180ms both;
+      }
+
+      @keyframes appshot-border-breathe {
+        0% {
+          opacity: 0;
+          transform: scale(0.992);
+          box-shadow:
+            0 0 0 1px rgba(255, 255, 255, 0.15),
+            0 0 0 rgba(66, 153, 255, 0),
+            0 0 0 rgba(66, 153, 255, 0);
+        }
+        34% {
+          opacity: 1;
+          transform: scale(1);
+          box-shadow:
+            0 0 0 1px rgba(255, 255, 255, 0.42),
+            0 0 22px rgba(66, 153, 255, 0.85),
+            0 0 58px rgba(66, 153, 255, 0.42);
+        }
+        100% {
+          opacity: 0;
+          transform: scale(1.006);
+          box-shadow:
+            0 0 0 1px rgba(255, 255, 255, 0),
+            0 0 28px rgba(66, 153, 255, 0),
+            0 0 78px rgba(66, 153, 255, 0);
+        }
+      }
+
+      @keyframes appshot-camera-flash {
+        0% {
+          opacity: 0;
+        }
+        14% {
+          opacity: 0.72;
+        }
+        100% {
+          opacity: 0;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="frame"></div>
+    <div class="flash"></div>
+  </body>
+</html>

--- a/apps/web/src/app-shell/header-action-controls.tsx
+++ b/apps/web/src/app-shell/header-action-controls.tsx
@@ -43,6 +43,7 @@ import {
 } from "lucide-react";
 
 import type { ProviderKind, RemoteAccessStatus } from "@/features/connection/hooks/use-remote-access";
+import { AppshotCapturePreview, AppshotsHeaderButton } from "@/features/appshot";
 import { isTauriRuntime } from "@/shared/lib/desktop-runtime";
 import { LocalModelDownloadProgress } from "@/app-shell/LocalModelDownloadProgress";
 import { UsagePopover } from "./UsagePopover";
@@ -131,6 +132,7 @@ export function HeaderActionControls({
 }: HeaderActionControlsProps) {
   return (
     <div className="relative z-10 flex items-center space-x-3 justify-end">
+      {isDesktopRuntime ? <AppshotCapturePreview /> : null}
       <LocalModelDownloadProgress />
       <button
         aria-label="Search"
@@ -147,125 +149,128 @@ export function HeaderActionControls({
 
       <div className="desktop-no-drag flex items-center justify-end gap-2">
         {isDesktopRuntime ? (
-          <Popover
-            open={desktopWebPopoverOpen}
-            onOpenChange={(open) => {
-              setDesktopWebPopoverOpen(open);
-              if (open) {
-                void refreshDesktopWebStatus();
-                void refreshRemoteAccessStatus();
-              }
-            }}
-          >
-            <PopoverTrigger asChild>
-              <button
-                aria-label="Open in Web"
-                className="relative size-8 flex items-center justify-center rounded-md text-muted-foreground transition-colors duration-200 ease-out hover:bg-accent hover:text-accent-foreground"
-                title={
-                  isRemoteAccessRunning
-                    ? "Tunnel active"
-                    : desktopWebStatus === "ready"
-                      ? "Open in Web"
-                      : "Start Web"
+          <>
+            <AppshotsHeaderButton onCloseAutoFocus={onCloseAutoFocusPrevent} />
+            <Popover
+              open={desktopWebPopoverOpen}
+              onOpenChange={(open) => {
+                setDesktopWebPopoverOpen(open);
+                if (open) {
+                  void refreshDesktopWebStatus();
+                  void refreshRemoteAccessStatus();
                 }
-              >
-                <Globe className="size-4" />
-                {isRemoteAccessRunning && (
-                  <span
-                    className={cn(
-                      "absolute right-1 top-1 size-2 rounded-full ring-1 ring-background",
-                      remoteAccessDotColor,
-                    )}
-                  />
-                )}
-              </button>
-            </PopoverTrigger>
-            <PopoverContent
-              align="end"
-              sideOffset={8}
-              className="w-80 max-h-[70vh] overflow-y-auto p-3 bg-popover border border-border shadow-md"
+              }}
             >
-              <div className="space-y-3">
-                <div className="space-y-1">
-                  <div className="flex items-center gap-2">
+              <PopoverTrigger asChild>
+                <button
+                  aria-label="Open in Web"
+                  className="relative size-8 flex items-center justify-center rounded-md text-muted-foreground transition-colors duration-200 ease-out hover:bg-accent hover:text-accent-foreground"
+                  title={
+                    isRemoteAccessRunning
+                      ? "Tunnel active"
+                      : desktopWebStatus === "ready"
+                        ? "Open in Web"
+                        : "Start Web"
+                  }
+                >
+                  <Globe className="size-4" />
+                  {isRemoteAccessRunning && (
                     <span
                       className={cn(
-                        "size-2 rounded-full",
-                        desktopWebStatus === "ready"
-                          ? "bg-success"
-                          : desktopWebStatus === "checking"
-                            ? "bg-warning"
-                            : "bg-muted-foreground/50",
+                        "absolute right-1 top-1 size-2 rounded-full ring-1 ring-background",
+                        remoteAccessDotColor,
                       )}
                     />
-                    <p className="text-sm font-medium text-popover-foreground">
+                  )}
+                </button>
+              </PopoverTrigger>
+              <PopoverContent
+                align="end"
+                sideOffset={8}
+                className="w-80 max-h-[70vh] overflow-y-auto p-3 bg-popover border border-border shadow-md"
+              >
+                <div className="space-y-3">
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={cn(
+                          "size-2 rounded-full",
+                          desktopWebStatus === "ready"
+                            ? "bg-success"
+                            : desktopWebStatus === "checking"
+                              ? "bg-warning"
+                              : "bg-muted-foreground/50",
+                        )}
+                      />
+                      <p className="text-sm font-medium text-popover-foreground">
+                        {desktopWebStatus === "ready"
+                          ? "Web access is ready"
+                          : "Browser access via sidecar"}
+                      </p>
+                    </div>
+                    <p className="text-xs text-muted-foreground leading-relaxed">
                       {desktopWebStatus === "ready"
-                        ? "Web access is ready"
-                        : "Browser access via sidecar"}
+                        ? "Open the current page in your browser using the desktop sidecar URL, with the same API port to avoid cross-origin mismatches."
+                        : "Use the local sidecar URL in your browser. Once the sidecar finishes warming up, the same page will open there."}
                     </p>
                   </div>
-                  <p className="text-xs text-muted-foreground leading-relaxed">
-                    {desktopWebStatus === "ready"
-                      ? "Open the current page in your browser using the desktop sidecar URL, with the same API port to avoid cross-origin mismatches."
-                      : "Use the local sidecar URL in your browser. Once the sidecar finishes warming up, the same page will open there."}
-                  </p>
-                </div>
 
-                {browserUrl ? (
-                  <div className="rounded-md border border-border bg-muted/30 px-3 py-2 font-mono text-[11px] text-muted-foreground break-all">
-                    {browserUrl}
-                  </div>
-                ) : null}
-
-                <div className="flex items-center gap-2">
-                  {!isRemoteAccessRunning && (
-                    <Button
-                      variant="outline"
-                      onClick={() => {
-                        setDesktopWebPopoverOpen(false);
-                        setRemoteAccessSettingsOpen(true);
-                        void setIsSettingsOpen(true);
-                      }}
-                      className="cursor-pointer"
-                    >
-                      Remote Access
-                    </Button>
-                  )}
-                  <Button
-                    onClick={() => void onOpenDesktopWeb()}
-                    disabled={isOpeningDesktopWeb}
-                    className="flex-1 cursor-pointer"
-                  >
-                    {isOpeningDesktopWeb
-                      ? "Starting..."
-                      : desktopWebStatus === "ready"
-                        ? "Open In Web"
-                        : "Start Web"}
-                    <ExternalLink className="size-4" />
-                  </Button>
-                </div>
-
-                {isRemoteAccessRunning && activeRemoteTunnels.length > 0 && (
-                  <>
-                    <div className="border-t border-border" />
-                    <div className="space-y-2">
-                      {activeRemoteTunnels.map((tunnel) => (
-                        <TunnelItem
-                          key={tunnel.provider}
-                          status={tunnel}
-                          onRenew={(ttlSecs, reuseToken) =>
-                            tunnel.provider
-                              ? renewRemoteAccess(tunnel.provider, ttlSecs, reuseToken).then(() => {})
-                              : Promise.resolve()
-                          }
-                        />
-                      ))}
+                  {browserUrl ? (
+                    <div className="rounded-md border border-border bg-muted/30 px-3 py-2 font-mono text-[11px] text-muted-foreground break-all">
+                      {browserUrl}
                     </div>
-                  </>
-                )}
-              </div>
-            </PopoverContent>
-          </Popover>
+                  ) : null}
+
+                  <div className="flex items-center gap-2">
+                    {!isRemoteAccessRunning && (
+                      <Button
+                        variant="outline"
+                        onClick={() => {
+                          setDesktopWebPopoverOpen(false);
+                          setRemoteAccessSettingsOpen(true);
+                          void setIsSettingsOpen(true);
+                        }}
+                        className="cursor-pointer"
+                      >
+                        Remote Access
+                      </Button>
+                    )}
+                    <Button
+                      onClick={() => void onOpenDesktopWeb()}
+                      disabled={isOpeningDesktopWeb}
+                      className="flex-1 cursor-pointer"
+                    >
+                      {isOpeningDesktopWeb
+                        ? "Starting..."
+                        : desktopWebStatus === "ready"
+                          ? "Open In Web"
+                          : "Start Web"}
+                      <ExternalLink className="size-4" />
+                    </Button>
+                  </div>
+
+                  {isRemoteAccessRunning && activeRemoteTunnels.length > 0 && (
+                    <>
+                      <div className="border-t border-border" />
+                      <div className="space-y-2">
+                        {activeRemoteTunnels.map((tunnel) => (
+                          <TunnelItem
+                            key={tunnel.provider}
+                            status={tunnel}
+                            onRenew={(ttlSecs, reuseToken) =>
+                              tunnel.provider
+                                ? renewRemoteAccess(tunnel.provider, ttlSecs, reuseToken).then(() => {})
+                                : Promise.resolve()
+                            }
+                          />
+                        ))}
+                      </div>
+                    </>
+                  )}
+                </div>
+              </PopoverContent>
+            </Popover>
+          </>
         ) : null}
 
         <Tooltip>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -155,6 +155,29 @@ html:not([data-theme-ready="true"]) body {
     }
   }
 
+  @keyframes appshot-capture-card-enter {
+    0% {
+      opacity: 0;
+      transform: translate3d(var(--appshot-enter-x, 0), var(--appshot-enter-y, -18px), 0) scale(0.72);
+      filter: blur(2px);
+    }
+    62% {
+      opacity: 1;
+      transform: translate3d(0, 0, 0) scale(1.015);
+      filter: blur(0);
+    }
+    100% {
+      opacity: 1;
+      transform: translate3d(0, 0, 0) scale(1);
+      filter: blur(0);
+    }
+  }
+
+  .appshot-capture-card-enter {
+    transform-origin: top right;
+    animation: appshot-capture-card-enter 460ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
   .no-scrollbar::-webkit-scrollbar {
     display: none;
   }

--- a/apps/web/src/features/appshot/__tests__/appshot-client-runtime.test.ts
+++ b/apps/web/src/features/appshot/__tests__/appshot-client-runtime.test.ts
@@ -1,0 +1,41 @@
+// @ts-expect-error bun:test is available at runtime but not in tsconfig types
+import { describe, expect, it } from "bun:test";
+import { Window } from "happy-dom";
+
+import {
+  getAppshotStatus,
+  isAppshotRuntimeAvailable,
+  listAppshotRecords,
+  listenAppshotPreview,
+  readAppshotRecords,
+} from "../lib/appshot-client";
+
+describe("S11 - Appshot browser runtime gating", () => {
+  it("returns non-desktop state and avoids Tauri record calls outside Tauri", async () => {
+    const browserWindow = new Window({ url: "http://localhost:3030" });
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: browserWindow,
+      writable: true,
+    });
+
+    try {
+      expect(isAppshotRuntimeAvailable()).toBe(false);
+      await expect(getAppshotStatus()).resolves.toMatchObject({
+        supported: false,
+        platform: "unknown",
+        reason: "Appshots require Atmos Desktop.",
+      });
+      await expect(listAppshotRecords()).resolves.toEqual([]);
+      await expect(readAppshotRecords(["1760000000000"])).resolves.toEqual([]);
+
+      const unlisten = await listenAppshotPreview(() => {
+        throw new Error("non-Tauri listener should not receive preview events");
+      });
+      expect(typeof unlisten).toBe("function");
+      expect(unlisten()).toBeUndefined();
+    } finally {
+      Reflect.deleteProperty(globalThis, "window");
+    }
+  });
+});

--- a/apps/web/src/features/appshot/__tests__/appshot-client-runtime.test.ts
+++ b/apps/web/src/features/appshot/__tests__/appshot-client-runtime.test.ts
@@ -13,6 +13,7 @@ import {
 describe("S11 - Appshot browser runtime gating", () => {
   it("returns non-desktop state and avoids Tauri record calls outside Tauri", async () => {
     const browserWindow = new Window({ url: "http://localhost:3030" });
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
     Object.defineProperty(globalThis, "window", {
       configurable: true,
       value: browserWindow,
@@ -35,7 +36,11 @@ describe("S11 - Appshot browser runtime gating", () => {
       expect(typeof unlisten).toBe("function");
       expect(unlisten()).toBeUndefined();
     } finally {
-      Reflect.deleteProperty(globalThis, "window");
+      if (previousWindow) {
+        Object.defineProperty(globalThis, "window", previousWindow);
+      } else {
+        Reflect.deleteProperty(globalThis, "window");
+      }
     }
   });
 });

--- a/apps/web/src/features/appshot/__tests__/appshot-payload.test.ts
+++ b/apps/web/src/features/appshot/__tests__/appshot-payload.test.ts
@@ -29,6 +29,7 @@ describe("appshot payload guards", () => {
       captured_at: "2026-05-28T00:00:00Z",
       quality: "screenshot_and_accessibility",
       screenshot_preview_base64: "a".repeat(MAX_INLINE_APPSHOT_IMAGE_CHARS),
+      source_bounds: null,
       permissions: [],
       warnings: [],
       expires_in_ms: 6_000,

--- a/apps/web/src/features/appshot/__tests__/appshot-payload.test.ts
+++ b/apps/web/src/features/appshot/__tests__/appshot-payload.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  MAX_INLINE_APPSHOT_IMAGE_CHARS,
+  sanitizePendingPreviewPayload,
+  sanitizeRecordDetailPayload,
+  toBoundedScreenshotDataUrl,
+} from "../lib/appshot-payload";
+import type {
+  AppshotPendingPreview,
+  AppshotRecordDetail,
+  AppshotRecordMetadata,
+} from "../types";
+
+describe("appshot payload guards", () => {
+  it("keeps bounded screenshot payloads renderable", () => {
+    expect(toBoundedScreenshotDataUrl("abc")).toBe("data:image/png;base64,abc");
+    expect(toBoundedScreenshotDataUrl("data:image/png;base64,abc")).toBe(
+      "data:image/png;base64,abc",
+    );
+    expect(toBoundedScreenshotDataUrl(null)).toBeNull();
+  });
+
+  it("drops oversized pending preview images before storing them in UI state", () => {
+    const preview: AppshotPendingPreview = {
+      preview_id: "preview-1",
+      app_name: "Safari",
+      window_title: "Docs",
+      captured_at: "2026-05-28T00:00:00Z",
+      quality: "screenshot_and_accessibility",
+      screenshot_preview_base64: "a".repeat(MAX_INLINE_APPSHOT_IMAGE_CHARS),
+      permissions: [],
+      warnings: [],
+      expires_in_ms: 6_000,
+    };
+
+    const sanitized = sanitizePendingPreviewPayload(preview);
+
+    expect(sanitized.screenshot_preview_base64).toBeNull();
+    expect(sanitized.warnings).toContain(
+      "Screenshot preview was hidden because the inline image payload is too large.",
+    );
+  });
+
+  it("drops oversized history thumbnails before storing row details", () => {
+    const detail: AppshotRecordDetail = {
+      timestamp: "1760000000000",
+      metadata: metadata(),
+      context_preview: "Window text",
+      snapshot_url: `data:image/png;base64,${"a".repeat(MAX_INLINE_APPSHOT_IMAGE_CHARS)}`,
+    };
+
+    const sanitized = sanitizeRecordDetailPayload(detail);
+
+    expect(sanitized.snapshot_url).toBeNull();
+    expect(sanitized.metadata.warnings).toContain(
+      "Screenshot preview was hidden because the inline image payload is too large.",
+    );
+  });
+});
+
+function metadata(): AppshotRecordMetadata {
+  return {
+    timestamp: "1760000000000",
+    captured_at: "2026-05-28T00:00:00Z",
+    platform: "macos",
+    app_name: "Safari",
+    bundle_id: null,
+    process_id: null,
+    window_title: "Docs",
+    window_id: null,
+    quality: "screenshot_and_accessibility",
+    record_dir: "/Users/example/.atmos/appshots/records/1760000000000",
+    snapshot_path:
+      "/Users/example/.atmos/appshots/records/1760000000000/snapshot.png",
+    context_path:
+      "/Users/example/.atmos/appshots/records/1760000000000/context.md",
+    metadata_path:
+      "/Users/example/.atmos/appshots/records/1760000000000/metadata.json",
+    screenshot: {
+      available: true,
+      width: 1200,
+      height: 800,
+      media_type: "image/png",
+    },
+    warnings: [],
+    context_bytes: 128,
+  };
+}

--- a/apps/web/src/features/appshot/__tests__/appshot-protocol.test.ts
+++ b/apps/web/src/features/appshot/__tests__/appshot-protocol.test.ts
@@ -1,0 +1,32 @@
+// @ts-expect-error bun:test is available at runtime but not in tsconfig types
+import { describe, expect, it } from "bun:test";
+
+import {
+  formatAppshotPrompt,
+  parseAppshotProtocol,
+} from "../lib/appshot-protocol";
+
+describe("appshot protocol", () => {
+  it("accepts first-line Appshot protocol text", () => {
+    const parsed = parseAppshotProtocol(
+      "atmos://appshots/1760000000000\r\nAppshot record is stored locally...",
+    );
+
+    expect(parsed?.timestamp).toBe("1760000000000");
+    expect(parsed?.promptText).toBe(formatAppshotPrompt("1760000000000"));
+  });
+
+  it("rejects malformed timestamps", () => {
+    expect(parseAppshotProtocol("atmos://appshots/176000000000")).toBeNull();
+    expect(parseAppshotProtocol("atmos://appshots/17600000000000")).toBeNull();
+    expect(parseAppshotProtocol("atmos://appshots/17600000000aa")).toBeNull();
+  });
+
+  it("does not parse Appshot URLs that are not the first line", () => {
+    expect(
+      parseAppshotProtocol(
+        "Please inspect this:\natmos://appshots/1760000000000",
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/features/appshot/__tests__/appshots-history-popover.test.tsx
+++ b/apps/web/src/features/appshot/__tests__/appshots-history-popover.test.tsx
@@ -1,0 +1,419 @@
+// @ts-expect-error bun:test is available at runtime but not in tsconfig types
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { Window } from "happy-dom";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import type {
+  AppshotCopyResponse,
+  AppshotRecordDetail,
+  AppshotRecordListItem,
+  AppshotStatus,
+} from "../types";
+
+type TestButtonProps = Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  "size"
+> & {
+  size?: string;
+  variant?: string;
+};
+
+type TestSpanProps = React.HTMLAttributes<HTMLSpanElement> & {
+  variant?: string;
+};
+
+type TestDivProps = React.HTMLAttributes<HTMLDivElement> & {
+  scrollbarGutter?: boolean;
+};
+
+type TestTextShimmerProps = {
+  as?: "span" | "p" | "div";
+  children?: React.ReactNode;
+  className?: string;
+  duration?: number;
+  spread?: number;
+  style?: React.CSSProperties;
+};
+
+const calls = {
+  copy: [] as string[],
+  delete: [] as string[],
+  list: 0,
+  read: [] as string[][],
+};
+
+let recordItems: AppshotRecordListItem[] = [];
+let recordDetails = new Map<string, AppshotRecordDetail>();
+
+mock.module("@workspace/ui", () => ({
+  Badge: ({ children, variant, ...props }: TestSpanProps) => {
+    void variant;
+    return <span {...props}>{children}</span>;
+  },
+  Button: ({
+    children,
+    size,
+    variant,
+    ...props
+  }: TestButtonProps) => {
+    void size;
+    void variant;
+    return <button {...props}>{children}</button>;
+  },
+  ScrollArea: ({
+    children,
+    scrollbarGutter,
+    ...props
+  }: TestDivProps) => {
+    void scrollbarGutter;
+    return <div {...props}>{children}</div>;
+  },
+  Skeleton: (props: React.HTMLAttributes<HTMLDivElement>) => (
+    <div data-testid="appshot-history-skeleton" {...props} />
+  ),
+  TextShimmer: ({
+    as = "span",
+    children,
+    className,
+    duration,
+    spread,
+    style,
+  }: TestTextShimmerProps) => {
+    void duration;
+    void spread;
+    const props = { className, style };
+    if (as === "p") {
+      return <p {...props}>{children}</p>;
+    }
+    if (as === "div") {
+      return <div {...props}>{children}</div>;
+    }
+    return <span {...props}>{children}</span>;
+  },
+  cn: (...values: Array<string | false | null | undefined>) =>
+    values.filter(Boolean).join(" "),
+  getFileIconProps: ({
+    className,
+  }: {
+    className?: string;
+    isDir: boolean;
+    name: string;
+  }) => ({
+    alt: "",
+    className,
+    src: "/icons/file.svg",
+  }),
+}));
+
+mock.module("../lib/appshot-client", () => ({
+  copyAppshotRecord: async (timestamp: string): Promise<AppshotCopyResponse> => {
+    calls.copy.push(timestamp);
+    return {
+      timestamp,
+      protocol_text: `atmos://appshots/${timestamp}`,
+      copied: true,
+    };
+  },
+  deleteAppshotRecord: async (timestamp: string): Promise<void> => {
+    calls.delete.push(timestamp);
+  },
+  getAppshotStatus: async (): Promise<AppshotStatus> => desktopStatus,
+  getDeniedAppshotPermissions: () => [],
+  listAppshotRecords: async (): Promise<AppshotRecordListItem[]> => {
+    calls.list += 1;
+    return recordItems;
+  },
+  openAppshotPermissionTarget: async (): Promise<void> => undefined,
+  readAppshotRecords: async (
+    timestamps: string[],
+  ): Promise<AppshotRecordDetail[]> => {
+    calls.read.push(timestamps);
+    return timestamps.map((timestamp) => {
+      const detail = recordDetails.get(timestamp);
+      if (!detail) {
+        throw new Error(`Missing Appshot detail for ${timestamp}`);
+      }
+      return detail;
+    });
+  },
+  watchAppshotStatusAfterPermissionOpen: () => () => undefined,
+}));
+
+const { AppshotsHistoryPopover } = await import(
+  "../components/AppshotsHistoryPopover"
+);
+
+const desktopStatus: AppshotStatus = {
+  supported: true,
+  platform: "macos",
+  reason: null,
+  trigger: {
+    mode: "macos_modifier_gesture",
+    enabled: true,
+    required_modifiers: ["fn", "option", "command"],
+    last_error: null,
+    permissions: [],
+  },
+  permissions: [],
+};
+
+let root: Root | null = null;
+
+beforeEach(() => {
+  installDom();
+  calls.copy = [];
+  calls.delete = [];
+  calls.list = 0;
+  calls.read = [];
+  recordItems = [];
+  recordDetails = new Map();
+});
+
+afterEach(async () => {
+  if (root) {
+    const currentRoot = root;
+    root = null;
+    await act(async () => {
+      currentRoot.unmount();
+    });
+  }
+  cleanupDom();
+});
+
+describe("S7/S8 - Header Appshots history", () => {
+  it("loads only the first 10 record details, pages more, copies, and deletes rows", async () => {
+    seedRecords(12);
+    const container = await renderHistoryPopover();
+
+    await flushUntil(() => uniqueReadTimestamps().length === 10);
+
+    const newestFirst = timestamps().toReversed();
+    expect(calls.list).toBe(1);
+    expect(uniqueReadTimestamps()).toEqual(newestFirst.slice(0, 10));
+    expect(container.textContent).toContain("App #11");
+    expect(container.textContent).toContain("App #02");
+    expect(container.textContent).not.toContain("App #01");
+    expect(container.textContent).not.toContain("App #00");
+
+    const readCallCountBeforeMore = calls.read.length;
+    await click(getButtonByText(container, "More"));
+    await flushUntil(() => uniqueReadTimestamps().length === 12);
+
+    expect(calls.read.length).toBeGreaterThan(readCallCountBeforeMore);
+    expect(uniqueReadTimestamps()).toEqual(newestFirst);
+    expect(container.textContent).toContain("App #01");
+    expect(container.textContent).toContain("App #00");
+
+    await click(getButtonsByLabel(container, "Copy Appshot reference")[0]);
+    await flushUntil(
+      () => getButtonsByLabel(container, "Copied Appshot reference").length > 0,
+    );
+
+    expect(calls.copy).toEqual([newestFirst[0]]);
+
+    await click(getButtonsByLabel(container, "Delete Appshot record")[0]);
+    await flushUntil(() => !container.textContent?.includes("App #11"));
+
+    expect(calls.delete).toEqual([newestFirst[0]]);
+    expect(container.textContent).not.toContain("App #11");
+    expect(container.textContent).toContain("App #10");
+  });
+});
+
+async function renderHistoryPopover(): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  await act(async () => {
+    root?.render(<AppshotsHistoryPopover open />);
+  });
+
+  return container;
+}
+
+function seedRecords(count: number): void {
+  const items: AppshotRecordListItem[] = [];
+  const details = new Map<string, AppshotRecordDetail>();
+
+  for (let index = 0; index < count; index += 1) {
+    const timestamp = timestampAt(index);
+    items.push({
+      timestamp,
+      record_dir: `~/.atmos/appshots/records/${timestamp}`,
+    });
+    details.set(timestamp, makeRecordDetail(timestamp, index));
+  }
+
+  recordItems = items;
+  recordDetails = details;
+}
+
+function timestamps(): string[] {
+  return recordItems.map((item) => item.timestamp);
+}
+
+function uniqueReadTimestamps(): string[] {
+  return Array.from(new Set(calls.read.flat()));
+}
+
+function timestampAt(index: number): string {
+  return String(1_760_000_000_000 + index);
+}
+
+function makeRecordDetail(
+  timestamp: string,
+  index: number,
+): AppshotRecordDetail {
+  const label = index.toString().padStart(2, "0");
+
+  return {
+    timestamp,
+    context_preview: `Context preview for App #${label}. This text is intentionally long enough to exercise row rendering.`,
+    snapshot_url: `data:image/png;base64,snapshot-${label}`,
+    metadata: {
+      timestamp,
+      captured_at: new Date(Number(timestamp)).toISOString(),
+      platform: "macos",
+      app_name: `App #${label}`,
+      bundle_id: `land.atmos.test.${label}`,
+      process_id: 10_000 + index,
+      window_title: `Window #${label}`,
+      window_id: `window-${label}`,
+      quality: "screenshot_and_accessibility",
+      record_dir: `~/.atmos/appshots/records/${timestamp}`,
+      snapshot_path: `~/.atmos/appshots/records/${timestamp}/snapshot.png`,
+      context_path: `~/.atmos/appshots/records/${timestamp}/context.md`,
+      metadata_path: `~/.atmos/appshots/records/${timestamp}/metadata.json`,
+      screenshot: {
+        available: true,
+        width: 1280,
+        height: 720,
+        media_type: "image/png",
+      },
+      warnings: [],
+      context_bytes: 128,
+    },
+  };
+}
+
+async function click(element: Element | undefined): Promise<void> {
+  if (!element) {
+    throw new Error("Expected element to click");
+  }
+
+  await act(async () => {
+    element.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+  });
+}
+
+function getButtonsByLabel(container: HTMLElement, label: string): HTMLButtonElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLButtonElement>(
+      `button[aria-label="${label}"]`,
+    ),
+  );
+}
+
+function getButtonByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent?.trim() === text,
+  );
+  if (!button) {
+    throw new Error(`Button not found: ${text}`);
+  }
+  return button;
+}
+
+async function flushUntil(predicate: () => boolean): Promise<void> {
+  for (let index = 0; index < 12; index += 1) {
+    if (predicate()) {
+      return;
+    }
+    await act(async () => {
+      await Promise.resolve();
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    });
+  }
+
+  expect(predicate()).toBe(true);
+}
+
+function installDom(): void {
+  const browserWindow = new Window({ url: "http://localhost:3030" });
+  const win = browserWindow as unknown as Window &
+    typeof globalThis & {
+      ResizeObserver?: typeof ResizeObserver;
+    };
+
+  const requestAnimationFrame = (callback: FrameRequestCallback): number =>
+    win.setTimeout(() => callback(Date.now()), 0) as unknown as number;
+  const cancelAnimationFrame = (handle: number): void => {
+    win.clearTimeout(handle);
+  };
+
+  setGlobal("window", win);
+  setGlobal("document", win.document);
+  setGlobal("navigator", win.navigator);
+  setGlobal("HTMLElement", win.HTMLElement);
+  setGlobal("HTMLButtonElement", win.HTMLButtonElement);
+  setGlobal("Element", win.Element);
+  setGlobal("Node", win.Node);
+  setGlobal("Text", win.Text);
+  setGlobal("Event", win.Event);
+  setGlobal("MouseEvent", win.MouseEvent);
+  setGlobal("MutationObserver", win.MutationObserver);
+  setGlobal("ResizeObserver", win.ResizeObserver);
+  setGlobal("getComputedStyle", win.getComputedStyle.bind(win));
+  setGlobal("requestAnimationFrame", requestAnimationFrame);
+  setGlobal("cancelAnimationFrame", cancelAnimationFrame);
+  setGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+
+  Object.defineProperty(win, "requestAnimationFrame", {
+    configurable: true,
+    value: requestAnimationFrame,
+    writable: true,
+  });
+  Object.defineProperty(win, "cancelAnimationFrame", {
+    configurable: true,
+    value: cancelAnimationFrame,
+    writable: true,
+  });
+  win.SyntaxError = SyntaxError;
+}
+
+function cleanupDom(): void {
+  for (const key of [
+    "window",
+    "document",
+    "navigator",
+    "HTMLElement",
+    "HTMLButtonElement",
+    "Element",
+    "Node",
+    "Text",
+    "Event",
+    "MouseEvent",
+    "MutationObserver",
+    "ResizeObserver",
+    "getComputedStyle",
+    "requestAnimationFrame",
+    "cancelAnimationFrame",
+    "IS_REACT_ACT_ENVIRONMENT",
+  ]) {
+    Reflect.deleteProperty(globalThis, key);
+  }
+}
+
+function setGlobal(key: string, value: unknown): void {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value,
+    writable: true,
+  });
+}

--- a/apps/web/src/features/appshot/__tests__/appshots-history-popover.test.tsx
+++ b/apps/web/src/features/appshot/__tests__/appshots-history-popover.test.tsx
@@ -8,6 +8,7 @@ import type {
   AppshotCopyResponse,
   AppshotRecordDetail,
   AppshotRecordListItem,
+  AppshotSnapshotView,
   AppshotStatus,
 } from "../types";
 
@@ -41,6 +42,7 @@ const calls = {
   delete: [] as string[],
   list: 0,
   read: [] as string[][],
+  readSnapshot: [] as string[],
 };
 
 let recordItems: AppshotRecordListItem[] = [];
@@ -137,6 +139,15 @@ mock.module("../lib/appshot-client", () => ({
       return detail;
     });
   },
+  readAppshotSnapshot: async (
+    timestamp: string,
+  ): Promise<AppshotSnapshotView> => {
+    calls.readSnapshot.push(timestamp);
+    return {
+      timestamp,
+      snapshot_url: `data:image/png;base64,full-${timestamp}`,
+    };
+  },
   watchAppshotStatusAfterPermissionOpen: () => () => undefined,
 }));
 
@@ -166,6 +177,7 @@ beforeEach(() => {
   calls.delete = [];
   calls.list = 0;
   calls.read = [];
+  calls.readSnapshot = [];
   recordItems = [];
   recordDetails = new Map();
 });
@@ -196,6 +208,12 @@ describe("S7/S8 - Header Appshots history", () => {
     expect(container.textContent).not.toContain("App #01");
     expect(container.textContent).not.toContain("App #00");
 
+    const recordsScrollArea = container.querySelector(
+      '[aria-label="Recent Appshot records"]',
+    );
+    expect(recordsScrollArea?.className).toContain("h-[min(42vh,360px)]");
+    expect(recordsScrollArea?.className).toContain("min-h-[160px]");
+
     const readCallCountBeforeMore = calls.read.length;
     await click(getButtonByText(container, "More"));
     await flushUntil(() => uniqueReadTimestamps().length === 12);
@@ -211,6 +229,11 @@ describe("S7/S8 - Header Appshots history", () => {
     );
 
     expect(calls.copy).toEqual([newestFirst[0]]);
+
+    await click(getButtonsByLabel(container, "Preview screenshot for App #11 - Window #11")[0]);
+    await flushUntil(() => calls.readSnapshot.length === 1);
+
+    expect(calls.readSnapshot).toEqual([newestFirst[0]]);
 
     await click(getButtonsByLabel(container, "Delete Appshot record")[0]);
     await flushUntil(() => !container.textContent?.includes("App #11"));

--- a/apps/web/src/features/appshot/__tests__/appshots-history-popover.test.tsx
+++ b/apps/web/src/features/appshot/__tests__/appshots-history-popover.test.tsx
@@ -328,11 +328,12 @@ function getButtonByText(container: HTMLElement, text: string): HTMLButtonElemen
   return button;
 }
 
-async function flushUntil(predicate: () => boolean): Promise<void> {
-  for (let index = 0; index < 12; index += 1) {
-    if (predicate()) {
-      return;
-    }
+async function flushUntil(
+  predicate: () => boolean,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (!predicate() && Date.now() - startedAt < timeoutMs) {
     await act(async () => {
       await Promise.resolve();
       await new Promise<void>((resolve) => {
@@ -340,7 +341,6 @@ async function flushUntil(predicate: () => boolean): Promise<void> {
       });
     });
   }
-
   expect(predicate()).toBe(true);
 }
 

--- a/apps/web/src/features/appshot/components/AppshotCapturePreview.tsx
+++ b/apps/web/src/features/appshot/components/AppshotCapturePreview.tsx
@@ -22,6 +22,7 @@ import { formatQualityLabel } from "../lib/appshot-protocol";
 import type { AppshotPendingPreview, AppshotPermissionState } from "../types";
 
 type ResolveState = "idle" | "accepting" | "discarding";
+type EntranceOffset = { x: number; y: number };
 
 export function AppshotCapturePreview() {
   const [preview, setPreview] = React.useState<AppshotPendingPreview | null>(null);
@@ -29,6 +30,10 @@ export function AppshotCapturePreview() {
   const [error, setError] = React.useState<string | null>(null);
   const [remainingMs, setRemainingMs] = React.useState(0);
   const [countdownPaused, setCountdownPaused] = React.useState(false);
+  const [entranceOffset, setEntranceOffset] = React.useState<EntranceOffset>({
+    x: 0,
+    y: -18,
+  });
   const previewRef = React.useRef<AppshotPendingPreview | null>(null);
   const timerRef = React.useRef<number | null>(null);
   const countdownIntervalRef = React.useRef<number | null>(null);
@@ -221,6 +226,7 @@ export function AppshotCapturePreview() {
       clearTimer();
       resolvingRef.current = false;
       previewRef.current = nextPreview;
+      setEntranceOffset(computeEntranceOffset(nextPreview));
       setPreview(nextPreview);
       setResolveState("idle");
       setError(null);
@@ -269,9 +275,14 @@ export function AppshotCapturePreview() {
 
   return createPortal(
     <div
+      key={preview.preview_id}
       className={cn(
-        "fixed right-4 top-12 z-[2147483647] w-80 rounded-md border-r border-border bg-background p-3 text-foreground shadow-none desktop-no-drag",
+        "appshot-capture-card-enter fixed right-4 top-12 z-[2147483647] w-80 rounded-md border border-border bg-popover p-3 text-popover-foreground shadow-md desktop-no-drag",
       )}
+      style={{
+        "--appshot-enter-x": `${entranceOffset.x}px`,
+        "--appshot-enter-y": `${entranceOffset.y}px`,
+      } as React.CSSProperties}
       role="status"
       aria-live="polite"
       onMouseEnter={pauseAutoAcceptCountdown}
@@ -378,6 +389,29 @@ export function AppshotCapturePreview() {
     </div>,
     portalContainer,
   );
+}
+
+function computeEntranceOffset(preview: AppshotPendingPreview): EntranceOffset {
+  const bounds = preview.source_bounds;
+  if (!bounds || typeof window === "undefined") {
+    return { x: 0, y: -18 };
+  }
+
+  const screenX = window.screenX || window.screenLeft || 0;
+  const screenY = window.screenY || window.screenTop || 0;
+  const targetCenterX = window.innerWidth - 16 - 160;
+  const targetCenterY = 48 + 180;
+  const sourceCenterX = bounds.x + bounds.width / 2 - screenX;
+  const sourceCenterY = bounds.y + bounds.height / 2 - screenY;
+
+  return {
+    x: clamp(sourceCenterX - targetCenterX, -900, 900),
+    y: clamp(sourceCenterY - targetCenterY, -700, 700),
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
 }
 
 function PreviewPermissionAction({

--- a/apps/web/src/features/appshot/components/AppshotCapturePreview.tsx
+++ b/apps/web/src/features/appshot/components/AppshotCapturePreview.tsx
@@ -35,6 +35,8 @@ export function AppshotCapturePreview() {
   const deadlineRef = React.useRef<number | null>(null);
   const remainingMsRef = React.useRef(0);
   const resolvingRef = React.useRef(false);
+  const mountedRef = React.useRef(false);
+  const permissionWatcherRef = React.useRef<(() => void) | null>(null);
   const [portalContainer, setPortalContainer] = React.useState<HTMLElement | null>(null);
 
   const clearCountdownInterval = React.useCallback(() => {
@@ -53,6 +55,11 @@ export function AppshotCapturePreview() {
     deadlineRef.current = null;
   }, [clearCountdownInterval]);
 
+  const clearPermissionWatcher = React.useCallback(() => {
+    permissionWatcherRef.current?.();
+    permissionWatcherRef.current = null;
+  }, []);
+
   const updateRemainingFromDeadline = React.useCallback(() => {
     const deadline = deadlineRef.current;
     if (deadline === null) {
@@ -65,6 +72,7 @@ export function AppshotCapturePreview() {
 
   const closePreview = React.useCallback(() => {
     clearTimer();
+    clearPermissionWatcher();
     resolvingRef.current = false;
     previewRef.current = null;
     remainingMsRef.current = 0;
@@ -73,7 +81,7 @@ export function AppshotCapturePreview() {
     setRemainingMs(0);
     setCountdownPaused(false);
     setResolveState("idle");
-  }, [clearTimer]);
+  }, [clearPermissionWatcher, clearTimer]);
 
   const acceptPreview = React.useCallback(
     async (targetPreview: AppshotPendingPreview | null = previewRef.current) => {
@@ -191,7 +199,17 @@ export function AppshotCapturePreview() {
     });
   }, []);
 
+  const watchPreviewPermissionsAfterOpen = React.useCallback(() => {
+    if (!mountedRef.current) {
+      return;
+    }
+    clearPermissionWatcher();
+    permissionWatcherRef.current =
+      watchAppshotStatusAfterPermissionOpen(refreshPreviewPermissions);
+  }, [clearPermissionWatcher, refreshPreviewPermissions]);
+
   React.useEffect(() => {
+    mountedRef.current = true;
     let cancelled = false;
     let unlisten: (() => void) | undefined;
 
@@ -225,11 +243,13 @@ export function AppshotCapturePreview() {
     });
 
     return () => {
+      mountedRef.current = false;
       cancelled = true;
       clearTimer();
+      clearPermissionWatcher();
       unlisten?.();
     };
-  }, [clearTimer, startAutoAcceptCountdown]);
+  }, [clearPermissionWatcher, clearTimer, startAutoAcceptCountdown]);
 
   React.useEffect(() => {
     setPortalContainer(document.body);
@@ -309,7 +329,7 @@ export function AppshotCapturePreview() {
                 key={permission.name}
                 permission={permission}
                 onError={setError}
-                onRefresh={refreshPreviewPermissions}
+                onWatchAfterOpen={watchPreviewPermissionsAfterOpen}
               />
             ))}
           </div>
@@ -363,11 +383,11 @@ export function AppshotCapturePreview() {
 function PreviewPermissionAction({
   permission,
   onError,
-  onRefresh,
+  onWatchAfterOpen,
 }: {
   permission: AppshotPermissionState;
   onError: (message: string) => void;
-  onRefresh: () => Promise<unknown> | unknown;
+  onWatchAfterOpen: () => void;
 }) {
   const action = permission.recovery_action;
 
@@ -390,7 +410,7 @@ function PreviewPermissionAction({
           onClick={() => {
             void openAppshotPermissionTarget(action.target)
               .then(() => {
-                watchAppshotStatusAfterPermissionOpen(onRefresh);
+                onWatchAfterOpen();
               })
               .catch((err) => {
                 onError(err instanceof Error ? err.message : String(err));

--- a/apps/web/src/features/appshot/components/AppshotCapturePreview.tsx
+++ b/apps/web/src/features/appshot/components/AppshotCapturePreview.tsx
@@ -1,0 +1,405 @@
+"use client";
+
+import React from "react";
+import { createPortal } from "react-dom";
+import { Button, cn } from "@workspace/ui";
+import { Check, Copy, ImageOff, Trash2, XCircle } from "lucide-react";
+
+import {
+  acceptAppshotPending,
+  discardAppshotPending,
+  getAppshotStatus,
+  listenAppshotPreview,
+  openAppshotPermissionTarget,
+  setAppshotPendingAutoAccept,
+  watchAppshotStatusAfterPermissionOpen,
+} from "../lib/appshot-client";
+import {
+  sanitizePendingPreviewPayload,
+  toBoundedScreenshotDataUrl,
+} from "../lib/appshot-payload";
+import { formatQualityLabel } from "../lib/appshot-protocol";
+import type { AppshotPendingPreview, AppshotPermissionState } from "../types";
+
+type ResolveState = "idle" | "accepting" | "discarding";
+
+export function AppshotCapturePreview() {
+  const [preview, setPreview] = React.useState<AppshotPendingPreview | null>(null);
+  const [resolveState, setResolveState] = React.useState<ResolveState>("idle");
+  const [error, setError] = React.useState<string | null>(null);
+  const [remainingMs, setRemainingMs] = React.useState(0);
+  const [countdownPaused, setCountdownPaused] = React.useState(false);
+  const previewRef = React.useRef<AppshotPendingPreview | null>(null);
+  const timerRef = React.useRef<number | null>(null);
+  const countdownIntervalRef = React.useRef<number | null>(null);
+  const deadlineRef = React.useRef<number | null>(null);
+  const remainingMsRef = React.useRef(0);
+  const resolvingRef = React.useRef(false);
+  const [portalContainer, setPortalContainer] = React.useState<HTMLElement | null>(null);
+
+  const clearCountdownInterval = React.useCallback(() => {
+    if (countdownIntervalRef.current !== null) {
+      window.clearInterval(countdownIntervalRef.current);
+      countdownIntervalRef.current = null;
+    }
+  }, []);
+
+  const clearTimer = React.useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    clearCountdownInterval();
+    deadlineRef.current = null;
+  }, [clearCountdownInterval]);
+
+  const updateRemainingFromDeadline = React.useCallback(() => {
+    const deadline = deadlineRef.current;
+    if (deadline === null) {
+      return;
+    }
+    const nextRemaining = Math.max(0, deadline - Date.now());
+    remainingMsRef.current = nextRemaining;
+    setRemainingMs(nextRemaining);
+  }, []);
+
+  const closePreview = React.useCallback(() => {
+    clearTimer();
+    resolvingRef.current = false;
+    previewRef.current = null;
+    remainingMsRef.current = 0;
+    setPreview(null);
+    setError(null);
+    setRemainingMs(0);
+    setCountdownPaused(false);
+    setResolveState("idle");
+  }, [clearTimer]);
+
+  const acceptPreview = React.useCallback(
+    async (targetPreview: AppshotPendingPreview | null = previewRef.current) => {
+      if (!targetPreview || resolvingRef.current) {
+        return;
+      }
+      resolvingRef.current = true;
+      clearTimer();
+      setResolveState("accepting");
+      setError(null);
+
+      try {
+        await acceptAppshotPending(targetPreview.preview_id);
+        closePreview();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.toLowerCase().includes("no longer pending")) {
+          closePreview();
+          return;
+        }
+        resolvingRef.current = false;
+        setResolveState("idle");
+        setError(message);
+      }
+    },
+    [clearTimer, closePreview],
+  );
+
+  const startAutoAcceptCountdown = React.useCallback(
+    (targetPreview: AppshotPendingPreview, durationMs: number) => {
+      clearTimer();
+      const delayMs = Math.max(500, durationMs);
+      deadlineRef.current = Date.now() + delayMs;
+      remainingMsRef.current = delayMs;
+      setRemainingMs(delayMs);
+      setCountdownPaused(false);
+      countdownIntervalRef.current = window.setInterval(updateRemainingFromDeadline, 200);
+      timerRef.current = window.setTimeout(() => {
+        void acceptPreview(targetPreview);
+      }, delayMs);
+    },
+    [acceptPreview, clearTimer, updateRemainingFromDeadline],
+  );
+
+  const discardPreview = React.useCallback(async () => {
+    const targetPreview = previewRef.current;
+    if (!targetPreview || resolvingRef.current) {
+      return;
+    }
+    resolvingRef.current = true;
+    clearTimer();
+    setResolveState("discarding");
+    setError(null);
+
+    try {
+      await discardAppshotPending(targetPreview.preview_id);
+      closePreview();
+    } catch (err) {
+      resolvingRef.current = false;
+      setResolveState("idle");
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [clearTimer, closePreview]);
+
+  const pauseAutoAcceptCountdown = React.useCallback(() => {
+    const targetPreview = previewRef.current;
+    if (!targetPreview || targetPreview.expires_in_ms <= 0 || resolvingRef.current) {
+      return;
+    }
+
+    const nextRemaining = Math.max(
+      0,
+      deadlineRef.current === null
+        ? remainingMsRef.current
+        : deadlineRef.current - Date.now(),
+    );
+    clearTimer();
+    remainingMsRef.current = nextRemaining;
+    setRemainingMs(nextRemaining);
+    setCountdownPaused(true);
+    void setAppshotPendingAutoAccept(targetPreview.preview_id, true).catch((err) => {
+      setError(err instanceof Error ? err.message : String(err));
+    });
+  }, [clearTimer]);
+
+  const resumeAutoAcceptCountdown = React.useCallback(() => {
+    const targetPreview = previewRef.current;
+    if (
+      !targetPreview ||
+      targetPreview.expires_in_ms <= 0 ||
+      resolvingRef.current ||
+      !countdownPaused
+    ) {
+      return;
+    }
+
+    const delayMs = Math.max(500, remainingMsRef.current);
+    void setAppshotPendingAutoAccept(targetPreview.preview_id, false, delayMs).catch((err) => {
+      setError(err instanceof Error ? err.message : String(err));
+    });
+    startAutoAcceptCountdown(targetPreview, delayMs);
+  }, [countdownPaused, startAutoAcceptCountdown]);
+
+  const refreshPreviewPermissions = React.useCallback(async () => {
+    const status = await getAppshotStatus();
+    const permissions = [...status.permissions, ...status.trigger.permissions];
+
+    setPreview((current) => {
+      if (!current) {
+        return current;
+      }
+      const nextPreview = { ...current, permissions };
+      previewRef.current = nextPreview;
+      return nextPreview;
+    });
+  }, []);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+
+    void listenAppshotPreview((incomingPreview) => {
+      if (cancelled) {
+        return;
+      }
+      const nextPreview = sanitizePendingPreviewPayload(incomingPreview);
+      clearTimer();
+      resolvingRef.current = false;
+      previewRef.current = nextPreview;
+      setPreview(nextPreview);
+      setResolveState("idle");
+      setError(null);
+      if (nextPreview.expires_in_ms > 0) {
+        startAutoAcceptCountdown(nextPreview, nextPreview.expires_in_ms);
+      } else {
+        setRemainingMs(0);
+        setCountdownPaused(false);
+      }
+    }).then((cleanup) => {
+      if (cancelled) {
+        cleanup();
+        return;
+      }
+      unlisten = cleanup;
+    }).catch((err) => {
+      if (!cancelled) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      clearTimer();
+      unlisten?.();
+    };
+  }, [clearTimer, startAutoAcceptCountdown]);
+
+  React.useEffect(() => {
+    setPortalContainer(document.body);
+  }, []);
+
+  if (!preview || !portalContainer) {
+    return null;
+  }
+
+  const screenshotSrc = toBoundedScreenshotDataUrl(preview.screenshot_preview_base64);
+  const busy = resolveState !== "idle";
+  const deniedPermissions = (preview.permissions ?? []).filter((permission) => !permission.granted);
+  const countdownSeconds = Math.ceil(remainingMs / 1_000);
+  const countdownLabel = countdownPaused
+    ? `Paused ${countdownSeconds}s`
+    : `${countdownSeconds}s`;
+
+  return createPortal(
+    <div
+      className={cn(
+        "fixed right-4 top-12 z-[2147483647] w-80 rounded-md border-r border-border bg-background p-3 text-foreground shadow-none desktop-no-drag",
+      )}
+      role="status"
+      aria-live="polite"
+      onMouseEnter={pauseAutoAcceptCountdown}
+      onMouseLeave={resumeAutoAcceptCountdown}
+    >
+      <div className="space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium">{preview.app_name}</p>
+            <p className="truncate text-xs text-muted-foreground">
+              {preview.window_title || formatQualityLabel(preview.quality)}
+            </p>
+          </div>
+          {preview.expires_in_ms > 0 ? (
+            <span className="rounded-md border border-border px-1.5 py-0.5 text-[10px] text-muted-foreground">
+              {countdownLabel}
+            </span>
+          ) : (
+            <span className="rounded-md border border-warning/30 bg-warning/10 px-1.5 py-0.5 text-[10px] text-warning">
+              Needs permission
+            </span>
+          )}
+        </div>
+
+        <div className="h-36 overflow-hidden rounded-md border border-border bg-background">
+          {screenshotSrc ? (
+            // eslint-disable-next-line @next/next/no-img-element -- Appshot previews are local Tauri data URLs, not remote optimized assets.
+            <img
+              src={screenshotSrc}
+              alt={`Appshot preview for ${preview.app_name}`}
+              className="h-full w-full object-cover"
+              draggable={false}
+            />
+          ) : (
+            <div className="flex h-full w-full flex-col items-center justify-center gap-2 text-muted-foreground">
+              <ImageOff className="size-5" />
+              <span className="text-xs">No screenshot preview</span>
+            </div>
+          )}
+        </div>
+
+        {preview.warnings.length > 0 ? (
+          <p className="line-clamp-2 text-xs text-warning">
+            {preview.warnings[0]}
+          </p>
+        ) : null}
+
+        {deniedPermissions.length > 0 ? (
+          <div className="space-y-2 rounded-md border border-warning/30 bg-warning/10 p-2">
+            <p className="text-xs font-medium text-popover-foreground">
+              Permissions required
+            </p>
+            {deniedPermissions.map((permission) => (
+              <PreviewPermissionAction
+                key={permission.name}
+                permission={permission}
+                onError={setError}
+                onRefresh={refreshPreviewPermissions}
+              />
+            ))}
+          </div>
+        ) : null}
+
+        {error ? (
+          <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-2 py-1.5 text-xs text-destructive">
+            <XCircle className="mt-0.5 size-3 shrink-0" />
+            <span className="min-w-0 break-words">{error}</span>
+          </div>
+        ) : null}
+
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            className="flex-1 cursor-pointer"
+            size="sm"
+            disabled={busy}
+            onClick={() => void acceptPreview()}
+          >
+            {resolveState === "accepting" ? (
+              <>
+                <Check className="size-4" />
+                Copying...
+              </>
+            ) : (
+              <>
+                <Copy className="size-4" />
+                Copy
+              </>
+            )}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={busy}
+            onClick={() => void discardPreview()}
+            className="cursor-pointer"
+          >
+            <Trash2 className="size-4" />
+            Delete
+          </Button>
+        </div>
+      </div>
+    </div>,
+    portalContainer,
+  );
+}
+
+function PreviewPermissionAction({
+  permission,
+  onError,
+  onRefresh,
+}: {
+  permission: AppshotPermissionState;
+  onError: (message: string) => void;
+  onRefresh: () => Promise<unknown> | unknown;
+}) {
+  const action = permission.recovery_action;
+
+  return (
+    <div className="flex items-start justify-between gap-2">
+      <div className="min-w-0">
+        <p className="text-xs font-medium text-popover-foreground">
+          {permission.display_name}
+        </p>
+        <p className="text-[11px] leading-5 text-muted-foreground">
+          {permission.required_for.join("; ")}
+        </p>
+      </div>
+      {action ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="xs"
+          className="shrink-0 cursor-pointer"
+          onClick={() => {
+            void openAppshotPermissionTarget(action.target)
+              .then(() => {
+                watchAppshotStatusAfterPermissionOpen(onRefresh);
+              })
+              .catch((err) => {
+                onError(err instanceof Error ? err.message : String(err));
+              });
+          }}
+        >
+          {action.label || "Open Settings"}
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/appshot/components/AppshotRecordRow.tsx
+++ b/apps/web/src/features/appshot/components/AppshotRecordRow.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Badge, Button, cn } from "@workspace/ui";
+import { Check, Copy, ImageOff, Trash2 } from "lucide-react";
+
+import { summarizeAppshotRecord } from "../lib/appshot-protocol";
+import type { AppshotRecordDetail } from "../types";
+
+type AppshotRecordRowProps = {
+  record: AppshotRecordDetail;
+  copied: boolean;
+  deleting: boolean;
+  copying: boolean;
+  onCopy: (timestamp: string) => void;
+  onDelete: (timestamp: string) => void;
+};
+
+export function AppshotRecordRow({
+  record,
+  copied,
+  deleting,
+  copying,
+  onCopy,
+  onDelete,
+}: AppshotRecordRowProps) {
+  const summary = summarizeAppshotRecord(record);
+  const disabled = deleting || copying;
+
+  return (
+    <div
+      className={cn(
+        "grid grid-cols-[72px_minmax(0,1fr)_auto] gap-3 rounded-md border border-border bg-muted/20 p-2",
+        deleting && "opacity-60",
+      )}
+    >
+      <div className="h-14 w-[72px] overflow-hidden rounded border border-border bg-background">
+        {record.snapshot_url ? (
+          // eslint-disable-next-line @next/next/no-img-element -- Appshot thumbnails are local Tauri data URLs, not remote optimized assets.
+          <img
+            src={record.snapshot_url}
+            alt={`Screenshot preview for ${summary.title}`}
+            className="h-full w-full object-cover"
+            draggable={false}
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+            <ImageOff className="size-4" />
+          </div>
+        )}
+      </div>
+
+      <div className="min-w-0 space-y-1">
+        <div className="flex min-w-0 items-center gap-2">
+          <p className="truncate text-xs font-medium text-popover-foreground">
+            {summary.appLabel}
+          </p>
+          <Badge
+            variant="outline"
+            className="h-5 rounded-md px-1.5 text-[10px] font-normal text-muted-foreground"
+          >
+            {summary.capturedAtLabel}
+          </Badge>
+        </div>
+        <p className="truncate text-[11px] text-muted-foreground">
+          {summary.title}
+        </p>
+        <p className="max-h-10 overflow-hidden whitespace-pre-wrap text-[11px] leading-5 text-muted-foreground">
+          {record.context_preview || "No text context was captured."}
+        </p>
+      </div>
+
+      <div className="flex items-start gap-1">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          disabled={disabled}
+          title={copied ? "Copied" : "Copy Appshot reference"}
+          aria-label={copied ? "Copied Appshot reference" : "Copy Appshot reference"}
+          onClick={() => onCopy(record.timestamp)}
+          className="cursor-pointer"
+        >
+          {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          disabled={disabled}
+          title="Delete Appshot record"
+          aria-label="Delete Appshot record"
+          onClick={() => onDelete(record.timestamp)}
+          className="cursor-pointer text-muted-foreground hover:text-destructive"
+        >
+          <Trash2 className="size-3" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/appshot/components/AppshotRecordRow.tsx
+++ b/apps/web/src/features/appshot/components/AppshotRecordRow.tsx
@@ -13,6 +13,7 @@ type AppshotRecordRowProps = {
   copying: boolean;
   onCopy: (timestamp: string) => void;
   onDelete: (timestamp: string) => void;
+  onPreview: (record: AppshotRecordDetail) => void;
 };
 
 export function AppshotRecordRow({
@@ -22,26 +23,38 @@ export function AppshotRecordRow({
   copying,
   onCopy,
   onDelete,
+  onPreview,
 }: AppshotRecordRowProps) {
   const summary = summarizeAppshotRecord(record);
   const disabled = deleting || copying;
+  const headline =
+    summary.title && summary.title !== summary.appLabel
+      ? `${summary.appLabel} - ${summary.title}`
+      : summary.appLabel;
 
   return (
     <div
       className={cn(
-        "grid grid-cols-[72px_minmax(0,1fr)_auto] gap-3 rounded-md border border-border bg-muted/20 p-2",
+        "grid h-[72px] grid-cols-[96px_minmax(0,1fr)_auto] overflow-hidden rounded-md border border-border bg-muted/20",
         deleting && "opacity-60",
       )}
     >
-      <div className="h-14 w-[72px] overflow-hidden rounded border border-border bg-background">
+      <div className="h-full w-24 overflow-hidden border-r border-border bg-background">
         {record.snapshot_url ? (
-          // eslint-disable-next-line @next/next/no-img-element -- Appshot thumbnails are local Tauri data URLs, not remote optimized assets.
-          <img
-            src={record.snapshot_url}
-            alt={`Screenshot preview for ${summary.title}`}
-            className="h-full w-full object-cover"
-            draggable={false}
-          />
+          <button
+            type="button"
+            className="block h-full w-full cursor-zoom-in overflow-hidden"
+            aria-label={`Preview screenshot for ${headline}`}
+            onClick={() => onPreview(record)}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element -- Appshot thumbnails are local Tauri data URLs, not remote optimized assets. */}
+            <img
+              src={record.snapshot_url}
+              alt={`Screenshot preview for ${headline}`}
+              className="h-full w-full object-cover"
+              draggable={false}
+            />
+          </button>
         ) : (
           <div className="flex h-full w-full items-center justify-center text-muted-foreground">
             <ImageOff className="size-4" />
@@ -49,27 +62,24 @@ export function AppshotRecordRow({
         )}
       </div>
 
-      <div className="min-w-0 space-y-1">
+      <div className="min-w-0 px-3 py-2">
         <div className="flex min-w-0 items-center gap-2">
-          <p className="truncate text-xs font-medium text-popover-foreground">
-            {summary.appLabel}
+          <p className="min-w-0 truncate text-xs font-medium text-popover-foreground">
+            {headline}
           </p>
           <Badge
             variant="outline"
-            className="h-5 rounded-md px-1.5 text-[10px] font-normal text-muted-foreground"
+            className="h-5 shrink-0 rounded-md px-1.5 text-[10px] font-normal text-muted-foreground"
           >
             {summary.capturedAtLabel}
           </Badge>
         </div>
-        <p className="truncate text-[11px] text-muted-foreground">
-          {summary.title}
-        </p>
-        <p className="max-h-10 overflow-hidden whitespace-pre-wrap text-[11px] leading-5 text-muted-foreground">
+        <p className="mt-1 line-clamp-2 whitespace-pre-wrap text-[11px] leading-4 text-muted-foreground">
           {record.context_preview || "No text context was captured."}
         </p>
       </div>
 
-      <div className="flex items-start gap-1">
+      <div className="flex items-start gap-1 px-2 py-2">
         <Button
           type="button"
           variant="ghost"

--- a/apps/web/src/features/appshot/components/AppshotsHeaderButton.tsx
+++ b/apps/web/src/features/appshot/components/AppshotsHeaderButton.tsx
@@ -40,7 +40,7 @@ export function AppshotsHeaderButton({ onCloseAutoFocus }: AppshotsHeaderButtonP
         align="end"
         sideOffset={8}
         onCloseAutoFocus={onCloseAutoFocus}
-        className="!z-[2147483647] w-[420px] max-w-[calc(100vw-1rem)] max-h-[72vh] overflow-hidden p-3 !border-y-0 !border-l-0 !border-r !border-border !bg-background !text-foreground !shadow-none"
+        className="!z-[2147483647] w-[420px] max-w-[calc(100vw-1rem)] max-h-[min(72vh,var(--radix-popover-content-available-height,72vh))] overflow-x-hidden overflow-y-auto overscroll-contain p-3 bg-popover border border-border shadow-md"
       >
         <AppshotsHistoryPopover open={open} />
       </PopoverContent>

--- a/apps/web/src/features/appshot/components/AppshotsHeaderButton.tsx
+++ b/apps/web/src/features/appshot/components/AppshotsHeaderButton.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import React from "react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@workspace/ui";
+import { Camera } from "lucide-react";
+
+import { AppshotsHistoryPopover } from "./AppshotsHistoryPopover";
+
+type AppshotsHeaderButtonProps = {
+  onCloseAutoFocus?: (event: Event) => void;
+};
+
+export function AppshotsHeaderButton({ onCloseAutoFocus }: AppshotsHeaderButtonProps) {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              aria-label="Appshots"
+              className="relative size-8 flex items-center justify-center rounded-md text-muted-foreground transition-colors duration-200 ease-out hover:bg-accent hover:text-accent-foreground"
+            >
+              <Camera className="size-4" />
+            </button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Appshots</TooltipContent>
+      </Tooltip>
+      <PopoverContent
+        align="end"
+        sideOffset={8}
+        onCloseAutoFocus={onCloseAutoFocus}
+        className="!z-[2147483647] w-[420px] max-w-[calc(100vw-1rem)] max-h-[72vh] overflow-hidden p-3 !border-y-0 !border-l-0 !border-r !border-border !bg-background !text-foreground !shadow-none"
+      >
+        <AppshotsHistoryPopover open={open} />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/features/appshot/components/AppshotsHistoryPopover.tsx
+++ b/apps/web/src/features/appshot/components/AppshotsHistoryPopover.tsx
@@ -9,6 +9,7 @@ import {
   RefreshCw,
   ShieldAlert,
 } from "lucide-react";
+import { ImagePreviewOverlay } from "@/shared/components/image-preview-overlay";
 
 import {
   copyAppshotRecord,
@@ -18,6 +19,7 @@ import {
   listAppshotRecords,
   openAppshotPermissionTarget,
   readAppshotRecords,
+  readAppshotSnapshot,
   watchAppshotStatusAfterPermissionOpen,
 } from "../lib/appshot-client";
 import { sanitizeRecordDetailPayloads } from "../lib/appshot-payload";
@@ -50,8 +52,14 @@ export function AppshotsHistoryPopover({ open }: AppshotsHistoryPopoverProps) {
   const [copyingTimestamp, setCopyingTimestamp] = React.useState<string | null>(null);
   const [copiedTimestamp, setCopiedTimestamp] = React.useState<string | null>(null);
   const [deletingTimestamp, setDeletingTimestamp] = React.useState<string | null>(null);
+  const [previewImage, setPreviewImage] = React.useState<{
+    timestamp: string;
+    src: string;
+    alt: string;
+  } | null>(null);
   const permissionWatcherRef = React.useRef<(() => void) | null>(null);
   const copyResetTimerRef = React.useRef<number | null>(null);
+  const previewRequestRef = React.useRef(0);
 
   const refreshStatus = React.useCallback(async () => {
     setStatusLoading(true);
@@ -145,6 +153,7 @@ export function AppshotsHistoryPopover({ open }: AppshotsHistoryPopoverProps) {
     return () => {
       permissionWatcherRef.current?.();
       clearCopyResetTimer();
+      previewRequestRef.current += 1;
     };
   }, [clearCopyResetTimer]);
 
@@ -200,8 +209,41 @@ export function AppshotsHistoryPopover({ open }: AppshotsHistoryPopoverProps) {
     }
   }, []);
 
+  const closePreviewImage = React.useCallback(() => {
+    previewRequestRef.current += 1;
+    setPreviewImage(null);
+  }, []);
+
+  const handlePreview = React.useCallback(async (record: AppshotRecordDetail) => {
+    if (!record.snapshot_url) {
+      return;
+    }
+    const requestId = previewRequestRef.current + 1;
+    previewRequestRef.current = requestId;
+    const alt = `Screenshot preview for ${record.metadata.app_name}`;
+    setPreviewImage({
+      timestamp: record.timestamp,
+      src: record.snapshot_url,
+      alt,
+    });
+    try {
+      const fullSnapshot = await readAppshotSnapshot(record.timestamp);
+      if (previewRequestRef.current === requestId) {
+        setPreviewImage({
+          timestamp: record.timestamp,
+          src: fullSnapshot.snapshot_url,
+          alt,
+        });
+      }
+    } catch (err) {
+      if (previewRequestRef.current === requestId) {
+        setHistoryError(err instanceof Error ? err.message : String(err));
+      }
+    }
+  }, []);
+
   return (
-    <div className="space-y-3">
+    <div className="flex min-h-0 flex-col gap-3">
       <div className="space-y-1">
         <div className="flex items-center justify-between gap-3">
           <div className="flex items-center gap-2">
@@ -264,7 +306,7 @@ export function AppshotsHistoryPopover({ open }: AppshotsHistoryPopoverProps) {
 
       <div className="border-t border-border" />
 
-      <div className="space-y-2">
+      <div className="flex min-h-0 flex-col gap-2">
         <div className="flex items-center justify-between">
           <p className="text-xs font-medium text-popover-foreground">Recent records</p>
           {records.length > 0 ? (
@@ -274,7 +316,11 @@ export function AppshotsHistoryPopover({ open }: AppshotsHistoryPopoverProps) {
           ) : null}
         </div>
 
-        <ScrollArea className="h-[min(54vh,480px)] pr-1" scrollbarGutter>
+        <ScrollArea
+          aria-label="Recent Appshot records"
+          className="h-[min(42vh,360px)] min-h-[160px] pr-1"
+          scrollbarGutter
+        >
           <div className="space-y-2">
             {historyLoading ? (
               <HistorySkeleton />
@@ -297,6 +343,7 @@ export function AppshotsHistoryPopover({ open }: AppshotsHistoryPopoverProps) {
                     deleting={deletingTimestamp === item.timestamp}
                     onCopy={handleCopy}
                     onDelete={handleDelete}
+                    onPreview={handlePreview}
                   />
                 );
               })
@@ -318,6 +365,13 @@ export function AppshotsHistoryPopover({ open }: AppshotsHistoryPopoverProps) {
           </Button>
         ) : null}
       </div>
+      {previewImage ? (
+        <ImagePreviewOverlay
+          src={previewImage.src}
+          alt={previewImage.alt}
+          onClose={closePreviewImage}
+        />
+      ) : null}
     </div>
   );
 }
@@ -384,14 +438,13 @@ function HistorySkeleton() {
 
 function HistorySkeletonRow() {
   return (
-    <div className="grid grid-cols-[72px_minmax(0,1fr)_auto] gap-3 rounded-md border border-border bg-muted/20 p-2">
-      <Skeleton className="h-14 w-[72px] rounded" />
-      <div className="space-y-2 py-1">
-        <Skeleton className="h-3 w-32" />
+    <div className="grid h-[72px] grid-cols-[96px_minmax(0,1fr)_auto] overflow-hidden rounded-md border border-border bg-muted/20">
+      <Skeleton className="h-full w-24 rounded-none" />
+      <div className="space-y-2 px-3 py-2">
         <Skeleton className="h-3 w-44" />
         <Skeleton className="h-3 w-full" />
       </div>
-      <div className="flex gap-1">
+      <div className="flex gap-1 px-2 py-2">
         <Skeleton className="size-6 rounded-md" />
         <Skeleton className="size-6 rounded-md" />
       </div>

--- a/apps/web/src/features/appshot/components/AppshotsHistoryPopover.tsx
+++ b/apps/web/src/features/appshot/components/AppshotsHistoryPopover.tsx
@@ -1,0 +1,389 @@
+"use client";
+
+import React from "react";
+import { Badge, Button, ScrollArea, Skeleton, cn } from "@workspace/ui";
+import {
+  AlertCircle,
+  Camera,
+  ChevronDown,
+  RefreshCw,
+  ShieldAlert,
+} from "lucide-react";
+
+import {
+  copyAppshotRecord,
+  deleteAppshotRecord,
+  getAppshotStatus,
+  getDeniedAppshotPermissions,
+  listAppshotRecords,
+  openAppshotPermissionTarget,
+  readAppshotRecords,
+  watchAppshotStatusAfterPermissionOpen,
+} from "../lib/appshot-client";
+import { sanitizeRecordDetailPayloads } from "../lib/appshot-payload";
+import type {
+  AppshotPermissionState,
+  AppshotRecordDetail,
+  AppshotRecordListItem,
+  AppshotSettingsTarget,
+  AppshotStatus,
+} from "../types";
+import { AppshotRecordRow } from "./AppshotRecordRow";
+
+type AppshotsHistoryPopoverProps = {
+  open: boolean;
+};
+
+const PAGE_SIZE = 10;
+const DETAIL_BATCH_SIZE = 3;
+
+export function AppshotsHistoryPopover({ open }: AppshotsHistoryPopoverProps) {
+  const [status, setStatus] = React.useState<AppshotStatus | null>(null);
+  const [statusError, setStatusError] = React.useState<string | null>(null);
+  const [statusLoading, setStatusLoading] = React.useState(false);
+  const [records, setRecords] = React.useState<AppshotRecordListItem[]>([]);
+  const [details, setDetails] = React.useState<Record<string, AppshotRecordDetail>>({});
+  const [visibleCount, setVisibleCount] = React.useState(PAGE_SIZE);
+  const [historyLoading, setHistoryLoading] = React.useState(false);
+  const [detailLoading, setDetailLoading] = React.useState(false);
+  const [historyError, setHistoryError] = React.useState<string | null>(null);
+  const [copyingTimestamp, setCopyingTimestamp] = React.useState<string | null>(null);
+  const [copiedTimestamp, setCopiedTimestamp] = React.useState<string | null>(null);
+  const [deletingTimestamp, setDeletingTimestamp] = React.useState<string | null>(null);
+  const permissionWatcherRef = React.useRef<(() => void) | null>(null);
+
+  const refreshStatus = React.useCallback(async () => {
+    setStatusLoading(true);
+    setStatusError(null);
+    try {
+      const nextStatus = await getAppshotStatus();
+      setStatus(nextStatus);
+    } catch (err) {
+      setStatusError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setStatusLoading(false);
+    }
+  }, []);
+
+  const refreshHistory = React.useCallback(async () => {
+    setHistoryLoading(true);
+    setHistoryError(null);
+    try {
+      const nextRecords = await listAppshotRecords();
+      setRecords([...nextRecords].sort((a, b) => b.timestamp.localeCompare(a.timestamp)));
+      setVisibleCount(PAGE_SIZE);
+      setDetails({});
+    } catch (err) {
+      setHistoryError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setHistoryLoading(false);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    if (!open) {
+      return;
+    }
+    void refreshStatus();
+    void refreshHistory();
+  }, [open, refreshHistory, refreshStatus]);
+
+  React.useEffect(() => {
+    if (!open || records.length === 0) {
+      return;
+    }
+
+    const visibleTimestamps = records.slice(0, visibleCount).map((item) => item.timestamp);
+    const missingTimestamps = visibleTimestamps.filter((timestamp) => !details[timestamp]);
+    if (missingTimestamps.length === 0) {
+      return;
+    }
+
+    const batchTimestamps = missingTimestamps.slice(0, DETAIL_BATCH_SIZE);
+    let cancelled = false;
+    setDetailLoading(true);
+    setHistoryError(null);
+    void readAppshotRecords(batchTimestamps)
+      .then((rows) => {
+        if (cancelled) {
+          return;
+        }
+        const sanitizedRows = sanitizeRecordDetailPayloads(rows);
+        setDetails((current) => {
+          const next = { ...current };
+          for (const row of sanitizedRows) {
+            next[row.timestamp] = row;
+          }
+          return next;
+        });
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setHistoryError(err instanceof Error ? err.message : String(err));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setDetailLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [details, open, records, visibleCount]);
+
+  React.useEffect(() => {
+    return () => {
+      permissionWatcherRef.current?.();
+    };
+  }, []);
+
+  const deniedPermissions = getDeniedAppshotPermissions(status);
+  const visibleRecords = records.slice(0, visibleCount);
+  const hasMore = visibleCount < records.length;
+
+  const handleOpenPermission = React.useCallback(
+    async (target: AppshotSettingsTarget) => {
+      try {
+        await openAppshotPermissionTarget(target);
+        permissionWatcherRef.current?.();
+        permissionWatcherRef.current = watchAppshotStatusAfterPermissionOpen(refreshStatus);
+      } catch (err) {
+        setStatusError(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [refreshStatus],
+  );
+
+  const handleCopy = React.useCallback(async (timestamp: string) => {
+    setCopyingTimestamp(timestamp);
+    setCopiedTimestamp(null);
+    try {
+      await copyAppshotRecord(timestamp);
+      setCopiedTimestamp(timestamp);
+      window.setTimeout(() => {
+        setCopiedTimestamp((current) => (current === timestamp ? null : current));
+      }, 1_500);
+    } catch (err) {
+      setHistoryError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCopyingTimestamp(null);
+    }
+  }, []);
+
+  const handleDelete = React.useCallback(async (timestamp: string) => {
+    setDeletingTimestamp(timestamp);
+    try {
+      await deleteAppshotRecord(timestamp);
+      setRecords((current) => current.filter((item) => item.timestamp !== timestamp));
+      setDetails((current) => {
+        const next = { ...current };
+        delete next[timestamp];
+        return next;
+      });
+    } catch (err) {
+      setHistoryError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setDeletingTimestamp(null);
+    }
+  }, []);
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <Camera className="size-4 text-muted-foreground" />
+            <p className="text-sm font-medium text-popover-foreground">Appshots</p>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            title="Refresh Appshots"
+            aria-label="Refresh Appshots"
+            onClick={() => {
+              void refreshStatus();
+              void refreshHistory();
+            }}
+            className="cursor-pointer"
+          >
+            <RefreshCw className={cn("size-3", (statusLoading || historyLoading) && "animate-spin")} />
+          </Button>
+        </div>
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          Capture another app with Fn + Option + Command, review the preview,
+          then copy a local Appshot reference for agents to read from disk.
+        </p>
+      </div>
+
+      {statusError ? <InlineError message={statusError} /> : null}
+      {historyError ? <InlineError message={historyError} /> : null}
+
+      {status && !status.supported ? (
+        <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+          {status.reason || "Appshots are not supported in this runtime."}
+        </div>
+      ) : null}
+
+      {status?.trigger.last_error ? (
+        <div className="rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning">
+          {status.trigger.last_error}
+        </div>
+      ) : null}
+
+      {deniedPermissions.length > 0 ? (
+        <div className="space-y-2 rounded-md border border-warning/30 bg-warning/10 p-2">
+          <div className="flex items-center gap-2 text-xs font-medium text-popover-foreground">
+            <ShieldAlert className="size-3.5 text-warning" />
+            Permissions required
+          </div>
+          <div className="space-y-2">
+            {deniedPermissions.map((permission) => (
+              <PermissionRecovery
+                key={permission.name}
+                permission={permission}
+                onOpenPermission={handleOpenPermission}
+              />
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="border-t border-border" />
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <p className="text-xs font-medium text-popover-foreground">Recent records</p>
+          {records.length > 0 ? (
+            <Badge variant="outline" className="rounded-md text-[10px] font-normal">
+              {records.length}
+            </Badge>
+          ) : null}
+        </div>
+
+        <ScrollArea className="h-[min(54vh,480px)] pr-1" scrollbarGutter>
+          <div className="space-y-2">
+            {historyLoading ? (
+              <HistorySkeleton />
+            ) : records.length === 0 ? (
+              <div className="rounded-md border border-border bg-muted/20 px-3 py-6 text-center text-xs text-muted-foreground">
+                No Appshots yet.
+              </div>
+            ) : (
+              visibleRecords.map((item) => {
+                const detail = details[item.timestamp];
+                if (!detail) {
+                  return <HistorySkeletonRow key={item.timestamp} />;
+                }
+                return (
+                  <AppshotRecordRow
+                    key={item.timestamp}
+                    record={detail}
+                    copied={copiedTimestamp === item.timestamp}
+                    copying={copyingTimestamp === item.timestamp}
+                    deleting={deletingTimestamp === item.timestamp}
+                    onCopy={handleCopy}
+                    onDelete={handleDelete}
+                  />
+                );
+              })
+            )}
+          </div>
+        </ScrollArea>
+
+        {hasMore ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={detailLoading}
+            onClick={() => setVisibleCount((current) => current + PAGE_SIZE)}
+            className="w-full cursor-pointer"
+          >
+            <ChevronDown className="size-4" />
+            More
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function PermissionRecovery({
+  permission,
+  onOpenPermission,
+}: {
+  permission: AppshotPermissionState;
+  onOpenPermission: (target: AppshotSettingsTarget) => Promise<void>;
+}) {
+  const action = permission.recovery_action;
+
+  return (
+    <div className="rounded-md border border-border bg-popover/70 p-2">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 space-y-1">
+          <p className="text-xs font-medium text-popover-foreground">
+            {permission.display_name}
+          </p>
+          <p className="text-[11px] leading-5 text-muted-foreground">
+            {permission.required_for.join("; ")}
+          </p>
+        </div>
+        {action ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="xs"
+            onClick={() => void onOpenPermission(action.target)}
+            className="shrink-0 cursor-pointer"
+          >
+            {action.label || "Open Settings"}
+          </Button>
+        ) : null}
+      </div>
+      {action?.manual_steps.length ? (
+        <p className="mt-2 text-[11px] leading-5 text-muted-foreground">
+          {action.manual_steps.join(" ")}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function InlineError({ message }: { message: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+      <AlertCircle className="mt-0.5 size-3.5 shrink-0" />
+      <span className="min-w-0 break-words">{message}</span>
+    </div>
+  );
+}
+
+function HistorySkeleton() {
+  return (
+    <>
+      <HistorySkeletonRow />
+      <HistorySkeletonRow />
+      <HistorySkeletonRow />
+    </>
+  );
+}
+
+function HistorySkeletonRow() {
+  return (
+    <div className="grid grid-cols-[72px_minmax(0,1fr)_auto] gap-3 rounded-md border border-border bg-muted/20 p-2">
+      <Skeleton className="h-14 w-[72px] rounded" />
+      <div className="space-y-2 py-1">
+        <Skeleton className="h-3 w-32" />
+        <Skeleton className="h-3 w-44" />
+        <Skeleton className="h-3 w-full" />
+      </div>
+      <div className="flex gap-1">
+        <Skeleton className="size-6 rounded-md" />
+        <Skeleton className="size-6 rounded-md" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/appshot/components/AppshotsHistoryPopover.tsx
+++ b/apps/web/src/features/appshot/components/AppshotsHistoryPopover.tsx
@@ -51,6 +51,7 @@ export function AppshotsHistoryPopover({ open }: AppshotsHistoryPopoverProps) {
   const [copiedTimestamp, setCopiedTimestamp] = React.useState<string | null>(null);
   const [deletingTimestamp, setDeletingTimestamp] = React.useState<string | null>(null);
   const permissionWatcherRef = React.useRef<(() => void) | null>(null);
+  const copyResetTimerRef = React.useRef<number | null>(null);
 
   const refreshStatus = React.useCallback(async () => {
     setStatusLoading(true);
@@ -133,11 +134,19 @@ export function AppshotsHistoryPopover({ open }: AppshotsHistoryPopoverProps) {
     };
   }, [details, open, records, visibleCount]);
 
+  const clearCopyResetTimer = React.useCallback(() => {
+    if (copyResetTimerRef.current !== null) {
+      window.clearTimeout(copyResetTimerRef.current);
+      copyResetTimerRef.current = null;
+    }
+  }, []);
+
   React.useEffect(() => {
     return () => {
       permissionWatcherRef.current?.();
+      clearCopyResetTimer();
     };
-  }, []);
+  }, [clearCopyResetTimer]);
 
   const deniedPermissions = getDeniedAppshotPermissions(status);
   const visibleRecords = records.slice(0, visibleCount);
@@ -159,10 +168,12 @@ export function AppshotsHistoryPopover({ open }: AppshotsHistoryPopoverProps) {
   const handleCopy = React.useCallback(async (timestamp: string) => {
     setCopyingTimestamp(timestamp);
     setCopiedTimestamp(null);
+    clearCopyResetTimer();
     try {
       await copyAppshotRecord(timestamp);
       setCopiedTimestamp(timestamp);
-      window.setTimeout(() => {
+      copyResetTimerRef.current = window.setTimeout(() => {
+        copyResetTimerRef.current = null;
         setCopiedTimestamp((current) => (current === timestamp ? null : current));
       }, 1_500);
     } catch (err) {
@@ -170,7 +181,7 @@ export function AppshotsHistoryPopover({ open }: AppshotsHistoryPopoverProps) {
     } finally {
       setCopyingTimestamp(null);
     }
-  }, []);
+  }, [clearCopyResetTimer]);
 
   const handleDelete = React.useCallback(async (timestamp: string) => {
     setDeletingTimestamp(timestamp);

--- a/apps/web/src/features/appshot/index.ts
+++ b/apps/web/src/features/appshot/index.ts
@@ -1,0 +1,18 @@
+export { AppshotCapturePreview } from "./components/AppshotCapturePreview";
+export { AppshotsHeaderButton } from "./components/AppshotsHeaderButton";
+export {
+  APPSHOT_PROTOCOL_PREFIX,
+  formatAppshotPrompt,
+  formatAppshotProtocolUrl,
+  isValidAppshotTimestamp,
+  parseAppshotProtocol,
+} from "./lib/appshot-protocol";
+export type {
+  AppshotAcceptResponse,
+  AppshotCopyResponse,
+  AppshotPendingPreview,
+  AppshotRecordDetail,
+  AppshotRecordListItem,
+  AppshotRecordMetadata,
+  AppshotStatus,
+} from "./types";

--- a/apps/web/src/features/appshot/lib/appshot-client.ts
+++ b/apps/web/src/features/appshot/lib/appshot-client.ts
@@ -1,0 +1,227 @@
+"use client";
+
+import { isTauriRuntime } from "@/shared/lib/desktop-runtime";
+
+import type {
+  AppshotAcceptResponse,
+  AppshotCopyResponse,
+  AppshotOpenPermissionsRequest,
+  AppshotPendingAutoAcceptRequest,
+  AppshotPendingPreview,
+  AppshotPermissionState,
+  AppshotRecordDetail,
+  AppshotRecordListItem,
+  AppshotReadRecordsRequest,
+  AppshotSettingsTarget,
+  AppshotStatus,
+} from "../types";
+
+type TauriInvoke = <T = unknown>(cmd: string, payload?: unknown) => Promise<T>;
+
+const PREVIEW_EVENT = "appshot://preview";
+
+async function getInvoke(): Promise<TauriInvoke> {
+  const internals = (window as {
+    __TAURI_INTERNALS__?: {
+      invoke?: TauriInvoke;
+    };
+  }).__TAURI_INTERNALS__;
+
+  if (internals?.invoke) {
+    return internals.invoke;
+  }
+
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke as TauriInvoke;
+}
+
+async function invokeAppshot<T>(
+  command: string,
+  payload?: Record<string, unknown>,
+): Promise<T> {
+  if (!isTauriRuntime()) {
+    throw new Error("Appshots are only available in Atmos Desktop.");
+  }
+
+  const invoke = await getInvoke();
+  return await invoke<T>(command, payload);
+}
+
+export function isAppshotRuntimeAvailable(): boolean {
+  return isTauriRuntime();
+}
+
+export async function getAppshotStatus(): Promise<AppshotStatus> {
+  if (!isTauriRuntime()) {
+    return nonDesktopStatus();
+  }
+
+  return await invokeAppshot<AppshotStatus>("appshot_status");
+}
+
+export async function acceptAppshotPending(
+  previewId: string,
+): Promise<AppshotAcceptResponse> {
+  return await invokeAppshot<AppshotAcceptResponse>("appshot_accept_pending", {
+    previewId,
+  });
+}
+
+export async function discardAppshotPending(previewId: string): Promise<void> {
+  await invokeAppshot<void>("appshot_discard_pending", { previewId });
+}
+
+export async function setAppshotPendingAutoAccept(
+  previewId: string,
+  held: boolean,
+  resumeInMs: number | null = null,
+): Promise<void> {
+  const req: AppshotPendingAutoAcceptRequest = {
+    preview_id: previewId,
+    held,
+    resume_in_ms: resumeInMs,
+  };
+  await invokeAppshot<void>("appshot_set_pending_auto_accept", { req });
+}
+
+export async function listAppshotRecords(): Promise<AppshotRecordListItem[]> {
+  if (!isTauriRuntime()) {
+    return [];
+  }
+
+  return await invokeAppshot<AppshotRecordListItem[]>("appshot_list_records");
+}
+
+export async function readAppshotRecords(
+  timestamps: string[],
+): Promise<AppshotRecordDetail[]> {
+  if (!isTauriRuntime() || timestamps.length === 0) {
+    return [];
+  }
+
+  const req: AppshotReadRecordsRequest = { timestamps };
+  return await invokeAppshot<AppshotRecordDetail[]>("appshot_read_records", {
+    req,
+  });
+}
+
+export async function copyAppshotRecord(
+  timestamp: string,
+): Promise<AppshotCopyResponse> {
+  return await invokeAppshot<AppshotCopyResponse>("appshot_copy_record", {
+    timestamp,
+  });
+}
+
+export async function deleteAppshotRecord(timestamp: string): Promise<void> {
+  await invokeAppshot<void>("appshot_delete_record", { timestamp });
+}
+
+export async function openAppshotPermissionTarget(
+  target: AppshotSettingsTarget,
+): Promise<void> {
+  const req: AppshotOpenPermissionsRequest = { target };
+  await invokeAppshot<void>("appshot_open_permissions", { req });
+}
+
+export async function listenAppshotPreview(
+  handler: (preview: AppshotPendingPreview) => void,
+): Promise<() => void> {
+  if (!isTauriRuntime()) {
+    return () => {};
+  }
+
+  const { listen } = await import("@tauri-apps/api/event");
+  const unlisten = await listen<AppshotPendingPreview>(PREVIEW_EVENT, (event) => {
+    if (event.payload) {
+      handler(event.payload);
+    }
+  });
+
+  return unlisten;
+}
+
+export function watchAppshotStatusAfterPermissionOpen(
+  refreshStatus: () => Promise<unknown> | unknown,
+  durationMs = 10_000,
+): () => void {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+
+  let stopped = false;
+  const startedAt = Date.now();
+  const refresh = () => {
+    if (!stopped) {
+      void refreshStatus();
+    }
+  };
+  const refreshUntilExpired = () => {
+    if (Date.now() - startedAt <= durationMs) {
+      refresh();
+    }
+  };
+  const onVisibilityChange = () => {
+    if (document.visibilityState === "visible") {
+      refreshUntilExpired();
+    }
+  };
+
+  window.addEventListener("focus", refreshUntilExpired);
+  document.addEventListener("visibilitychange", onVisibilityChange);
+  const intervalId = window.setInterval(refreshUntilExpired, 1_000);
+  const initialTimeoutId = window.setTimeout(refresh, 750);
+  const stopTimeoutId = window.setTimeout(() => {
+    cleanup();
+  }, durationMs);
+
+  function cleanup() {
+    if (stopped) {
+      return;
+    }
+    stopped = true;
+    window.removeEventListener("focus", refreshUntilExpired);
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+    window.clearInterval(intervalId);
+    window.clearTimeout(initialTimeoutId);
+    window.clearTimeout(stopTimeoutId);
+  }
+
+  return cleanup;
+}
+
+export function getDeniedAppshotPermissions(
+  status: AppshotStatus | null,
+): AppshotPermissionState[] {
+  if (!status) {
+    return [];
+  }
+
+  const byName = new Map<string, AppshotPermissionState>();
+  for (const permission of [
+    ...status.permissions,
+    ...status.trigger.permissions,
+  ]) {
+    if (permission.granted) {
+      continue;
+    }
+    byName.set(permission.name, permission);
+  }
+  return Array.from(byName.values());
+}
+
+function nonDesktopStatus(): AppshotStatus {
+  return {
+    supported: false,
+    platform: "unknown",
+    reason: "Appshots require Atmos Desktop.",
+    trigger: {
+      mode: "unsupported",
+      enabled: false,
+      required_modifiers: [],
+      last_error: null,
+      permissions: [],
+    },
+    permissions: [],
+  };
+}

--- a/apps/web/src/features/appshot/lib/appshot-client.ts
+++ b/apps/web/src/features/appshot/lib/appshot-client.ts
@@ -13,6 +13,7 @@ import type {
   AppshotRecordListItem,
   AppshotReadRecordsRequest,
   AppshotSettingsTarget,
+  AppshotSnapshotView,
   AppshotStatus,
 } from "../types";
 
@@ -102,6 +103,14 @@ export async function readAppshotRecords(
   const req: AppshotReadRecordsRequest = { timestamps };
   return await invokeAppshot<AppshotRecordDetail[]>("appshot_read_records", {
     req,
+  });
+}
+
+export async function readAppshotSnapshot(
+  timestamp: string,
+): Promise<AppshotSnapshotView> {
+  return await invokeAppshot<AppshotSnapshotView>("appshot_read_snapshot", {
+    timestamp,
   });
 }
 

--- a/apps/web/src/features/appshot/lib/appshot-payload.ts
+++ b/apps/web/src/features/appshot/lib/appshot-payload.ts
@@ -1,0 +1,69 @@
+import type { AppshotPendingPreview, AppshotRecordDetail } from "../types";
+
+export const MAX_INLINE_APPSHOT_IMAGE_CHARS = 512 * 1024;
+const OVERSIZED_WARNING =
+  "Screenshot preview was hidden because the inline image payload is too large.";
+
+export function toBoundedScreenshotDataUrl(payload: string | null): string | null {
+  if (!payload) {
+    return null;
+  }
+
+  const dataUrl = payload.startsWith("data:")
+    ? payload
+    : `data:image/png;base64,${payload}`;
+
+  if (dataUrl.length > MAX_INLINE_APPSHOT_IMAGE_CHARS) {
+    return null;
+  }
+
+  return dataUrl;
+}
+
+export function sanitizePendingPreviewPayload(
+  preview: AppshotPendingPreview,
+): AppshotPendingPreview {
+  if (!preview.screenshot_preview_base64) {
+    return preview;
+  }
+
+  if (toBoundedScreenshotDataUrl(preview.screenshot_preview_base64)) {
+    return preview;
+  }
+
+  return {
+    ...preview,
+    screenshot_preview_base64: null,
+    warnings: appendOversizedWarning(preview.warnings),
+  };
+}
+
+export function sanitizeRecordDetailPayload(
+  detail: AppshotRecordDetail,
+): AppshotRecordDetail {
+  if (!detail.snapshot_url || toBoundedScreenshotDataUrl(detail.snapshot_url)) {
+    return detail;
+  }
+
+  return {
+    ...detail,
+    snapshot_url: null,
+    metadata: {
+      ...detail.metadata,
+      warnings: appendOversizedWarning(detail.metadata.warnings),
+    },
+  };
+}
+
+export function sanitizeRecordDetailPayloads(
+  details: AppshotRecordDetail[],
+): AppshotRecordDetail[] {
+  return details.map(sanitizeRecordDetailPayload);
+}
+
+function appendOversizedWarning(warnings: string[]): string[] {
+  if (warnings.includes(OVERSIZED_WARNING)) {
+    return warnings;
+  }
+  return [...warnings, OVERSIZED_WARNING];
+}

--- a/apps/web/src/features/appshot/lib/appshot-protocol.ts
+++ b/apps/web/src/features/appshot/lib/appshot-protocol.ts
@@ -1,0 +1,96 @@
+import type { AppshotRecordDetail, AppshotRecordSummary, AppshotQuality } from "../types";
+
+export const APPSHOT_PROTOCOL_PREFIX = "atmos://appshots/";
+export const APPSHOT_TIMESTAMP_PATTERN = /^\d{13}$/;
+
+export type ParsedAppshotProtocol = {
+  timestamp: string;
+  protocolUrl: string;
+  promptText: string;
+};
+
+export function isValidAppshotTimestamp(timestamp: string): boolean {
+  return APPSHOT_TIMESTAMP_PATTERN.test(timestamp);
+}
+
+export function formatAppshotProtocolUrl(timestamp: string): string {
+  assertValidTimestamp(timestamp);
+  return `${APPSHOT_PROTOCOL_PREFIX}${timestamp}`;
+}
+
+export function formatAppshotPrompt(timestamp: string): string {
+  assertValidTimestamp(timestamp);
+  return `${formatAppshotProtocolUrl(timestamp)}
+Appshot record is stored locally at ~/.atmos/appshots/records/${timestamp}/. Read metadata.json, context.md, and snapshot.png in that directory before answering. Inspect snapshot.png when visual context matters.`;
+}
+
+export function parseAppshotProtocol(text: string): ParsedAppshotProtocol | null {
+  const normalized = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const firstLine = normalized.split("\n", 1)[0]?.trim() ?? "";
+  if (!firstLine.startsWith(APPSHOT_PROTOCOL_PREFIX)) {
+    return null;
+  }
+
+  const timestamp = firstLine.slice(APPSHOT_PROTOCOL_PREFIX.length);
+  if (!isValidAppshotTimestamp(timestamp)) {
+    return null;
+  }
+
+  return {
+    timestamp,
+    protocolUrl: formatAppshotProtocolUrl(timestamp),
+    promptText: formatAppshotPrompt(timestamp),
+  };
+}
+
+export function summarizeAppshotRecord(record: AppshotRecordDetail): AppshotRecordSummary {
+  const { metadata } = record;
+  return {
+    timestamp: record.timestamp,
+    appLabel: metadata.app_name || "Unknown app",
+    capturedAtLabel: formatAppshotTimestamp(metadata.captured_at || record.timestamp),
+    qualityLabel: formatQualityLabel(metadata.quality),
+    title: metadata.window_title?.trim() || metadata.app_name || `Appshot ${record.timestamp}`,
+  };
+}
+
+export function formatAppshotTimestamp(value: string): string {
+  const fromIso = new Date(value);
+  const date = Number.isNaN(fromIso.getTime()) && isValidAppshotTimestamp(value)
+    ? new Date(Number(value))
+    : fromIso;
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+export function formatQualityLabel(quality: AppshotQuality): string {
+  switch (quality) {
+    case "screenshot_and_accessibility":
+      return "Screenshot + UI tree";
+    case "screenshot_only":
+      return "Screenshot only";
+    case "accessibility_only":
+      return "UI tree only";
+    case "metadata_only":
+      return "Metadata only";
+    case "unsupported":
+      return "Unsupported";
+    default:
+      return quality;
+  }
+}
+
+function assertValidTimestamp(timestamp: string): void {
+  if (!isValidAppshotTimestamp(timestamp)) {
+    throw new Error("Invalid Appshot timestamp");
+  }
+}

--- a/apps/web/src/features/appshot/types.ts
+++ b/apps/web/src/features/appshot/types.ts
@@ -9,13 +9,11 @@ export type AppshotQuality =
 
 export type AppshotPermissionName =
   | "accessibility"
-  | "screen_recording"
-  | "input_monitoring";
+  | "screen_recording";
 
 export type AppshotSettingsTarget =
   | "accessibility"
   | "screen_recording"
-  | "input_monitoring"
   | "privacy_security";
 
 export type AppshotTriggerMode =

--- a/apps/web/src/features/appshot/types.ts
+++ b/apps/web/src/features/appshot/types.ts
@@ -58,6 +58,7 @@ export type AppshotPendingPreview = {
   captured_at: string;
   quality: AppshotQuality;
   screenshot_preview_base64: string | null;
+  source_bounds: AppshotWindowBounds | null;
   permissions?: AppshotPermissionState[] | null;
   warnings: string[];
   expires_in_ms: number;
@@ -74,6 +75,13 @@ export type AppshotScreenshotMetadata = {
   width: number | null;
   height: number | null;
   media_type: string;
+};
+
+export type AppshotWindowBounds = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
 };
 
 export type AppshotRecordMetadata = {
@@ -118,6 +126,11 @@ export type AppshotRecordDetail = {
   metadata: AppshotRecordMetadata;
   context_preview: string;
   snapshot_url: string | null;
+};
+
+export type AppshotSnapshotView = {
+  timestamp: string;
+  snapshot_url: string;
 };
 
 export type AppshotReadRecordsRequest = {

--- a/apps/web/src/features/appshot/types.ts
+++ b/apps/web/src/features/appshot/types.ts
@@ -1,0 +1,139 @@
+export type AppshotPlatform = "macos" | "windows" | "linux" | "unknown";
+
+export type AppshotQuality =
+  | "screenshot_and_accessibility"
+  | "screenshot_only"
+  | "accessibility_only"
+  | "metadata_only"
+  | "unsupported";
+
+export type AppshotPermissionName =
+  | "accessibility"
+  | "screen_recording"
+  | "input_monitoring";
+
+export type AppshotSettingsTarget =
+  | "accessibility"
+  | "screen_recording"
+  | "input_monitoring"
+  | "privacy_security";
+
+export type AppshotTriggerMode =
+  | "macos_modifier_gesture"
+  | "regular_hotkey_fallback"
+  | "unsupported";
+
+export type AppshotPermissionRecoveryAction = {
+  label: string;
+  target: AppshotSettingsTarget;
+  manual_steps: string[];
+};
+
+export type AppshotPermissionState = {
+  name: AppshotPermissionName;
+  display_name: string;
+  granted: boolean;
+  required_for: string[];
+  recovery_action: AppshotPermissionRecoveryAction | null;
+};
+
+export type AppshotTriggerStatus = {
+  mode: AppshotTriggerMode;
+  enabled: boolean;
+  required_modifiers: string[];
+  last_error: string | null;
+  permissions: AppshotPermissionState[];
+};
+
+export type AppshotStatus = {
+  supported: boolean;
+  platform: AppshotPlatform;
+  reason: string | null;
+  trigger: AppshotTriggerStatus;
+  permissions: AppshotPermissionState[];
+};
+
+export type AppshotPendingPreview = {
+  preview_id: string;
+  app_name: string;
+  window_title: string | null;
+  captured_at: string;
+  quality: AppshotQuality;
+  screenshot_preview_base64: string | null;
+  permissions?: AppshotPermissionState[] | null;
+  warnings: string[];
+  expires_in_ms: number;
+};
+
+export type AppshotPendingAutoAcceptRequest = {
+  preview_id: string;
+  held: boolean;
+  resume_in_ms: number | null;
+};
+
+export type AppshotScreenshotMetadata = {
+  available: boolean;
+  width: number | null;
+  height: number | null;
+  media_type: string;
+};
+
+export type AppshotRecordMetadata = {
+  timestamp: string;
+  captured_at: string;
+  platform: AppshotPlatform;
+  app_name: string;
+  bundle_id: string | null;
+  process_id: number | null;
+  window_title: string | null;
+  window_id: string | null;
+  quality: AppshotQuality;
+  record_dir: string;
+  snapshot_path: string;
+  context_path: string;
+  metadata_path: string;
+  screenshot: AppshotScreenshotMetadata;
+  warnings: string[];
+  context_bytes: number;
+};
+
+export type AppshotAcceptResponse = {
+  timestamp: string;
+  record_dir: string;
+  protocol_text: string;
+  metadata: AppshotRecordMetadata;
+};
+
+export type AppshotCopyResponse = {
+  timestamp: string;
+  protocol_text: string;
+  copied: boolean;
+};
+
+export type AppshotRecordListItem = {
+  timestamp: string;
+  record_dir: string;
+};
+
+export type AppshotRecordDetail = {
+  timestamp: string;
+  metadata: AppshotRecordMetadata;
+  context_preview: string;
+  snapshot_url: string | null;
+};
+
+export type AppshotReadRecordsRequest = {
+  timestamps: string[];
+};
+
+export type AppshotOpenPermissionsRequest = {
+  target: AppshotSettingsTarget;
+};
+
+export type AppshotRecordSummary = {
+  timestamp: string;
+  appLabel: string;
+  capturedAtLabel: string;
+  qualityLabel: string;
+  title: string;
+};

--- a/apps/web/src/features/automations/components/AutomationSetup.tsx
+++ b/apps/web/src/features/automations/components/AutomationSetup.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { createPortal } from "react-dom";
 import { useQueryState } from "nuqs";
 import {
   Button,
@@ -42,10 +43,29 @@ import type {
 import {
   type ComposerHandle,
 } from "@/features/welcome/components/PromptComposer";
+import {
+  type MentionNavItem,
+  type MentionPopoverState,
+  WelcomeMentionPopover,
+} from "@/features/welcome/components/WelcomeMentionPopover";
+import { SlashCommandPopover } from "@/features/welcome/components/SlashCommandPopover";
 import { WelcomeAgentSelector } from "@/features/welcome/components/WelcomeComposerControls";
 import { WelcomeComposerCard } from "@/features/welcome/components/WelcomeComposerCard";
 import { WelcomePageBackdrop } from "@/features/welcome/components/WelcomePageShell";
-import type { AgentMenuOption } from "@/features/welcome/lib/welcome-page-helpers";
+import { useWelcomeComposerAttachments } from "@/features/welcome/hooks/use-welcome-composer-attachments";
+import { useWelcomeMentionSearch } from "@/features/welcome/hooks/use-welcome-mention-search";
+import {
+  type WelcomeSlashPopoverState,
+  useWelcomeSlashNavigation,
+} from "@/features/welcome/hooks/use-welcome-slash-navigation";
+import { useWelcomeSlashSearch } from "@/features/welcome/hooks/use-welcome-slash-search";
+import {
+  blobToBase64,
+  resolvePromptPlaceholders,
+  type AgentMenuOption,
+  type MentionFileCandidate,
+} from "@/features/welcome/lib/welcome-page-helpers";
+import type { SkillInfo } from "@/api/ws-api";
 import { AtmosWordmark } from "@/shared/components/ui/AtmosWordmark";
 import type { Project } from "@/shared/types/domain";
 import { settingsModalParams } from "@/shared/lib/nuqs/searchParams";
@@ -94,6 +114,15 @@ export function AutomationSetup({
   onUpdate: (request: AutomationUpdateRequest) => Promise<AutomationDetail>;
 }) {
   const composerRef = React.useRef<ComposerHandle | null>(null);
+  const {
+    attachments,
+    clearAttachments,
+    handleAttachmentRemove,
+    handleImagePaste,
+    previewAttachment,
+    setPreviewAttachment,
+    syncAttachmentPlaceholders,
+  } = useWelcomeComposerAttachments(composerRef);
   const previewRequestIdRef = React.useRef(0);
   const [, setSettingsModalOpen] = useQueryState("settingsModal", settingsModalParams.settingsModal);
   const [, setActiveSettingTab] = useQueryState("activeSettingTab", settingsModalParams.activeSettingTab);
@@ -116,10 +145,22 @@ export function AutomationSetup({
   const [submitting, setSubmitting] = React.useState(false);
   const [submitError, setSubmitError] = React.useState<string | null>(null);
   const [headline, setHeadline] = React.useState<AutomationHeadline>(DEFAULT_AUTOMATION_HEADLINE);
+  const [mentionPopover, setMentionPopover] = React.useState<MentionPopoverState>(null);
+  const [slashPopover, setSlashPopover] = React.useState<WelcomeSlashPopoverState>(null);
 
   const workspaces = React.useMemo(() => flattenWorkspaces(projects), [projects]);
   const selectedAgent = agents.find((agent) => agent.agent_id === agentId) ?? null;
   const supportedAgents = agents.filter((agent) => agent.automation_supported);
+  const selectedTargetProject = React.useMemo(() => {
+    if (targetKind === "project" || targetKind === "new_workspace") {
+      return projects.find((project) => project.id === projectGuid) ?? null;
+    }
+    if (targetKind === "workspace") {
+      return workspaces.find((item) => item.workspace.id === workspaceGuid)?.project ?? null;
+    }
+    return null;
+  }, [projectGuid, projects, targetKind, workspaceGuid, workspaces]);
+  const selectedProjectPath = selectedTargetProject?.mainFilePath ?? null;
   const agentOptions = React.useMemo<AgentMenuOption[]>(
     () =>
       agents.map((agent) => ({
@@ -138,6 +179,94 @@ export function AutomationSetup({
     [agents],
   );
   const selectedAgentOption = agentOptions.find((agent) => agent.id === agentId);
+  const {
+    filteredAgents,
+    filteredProjects,
+    filteredSkills,
+    isSkillsLoading,
+  } = useWelcomeSlashSearch({
+    availableAgents: agentOptions,
+    popover: slashPopover,
+    projects,
+  });
+  const selectMentionFile = React.useCallback(
+    (item: MentionFileCandidate) => {
+      const popover = mentionPopover;
+      if (!popover) return;
+      composerRef.current?.applyMentionAtRange(
+        popover.atOffset,
+        popover.query.length,
+        { kind: "file", relativePath: item.relativePath },
+      );
+      setMentionPopover(null);
+    },
+    [mentionPopover],
+  );
+  const selectMentionNavItem = React.useCallback(
+    (item: MentionNavItem) => {
+      if (item.type === "file") {
+        selectMentionFile(item.file);
+      }
+    },
+    [selectMentionFile],
+  );
+  const {
+    activeMentionFileIndex,
+    isMentionFilesLoading,
+    mentionFiles,
+    mentionPopoverListRef,
+    setIsMentionFilesLoading,
+    setMentionItemRef,
+  } = useWelcomeMentionSearch({
+    issuePreview: null,
+    onSelectNavItem: selectMentionNavItem,
+    popover: mentionPopover,
+    prPreview: null,
+    selectedProjectPath,
+  });
+  const selectSlashSkill = React.useCallback(
+    (skill: SkillInfo) => {
+      const popover = slashPopover;
+      if (!popover) return;
+      composerRef.current?.applySlashAtRange(
+        popover.slashOffset,
+        popover.query.length,
+        { kind: "skill", absolutePath: skill.path, name: skill.name },
+      );
+      setSlashPopover(null);
+    },
+    [slashPopover],
+  );
+  const selectSlashProject = React.useCallback(
+    (project: { id: string }) => {
+      setTargetKind("project");
+      setProjectGuid(project.id);
+      setWorkspaceGuid("");
+      setSubmitError(null);
+      setSlashPopover(null);
+    },
+    [],
+  );
+  const selectSlashAgent = React.useCallback((agent: AgentMenuOption) => {
+    setAgentId(agent.id);
+    setSubmitError(null);
+    setSlashPopover(null);
+  }, []);
+  const {
+    activeIndex: activeSlashItemIndex,
+    expandedSections,
+    listRef: slashPopoverListRef,
+    setExpandedSections,
+    setItemRef: setSlashItemRef,
+  } = useWelcomeSlashNavigation({
+    filteredAgents,
+    filteredProjects,
+    filteredSkills,
+    onSelectAgent: selectSlashAgent,
+    onSelectProject: selectSlashProject,
+    onSelectSkill: selectSlashSkill,
+    popover: slashPopover,
+  });
   const {
     githubPrereqs,
     githubRelayReady,
@@ -178,6 +307,7 @@ export function AutomationSetup({
 
   React.useEffect(() => {
     if (mode === "edit" && initialAutomation) {
+      clearAttachments();
       setDisplayName(initialAutomation.display_name);
       setInstructions(initialAutomation.instructions);
       setAgentId(initialAutomation.agent_id);
@@ -196,7 +326,7 @@ export function AutomationSetup({
         composerRef.current?.setText(initialAutomation.instructions);
       });
     }
-  }, [initialAutomation, mode]);
+  }, [clearAttachments, initialAutomation, mode]);
 
   React.useEffect(() => {
     if (!agentId && supportedAgents.length > 0) {
@@ -333,15 +463,26 @@ export function AutomationSetup({
 
     setSubmitting(true);
     try {
+      const rawInstructions = composerRef.current?.getText() ?? instructions;
+      const resolvedInstructions = resolvePromptPlaceholders(rawInstructions, []);
+      const attachmentPayload = await Promise.all(
+        attachments.map(async (attachment) => ({
+          filename: attachment.filename,
+          mime: attachment.blob.type || "application/octet-stream",
+          data_base64: await blobToBase64(attachment.blob),
+        })),
+      );
+
       if (mode === "create") {
         await createAutomationWithGithubRoute({
           request: {
             display_name: displayName.trim(),
-            instructions: instructions.trim(),
+            instructions: resolvedInstructions.trim(),
             agent_id: agentId,
             target,
             schedule: requestSchedule,
             trigger: triggerInputForSubmit(trigger, githubConfig, false),
+            attachments: attachmentPayload,
           },
           githubConfig,
           githubRouteReady,
@@ -354,10 +495,11 @@ export function AutomationSetup({
           request: {
             automation_guid: initialAutomation.guid,
             display_name: displayName.trim(),
-            instructions: instructions.trim(),
+            instructions: resolvedInstructions.trim(),
             agent_id: agentId,
             target,
             schedule: requestSchedule,
+            attachments: attachmentPayload,
           },
           initialAutomation,
           trigger,
@@ -368,6 +510,7 @@ export function AutomationSetup({
           updateAutomation: onUpdate,
         });
       }
+      clearAttachments();
     } catch (err) {
       setSubmitError(err instanceof Error ? err.message : "Failed to save automation");
     } finally {
@@ -435,21 +578,55 @@ export function AutomationSetup({
                 }}
               />
               <WelcomeComposerCard
-                attachments={[]}
+                attachments={attachments}
                 composerRef={composerRef}
                 disabledSubmit={disabledSubmit}
                 isInitialProjectsLoading={projectsLoading}
                 isSubmitting={submitting}
-                onAtCancel={() => undefined}
-                onAtTrigger={() => undefined}
-                onAttachmentPreview={() => undefined}
-                onAttachmentRemove={() => undefined}
-                onImagePaste={() => undefined}
-                onSlashCancel={() => undefined}
-                onSlashTrigger={() => undefined}
+                onAtCancel={() => {
+                  setMentionPopover(null);
+                  setIsMentionFilesLoading(false);
+                }}
+                onAtTrigger={(ctx) => {
+                  setMentionPopover({
+                    top: ctx.caretRect.bottom + 4,
+                    left: ctx.caretRect.left,
+                    atOffset: ctx.atOffset,
+                    query: ctx.query,
+                  });
+                }}
+                onAttachmentPreview={(attachment) => setPreviewAttachment(attachment)}
+                onAttachmentRemove={handleAttachmentRemove}
+                onImagePaste={handleImagePaste}
+                onSlashCancel={() => {
+                  setSlashPopover(null);
+                  setExpandedSections({
+                    skills: false,
+                    projects: false,
+                    agents: false,
+                  });
+                }}
+                onSlashTrigger={(ctx) => {
+                  setSlashPopover({
+                    top: ctx.caretRect.bottom + 4,
+                    left: ctx.caretRect.left,
+                    slashOffset: ctx.slashOffset,
+                    query: ctx.query,
+                  });
+                }}
                 onTextChange={(text) => {
                   setInstructions(text);
                   setSubmitError(null);
+                  setMentionPopover((prev) => {
+                    if (!prev) return prev;
+                    if (text.length < prev.atOffset) return null;
+                    if (text.charAt(prev.atOffset - 1) !== "@") return null;
+                    const newQuery = text.slice(prev.atOffset);
+                    const spaceIdx = newQuery.search(/\s/);
+                    if (spaceIdx >= 0) return null;
+                    return newQuery === prev.query ? prev : { ...prev, query: newQuery };
+                  });
+                  syncAttachmentPlaceholders(text);
                 }}
                 placeholder={<span>{placeholder}</span>}
                 controls={
@@ -555,6 +732,51 @@ export function AutomationSetup({
                   />
                 }
               />
+              <WelcomeMentionPopover
+                activeIndex={activeMentionFileIndex}
+                issuePreview={null}
+                isLoading={isMentionFilesLoading}
+                listRef={mentionPopoverListRef}
+                mentionFiles={mentionFiles}
+                onClose={() => setMentionPopover(null)}
+                onSelectFile={selectMentionFile}
+                onSelectNavItem={selectMentionNavItem}
+                onSetItemRef={setMentionItemRef}
+                popover={mentionPopover}
+                prPreview={null}
+              />
+              <SlashCommandPopover
+                activeIndex={activeSlashItemIndex}
+                expandedSections={expandedSections}
+                filteredAgents={filteredAgents}
+                filteredProjects={filteredProjects}
+                filteredSkills={filteredSkills}
+                isSkillsLoading={isSkillsLoading}
+                listRef={slashPopoverListRef}
+                onClose={() => setSlashPopover(null)}
+                onSelectAgent={selectSlashAgent}
+                onSelectProject={selectSlashProject}
+                onSelectSkill={selectSlashSkill}
+                popover={slashPopover}
+                setExpandedSections={setExpandedSections}
+                setItemRef={setSlashItemRef}
+              />
+              {previewAttachment && typeof document !== "undefined"
+                ? createPortal(
+                    <div
+                      className="fixed inset-0 z-[2147483647] flex cursor-zoom-out items-center justify-center bg-black/80 backdrop-blur-sm"
+                      onClick={() => setPreviewAttachment(null)}
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element -- previews use local object URLs and must not go through Next image optimization. */}
+                      <img
+                        src={previewAttachment.objectUrl}
+                        alt={previewAttachment.filename}
+                        className="max-h-[92vh] max-w-[92vw] rounded-md object-contain shadow-2xl"
+                      />
+                    </div>,
+                    document.body,
+                  )
+                : null}
             </div>
           </form>
         </div>

--- a/apps/web/src/features/automations/components/AutomationSetup.tsx
+++ b/apps/web/src/features/automations/components/AutomationSetup.tsx
@@ -7,7 +7,7 @@ import {
   Button,
   TooltipProvider,
 } from "@workspace/ui";
-import { ArrowLeft, LoaderCircle } from "lucide-react";
+import { ArrowLeft, LoaderCircle, X } from "lucide-react";
 
 import {
   AutomationSetupControls,
@@ -85,6 +85,8 @@ const AUTOMATION_HEADLINES: AutomationHeadline[] = [
   "keep_running",
 ];
 const DEFAULT_AUTOMATION_HEADLINE: AutomationHeadline = "automate_next";
+const PREVIEW_FOCUSABLE_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
 export function AutomationSetup({
   mode,
@@ -124,6 +126,7 @@ export function AutomationSetup({
     syncAttachmentPlaceholders,
   } = useWelcomeComposerAttachments(composerRef);
   const previewRequestIdRef = React.useRef(0);
+  const previewDialogRef = React.useRef<HTMLDivElement | null>(null);
   const [, setSettingsModalOpen] = useQueryState("settingsModal", settingsModalParams.settingsModal);
   const [, setActiveSettingTab] = useQueryState("activeSettingTab", settingsModalParams.activeSettingTab);
   const [timezone, setTimezone] = React.useState(resolveTimezone);
@@ -147,6 +150,59 @@ export function AutomationSetup({
   const [headline, setHeadline] = React.useState<AutomationHeadline>(DEFAULT_AUTOMATION_HEADLINE);
   const [mentionPopover, setMentionPopover] = React.useState<MentionPopoverState>(null);
   const [slashPopover, setSlashPopover] = React.useState<WelcomeSlashPopoverState>(null);
+
+  React.useEffect(() => {
+    if (!previewAttachment || typeof document === "undefined") return;
+
+    const previousFocus =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const focusFrame = window.requestAnimationFrame(() => {
+      const dialog = previewDialogRef.current;
+      if (!dialog) return;
+      const firstFocusable = dialog.querySelector<HTMLElement>(PREVIEW_FOCUSABLE_SELECTOR);
+      (firstFocusable ?? dialog).focus();
+    });
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setPreviewAttachment(null);
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const dialog = previewDialogRef.current;
+      if (!dialog) return;
+      const focusable = Array.from(
+        dialog.querySelectorAll<HTMLElement>(PREVIEW_FOCUSABLE_SELECTOR),
+      ).filter((element) => !element.hasAttribute("disabled"));
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialog.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      if (event.shiftKey && (active === first || !dialog.contains(active))) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.cancelAnimationFrame(focusFrame);
+      document.removeEventListener("keydown", handleKeyDown);
+      if (previousFocus && document.contains(previousFocus)) {
+        window.requestAnimationFrame(() => previousFocus.focus());
+      }
+    };
+  }, [previewAttachment, setPreviewAttachment]);
 
   const workspaces = React.useMemo(() => flattenWorkspaces(projects), [projects]);
   const selectedAgent = agents.find((agent) => agent.agent_id === agentId) ?? null;
@@ -472,9 +528,10 @@ export function AutomationSetup({
           data_base64: await blobToBase64(attachment.blob),
         })),
       );
+      let savedAutomation: AutomationDetail | null = null;
 
       if (mode === "create") {
-        await createAutomationWithGithubRoute({
+        savedAutomation = await createAutomationWithGithubRoute({
           request: {
             display_name: displayName.trim(),
             instructions: resolvedInstructions.trim(),
@@ -491,7 +548,7 @@ export function AutomationSetup({
           updateAutomation: onUpdate,
         });
       } else if (initialAutomation) {
-        await updateAutomationWithGithubRoute({
+        savedAutomation = await updateAutomationWithGithubRoute({
           request: {
             automation_guid: initialAutomation.guid,
             display_name: displayName.trim(),
@@ -509,6 +566,10 @@ export function AutomationSetup({
           githubPrereqs,
           updateAutomation: onUpdate,
         });
+      }
+      if (savedAutomation) {
+        setInstructions(savedAutomation.instructions);
+        composerRef.current?.setText(savedAutomation.instructions);
       }
       clearAttachments();
     } catch (err) {
@@ -764,9 +825,22 @@ export function AutomationSetup({
               {previewAttachment && typeof document !== "undefined"
                 ? createPortal(
                     <div
+                      ref={previewDialogRef}
+                      role="dialog"
+                      aria-modal="true"
+                      aria-label={`Preview attachment ${previewAttachment.filename}`}
+                      tabIndex={-1}
                       className="fixed inset-0 z-[2147483647] flex cursor-zoom-out items-center justify-center bg-black/80 backdrop-blur-sm"
                       onClick={() => setPreviewAttachment(null)}
                     >
+                      <button
+                        type="button"
+                        className="absolute right-4 top-4 inline-flex size-10 items-center justify-center rounded-md border border-white/20 bg-black/40 text-white shadow-lg transition hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                        onClick={() => setPreviewAttachment(null)}
+                      >
+                        <X className="size-5" />
+                        <span className="sr-only">Close preview</span>
+                      </button>
                       {/* eslint-disable-next-line @next/next/no-img-element -- previews use local object URLs and must not go through Next image optimization. */}
                       <img
                         src={previewAttachment.objectUrl}

--- a/apps/web/src/features/automations/types.ts
+++ b/apps/web/src/features/automations/types.ts
@@ -111,6 +111,7 @@ export interface AutomationCreateRequest {
   target: AutomationTargetInput;
   schedule: AutomationScheduleInput | null;
   trigger?: AutomationTriggerInput | null;
+  attachments?: AutomationAttachmentPayload[];
 }
 
 export interface AutomationUpdateRequest {
@@ -121,6 +122,13 @@ export interface AutomationUpdateRequest {
   target?: AutomationTargetInput;
   schedule?: AutomationScheduleInput | null;
   trigger?: AutomationTriggerInput | null;
+  attachments?: AutomationAttachmentPayload[];
+}
+
+export interface AutomationAttachmentPayload {
+  filename: string;
+  mime?: string | null;
+  data_base64: string;
 }
 
 export interface AutomationRunSummary {

--- a/apps/web/src/features/welcome/components/PromptComposer.tsx
+++ b/apps/web/src/features/welcome/components/PromptComposer.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { createPortal } from "react-dom";
 import { cn, getFileIconProps } from "@workspace/ui";
+import { parseAppshotProtocol } from "@/features/appshot/lib/appshot-protocol";
 
 export type MentionRef =
   | { kind: "issue" | "pr"; number: number }
@@ -59,7 +60,8 @@ interface PromptComposerProps extends ComposerCallbacks {
   onSubmit?: () => void;
 }
 
-const TOKEN_REGEX = /(@(?:issue|pr)#\d+|@file:[^\s]+|\/skill:[^\s]+|\[#img-\d+\])/g;
+const TOKEN_REGEX =
+  /(@(?:issue|pr)#\d+|@file:[^\s]+|\/skill:[^\s]+|\[#img-\d+\]|\[#appshot:\d{13}\])/g;
 
 /**
  * SVG icons used inside chips live as static assets under
@@ -143,6 +145,14 @@ function buildChipNode(token: string): HTMLSpanElement {
     span.dataset.kind = "img";
     span.className += " border-border/70 bg-muted/60 text-foreground";
     span.textContent = token.replace(/[\[\]]/g, "");
+  } else if (token.startsWith("[#appshot:")) {
+    span.dataset.kind = "appshot";
+    const timestamp = token.slice("[#appshot:".length, -1);
+    span.dataset.tooltip = `Appshot ${timestamp}`;
+    span.className += " border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+    const label = document.createElement("span");
+    label.textContent = `Appshot · ${timestamp}`;
+    span.appendChild(label);
   }
   return span;
 }
@@ -574,8 +584,19 @@ export const PromptComposer = React.forwardRef<ComposerHandle, PromptComposerPro
       }
       if (imageHandled) return;
       // Plain text paste — strip rich formatting
-      event.preventDefault();
       const text = event.clipboardData.getData("text/plain");
+      const appshotProtocol = parseAppshotProtocol(text);
+      if (appshotProtocol && editorRef.current) {
+        event.preventDefault();
+        insertNodeAtCaret(
+          editorRef.current,
+          buildChipNode(`[#appshot:${appshotProtocol.timestamp}]`),
+        );
+        insertNodeAtCaret(editorRef.current, document.createTextNode("\u00A0"));
+        fireChange();
+        return;
+      }
+      event.preventDefault();
       if (text) {
         document.execCommand("insertText", false, text);
       }

--- a/apps/web/src/features/welcome/components/PromptComposer.tsx
+++ b/apps/web/src/features/welcome/components/PromptComposer.tsx
@@ -149,7 +149,7 @@ function buildChipNode(token: string): HTMLSpanElement {
     span.dataset.kind = "appshot";
     const timestamp = token.slice("[#appshot:".length, -1);
     span.dataset.tooltip = `Appshot ${timestamp}`;
-    span.className += " border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+    span.className += " border-success/30 bg-success/10 text-success";
     const label = document.createElement("span");
     label.textContent = `Appshot · ${timestamp}`;
     span.appendChild(label);

--- a/apps/web/src/features/welcome/components/WelcomeComposerFooter.tsx
+++ b/apps/web/src/features/welcome/components/WelcomeComposerFooter.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React from "react";
-import { createPortal } from "react-dom";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@workspace/ui";
 import {
   Eye,
@@ -12,6 +11,7 @@ import {
   Sparkles,
 } from "lucide-react";
 import type { ComposerAttachment } from "@/features/welcome/components/AttachmentBar";
+import { ImagePreviewOverlay } from "@/shared/components/image-preview-overlay";
 import { SlashCommandPopover } from "@/features/welcome/components/SlashCommandPopover";
 import { WelcomeAdvancedOptions } from "@/features/welcome/components/WelcomeAdvancedOptions";
 import { WelcomeMentionPopover } from "@/features/welcome/components/WelcomeMentionPopover";
@@ -67,22 +67,13 @@ export function WelcomeComposerFooter({
         <WelcomeMentionPopover {...mentionPopoverProps} />
         <SlashCommandPopover {...slashPopoverProps} />
 
-        {previewAttachment && typeof document !== "undefined"
-          ? createPortal(
-              <div
-                className="fixed inset-0 z-[2147483647] flex cursor-zoom-out items-center justify-center bg-black/80 backdrop-blur-sm"
-                onClick={onPreviewAttachmentClose}
-              >
-                {/* eslint-disable-next-line @next/next/no-img-element -- previews use local object URLs and must not go through Next image optimization. */}
-                <img
-                  src={previewAttachment.objectUrl}
-                  alt={previewAttachment.filename}
-                  className="max-h-[92vh] max-w-[92vw] rounded-md object-contain shadow-2xl"
-                />
-              </div>,
-              document.body,
-            )
-          : null}
+        {previewAttachment ? (
+          <ImagePreviewOverlay
+            src={previewAttachment.objectUrl}
+            alt={previewAttachment.filename}
+            onClose={onPreviewAttachmentClose}
+          />
+        ) : null}
 
         {summaryItems.length > 0 ? (
           <div className="scrollbar-on-hover flex min-w-0 items-center gap-1 overflow-x-auto whitespace-nowrap pr-1">

--- a/apps/web/src/features/welcome/components/__tests__/prompt-composer-appshot-paste.test.tsx
+++ b/apps/web/src/features/welcome/components/__tests__/prompt-composer-appshot-paste.test.tsx
@@ -1,0 +1,142 @@
+// @ts-expect-error bun:test is available at runtime but not in tsconfig types
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { Window } from "happy-dom";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import type { ComposerHandle } from "../PromptComposer";
+
+type TestIconProps = {
+  name: string;
+  isDir: boolean;
+  className?: string;
+};
+
+mock.module("@workspace/ui", () => ({
+  cn: (...values: Array<string | false | null | undefined>) =>
+    values.filter(Boolean).join(" "),
+  getFileIconProps: ({ className }: TestIconProps) => ({
+    alt: "",
+    className,
+    src: "/icons/file.svg",
+  }),
+}));
+
+const { PromptComposer } = await import("../PromptComposer");
+
+const timestamp = "1760000000000";
+let root: Root | null = null;
+
+beforeEach(() => {
+  installDom();
+});
+
+afterEach(async () => {
+  if (root) {
+    const currentRoot = root;
+    root = null;
+    await act(async () => {
+      currentRoot.unmount();
+    });
+  }
+  cleanupDom();
+});
+
+describe("PromptComposer Appshot paste handling", () => {
+  it("collapses first-line Appshot protocol text into an Appshot chip token", async () => {
+    const composerRef = React.createRef<ComposerHandle>();
+    let latestText = "";
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(
+        <PromptComposer
+          ref={composerRef}
+          onTextChange={(text) => {
+            latestText = text;
+          }}
+        />,
+      );
+    });
+
+    const editor = container.querySelector<HTMLElement>("[contenteditable='true']");
+    if (!editor) {
+      throw new Error("PromptComposer editor not found");
+    }
+
+    await act(async () => {
+      editor.dispatchEvent(
+        pasteEvent(
+          `atmos://appshots/${timestamp}\nAppshot record is stored locally at ~/.atmos/appshots/records/${timestamp}/.`,
+        ),
+      );
+    });
+
+    expect(editor.textContent).toContain(`Appshot · ${timestamp}`);
+    expect(latestText.trim()).toBe(`[#appshot:${timestamp}]`);
+    expect(composerRef.current?.getText().trim()).toBe(`[#appshot:${timestamp}]`);
+  });
+});
+
+function pasteEvent(text: string): Event {
+  const event = new Event("paste", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "clipboardData", {
+    configurable: true,
+    value: {
+      getData: (type: string) => (type === "text/plain" ? text : ""),
+      items: [],
+    },
+  });
+  return event;
+}
+
+function installDom(): void {
+  const browserWindow = new Window({ url: "http://localhost:3030" });
+  const win = browserWindow as unknown as Window &
+    typeof globalThis & {
+      ResizeObserver?: typeof ResizeObserver;
+    };
+
+  setGlobal("window", win);
+  setGlobal("document", win.document);
+  setGlobal("navigator", win.navigator);
+  setGlobal("HTMLElement", win.HTMLElement);
+  setGlobal("Element", win.Element);
+  setGlobal("Node", win.Node);
+  setGlobal("Text", win.Text);
+  setGlobal("Event", win.Event);
+  setGlobal("MutationObserver", win.MutationObserver);
+  setGlobal("ResizeObserver", win.ResizeObserver);
+  setGlobal("getComputedStyle", win.getComputedStyle.bind(win));
+  setGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  win.SyntaxError = SyntaxError;
+}
+
+function cleanupDom(): void {
+  for (const key of [
+    "window",
+    "document",
+    "navigator",
+    "HTMLElement",
+    "Element",
+    "Node",
+    "Text",
+    "Event",
+    "MutationObserver",
+    "ResizeObserver",
+    "getComputedStyle",
+    "IS_REACT_ACT_ENVIRONMENT",
+  ]) {
+    Reflect.deleteProperty(globalThis, key);
+  }
+}
+
+function setGlobal(key: string, value: unknown): void {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value,
+    writable: true,
+  });
+}

--- a/apps/web/src/features/welcome/lib/__tests__/welcome-appshot-placeholders.test.ts
+++ b/apps/web/src/features/welcome/lib/__tests__/welcome-appshot-placeholders.test.ts
@@ -1,0 +1,54 @@
+// @ts-expect-error bun:test is available at runtime but not in tsconfig types
+import { describe, expect, it, mock } from "bun:test";
+
+import type { ComposerAttachment } from "../../components/AttachmentBar";
+
+mock.module("next/font/local", () => ({
+  default: () => ({ className: "", style: {}, variable: "" }),
+}));
+
+mock.module("@/shared/components/ui/AtmosWordmark", () => ({
+  AtmosWordmark: () => null,
+}));
+
+const { formatAppshotPrompt } = await import("@/features/appshot/lib/appshot-protocol");
+const { resolvePromptPlaceholders } = await import("../welcome-page-helpers");
+
+const timestamp = "1760000000000";
+
+describe("Welcome Appshot prompt placeholders", () => {
+  it("expands Appshot chips while keeping existing placeholder behavior", () => {
+    const attachments: ComposerAttachment[] = [
+      {
+        id: "img-1",
+        number: 1,
+        ext: "png",
+        filename: "img-1.png",
+        blob: new Blob(["x"], { type: "image/png" }),
+        objectUrl: "blob:img-1",
+      },
+    ];
+
+    expect(
+      resolvePromptPlaceholders(
+        `Fix @issue#123 with @file:src/app.ts [#img-1] [#appshot:${timestamp}]`,
+        attachments,
+      ),
+    ).toBe(
+      [
+        "Fix .atmos/context/requirement.md with src/app.ts .atmos/attachments/img-1.png",
+        formatAppshotPrompt(timestamp),
+      ].join(" "),
+    );
+  });
+
+  it("leaves malformed Appshot chips untouched", () => {
+    expect(resolvePromptPlaceholders("[#appshot:123]", [])).toBe("[#appshot:123]");
+  });
+
+  it("can expand Appshot chips while preserving image tokens for backend attachment resolution", () => {
+    expect(resolvePromptPlaceholders(`Analyze [#img-1] [#appshot:${timestamp}]`, [])).toBe(
+      `Analyze [#img-1] ${formatAppshotPrompt(timestamp)}`,
+    );
+  });
+});

--- a/apps/web/src/features/welcome/lib/welcome-page-helpers.tsx
+++ b/apps/web/src/features/welcome/lib/welcome-page-helpers.tsx
@@ -8,6 +8,7 @@ import type {
 } from "@/api/ws-api";
 import { AtmosWordmark } from "@/shared/components/ui/AtmosWordmark";
 import type { ComposerAttachment } from "@/features/welcome/components/AttachmentBar";
+import { formatAppshotPrompt } from "@/features/appshot/lib/appshot-protocol";
 
 export interface RepoContext {
   owner: string;
@@ -333,6 +334,9 @@ export function resolvePromptPlaceholders(text: string, atts: ComposerAttachment
   return text
     .replace(/@(?:issue|pr)#\d+/g, () => ".atmos/context/requirement.md")
     .replace(/@file:([^\s]+)/g, (_match, relativePath: string) => relativePath)
+    .replace(/\[#appshot:(\d{13})\]/g, (_match, timestamp: string) =>
+      formatAppshotPrompt(timestamp),
+    )
     .replace(/\[#img-(\d+)\]/g, (match, n: string) => {
       const att = atts.find((a) => a.number === Number(n));
       return att ? `.atmos/attachments/${att.filename}` : match;

--- a/apps/web/src/shared/components/image-preview-overlay.tsx
+++ b/apps/web/src/shared/components/image-preview-overlay.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import React from "react";
+import { createPortal } from "react-dom";
+
+type ImagePreviewOverlayProps = {
+  alt: string;
+  src: string;
+  onClose: () => void;
+};
+
+export function ImagePreviewOverlay({
+  alt,
+  src,
+  onClose,
+}: ImagePreviewOverlayProps) {
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={alt}
+      className="fixed inset-0 z-[2147483647] flex cursor-zoom-out items-center justify-center bg-black/80 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element -- previews use local object/data URLs and must not go through Next image optimization. */}
+      <img
+        src={src}
+        alt={alt}
+        className="max-h-[92vh] max-w-[92vw] rounded-md object-contain shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      />
+    </div>,
+    document.body,
+  );
+}

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "1.2.0-beta.8",
+      "version": "1.2.0-beta.10",
       "devDependencies": {
         "@tauri-apps/cli": "^2.0.0",
       },
@@ -186,6 +186,7 @@
         "@xterm/addon-unicode11": "^0.9.0",
         "eslint": "^9",
         "eslint-config-next": "16.2.0",
+        "happy-dom": "^20.9.0",
         "shiki": "^3.22.0",
         "tailwindcss": "^4.3.0",
         "tw-animate-css": "^1.4.0",
@@ -1253,6 +1254,10 @@
 
     "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.53.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.53.0", "@typescript-eslint/type-utils": "8.53.0", "@typescript-eslint/utils": "8.53.0", "@typescript-eslint/visitor-keys": "8.53.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.53.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-eEXsVvLPu8Z4PkFibtuFJLJOTAV/nPdgtSjkGoPpddpFk3/ym2oy97jynY6ic2m6+nc5M8SE1e9v/mHKsulcJg=="],
 
     "@typescript-eslint/parser": ["@typescript-eslint/parser@8.53.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.53.0", "@typescript-eslint/types": "8.53.0", "@typescript-eslint/typescript-estree": "8.53.0", "@typescript-eslint/visitor-keys": "8.53.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg=="],
@@ -1613,7 +1618,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.21.5", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-mLCNbrQli11K1ySUmuNt4ZUB3OpGIDq4q2vTBTf5cL2lpsRjI9QKqSD0ndjW8FyvcW/Jj46gMe9syyHAsvMa/A=="],
 
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "error-stack-parser": ["error-stack-parser@2.1.4", "", { "dependencies": { "stackframe": "^1.3.4" } }, "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ=="],
 
@@ -1786,6 +1791,8 @@
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "hachure-fill": ["hachure-fill@0.5.2", "https://registry.npmmirror.com/hachure-fill/-/hachure-fill-0.5.2.tgz", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -2697,6 +2704,8 @@
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "which-boxed-primitive": ["which-boxed-primitive@1.1.1", "", { "dependencies": { "is-bigint": "^1.1.0", "is-boolean-object": "^1.2.1", "is-number-object": "^1.1.1", "is-string": "^1.1.1", "is-symbol": "^1.1.1" } }, "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA=="],
@@ -2713,7 +2722,7 @@
 
     "wrangler": ["wrangler@4.92.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260515.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260515.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260515.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-/DKpQHPxkuZbQsO9dFW2700VTD/4DSZMHjy92fO/frNoDRi/zQsFCAd2ONCV6TGqcUoXcP3D8Bo2gj/L4M0qQQ=="],
 
-    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
@@ -2811,6 +2820,8 @@
 
     "@tldraw/editor/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
+    "@types/ws/@types/node": ["@types/node@25.0.9", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw=="],
+
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
@@ -2867,6 +2878,8 @@
 
     "fumadocs-ui/unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
 
+    "happy-dom/@types/node": ["@types/node@25.0.9", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw=="],
+
     "landing/lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
@@ -2877,11 +2890,15 @@
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "nuqs/@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
@@ -2906,6 +2923,8 @@
     "styled-components/postcss": ["postcss@8.4.49", "", { "dependencies": { "nanoid": "^3.3.7", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA=="],
 
     "web/lucide-react": ["lucide-react@0.563.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA=="],
+
+    "@types/ws/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -2994,6 +3013,8 @@
     "fumadocs-ui/shiki/@shikijs/themes": ["@shikijs/themes@4.1.0", "", { "dependencies": { "@shikijs/types": "4.1.0" } }, "sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw=="],
 
     "fumadocs-ui/shiki/@shikijs/types": ["@shikijs/types@4.1.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA=="],
+
+    "happy-dom/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 

--- a/crates/core-service/src/service/automation/artifacts.rs
+++ b/crates/core-service/src/service/automation/artifacts.rs
@@ -3,11 +3,19 @@ use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
 use crate::error::{Result, ServiceError};
+use crate::WorkspaceAttachmentPayload;
 
 pub const AUTOMATIONS_DIR: &str = "automations";
 pub const DEFINITIONS_DIR: &str = "definitions";
 pub const RUNS_DIR: &str = "runs";
 pub const INSTRUCTIONS_FILE: &str = "instructions.md";
+pub const ATTACHMENTS_DIR: &str = "attachments";
+
+#[derive(Debug, Clone)]
+pub struct WrittenAttachment {
+    pub token: String,
+    pub path: PathBuf,
+}
 
 pub fn automation_root() -> Result<PathBuf> {
     let home = dirs::home_dir()
@@ -29,6 +37,10 @@ pub fn definition_dir(automation_guid: &str) -> Result<PathBuf> {
 
 pub fn instructions_path(automation_guid: &str) -> Result<PathBuf> {
     Ok(definition_dir(automation_guid)?.join(INSTRUCTIONS_FILE))
+}
+
+pub fn attachments_dir(automation_guid: &str) -> Result<PathBuf> {
+    Ok(definition_dir(automation_guid)?.join(ATTACHMENTS_DIR))
 }
 
 pub fn write_instructions(automation_guid: &str, instructions: &str) -> Result<PathBuf> {
@@ -102,6 +114,60 @@ pub fn write_user_private_file(path: &Path, content: &str) -> Result<()> {
     })?;
     set_file_permissions(path)?;
     Ok(())
+}
+
+pub fn write_attachments(
+    automation_guid: &str,
+    attachments: Vec<WorkspaceAttachmentPayload>,
+) -> Result<Vec<WrittenAttachment>> {
+    if attachments.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    use base64::Engine;
+
+    let dir = attachments_dir(automation_guid)?;
+    ensure_user_private_dir(&dir)?;
+    let mut written = Vec::new();
+
+    for attachment in attachments {
+        let safe = attachment
+            .filename
+            .replace(['/', '\\'], "_")
+            .trim()
+            .to_string();
+        if safe.is_empty() {
+            continue;
+        }
+
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(attachment.data_base64.as_bytes())
+            .map_err(|error| {
+                ServiceError::Validation(format!("Failed to decode attachment {safe}: {error}"))
+            })?;
+        let path = dir.join(&safe);
+        fs::write(&path, bytes).map_err(|error| {
+            ServiceError::Validation(format!(
+                "Failed to write automation attachment {safe}: {error}"
+            ))
+        })?;
+        set_file_permissions(&path)?;
+
+        if let Some(token) = image_placeholder_token(&safe) {
+            written.push(WrittenAttachment { token, path });
+        }
+    }
+
+    Ok(written)
+}
+
+fn image_placeholder_token(filename: &str) -> Option<String> {
+    let stem = filename.split('.').next()?;
+    let number = stem.strip_prefix("img-")?;
+    if number.is_empty() || !number.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    Some(format!("[#img-{number}]"))
 }
 
 fn ensure_path_under_root(path: &Path, root: &Path) -> Result<()> {

--- a/crates/core-service/src/service/automation/artifacts.rs
+++ b/crates/core-service/src/service/automation/artifacts.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
@@ -13,7 +14,7 @@ pub const ATTACHMENTS_DIR: &str = "attachments";
 
 #[derive(Debug, Clone)]
 pub struct WrittenAttachment {
-    pub token: String,
+    pub placeholder_token: Option<String>,
     pub path: PathBuf,
 }
 
@@ -68,12 +69,12 @@ pub fn stage_instructions(automation_guid: &str, instructions: &str) -> Result<S
     })
 }
 
-pub fn commit_staged_instructions(staged: StagedInstructions) -> Result<PathBuf> {
+pub fn commit_staged_instructions(staged: &StagedInstructions) -> Result<PathBuf> {
     fs::rename(&staged.temp_path, &staged.final_path).map_err(|error| {
         ServiceError::Validation(format!("Failed to update automation instructions: {error}"))
     })?;
     set_file_permissions(&staged.final_path)?;
-    Ok(staged.final_path)
+    Ok(staged.final_path.clone())
 }
 
 pub fn discard_staged_instructions(staged: &StagedInstructions) {
@@ -120,45 +121,103 @@ pub fn write_attachments(
     automation_guid: &str,
     attachments: Vec<WorkspaceAttachmentPayload>,
 ) -> Result<Vec<WrittenAttachment>> {
+    let dir = attachments_dir(automation_guid)?;
+    write_attachments_to_dir(&dir, attachments)
+}
+
+fn write_attachments_to_dir(
+    dir: &Path,
+    attachments: Vec<WorkspaceAttachmentPayload>,
+) -> Result<Vec<WrittenAttachment>> {
     if attachments.is_empty() {
         return Ok(Vec::new());
     }
 
     use base64::Engine;
 
-    let dir = attachments_dir(automation_guid)?;
-    ensure_user_private_dir(&dir)?;
-    let mut written = Vec::new();
-
+    let mut seen_filenames = HashSet::new();
+    let mut pending = Vec::new();
     for attachment in attachments {
-        let safe = attachment
-            .filename
-            .replace(['/', '\\'], "_")
-            .trim()
-            .to_string();
+        let safe = normalize_attachment_filename(&attachment.filename);
         if safe.is_empty() {
             continue;
         }
-
-        let bytes = base64::engine::general_purpose::STANDARD
-            .decode(attachment.data_base64.as_bytes())
-            .map_err(|error| {
-                ServiceError::Validation(format!("Failed to decode attachment {safe}: {error}"))
-            })?;
-        let path = dir.join(&safe);
-        fs::write(&path, bytes).map_err(|error| {
-            ServiceError::Validation(format!(
-                "Failed to write automation attachment {safe}: {error}"
-            ))
-        })?;
-        set_file_permissions(&path)?;
-
-        if let Some(token) = image_placeholder_token(&safe) {
-            written.push(WrittenAttachment { token, path });
+        if !seen_filenames.insert(safe.clone()) {
+            return Err(ServiceError::Validation(format!(
+                "Duplicate automation attachment filename: {safe}"
+            )));
         }
+        pending.push((safe, attachment));
+    }
+
+    if pending.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    ensure_user_private_dir(dir)?;
+    let mut written = Vec::new();
+    let mut written_paths = Vec::new();
+
+    for (safe, attachment) in pending {
+        let bytes = match base64::engine::general_purpose::STANDARD
+            .decode(attachment.data_base64.as_bytes())
+        {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                discard_attachment_paths(&written_paths);
+                return Err(ServiceError::Validation(format!(
+                    "Failed to decode attachment {safe}: {error}"
+                )));
+            }
+        };
+        let path = dir.join(&safe);
+        if let Err(error) = fs::write(&path, bytes) {
+            let mut cleanup_paths = written_paths.clone();
+            cleanup_paths.push(path.clone());
+            discard_attachment_paths(&cleanup_paths);
+            return Err(ServiceError::Validation(format!(
+                "Failed to write automation attachment {safe}: {error}"
+            )));
+        }
+        written_paths.push(path.clone());
+        if let Err(error) = set_file_permissions(&path) {
+            discard_attachment_paths(&written_paths);
+            return Err(error);
+        }
+
+        written.push(WrittenAttachment {
+            placeholder_token: image_placeholder_token(&safe),
+            path,
+        });
     }
 
     Ok(written)
+}
+
+pub fn discard_written_attachments(attachments: &[WrittenAttachment]) {
+    let paths = attachments
+        .iter()
+        .map(|attachment| attachment.path.clone())
+        .collect::<Vec<_>>();
+    discard_attachment_paths(&paths);
+}
+
+fn normalize_attachment_filename(filename: &str) -> String {
+    filename.replace(['/', '\\'], "_").trim().to_string()
+}
+
+fn discard_attachment_paths(paths: &[PathBuf]) {
+    for path in paths {
+        if let Err(error) = fs::remove_file(path) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(
+                    "Failed to clean up automation attachment {}: {}",
+                    path.display(),
+                    error
+                );
+            }
+        }
+    }
 }
 
 fn image_placeholder_token(filename: &str) -> Option<String> {
@@ -211,4 +270,56 @@ fn set_file_permissions(path: &Path) -> Result<()> {
 #[cfg(not(unix))]
 fn set_file_permissions(_path: &Path) -> Result<()> {
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn attachment(filename: &str, data_base64: &str) -> WorkspaceAttachmentPayload {
+        WorkspaceAttachmentPayload {
+            filename: filename.to_string(),
+            mime: Some("image/png".to_string()),
+            data_base64: data_base64.to_string(),
+        }
+    }
+
+    #[test]
+    fn rejects_duplicate_normalized_attachment_filenames_before_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let error = write_attachments_to_dir(
+            dir.path(),
+            vec![
+                attachment("a/b.png", "aGVsbG8="),
+                attachment("a\\b.png", "aGVsbG8="),
+            ],
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ServiceError::Validation(message) if message.contains("Duplicate automation attachment filename")
+        ));
+        assert!(!dir.path().join("a_b.png").exists());
+    }
+
+    #[test]
+    fn rolls_back_written_attachments_when_later_decode_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let first_path = dir.path().join("img-1.png");
+        let error = write_attachments_to_dir(
+            dir.path(),
+            vec![
+                attachment("img-1.png", "aGVsbG8="),
+                attachment("img-2.png", "not base64"),
+            ],
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ServiceError::Validation(message) if message.contains("Failed to decode attachment img-2.png")
+        ));
+        assert!(!first_path.exists());
+    }
 }

--- a/crates/core-service/src/service/automation/mod.rs
+++ b/crates/core-service/src/service/automation/mod.rs
@@ -26,6 +26,7 @@ use tokio::sync::{broadcast, Mutex};
 use uuid::Uuid;
 
 use crate::error::{Result, ServiceError};
+use crate::WorkspaceAttachmentPayload;
 
 use super::notification::NotificationService;
 use super::project::ProjectService;
@@ -209,6 +210,8 @@ pub struct AutomationCreateReq {
     pub agent_id: String,
     pub target: AutomationTargetInput,
     #[serde(default)]
+    pub attachments: Vec<WorkspaceAttachmentPayload>,
+    #[serde(default)]
     pub schedule: Option<AutomationScheduleInput>,
     #[serde(default)]
     pub trigger: Option<AutomationTriggerInput>,
@@ -221,6 +224,8 @@ pub struct AutomationUpdateReq {
     pub display_name: Option<String>,
     #[serde(default)]
     pub instructions: Option<String>,
+    #[serde(default)]
+    pub attachments: Vec<WorkspaceAttachmentPayload>,
     #[serde(default)]
     pub agent_id: Option<String>,
     #[serde(default)]
@@ -427,7 +432,6 @@ impl AutomationService {
 
     pub async fn create_automation(&self, req: AutomationCreateReq) -> Result<AutomationDetail> {
         let display_name = validate_display_name(req.display_name)?;
-        let instructions = validate_instructions(req.instructions)?;
         self.validate_agent(&req.agent_id)?;
         self.validate_target(&req.target).await?;
         let normalized_schedule = req
@@ -440,6 +444,11 @@ impl AutomationService {
 
         let automation_guid = Uuid::new_v4().to_string();
         let definition_dir = artifacts::definition_dir(&automation_guid)?;
+        let attachment_paths = artifacts::write_attachments(&automation_guid, req.attachments)?;
+        let instructions = validate_instructions(resolve_attachment_placeholders(
+            req.instructions,
+            &attachment_paths,
+        ))?;
         let instructions_path = artifacts::write_instructions(&automation_guid, &instructions)?;
         let artifact_root = artifacts::automation_root()?;
 
@@ -498,7 +507,16 @@ impl AutomationService {
                 ServiceError::NotFound(format!("Automation {} not found", req.automation_guid))
             })?;
 
-        let validated_instructions = req.instructions.map(validate_instructions).transpose()?;
+        let attachment_paths = artifacts::write_attachments(&req.automation_guid, req.attachments)?;
+        let validated_instructions = req
+            .instructions
+            .map(|instructions| {
+                validate_instructions(resolve_attachment_placeholders(
+                    instructions,
+                    &attachment_paths,
+                ))
+            })
+            .transpose()?;
         let display_name = req.display_name.map(validate_display_name).transpose()?;
         if let Some(agent_id) = req.agent_id.as_deref() {
             self.validate_agent(agent_id)?;
@@ -858,6 +876,17 @@ fn cleanup_failed_automation_create_artifacts(instructions_path: &Path, definiti
     }
 }
 
+fn resolve_attachment_placeholders(
+    instructions: String,
+    attachments: &[artifacts::WrittenAttachment],
+) -> String {
+    attachments
+        .iter()
+        .fold(instructions, |current, attachment| {
+            current.replace(&attachment.token, &attachment.path.display().to_string())
+        })
+}
+
 impl From<automation::Model> for AutomationSummary {
     fn from(model: automation::Model) -> Self {
         Self {
@@ -915,6 +944,7 @@ impl From<automation_run::Model> for AutomationRunSummary {
 #[cfg(test)]
 mod tests {
     use serde_json::json;
+    use std::path::PathBuf;
 
     use super::*;
 
@@ -977,5 +1007,18 @@ mod tests {
         assert!(!trigger.enabled);
         assert_eq!(trigger.status, AutomationTriggerStatus::NeedsSetup.as_str());
         assert!(trigger.config_json.is_some());
+    }
+
+    #[test]
+    fn resolves_written_attachment_tokens_to_paths() {
+        let resolved = resolve_attachment_placeholders(
+            "Inspect [#img-1] and keep [#img-2].".to_string(),
+            &[artifacts::WrittenAttachment {
+                token: "[#img-1]".to_string(),
+                path: PathBuf::from("/tmp/atmos/img-1.png"),
+            }],
+        );
+
+        assert_eq!(resolved, "Inspect /tmp/atmos/img-1.png and keep [#img-2].");
     }
 }

--- a/crates/core-service/src/service/automation/mod.rs
+++ b/crates/core-service/src/service/automation/mod.rs
@@ -444,13 +444,30 @@ impl AutomationService {
 
         let automation_guid = Uuid::new_v4().to_string();
         let definition_dir = artifacts::definition_dir(&automation_guid)?;
-        let attachment_paths = artifacts::write_attachments(&automation_guid, req.attachments)?;
-        let instructions = validate_instructions(resolve_attachment_placeholders(
-            req.instructions,
-            &attachment_paths,
-        ))?;
-        let instructions_path = artifacts::write_instructions(&automation_guid, &instructions)?;
-        let artifact_root = artifacts::automation_root()?;
+        let attachment_paths = match artifacts::write_attachments(&automation_guid, req.attachments)
+        {
+            Ok(paths) => paths,
+            Err(error) => {
+                cleanup_failed_automation_create_artifacts(&definition_dir);
+                return Err(error);
+            }
+        };
+        let create_artifacts = (|| {
+            let instructions = validate_instructions(resolve_attachment_placeholders(
+                req.instructions,
+                &attachment_paths,
+            ))?;
+            let instructions_path = artifacts::write_instructions(&automation_guid, &instructions)?;
+            let artifact_root = artifacts::automation_root()?;
+            Ok((instructions_path, artifact_root))
+        })();
+        let (instructions_path, artifact_root) = match create_artifacts {
+            Ok(paths) => paths,
+            Err(error) => {
+                cleanup_failed_automation_create_artifacts(&definition_dir);
+                return Err(error);
+            }
+        };
 
         let repo = AutomationRepo::new(&self.db);
         let model = match repo
@@ -484,7 +501,7 @@ impl AutomationService {
         {
             Ok(model) => model,
             Err(error) => {
-                cleanup_failed_automation_create_artifacts(&instructions_path, &definition_dir);
+                cleanup_failed_automation_create_artifacts(&definition_dir);
                 return Err(error.into());
             }
         };
@@ -507,16 +524,6 @@ impl AutomationService {
                 ServiceError::NotFound(format!("Automation {} not found", req.automation_guid))
             })?;
 
-        let attachment_paths = artifacts::write_attachments(&req.automation_guid, req.attachments)?;
-        let validated_instructions = req
-            .instructions
-            .map(|instructions| {
-                validate_instructions(resolve_attachment_placeholders(
-                    instructions,
-                    &attachment_paths,
-                ))
-            })
-            .transpose()?;
         let display_name = req.display_name.map(validate_display_name).transpose()?;
         if let Some(agent_id) = req.agent_id.as_deref() {
             self.validate_agent(agent_id)?;
@@ -543,6 +550,23 @@ impl AutomationService {
             req.schedule.as_ref().map(|schedule| schedule.is_some()),
             &existing,
         )?;
+        let attachment_paths = artifacts::write_attachments(&req.automation_guid, req.attachments)?;
+        let validated_instructions = match req
+            .instructions
+            .map(|instructions| {
+                validate_instructions(resolve_attachment_placeholders(
+                    instructions,
+                    &attachment_paths,
+                ))
+            })
+            .transpose()
+        {
+            Ok(instructions) => instructions,
+            Err(error) => {
+                artifacts::discard_written_attachments(&attachment_paths);
+                return Err(error);
+            }
+        };
 
         let update = UpdateAutomationRecord {
             display_name,
@@ -590,7 +614,14 @@ impl AutomationService {
         let staged_instructions = validated_instructions
             .as_deref()
             .map(|instructions| artifacts::stage_instructions(&existing.guid, instructions))
-            .transpose()?;
+            .transpose();
+        let staged_instructions = match staged_instructions {
+            Ok(staged) => staged,
+            Err(error) => {
+                artifacts::discard_written_attachments(&attachment_paths);
+                return Err(error);
+            }
+        };
 
         let model = match repo.update_automation(&req.automation_guid, update).await {
             Ok(model) => model,
@@ -598,11 +629,16 @@ impl AutomationService {
                 if let Some(staged) = staged_instructions.as_ref() {
                     artifacts::discard_staged_instructions(staged);
                 }
+                artifacts::discard_written_attachments(&attachment_paths);
                 return Err(error.into());
             }
         };
-        if let Some(staged) = staged_instructions {
-            artifacts::commit_staged_instructions(staged)?;
+        if let Some(staged) = staged_instructions.as_ref() {
+            if let Err(error) = artifacts::commit_staged_instructions(staged) {
+                artifacts::discard_staged_instructions(staged);
+                artifacts::discard_written_attachments(&attachment_paths);
+                return Err(error);
+            }
         }
         let detail = self.detail_from_model(model)?;
         let _ = self.event_tx.send(AutomationEvent::DefinitionUpdated {
@@ -855,16 +891,7 @@ fn normalize_trigger_config(
     }
 }
 
-fn cleanup_failed_automation_create_artifacts(instructions_path: &Path, definition_dir: &Path) {
-    if let Err(error) = std::fs::remove_file(instructions_path) {
-        if error.kind() != std::io::ErrorKind::NotFound {
-            tracing::warn!(
-                "Failed to clean up automation instructions {} after create error: {}",
-                instructions_path.display(),
-                error
-            );
-        }
-    }
+fn cleanup_failed_automation_create_artifacts(definition_dir: &Path) {
     if let Err(error) = std::fs::remove_dir_all(definition_dir) {
         if error.kind() != std::io::ErrorKind::NotFound {
             tracing::warn!(
@@ -883,7 +910,11 @@ fn resolve_attachment_placeholders(
     attachments
         .iter()
         .fold(instructions, |current, attachment| {
-            current.replace(&attachment.token, &attachment.path.display().to_string())
+            if let Some(token) = attachment.placeholder_token.as_deref() {
+                current.replace(token, &attachment.path.display().to_string())
+            } else {
+                current
+            }
         })
 }
 
@@ -1014,7 +1045,7 @@ mod tests {
         let resolved = resolve_attachment_placeholders(
             "Inspect [#img-1] and keep [#img-2].".to_string(),
             &[artifacts::WrittenAttachment {
-                token: "[#img-1]".to_string(),
+                placeholder_token: Some("[#img-1]".to_string()),
                 path: PathBuf::from("/tmp/atmos/img-1.png"),
             }],
         );

--- a/specs/APP/APP-021_appshots-cross-app-snapshot/BRAINSTORM.md
+++ b/specs/APP/APP-021_appshots-cross-app-snapshot/BRAINSTORM.md
@@ -1,0 +1,85 @@
+# Brainstorm · APP-021: Appshots Cross-App Snapshot
+
+> Problem space and exploration. Settled content graduates to PRD.md; committed architecture graduates to TECH.md.
+
+## Context
+
+Atmos already runs as a Tauri desktop app with a Rust native layer and a shared local API runtime. That makes it a realistic host for a Codex-style Appshots capability: a user-triggered snapshot of another desktop application's current window, combining screenshot pixels with the operating system accessibility tree.
+
+The key product framing is not "read arbitrary app memory." The useful capability is "capture what the user can inspect through OS permissions and accessibility APIs, persist it as a local timestamped record, and copy a lightweight protocol reference that tells agents where to read the record."
+
+## Goals (draft)
+
+- Let a desktop user capture the current external app state from any app through a native global shortcut.
+- Persist accepted captures under `~/.atmos/appshots/records/{timestamp}/` with `snapshot.png`, `context.md`, and `metadata.json`.
+- Make the copied format recognizable across Atmos surfaces through a stable `atmos://appshots/{timestamp}` first line plus fixed agent instruction.
+- Capture both visual context and semantic UI structure when platform permissions and target app accessibility support allow it.
+- Keep the feature explicit, local, and privacy-preserving: no background capture, no silent upload, no password field extraction.
+- Start where Atmos can deliver a high-quality first version: macOS desktop, with stable unsupported/fallback behavior on other platforms.
+
+## Options
+
+### Option A - Shortcut plus local record
+
+Register a native global shortcut. When pressed from any app, Atmos captures the focused window, shows a right-top preview popover, and either discards or persists the capture as a local record directory. Clipboard contains only `atmos://appshots/{timestamp}` plus an instruction that points agents at the directory.
+
+**Pros**: Decouples capture from ACP Chat; works anywhere text paste works; stores real images naturally; keeps clipboard small; agent can inspect files directly.
+**Cons**: Requires local file retention and delete controls; global modifier-only shortcut may need lower-level native event handling.
+**Unknown**: Whether `Fn + Cmd + Option` can be registered reliably without a non-modifier key.
+
+### Option B - Global shortcut first
+
+Register a desktop global shortcut that captures the currently focused app without returning focus to Atmos and immediately persists/copies without showing a preview.
+
+**Pros**: Closest to Codex Appshots behavior; avoids the "Atmos is now foreground" problem.
+**Cons**: Adds shortcut registration, conflict handling, settings UI, and more cross-platform variation.
+**Unknown**: Whether shortcut conflicts are acceptable for v1 or should be deferred to Settings.
+
+### Option C - Surface-local Appshot chips
+
+Teach selected Atmos composers, starting with the Welcome page composer and Automation setup composer, to detect pasted `atmos://appshots/{timestamp}` protocol text. The UI collapses it into a compact Appshot label like file references and skill chips, while submission keeps the protocol reference and fixed instruction.
+
+**Pros**: Keeps protocol prompt text out of the visible composer; follows existing `@file` and `/skill` chip behavior; sends agents a stable local record reference without visual noise.
+**Cons**: Requires tokenization, serialization, deletion, tooltip, and submit-time expansion support in each rich composer.
+**Unknown**: Whether the same chip parser should become a shared composer primitive or stay Welcome-specific in v1.
+
+## Key forks in the road
+
+- **Trigger model**: Modifier-only global shortcut vs. fallback configurable shortcut. Decide in TECH after OS validation.
+- **Consumption model**: Local record directory is the source of truth; clipboard carries only a protocol reference plus fixed instruction.
+- **Platform scope**: macOS desktop is the primary v1 target; Windows/Linux expose unsupported or degraded states until native backends are designed.
+- **Screenshot handling**: `snapshot.png` is a canonical file inside each accepted record directory.
+- **Persistence**: Use local Appshot record directories, not workspace attachments, for v1.
+- **Transport**: Use native Tauri commands/events for local desktop capture and record management.
+- **Fallback quality**: Prefer screenshot plus accessibility tree, then screenshot-only, then metadata-only failure messaging.
+
+## Open questions
+
+- [ ] Can `Fn + Cmd + Option` be captured reliably on macOS, or does v1 need a configurable fallback chord?
+- [ ] Should auto-accept after 6 seconds show a toast after the preview disappears?
+- [ ] Should screenshot-unavailable records use a placeholder `snapshot.png`, or should acceptance require screenshot permission?
+- [ ] What is the maximum accessibility tree size that stays useful without flooding the agent prompt?
+- [ ] How should hosted web/relay mode message that Appshots require local Desktop runtime?
+
+## References
+
+- Existing desktop native commands: `apps/desktop/src-tauri/src/commands.rs`
+- Tauri command registration: `apps/desktop/src-tauri/src/main.rs`
+- Desktop runtime bridge: `apps/web/src/shared/lib/desktop-runtime.ts`
+- Welcome composer rich-token implementation: `apps/web/src/features/welcome/components/PromptComposer.tsx`
+- Welcome submit-time placeholder expansion: `apps/web/src/features/welcome/lib/welcome-page-helpers.tsx`
+- Welcome create-workspace submit flow: `apps/web/src/features/welcome/components/WelcomePage.tsx`
+- Related specs: `APP-009_desktop-tauri`, `APP-004_local-agent-integration-acp`, `APP-016_atmos-computer`
+
+## Ready to promote
+
+- Promote to PRD: The first shippable version is Desktop-only, user-triggered, and local-record-first, not ACP Chat-specific.
+- Promote to PRD: The Appshot protocol text must start with `atmos://appshots/{timestamp}`.
+- Promote to PRD: Accepted records use `~/.atmos/appshots/records/{timestamp}/snapshot.png`, `context.md`, and `metadata.json`.
+- Promote to PRD: Welcome page and Automation setup composers should detect pasted Appshot protocol text, show a compact label, and submit the protocol prompt instruction.
+- Promote to PRD: macOS is the primary v1 platform; Windows and Linux should expose clear unsupported or degraded states until implemented.
+- Promote to PRD: Delete from the preview discards without persisting; Copy or 6-second timeout persists and copies protocol text.
+- Promote to TECH: Implement capture as a Tauri native command, not as a new loopback REST endpoint.
+- Promote to TECH: Normalize platform output into `snapshot.png`, `context.md`, and `metadata.json`.
+- Promote to TECH: Extend the shared composer token parser with an Appshot token that displays a label but serializes to a compact token and expands to protocol prompt text at submit time in supported submit flows.
+- Promote to TECH: Accessibility traversal must redact secure text fields, cap depth/node count, and avoid logging captured content.

--- a/specs/APP/APP-021_appshots-cross-app-snapshot/PRD.md
+++ b/specs/APP/APP-021_appshots-cross-app-snapshot/PRD.md
@@ -1,0 +1,120 @@
+# PRD · APP-021: Appshots Cross-App Snapshot
+
+> Product Requirements · WHAT and WHY. Settled direction for user-triggered cross-app desktop snapshots as persisted local records with lightweight clipboard references.
+
+## Context
+
+- **Problem**: Atmos users often need to bring context from another desktop app into Atmos, but the current workaround is manual description, screenshots, or ad hoc copy-paste.
+- **Why now**: Atmos has a Tauri desktop shell with native Rust commands, which can request OS-level screen and accessibility permissions that the web app cannot access.
+- **Related specs**: `APP-009_desktop-tauri`, `APP-004_local-agent-integration-acp`, `APP-016_atmos-computer`.
+
+## Goals
+
+1. Primary - let a Desktop user press a global native shortcut from any app, capture that app's current window context, and see a short-lived Appshot preview in Atmos.
+2. Primary - persist accepted Appshots as timestamped local record directories under `~/.atmos/appshots/records/{timestamp}/`.
+3. Primary - copy only an Atmos protocol reference plus a fixed prompt instruction to the clipboard, so agents read the record from disk instead of receiving a pasted content dump.
+4. Primary - let supported Atmos composers, starting with Welcome and Automation setup, recognize `atmos://appshots/{timestamp}` references on paste, render them as compact labels, and submit the protocol reference/instruction as prompt text.
+5. Secondary - preserve useful structure from the target UI through accessibility data and a screenshot preview.
+6. Secondary - make platform limitations and permission requirements obvious before the user expects the feature to work.
+
+## Users & Scenarios
+
+- **Primary persona**: An Atmos desktop user working with an agent while also using another desktop app such as Cursor, a browser, a design tool, a database client, or a terminal.
+- **Scenario 1**: The user presses the global Appshot shortcut while another app is focused, sees a right-top Atmos popover with a screenshot preview, and either copies, deletes, or lets it auto-save/copy after six seconds.
+- **Scenario 2**: The user pastes the copied `atmos://appshots/{timestamp}` reference into a supported Atmos composer such as Welcome or Automation setup, sees a compact Appshot label, and submits a prompt that tells the agent where the local record lives.
+- **Scenario 3**: The user opens the Header Appshots button near Open in Web, reads the short feature explanation, reviews recent Appshot records, copies an older record, or deletes a stale record.
+- **Scenario 4**: The user has not granted Screen Recording, Accessibility, or shortcut permissions yet and needs a clear recovery path instead of a silent failure.
+
+```mermaid
+flowchart LR
+  A["User works in another desktop app"] --> B["Global shortcut"]
+  B --> C{"Capture result"}
+  C -->|"Captured"| D["Right-top Atmos preview popover"]
+  C -->|"No permission or no target"| E["Permission/no-target state"]
+  D -->|"Delete"| F["Discard without writing record"]
+  D -->|"Copy or 6s timeout"| G["Write timestamped record"]
+  G --> H["Copy atmos://appshots/{timestamp} + prompt instruction"]
+  H --> I["Paste into supported composer"]
+  I --> J["Composer shows compact Appshot label"]
+  J --> K["Submit sends protocol reference/instruction"]
+```
+
+## User Stories
+
+- As an Atmos desktop user, I want a global shortcut that works while another app is focused, so that I can capture context without first switching to Atmos.
+- As an Atmos desktop user, I want a brief preview popover with copy and delete controls, so that I can reject bad captures and keep useful ones with minimal interruption.
+- As a Welcome or Automation setup user, I want pasted Appshot references to appear as compact labels, so that the composer stays readable.
+- As an agent user, I want the submitted prompt to include the Appshot protocol reference and a fixed instruction pointing at the local records directory, so that the agent can read the stored screenshot, metadata, and text itself.
+- As a returning user, I want a Header Appshots history popover, so that I can copy or delete recent records without recapturing.
+- As a privacy-conscious user, I want the capture to happen only when I trigger it, so that Atmos is not continuously watching other apps.
+- As a user on an unsupported platform or missing permission, I want a clear explanation and recovery path, so that I know whether the issue is permissions, platform support, or target app accessibility quality.
+
+## Functional Requirements
+
+### Must Have
+
+- **M1**: Desktop users can trigger Appshot capture from any focused app through a native global shortcut. The requested chord is `Fn + Cmd + Option`; implementation must validate whether modifier-only registration is possible on each target OS.
+- **M2**: After a successful capture, Atmos shows a small right-top popover with a screenshot preview, a Copy button, and a Delete button.
+- **M3**: The capture popover auto-resolves after 6 seconds with a visible countdown. Hover pauses the countdown and auto-accept; mouse leave resumes it. Delete discards the capture without writing a record. Copy or timeout writes the record and copies a protocol reference.
+- **M4**: Accepted captures are written under `~/.atmos/appshots/records/{timestamp}/`, where `{timestamp}` is a 13-digit Unix epoch millisecond id.
+- **M5**: Each record directory uses three canonical files: `snapshot.png` for the captured window image, `context.md` for normalized accessibility/text content, and `metadata.json` for app name, window title, platform, quality, capture time, warnings, and file paths.
+- **M6**: The clipboard text is not the full Appshot content. It contains `atmos://appshots/{timestamp}` plus a fixed prompt instruction that tells the agent where the record is stored.
+- **M7**: Supported Atmos composers that submit prompts to agents, starting with the Welcome page composer and Automation setup composer, detect `atmos://appshots/{timestamp}` references, replace the visible pasted reference with a compact Appshot label, and preserve the protocol prompt text for submission.
+- **M8**: Pasting the same protocol text outside supported Atmos composers behaves like normal text.
+- **M9**: Header right action controls include an Appshots button immediately to the left of Open in Web in Desktop runtime.
+- **M10**: The Header Appshots popover explains the feature and lists recent local records sorted newest first by timestamp.
+- **M11**: History loads record filenames first and displays concrete content for the first 10 records; users can click More to reveal the next page.
+- **M12**: Each visible history item shows app name, capture time, screenshot thumbnail, truncated text, Copy, and Delete.
+- **M13**: Copy from history writes the same `atmos://appshots/{timestamp}` plus fixed prompt instruction to the clipboard. Delete removes the entire `~/.atmos/appshots/records/{timestamp}/` directory.
+- **M14**: Captured sensitive fields are omitted or redacted where the platform exposes secure text semantics.
+- **M15**: Appshot capture is available only through explicit user action; Atmos does not run background capture or automatic periodic sampling.
+- **M16**: Non-Desktop runtimes and unsupported desktop platforms show an unsupported state rather than a broken control.
+- **M17**: When Appshots require missing macOS permissions, Atmos identifies the missing permission, explains why it is needed, provides an Open System Settings action for the relevant pane, and re-checks permission status after the user returns.
+
+### Nice to Have
+
+- **N1**: User-configurable global shortcut if `Fn + Cmd + Option` conflicts or cannot be registered as a complete chord.
+- **N2**: OCR or vision-model fallback when accessibility data is poor.
+- **N3**: Manual redaction tools for screenshot regions or accessibility tree nodes before copying.
+- **N4**: Windows and Linux platform backends with parity to the macOS user flow.
+- **N5**: Appshot label support in every Atmos rich composer beyond the Welcome and Automation setup composers.
+
+## Out of Scope
+
+- **Reading app memory or private data stores** - Appshots only use screenshot and OS accessibility surfaces granted by the user.
+- **Continuous monitoring** - v1 is user-triggered capture only.
+- **Remote browser capture** - hosted web and relay clients cannot access local OS accessibility APIs directly.
+- **Guaranteed offscreen content extraction** - accessibility trees may expose offscreen nodes, but this is target-app dependent and not a product guarantee.
+- **Full automation or control of other apps** - this spec captures context only; it does not click, type, or manipulate the target app.
+- **Cross-platform parity in v1** - macOS is the first-class target; Windows and Linux can be designed behind the same abstraction but need not ship fully in the first release.
+- **Full-content clipboard copy** - v1 copies a lightweight protocol reference and prompt instruction, not the full Appshot body.
+- **Cloud sync** - records are local under `~/.atmos/appshots/records/`; syncing or sharing records is out of scope.
+
+## Success Metrics
+
+- Leading: At least one internal dogfood workflow can capture another app from a global shortcut, accept or auto-accept the preview, paste an `atmos://appshots/{timestamp}` reference into a supported composer such as Welcome or Automation setup, and submit it to an agent.
+- Leading: Permission-denied states produce an actionable UI path on macOS, including a settings-opening action and a successful status refresh after authorization.
+- Quality: Saved Appshot records include `metadata.json`, `snapshot.png`, `context.md`, and at least one non-empty content source in supported happy-path cases.
+- Quality: Welcome and Automation setup composers show compact Appshot labels instead of the full protocol/prompt text, while submit-time prompt text includes the protocol reference and fixed instruction.
+- Quality: Header history can page through records 10 at a time and copy/delete any visible record.
+- Safety: Captured Appshot record content is not written to application logs.
+- Qualitative: Dogfood users report that the agent receives enough context to answer basic "what is on this screen?" questions for common Electron/WebView/native apps.
+
+## Risks & Open Questions
+
+- **Risk**: Users may overestimate what accessibility can read from canvas, games, virtualized lists, or self-drawn controls.
+- **Risk**: `Fn + Cmd + Option` may not be registerable as a modifier-only global shortcut through standard OS shortcut APIs; a lower-level event tap may require extra permissions and careful conflict handling.
+- **Risk**: The capture action can accidentally capture Atmos unless native code tracks the last external window.
+- **Risk**: Record directories can accumulate screenshots and text over time; history deletion and future retention cleanup must be predictable.
+- **Open**: Should timeout auto-accept also show a toast after the popover disappears?
+- **Open**: Should history deletion be immediate or require confirmation for records newer than the current session?
+
+## Milestones
+
+- Phase 1 - macOS capture prototype behind a Desktop-only feature flag, with permission status, System Settings recovery actions, and normalized record generation.
+- Phase 2 - Global shortcut and right-top capture preview popover with 6-second auto-accept, Copy, and Delete.
+- Phase 3 - Record persistence under `~/.atmos/appshots/records/{timestamp}/` with `snapshot.png`, `context.md`, `metadata.json`, and clipboard protocol generation as `atmos://appshots/{timestamp}` plus fixed instruction.
+- Phase 4 - Welcome and Automation setup composer paste detection, compact Appshot label rendering, deletion, tooltip/metadata display, and submit-time preservation of protocol prompt text.
+- Phase 5 - Header Appshots button/history popover with paged recent records, thumbnails, truncated text, Copy, and Delete.
+- Phase 6 - Dogfood hardening: redaction rules, size limits, logging audit, and unsupported platform states.
+- Phase 7 - Evaluate configurable shortcuts, additional composer surfaces, and Windows/Linux backends as follow-up work.

--- a/specs/APP/APP-021_appshots-cross-app-snapshot/REVIEW.md
+++ b/specs/APP/APP-021_appshots-cross-app-snapshot/REVIEW.md
@@ -176,6 +176,8 @@ Use bounded thumbnails or file/blob URLs for UI previews. The native record can 
 
 - 2026-05-28 - Native preview/history payloads now use `MAX_INLINE_SNAPSHOT_BYTES`; full `snapshot.png` stays on disk, while oversized inline images are omitted with a warning.
 - 2026-05-28 - Web preview/history state now applies payload sanitizers, and history reads details in bounded batches instead of inlining all 10 row thumbnails at once.
+- 2026-05-28 - Native records now resize persisted `snapshot.png` to a bounded desktop-friendly image, history rows generate thumbnails, and thumbnail click-through lazily loads a larger preview using the shared composer image overlay.
+- 2026-05-28 - Capture UX now adds a bounded native target-window border/flash overlay before screenshot capture and animates the pending card from the target window bounds into the Atmos preview popover.
 - 2026-05-28 - Verified with `cargo test -p atmos-desktop appshot`, focused web Appshot tests, and `bun --filter web typecheck`.
 
 ---

--- a/specs/APP/APP-021_appshots-cross-app-snapshot/REVIEW.md
+++ b/specs/APP/APP-021_appshots-cross-app-snapshot/REVIEW.md
@@ -1,0 +1,299 @@
+# REVIEW · APP-021: Appshots Cross-App Snapshot - Implementation Review
+
+> Post-implementation review log for functional completeness, architecture, maintainability, code size, testability, and follow-up fixes. Complements the planning quartet ([BRAINSTORM](./BRAINSTORM.md) -> [PRD](./PRD.md) -> [TECH](./TECH.md) -> [TEST](./TEST.md)); does not replace them.
+
+**Review date**: 2026-05-28
+**Review scope**: functional review + quality review
+**Related code**: `apps/desktop/src-tauri/src/appshot`, `apps/web/src/features/appshot`, `apps/web/src/features/welcome/components/PromptComposer.tsx`, `apps/web/src/features/automations/components/AutomationSetup.tsx`
+
+---
+
+## Index
+
+| Id | Severity | Area | Title | Status |
+|----|----------|------|-------|--------|
+| REV-001 | P1 | frontend | Automation composer did not resolve shared composer tokens | verified |
+| REV-002 | P2 | backend | Accepted pending captures are not copy-atomic or retryable | verified |
+| REV-003 | P2 | backend | Permission-blocked pending captures never expire | verified |
+| REV-004 | P2 | performance | Preview and history payloads embed full PNGs | verified |
+| REV-005 | P2 | backend | Native capture subprocesses have no timeout | verified |
+| REV-006 | P2 | test | Required history, gating, record, and redaction coverage is missing | verified |
+| REV-007 | P1 | backend | Long target pages can block window lookup and drop screenshots | verified |
+
+---
+
+## REV-001 · Automation composer did not resolve shared composer tokens
+
+| Field | Value |
+|-------|--------|
+| **Status** | verified |
+| **Severity** | P1 |
+| **Area** | frontend |
+| **Reported by** | internal review |
+| **Owner** | unassigned |
+
+### Finding
+
+Appshot protocol parsing is implemented in the shared `PromptComposer`, and the updated product scope requires both Welcome and Automation setup to behave as supported prompt composers. Automation setup reused `WelcomeComposerCard`/`PromptComposer`, but originally submitted `instructions.trim()` directly without expanding Appshot chips, `@file` chips, or pasted image placeholders into agent-readable paths. As a result, a saved automation could persist internal composer tokens literally.
+
+### Evidence
+
+- `apps/web/src/features/welcome/components/PromptComposer.tsx:63` - `TOKEN_REGEX` recognizes `[#appshot:<timestamp>]` globally inside the shared composer.
+- `apps/web/src/features/welcome/components/PromptComposer.tsx:587` - paste handling parses any first-line Appshot protocol and inserts an Appshot chip.
+- `apps/web/src/features/automations/components/AutomationSetup.tsx` - automation setup reuses `WelcomeComposerCard`, so it must also reuse the Welcome composer submit-time resolver.
+- `specs/APP/APP-021_appshots-cross-app-snapshot/PRD.md` - product scope now lists Welcome and Automation setup as supported composers.
+- `specs/APP/APP-021_appshots-cross-app-snapshot/TECH.md` - technical design now requires Automation setup to expand Appshot and `@file` placeholders and send pasted image attachments to the automation backend.
+
+### Required fix
+
+Keep `PromptComposer` shared, update PRD/TECH/TEST to include Automation setup as a supported composer, and make Automation setup use the same placeholder resolution and attachment persistence path as workspace creation.
+
+### Acceptance
+
+- [x] Pasting Appshot protocol text into the Welcome composer renders one compact Appshot label and submits the protocol prompt text.
+- [x] Pasting the same text into Automation setup renders one compact Appshot label and submit explicitly expands it after the PRD/TECH/TEST update.
+- [x] Automation setup supports the same image paste path and backend attachment resolution as workspace creation.
+
+### Fix log
+
+- 2026-05-28 - Product scope updated in `PRD.md`, `TECH.md`, and `TEST.md` to treat Automation setup as a supported prompt composer.
+- 2026-05-28 - `AutomationSetup` now uses shared `WelcomeComposerCard` attachment, `@file`, `/skill`, and Appshot placeholder flows; submit calls `resolvePromptPlaceholders` and sends image attachment payloads to the automation service.
+- 2026-05-28 - Automation backend now writes pasted image attachments under `~/.atmos/automations/definitions/{automation_guid}/attachments/` and replaces `[#img-n]` tokens with absolute paths before validation/persistence.
+- 2026-05-28 - Verified with `bun --filter web typecheck`, focused web placeholder tests, and `cargo test -p core-service resolves_written_attachment_tokens_to_paths`.
+
+---
+
+## REV-002 · Accepted pending captures are not copy-atomic or retryable
+
+| Field | Value |
+|-------|--------|
+| **Status** | verified |
+| **Severity** | P2 |
+| **Area** | backend |
+| **Reported by** | internal review |
+| **Owner** | unassigned |
+
+### Finding
+
+Accepting a pending Appshot removes it from memory before the record write and clipboard copy complete. `records::write_record` finalizes the record directory before calling `pbcopy`; if the clipboard write fails, the command returns an error after the pending entry is gone and the record has already been persisted. The UI then cannot retry the same pending capture because a second Copy sees "no longer pending"; native auto-accept also ignores that error entirely.
+
+### Evidence
+
+- `apps/desktop/src-tauri/src/appshot/pending.rs:51` - `accept` removes the pending capture from the map before writing/copying.
+- `apps/desktop/src-tauri/src/appshot/records.rs:110` - the temp directory is renamed into final `records/{timestamp}` before clipboard copy.
+- `apps/desktop/src-tauri/src/appshot/records.rs:117` - `pbcopy` failure is returned after the final record exists.
+- `apps/desktop/src-tauri/src/appshot/pending.rs:68` - native auto-accept discards the accept result and does not surface copy failure.
+- `apps/web/src/features/appshot/components/AppshotCapturePreview.tsx:57` - UI shows the copy error, but retrying the same pending id is no longer possible.
+
+### Required fix
+
+Make pending acceptance resolve atomically from the user perspective. Either copy before removing the pending entry, keep enough accepted-record state to retry clipboard copy, or return a successful response with the saved timestamp plus a clear copy failure state and a retry action. Native auto-accept should surface or log the copy failure without silently losing it.
+
+### Acceptance
+
+- [x] If clipboard copy fails, the user can retry copying the saved Appshot reference or the pending preview remains recoverable.
+- [x] Auto-accept failures do not silently disappear.
+- [x] Targeted native tests or an injected clipboard failure path cover the behavior.
+
+### Fix log
+
+- 2026-05-28 - Fixed in native backend: pending accept now keeps recoverable state on write/copy failure, retries copy the same saved timestamp, discard cleans up a saved-but-not-copied record, and auto-accept logs failures. Added injected clipboard failure test.
+- 2026-05-28 - Verified with `cargo test -p atmos-desktop appshot`.
+
+---
+
+## REV-003 · Permission-blocked pending captures never expire
+
+| Field | Value |
+|-------|--------|
+| **Status** | verified |
+| **Severity** | P2 |
+| **Area** | backend |
+| **Reported by** | internal review |
+| **Owner** | unassigned |
+
+### Finding
+
+Pending captures with any denied permission are inserted into the in-memory pending map with `expires_in_ms = 0`. The native auto-accept path is only scheduled when `expires_in_ms > 0`, and there is no separate cleanup. Repeated captures while Screen Recording or Accessibility is denied can accumulate pending entries containing captured metadata/context until the app exits.
+
+### Evidence
+
+- `apps/desktop/src-tauri/src/appshot/pending.rs:25` - pending insertion detects any denied permission.
+- `apps/desktop/src-tauri/src/appshot/pending.rs:38` - denied-permission previews get `expires_in_ms: 0`.
+- `apps/desktop/src-tauri/src/appshot/pending.rs:44` - the denied-permission capture is still inserted into the pending map.
+- `apps/desktop/src-tauri/src/appshot/mod.rs:95` - native auto-accept is only scheduled for positive `expires_in_ms`.
+
+### Required fix
+
+Add an explicit cleanup policy for non-expiring previews. Options include not storing non-acceptable permission previews, expiring them after a longer bounded window, replacing the previous pending preview when a new one arrives, or discarding them after the user opens permissions. Keep permission recovery visible without retaining unbounded captured data.
+
+### Acceptance
+
+- [x] Repeated permission-denied captures cannot grow the pending map without bound.
+- [x] Permission recovery UI remains usable.
+- [x] A native unit test or small test-only hook proves denied-permission pending entries are cleaned up or bounded.
+
+### Fix log
+
+- 2026-05-28 - Fixed in native backend: denied-permission previews are internally bounded by TTL and replacement policy, so repeated blocked captures keep at most one blocked pending entry. Added unit coverage for replacement behavior.
+- 2026-05-28 - Verified with `cargo test -p atmos-desktop appshot`.
+
+---
+
+## REV-004 · Preview and history payloads embed full PNGs
+
+| Field | Value |
+|-------|--------|
+| **Status** | verified |
+| **Severity** | P2 |
+| **Area** | performance |
+| **Reported by** | internal review |
+| **Owner** | unassigned |
+
+### Finding
+
+The preview event and history detail API encode the full `snapshot.png` as base64/data URLs. A Retina full-window screenshot can be several MB, so a single shortcut event can push a large payload through Tauri event serialization and React state, and the history popover can load up to ten full screenshots for thumbnail rows. This conflicts with the lightweight preview/history intent and the TEST performance budget.
+
+### Evidence
+
+- `apps/desktop/src-tauri/src/appshot/pending.rs:20` - the pending preview base64-encodes `captured.screenshot_png` directly.
+- `apps/desktop/src-tauri/src/appshot/records.rs:206` - each visible history detail reads `snapshot.png` into a data URL.
+- `apps/desktop/src-tauri/src/appshot/records.rs:260` - `read_snapshot_data_url` base64-encodes the entire PNG.
+- `apps/web/src/features/appshot/components/AppshotsHistoryPopover.tsx:94` - history reads details for the first 10 visible timestamps.
+- `specs/APP/APP-021_appshots-cross-app-snapshot/TEST.md:143` - history should render first 10 detail rows within 300 ms for normal record sizes.
+
+### Required fix
+
+Use bounded thumbnails or file/blob URLs for UI previews. The native record can still preserve the full `snapshot.png`, but preview event payloads and history row thumbnails should be size-capped and should not inline ten full-resolution images.
+
+### Acceptance
+
+- [x] Preview payload size is bounded independently of source window size.
+- [x] History details for the first 10 rows do not inline ten full-resolution screenshots.
+- [x] A test or measurement documents the payload cap and verifies thumbnail rendering.
+
+### Fix log
+
+- 2026-05-28 - Native preview/history payloads now use `MAX_INLINE_SNAPSHOT_BYTES`; full `snapshot.png` stays on disk, while oversized inline images are omitted with a warning.
+- 2026-05-28 - Web preview/history state now applies payload sanitizers, and history reads details in bounded batches instead of inlining all 10 row thumbnails at once.
+- 2026-05-28 - Verified with `cargo test -p atmos-desktop appshot`, focused web Appshot tests, and `bun --filter web typecheck`.
+
+---
+
+## REV-005 · Native capture subprocesses have no timeout
+
+| Field | Value |
+|-------|--------|
+| **Status** | verified |
+| **Severity** | P2 |
+| **Area** | backend |
+| **Reported by** | internal review |
+| **Owner** | unassigned |
+
+### Finding
+
+The macOS v1 backend shells out to `osascript` and `screencapture` without any timeout or cancellation. If System Events stalls on a target app, secure input mode, permission prompt, or a hung accessibility tree traversal, the capture task can sit indefinitely and the user may see no preview or recovery state. This is especially risky because the global shortcut can be pressed repeatedly.
+
+### Evidence
+
+- `apps/desktop/src-tauri/src/appshot/macos.rs:116` - capture work is offloaded to `spawn_blocking`, but no deadline is applied.
+- `apps/desktop/src-tauri/src/appshot/macos.rs:438` - `screencapture` waits for process completion without timeout.
+- `apps/desktop/src-tauri/src/appshot/macos.rs:513` - `run_osascript` uses `Command::output()` without timeout for both frontmost-window and accessibility traversal.
+- `specs/APP/APP-021_appshots-cross-app-snapshot/TEST.md:141` - happy-path capture preview has p50/p95 timing expectations.
+
+### Required fix
+
+Wrap each external process with a bounded timeout and return a partial Appshot with warnings when a subprocess exceeds the deadline. Longer-term, move toward direct macOS APIs where practical, but v1 should not allow unbounded subprocess waits.
+
+### Acceptance
+
+- [x] Hung `osascript` or `screencapture` calls fail into a visible warning/error within a defined deadline.
+- [x] Repeated shortcut presses cannot accumulate indefinitely blocked capture workers.
+- [x] A targeted test or injected command runner covers timeout behavior.
+
+### Fix log
+
+- 2026-05-28 - Fixed in native backend: frontmost-window `osascript`, accessibility-tree `osascript`, and `screencapture` now run through a timeout-bound process wrapper and downgrade failures to warnings/partial capture. Added command-runner timeout tests.
+- 2026-05-28 - Verified with `cargo test -p atmos-desktop appshot`.
+
+---
+
+## REV-006 · Required history, gating, record, and redaction coverage is missing
+
+| Field | Value |
+|-------|--------|
+| **Status** | verified |
+| **Severity** | P2 |
+| **Area** | test |
+| **Reported by** | internal review |
+| **Owner** | unassigned |
+
+### Finding
+
+The current automated coverage only validates protocol formatting/parsing, submit-time Appshot placeholder expansion, base64 helpers, timestamp validation, and preview truncation. The APP-021 TEST acceptance calls for coverage of Header history UI, web gating, canonical record file layout, and secure-field redaction, but those paths have no automated checks yet.
+
+### Evidence
+
+- `apps/web/src/features/appshot/__tests__/appshot-protocol.test.ts:9` - web Appshot tests cover parser behavior only.
+- `apps/web/src/features/welcome/lib/__tests__/welcome-appshot-placeholders.test.ts:15` - Welcome tests cover placeholder expansion only.
+- `apps/desktop/src-tauri/src/appshot/records.rs:281` - native record tests cover preview truncation only, not three-file layout or deletion.
+- `apps/desktop/src-tauri/src/appshot/protocol.rs:17` - native protocol tests cover timestamp/prompt formatting only.
+- `specs/APP/APP-021_appshots-cross-app-snapshot/TEST.md:167` - acceptance requires `bun test` coverage for protocol parsing, Welcome paste handling, submit expansion, Header history UI, and web gating.
+- `specs/APP/APP-021_appshots-cross-app-snapshot/TEST.md:159` - acceptance requires canonical record file verification.
+- `specs/APP/APP-021_appshots-cross-app-snapshot/TEST.md:150` - regression checklist requires secure text redaction checks.
+
+### Required fix
+
+Add focused tests for the high-risk paths: Header history pagination/copy/delete rendering with mocked Tauri client, Desktop-vs-browser gating, native record write/delete layout with an injectable data root or temp home, and redaction normalization independent of real macOS accessibility.
+
+### Acceptance
+
+- [x] Header history pagination/copy/delete behavior has a web test.
+- [x] Browser/non-Tauri gating has a web test.
+- [x] Native record write/delete creates and removes `snapshot.png`, `context.md`, and `metadata.json` under a test data root.
+- [x] Secure-field redaction is covered without needing real OS accessibility.
+
+### Fix log
+
+- 2026-05-28 - Native coverage added: record layout/delete test for `snapshot.png`, `context.md`, and `metadata.json`; retryable clipboard failure test; permission-blocked replacement test; timeout-bound command runner tests; secure-field AppleScript redaction condition test.
+- 2026-05-28 - Web coverage added: history pagination/copy/delete test, browser/non-Tauri gating test, Appshot payload guard test, and Welcome/Automation placeholder expansion behavior test.
+- 2026-05-28 - Verified with focused web Appshot tests, `cargo test -p atmos-desktop appshot`, and `bun --filter web typecheck`.
+
+---
+
+## REV-007 · Long target pages can block window lookup and drop screenshots
+
+| Field | Value |
+|-------|--------|
+| **Status** | verified |
+| **Severity** | P1 |
+| **Area** | backend |
+| **Reported by** | dogfood |
+| **Owner** | unassigned |
+
+### Finding
+
+Dogfood records showed that the macOS capture path used System Events to identify the frontmost window and read bounds before screenshot capture. On long/heavy app pages, that lookup could time out, leaving `app_name: "Unknown App"` and no window bounds, so `snapshot.png` degraded to a 1x1 placeholder even though Screen Recording permission was granted. The same records also exposed an invalid AppleScript redaction condition that made every Accessibility tree capture fail with a syntax error.
+
+### Evidence
+
+- `~/.atmos/appshots/records/1779960519355/metadata.json` - `quality: "metadata_only"`, `app_name: "Unknown App"`, `snapshot.png` is 1x1, warnings include `frontmost window lookup timed out after 2500 ms`.
+- `~/.atmos/appshots/records/1779960703397/metadata.json` and `1779960830548/metadata.json` - app/window screenshots were present, but Accessibility always failed with `syntax error: 预期是行的结尾，却找到标识符`.
+- Previous `apps/desktop/src-tauri/src/appshot/macos.rs` coupled window bounds to System Events before running `screencapture -R`.
+
+### Required fix
+
+Make app/window identification and screenshot bounds independent from Accessibility traversal. Use fast native window metadata (`NSWorkspace` and CoreGraphics window list) for app, pid, window id, title, and bounds. Keep System Events only as a fallback/semantic tree path. Fix AppleScript redaction condition syntax so Accessibility failures represent target app limitations or timeout, not a generated script bug.
+
+### Acceptance
+
+- [x] Long or complex target pages can still produce app metadata and a real `snapshot.png` when Accessibility tree traversal times out.
+- [x] Accessibility script no longer emits the redaction-condition syntax error.
+- [x] Native tests cover frontmost window selection behavior and the redaction condition shape.
+
+### Fix log
+
+- 2026-05-28 - macOS capture now uses `NSWorkspace.frontmostApplication()` plus `CGWindowListCopyWindowInfo` for app identity and window bounds before screenshot capture; System Events is a fallback for metadata and remains the v1 Accessibility tree source.
+- 2026-05-28 - `CapturedAppshot.window_id` is populated from CoreGraphics when available, and `context.md` includes Window ID.
+- 2026-05-28 - AppleScript redaction clauses are parenthesized, fixing the observed syntax error.
+- 2026-05-28 - Added native tests for pid-matched window selection, non-Atmos fallback selection, app-only selection, and redaction condition syntax. Verified with `cargo test -p atmos-desktop appshot`.

--- a/specs/APP/APP-021_appshots-cross-app-snapshot/TECH.md
+++ b/specs/APP/APP-021_appshots-cross-app-snapshot/TECH.md
@@ -185,7 +185,7 @@ fn on_flags_changed(flags: ModifierFlags, state: &mut ModifierGestureState) {
 Implementation notes:
 
 - `Fn` / Globe behavior can vary by keyboard and macOS settings. `appshot_status` must report when the function modifier cannot be observed, and the feature must not silently remap the gesture to `Option + Command`.
-- This listener may require Accessibility and/or Input Monitoring permission depending on the concrete API. Permission failure is a normal disabled state with recovery UI.
+- The implemented macOS listener uses Accessibility-trusted global modifier events; Input Monitoring is not treated as a required permission for the Appshot gesture. Permission failure is a normal disabled state with recovery UI.
 - The listener should be registered during Desktop app startup and torn down on app shutdown. If macOS disables the event tap, re-enable it once and then report a degraded trigger status if it repeatedly fails.
 
 The trigger must capture the currently focused external app, not the Atmos window.
@@ -196,9 +196,8 @@ Permissions are part of the Appshot UX, not a terminal error path. Any missing p
 
 Required macOS permission surfaces:
 
-- Accessibility: needed for `AXUIElement` traversal and may also satisfy the global modifier listener depending on the chosen implementation.
+- Accessibility: needed for `AXUIElement` traversal and the implemented global modifier listener.
 - Screen Recording / Screen & System Audio Recording: needed for window screenshots.
-- Input Monitoring: may be needed if the modifier gesture listener uses a lower-level event tap that macOS classifies as input monitoring.
 
 Native owns settings navigation:
 
@@ -218,7 +217,7 @@ Use macOS-native APIs through target-specific Rust bindings:
 - Screenshot: v1 uses `screencapture -R` with validated CoreGraphics window bounds; later hardening can move to ScreenCaptureKit or CoreGraphics per-window capture. Never fall back to full-screen capture when the focused window bounds are unknown.
 - Accessibility tree: v1 may use System Events traversal over the frontmost app/window; later hardening can replace this with direct `AXUIElementCreateApplication`, focused window lookup, and recursive `AXUIElementCopyAttributeValue`. Accessibility timeout or syntax/runtime failure must only degrade the record to screenshot-only/accessibility-unavailable; it must not prevent app metadata or `snapshot.png` from being captured.
 - Permissions:
-  - Appshot trigger listener: preflight the chosen `flagsChanged` listener path and surface missing Accessibility/Input Monitoring-style permission as `AppshotPermissionState`.
+  - Appshot trigger listener: preflight the chosen `flagsChanged` listener path and surface missing Accessibility permission as `AppshotPermissionState`.
   - Accessibility: preflight with the AX trust APIs and open System Settings when missing.
   - Screen Recording: preflight/request with CoreGraphics/ScreenCaptureKit-supported APIs and open the relevant System Settings pane when missing.
 
@@ -472,7 +471,6 @@ pub struct AppshotScreenshotMetadata {
 pub enum AppshotPermissionName {
     Accessibility,
     ScreenRecording,
-    InputMonitoring,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -480,7 +478,6 @@ pub enum AppshotPermissionName {
 pub enum AppshotSettingsTarget {
     Accessibility,
     ScreenRecording,
-    InputMonitoring,
     PrivacySecurity,
 }
 

--- a/specs/APP/APP-021_appshots-cross-app-snapshot/TECH.md
+++ b/specs/APP/APP-021_appshots-cross-app-snapshot/TECH.md
@@ -114,10 +114,11 @@ pub async fn appshot_open_permissions(req: AppshotOpenPermissionsRequest) -> Res
 The product flow is trigger-driven:
 
 1. Native trigger listener observes the configured Appshot gesture and calls capture with `target: "frontmost"` or a platform-specific active-window target.
-2. Native stores a pending capture under an opaque `preview_id`.
-3. Native emits an app event to the main WebView, for example `appshot://preview`, with metadata and screenshot preview bytes.
-4. Web UI calls `appshot_accept_pending` on Copy or after the 6-second timer.
-5. Web UI calls `appshot_discard_pending` on Delete.
+2. Native plays a short capture affordance against the target window bounds: a transparent always-on-top overlay shows a blue breathing border and a camera-flash frame, then closes before the real screenshot is taken so `snapshot.png` does not include the affordance.
+3. Native stores a pending capture under an opaque `preview_id`.
+4. Native emits an app event to the main WebView, for example `appshot://preview`, with metadata, source window bounds, and screenshot preview bytes.
+5. Web UI calls `appshot_accept_pending` on Copy or after the 6-second timer.
+6. Web UI calls `appshot_discard_pending` on Delete.
 
 Native must also own a 6-second timeout for each pending capture so auto-accept still happens if the WebView event is delayed or the UI timer is interrupted. Delete must win if it arrives before the timeout resolves.
 
@@ -134,7 +135,7 @@ Accepted Appshots are stored as directories, not single JSON blobs:
 ```
 
 - Directory name is the 13-digit Unix epoch millisecond timestamp and is the stable record id.
-- `snapshot.png` is the captured window image. The preview popover and history popover use this file for thumbnails. Accepted records keep the three-file contract stable; if screenshot capture fails but a degraded text-only record is still accepted, write a placeholder PNG and mark `screenshot.available = false` in `metadata.json`.
+- `snapshot.png` is the captured window image, resized to a bounded desktop-friendly maximum edge before persistence so local records do not store multi-megabyte Retina captures by default. The preview popover and history popover use generated thumbnails from this file; clicking a history thumbnail lazily loads a larger view into the shared composer image preview overlay. Accepted records keep the three-file contract stable; if screenshot capture fails but a degraded text-only record is still accepted, write a placeholder PNG and mark `screenshot.available = false` in `metadata.json`.
 - `context.md` is agent-readable Markdown with the normalized accessibility tree, focused element, extracted text, warnings, and short capture notes.
 - `metadata.json` is structured data for UI and tooling. It includes timestamp, paths, platform, app name, bundle id/process id, window title/id, screenshot dimensions, capture quality, permission states, warnings, and byte counts.
 - Writes should be atomic: write into a temp directory under `~/.atmos/appshots/tmp/`, then rename to `records/{timestamp}` after all files are complete. Deletion removes the whole record directory.
@@ -270,10 +271,10 @@ apps/web/src/features/appshot/
 ```
 
 - `appshot-client.ts` checks `isTauriRuntime()` from `apps/web/src/shared/lib/desktop-runtime.ts` before invoking native commands.
-- `AppshotCapturePreview` listens for native preview events and renders the right-top 6-second popover with screenshot thumbnail, live countdown, Copy, and Delete. Hovering the preview pauses the frontend countdown and native auto-accept; leaving the preview resumes both from the remaining time.
+- `AppshotCapturePreview` listens for native preview events and renders the right-top 6-second popover with screenshot thumbnail, live countdown, Copy, and Delete. When source bounds are available, the card animates from the captured app's screen position into the Atmos right-top corner. Hovering the preview pauses the frontend countdown and native auto-accept; leaving the preview resumes both from the remaining time.
 - `AppshotsHeaderButton` is inserted immediately to the left of the existing Open in Web button in `apps/web/src/app-shell/header-action-controls.tsx`.
 - `AppshotsHistoryPopover` explains Appshots, lists recent local records, and shows missing-permission recovery actions before the history list when Appshots are disabled by permissions.
-- `AppshotRecordRow` renders app name, capture time, thumbnail from `snapshot.png`, truncated `context.md`, Copy, and Delete.
+- `AppshotRecordRow` renders app name, capture time, thumbnail from `snapshot.png`, truncated `context.md`, Copy, and Delete. Clicking the thumbnail opens the shared image preview overlay used by the composer image viewer.
 - `appshot-protocol.ts` owns `APPSHOT_PROTOCOL_PREFIX = "atmos://appshots/"`, `parseAppshotProtocol(text)`, `formatAppshotPrompt(timestamp)`, and `summarizeAppshotRecord`.
 - The parser accepts protocol text when the first line matches `atmos://appshots/<13-digit timestamp>` after normalizing line endings. Random Appshot URLs elsewhere in text do not become composer labels.
 - `appshot-client.ts` exposes `openAppshotPermissionTarget(target)` and refreshes `appshot_status` when the window regains focus after a settings action.
@@ -572,6 +573,7 @@ type AppshotPreviewEvent = {
   captured_at: string;
   quality: string;
   screenshot_preview_base64?: string;
+  source_bounds?: { x: number; y: number; width: number; height: number };
   permissions: AppshotPermissionState[];
   warnings: string[];
   expires_in_ms: 6000;

--- a/specs/APP/APP-021_appshots-cross-app-snapshot/TECH.md
+++ b/specs/APP/APP-021_appshots-cross-app-snapshot/TECH.md
@@ -1,0 +1,674 @@
+# TECH · APP-021: Appshots Cross-App Snapshot
+
+> Technical Design · HOW. Implements PRD APP-021: Appshots Cross-App Snapshot.
+
+## Scope summary
+
+This design adds user-triggered cross-app snapshots to Atmos Desktop, shows a short-lived preview, persists accepted captures as local timestamped records, and copies a lightweight `atmos://appshots/{timestamp}` protocol reference. Atmos consumers, starting with the Welcome page composer and Automation setup composer, detect pasted references and render compact Appshot labels while submitting the protocol reference plus fixed agent instruction. It addresses PRD M1-M17. N1 configurable shortcut, N2 OCR, N3 manual redaction, N4 full Windows/Linux parity, and N5 broader all-composer support are deferred unless explicitly pulled into implementation.
+
+## Architecture overview
+
+Appshot capture is a desktop-native capability. The web app cannot read other windows or OS accessibility trees, and the local API process is not the foreground desktop app. The first implementation therefore lives in the Tauri process. Native capture creates a pending in-memory Appshot, emits a preview event to the WebView, and resolves the pending capture by delete, explicit copy, or a 6-second auto-accept timeout.
+
+```mermaid
+sequenceDiagram
+  participant OS as Global Shortcut
+  participant Native as Tauri appshot module
+  participant Web as Atmos WebView
+  participant FS as ~/.atmos/appshots/records
+  participant Clip as System clipboard
+  participant Composer as Supported composer
+
+  OS->>Native: Fn+Cmd+Option pressed
+  Native->>Native: capture screenshot + accessibility
+  Native->>Web: appshot://preview event
+  Web->>Web: show right-top preview for 6s
+  alt Delete
+    Web->>Native: appshot_discard_pending(preview_id)
+    Native->>Native: drop pending capture
+  else Copy or timeout
+    Web->>Native: appshot_accept_pending(preview_id)
+    Native->>FS: write {timestamp}/snapshot.png + context.md + metadata.json
+    Native->>Clip: copy atmos://appshots/{timestamp} + instruction
+  end
+  Clip->>Composer: paste protocol text
+  Composer->>Composer: render compact Appshot label
+```
+
+No new loopback REST endpoint is required. The clipboard artifact is a protocol reference and fixed prompt instruction, not the full Appshot body. The first line is:
+
+```text
+atmos://appshots/{timestamp}
+```
+
+where `{timestamp}` is a 13-digit Unix epoch millisecond id. The clipboard text must also include a fixed instruction:
+
+```text
+atmos://appshots/1760000000000
+Appshot record is stored locally at ~/.atmos/appshots/records/1760000000000/. Read metadata.json, context.md, and snapshot.png in that directory before answering. Inspect snapshot.png when visual context matters.
+```
+
+The record, not the clipboard, is the source of truth.
+
+## Module-by-module design
+
+### apps/desktop/src-tauri
+
+Add a new native module:
+
+```text
+apps/desktop/src-tauri/src/appshot/
+  mod.rs
+  types.rs
+  clipboard.rs
+  protocol.rs
+  records.rs
+  shortcut.rs
+  pending.rs
+  macos.rs
+  unsupported.rs
+```
+
+- `types.rs` owns serializable request/response structs shared by all platform backends.
+- `protocol.rs` formats and parses `atmos://appshots/{timestamp}` clipboard text.
+- `records.rs` owns `~/.atmos/appshots/records/` storage, listing, detail reading, copy, and deletion.
+- `shortcut.rs` owns the Appshot trigger. On macOS v1 this is a modifier-only gesture listener, not a traditional hotkey registration.
+- `pending.rs` stores pending captures for Copy/Delete/timeout resolution.
+- `clipboard.rs` writes protocol text to the system clipboard. Prefer `tauri-plugin-clipboard-manager` if the implementation does not already have a supported clipboard API.
+- `macos.rs` implements screenshot and accessibility capture behind `#[cfg(target_os = "macos")]`.
+- `unsupported.rs` returns structured unsupported status for platforms without a backend.
+- `commands.rs` exposes thin Tauri commands and delegates into `appshot`.
+- `main.rs` registers the new commands in `tauri::generate_handler!`.
+
+<!-- updated 2026-05-28: implementation keeps v1 target resolution inside macos.rs; no separate tracker module is required until last-non-Atmos-window recovery is added. Target resolution now uses NSWorkspace/CoreGraphics first so screenshot capture is not coupled to System Events accessibility traversal. -->
+
+New commands:
+
+```rust
+#[tauri::command]
+pub async fn appshot_status() -> Result<AppshotStatus, String>;
+
+#[tauri::command]
+pub async fn appshot_accept_pending(preview_id: String) -> Result<AppshotAcceptResponse, String>;
+
+#[tauri::command]
+pub async fn appshot_discard_pending(preview_id: String) -> Result<(), String>;
+
+#[tauri::command]
+pub async fn appshot_list_records() -> Result<Vec<AppshotRecordListItem>, String>;
+
+#[tauri::command]
+pub async fn appshot_read_records(req: AppshotReadRecordsRequest)
+    -> Result<Vec<AppshotRecordDetail>, String>;
+
+#[tauri::command]
+pub async fn appshot_copy_record(timestamp: String) -> Result<AppshotCopyResponse, String>;
+
+#[tauri::command]
+pub async fn appshot_delete_record(timestamp: String) -> Result<(), String>;
+
+#[tauri::command]
+pub async fn appshot_open_permissions(req: AppshotOpenPermissionsRequest) -> Result<(), String>;
+```
+
+The product flow is trigger-driven:
+
+1. Native trigger listener observes the configured Appshot gesture and calls capture with `target: "frontmost"` or a platform-specific active-window target.
+2. Native stores a pending capture under an opaque `preview_id`.
+3. Native emits an app event to the main WebView, for example `appshot://preview`, with metadata and screenshot preview bytes.
+4. Web UI calls `appshot_accept_pending` on Copy or after the 6-second timer.
+5. Web UI calls `appshot_discard_pending` on Delete.
+
+Native must also own a 6-second timeout for each pending capture so auto-accept still happens if the WebView event is delayed or the UI timer is interrupted. Delete must win if it arrives before the timeout resolves.
+
+#### Record directory layout
+
+Accepted Appshots are stored as directories, not single JSON blobs:
+
+```text
+~/.atmos/appshots/records/
+  1760000000000/
+    snapshot.png
+    context.md
+    metadata.json
+```
+
+- Directory name is the 13-digit Unix epoch millisecond timestamp and is the stable record id.
+- `snapshot.png` is the captured window image. The preview popover and history popover use this file for thumbnails. Accepted records keep the three-file contract stable; if screenshot capture fails but a degraded text-only record is still accepted, write a placeholder PNG and mark `screenshot.available = false` in `metadata.json`.
+- `context.md` is agent-readable Markdown with the normalized accessibility tree, focused element, extracted text, warnings, and short capture notes.
+- `metadata.json` is structured data for UI and tooling. It includes timestamp, paths, platform, app name, bundle id/process id, window title/id, screenshot dimensions, capture quality, permission states, warnings, and byte counts.
+- Writes should be atomic: write into a temp directory under `~/.atmos/appshots/tmp/`, then rename to `records/{timestamp}` after all files are complete. Deletion removes the whole record directory.
+
+#### Global modifier gesture
+
+The requested trigger is `Fn + Option + Command`. Treat it as a modifier-only gesture, not a traditional global shortcut. Do not build macOS v1 on Tauri/global-shortcut or Carbon-style hotkey registration because those APIs usually model a shortcut as modifier flags plus one non-modifier key.
+
+Preferred macOS implementation:
+
+- Install a listen-only global event tap for modifier state changes, for example `CGEventTapCreate(..., kCGEventTapOptionListenOnly, CGEventMaskBit(kCGEventFlagsChanged), ...)`.
+- If the event tap path is not viable in Rust bindings, use `NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged)` behind a small Swift/Objective-C bridge.
+- Subscribe only to `flagsChanged` / modifier events for the Appshot trigger. Do not monitor normal `keyDown` text input for this feature.
+- Derive the active modifier state from event flags and key codes. Track `function`, `option`, and `command` as booleans.
+- Fire only on the transition from "not all required modifiers down" to "all required modifiers down".
+- Keep a `fired` latch until any required modifier is released, plus a short cooldown such as 800 ms, so repeated `flagsChanged` events cannot create duplicate captures.
+- If Atmos is frontmost when the gesture fires, return a no-target preview/status instead of capturing Atmos. A future tracker can recover the last non-Atmos foreground window if dogfood proves that flow is needed.
+
+Pseudo-code:
+
+```rust
+struct ModifierGestureState {
+    function_down: bool,
+    option_down: bool,
+    command_down: bool,
+    fired: bool,
+    last_fire_at_ms: Option<u64>,
+}
+
+fn on_flags_changed(flags: ModifierFlags, state: &mut ModifierGestureState) {
+    state.function_down = flags.function;
+    state.option_down = flags.option;
+    state.command_down = flags.command;
+
+    let gesture_down = state.function_down && state.option_down && state.command_down;
+    if gesture_down && !state.fired && cooldown_elapsed(state.last_fire_at_ms) {
+        state.fired = true;
+        state.last_fire_at_ms = Some(now_ms());
+        take_appshot_for_frontmost_or_last_non_atmos_window();
+    }
+
+    if !gesture_down {
+        state.fired = false;
+    }
+}
+```
+
+Implementation notes:
+
+- `Fn` / Globe behavior can vary by keyboard and macOS settings. `appshot_status` must report when the function modifier cannot be observed, and the feature must not silently remap the gesture to `Option + Command`.
+- This listener may require Accessibility and/or Input Monitoring permission depending on the concrete API. Permission failure is a normal disabled state with recovery UI.
+- The listener should be registered during Desktop app startup and torn down on app shutdown. If macOS disables the event tap, re-enable it once and then report a degraded trigger status if it repeatedly fails.
+
+The trigger must capture the currently focused external app, not the Atmos window.
+
+#### Permission recovery flow
+
+Permissions are part of the Appshot UX, not a terminal error path. Any missing permission reported by `appshot_status` or a capture attempt must produce a visible recovery state with a one-click settings action when the platform supports it.
+
+Required macOS permission surfaces:
+
+- Accessibility: needed for `AXUIElement` traversal and may also satisfy the global modifier listener depending on the chosen implementation.
+- Screen Recording / Screen & System Audio Recording: needed for window screenshots.
+- Input Monitoring: may be needed if the modifier gesture listener uses a lower-level event tap that macOS classifies as input monitoring.
+
+Native owns settings navigation:
+
+1. `appshot_status()` returns `permissions` and `trigger.permissions`, each with display text, `granted`, why it is needed, and an optional recovery action.
+2. Web UI renders missing permissions in the preview error state and Header Appshots popover with an "Open System Settings" action.
+3. Clicking the action calls `appshot_open_permissions({ target })`.
+4. Native opens the best available macOS System Settings destination for that target. Prefer a direct Privacy & Security pane deep link after validating it on the supported macOS versions; fall back to the Privacy & Security root pane plus manual instructions if a direct pane cannot be opened.
+5. When Atmos regains focus, and once per second for up to 10 seconds after opening settings, Web UI calls `appshot_status()` again so the state updates immediately after authorization.
+
+Do not hardcode System Settings URL schemes in `apps/web`; macOS pane identifiers and labels are native compatibility details. The web layer only receives `AppshotSettingsTarget` and user-facing fallback instructions from Tauri.
+
+### macOS backend
+
+Use macOS-native APIs through target-specific Rust bindings:
+
+- Active app/window: use `NSWorkspace.frontmostApplication()` for app identity and `CGWindowListCopyWindowInfo` for top-level visible window metadata, bounds, owner pid, and window id. This lookup must be fast and independent from Accessibility tree traversal. Fall back to the previous System Events lookup only if native metadata is unavailable.
+- Screenshot: v1 uses `screencapture -R` with validated CoreGraphics window bounds; later hardening can move to ScreenCaptureKit or CoreGraphics per-window capture. Never fall back to full-screen capture when the focused window bounds are unknown.
+- Accessibility tree: v1 may use System Events traversal over the frontmost app/window; later hardening can replace this with direct `AXUIElementCreateApplication`, focused window lookup, and recursive `AXUIElementCopyAttributeValue`. Accessibility timeout or syntax/runtime failure must only degrade the record to screenshot-only/accessibility-unavailable; it must not prevent app metadata or `snapshot.png` from being captured.
+- Permissions:
+  - Appshot trigger listener: preflight the chosen `flagsChanged` listener path and surface missing Accessibility/Input Monitoring-style permission as `AppshotPermissionState`.
+  - Accessibility: preflight with the AX trust APIs and open System Settings when missing.
+  - Screen Recording: preflight/request with CoreGraphics/ScreenCaptureKit-supported APIs and open the relevant System Settings pane when missing.
+
+Traversal rules:
+
+- Cap depth, total nodes, and total text bytes using request limits. The macOS v1 defaults are depth 8, 420 nodes, 24 KB raw accessibility tree, and 28 KB final `context.md`.
+- Include role, name/title, value, description, URL, bounds, focused, enabled, selected, and settable flags when exposed.
+- Redact values for secure text fields and password-like roles.
+- Skip invisible, zero-size, or structurally empty nodes unless they have useful text or focus state.
+- Preserve partial failures in `warnings` instead of throwing away the whole appshot.
+
+### Windows/Linux backends
+
+For v1, compile stubs can return:
+
+```rust
+AppshotStatus {
+    supported: false,
+    platform: "windows" | "linux",
+    reason: Some("Appshots are currently available on macOS desktop builds only."),
+    trigger: AppshotTriggerStatus {
+        mode: AppshotTriggerMode::Unsupported,
+        enabled: false,
+        required_modifiers: vec![],
+        last_error: Some("No native Appshot backend for this platform."),
+        permissions: vec![],
+    },
+    permissions: vec![],
+}
+```
+
+The module boundary should still match the future target design:
+
+- Windows: UI Automation plus Windows Graphics Capture.
+- Linux: AT-SPI2 plus xdg-desktop-portal/PipeWire on Wayland or X11 capture APIs on X11.
+
+### apps/web shared appshot feature
+
+Add feature-local protocol/history helpers and UI components:
+
+```text
+apps/web/src/features/appshot/
+  components/AppshotCapturePreview.tsx
+  components/AppshotsHeaderButton.tsx
+  components/AppshotsHistoryPopover.tsx
+  components/AppshotRecordRow.tsx
+  lib/appshot-client.ts
+  lib/appshot-protocol.ts
+  types.ts
+```
+
+- `appshot-client.ts` checks `isTauriRuntime()` from `apps/web/src/shared/lib/desktop-runtime.ts` before invoking native commands.
+- `AppshotCapturePreview` listens for native preview events and renders the right-top 6-second popover with screenshot thumbnail, live countdown, Copy, and Delete. Hovering the preview pauses the frontend countdown and native auto-accept; leaving the preview resumes both from the remaining time.
+- `AppshotsHeaderButton` is inserted immediately to the left of the existing Open in Web button in `apps/web/src/app-shell/header-action-controls.tsx`.
+- `AppshotsHistoryPopover` explains Appshots, lists recent local records, and shows missing-permission recovery actions before the history list when Appshots are disabled by permissions.
+- `AppshotRecordRow` renders app name, capture time, thumbnail from `snapshot.png`, truncated `context.md`, Copy, and Delete.
+- `appshot-protocol.ts` owns `APPSHOT_PROTOCOL_PREFIX = "atmos://appshots/"`, `parseAppshotProtocol(text)`, `formatAppshotPrompt(timestamp)`, and `summarizeAppshotRecord`.
+- The parser accepts protocol text when the first line matches `atmos://appshots/<13-digit timestamp>` after normalizing line endings. Random Appshot URLs elsewhere in text do not become composer labels.
+- `appshot-client.ts` exposes `openAppshotPermissionTarget(target)` and refreshes `appshot_status` when the window regains focus after a settings action.
+
+Clipboard text example:
+
+```text
+atmos://appshots/1760000000000
+Appshot record is stored locally at ~/.atmos/appshots/records/1760000000000/. Read metadata.json, context.md, and snapshot.png in that directory before answering. Inspect snapshot.png when visual context matters.
+```
+
+The first line is a stable protocol marker, not a route that must be navigable in v1. The second line is fixed prompt text generated by Atmos, not user-authored content.
+
+#### Header history popover
+
+`HeaderActionControls` already owns the Open in Web popover. Add the Appshots button immediately before that trigger when `isDesktopRuntime` is true.
+
+History loading flow:
+
+1. `appshot_list_records()` returns a lightweight sorted list of record IDs by reading subdirectory names from `~/.atmos/appshots/records/` and sorting descending.
+2. Web state keeps the full timestamp list and a visible count, initially 10.
+3. Web calls `appshot_read_records({ timestamps: visibleTimestamps })` for the visible IDs only.
+4. Clicking More increases the visible count by 10 and reads the next page details.
+5. Copy calls `appshot_copy_record(timestamp)`.
+6. Delete calls `appshot_delete_record(timestamp)` and removes the row locally after success.
+
+This keeps startup cheap because the app does not parse every `context.md` and `metadata.json` before the user asks for more rows.
+
+### apps/web shared prompt composers
+
+Update the existing shared composer token system in `apps/web/src/features/welcome/components/PromptComposer.tsx` and each supported submit path that reuses it:
+
+- Extend `TOKEN_REGEX` with an Appshot token shape, for example `[#appshot:<id>]`.
+- On paste, before plain text insertion, detect `parseAppshotProtocol(text)`.
+- If detected, prevent default paste, insert a non-editable Appshot chip, serialize it as `[#appshot:<timestamp>]`, and fire `onTextChange`.
+- Best effort: in Desktop runtime, read `metadata.json` for the timestamp to label the chip with app/window names. If the record cannot be read, label it with the timestamp and keep the pasted protocol text.
+- The visible chip label should be compact, for example `Appshot · Cursor · Cursor Agents`.
+- Tooltip should show safe metadata only: app name, window title, captured time, quality. Do not show the full tree in a hover tooltip.
+- Deleting the chip removes the serialized Appshot token from composer text.
+
+Update `apps/web/src/features/welcome/lib/welcome-page-helpers.tsx`:
+
+- Extend `resolvePromptPlaceholders(text, attachments)` or add a sibling resolver so `[#appshot:<timestamp>]` expands to the protocol reference plus fixed prompt instruction.
+- Existing placeholder behavior for `@file`, `/skill`, and image attachments must remain unchanged.
+
+Update `apps/web/src/features/welcome/components/WelcomePage.tsx`:
+
+- Use the serialized Appshot token from `PromptComposer` during submit-time resolution.
+- Ensure both `initialRequirement` and `queueAgentRun({ prompt })` receive the expanded protocol prompt text, not the compact token.
+
+Update `apps/web/src/features/automations/components/AutomationSetup.tsx`:
+
+- Reuse the same `PromptComposer` features as Welcome for Appshot chips, `@file` mentions, `/skill` chips, and image paste.
+- Resolve Appshot and file placeholders before create/update requests.
+- Send image attachment payloads with automation create/update so the backend can write them under the automation definition directory and replace `[#img-n]` placeholders with concrete local file paths.
+
+### apps/api
+
+No new API route is needed for capture or parsing. The Welcome page already resolves composer placeholders before workspace creation and queued agent run:
+
+- Submit flow: `apps/web/src/features/welcome/components/WelcomePage.tsx`
+- Placeholder resolver: `apps/web/src/features/welcome/lib/welcome-page-helpers.tsx`
+
+Do not create a parallel REST endpoint for Appshot capture or history. The OS capture and local record file operations happen inside the Tauri process.
+
+### crates/core-service and crates/infra
+
+Appshot persistence itself remains local filesystem state owned by the Tauri desktop layer under `~/.atmos/appshots/records/{timestamp}/`; no Appshot database table or loopback API route is required for v1.
+
+Automation setup needs one service-layer extension because it reuses the same rich composer image-paste path as workspace creation:
+
+- Add optional image attachment payloads to automation create/update requests.
+- Write attachments under `~/.atmos/automations/definitions/{automation_guid}/attachments/`.
+- Replace `[#img-n]` placeholders in saved automation instructions with concrete local attachment paths before validation/persistence.
+
+No infra migration is required. If a later version syncs Appshot history or exposes it through the loopback API, introduce a separate PRD/TECH update before adding database tables or API routes.
+
+## Data model
+
+Rust structs in `apps/desktop/src-tauri/src/appshot/types.rs`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AppshotPlatform {
+    Macos,
+    Windows,
+    Linux,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AppshotQuality {
+    ScreenshotAndAccessibility,
+    ScreenshotOnly,
+    AccessibilityOnly,
+    MetadataOnly,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotPendingPreview {
+    pub preview_id: String,
+    pub app_name: String,
+    pub window_title: Option<String>,
+    pub captured_at: String,
+    pub quality: AppshotQuality,
+    pub screenshot_preview_base64: Option<String>,
+    pub permissions: Vec<AppshotPermissionState>,
+    pub warnings: Vec<String>,
+    pub expires_in_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotStatus {
+    pub supported: bool,
+    pub platform: AppshotPlatform,
+    pub reason: Option<String>,
+    pub trigger: AppshotTriggerStatus,
+    pub permissions: Vec<AppshotPermissionState>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotAcceptResponse {
+    pub timestamp: String,
+    pub record_dir: String,
+    pub protocol_text: String,
+    pub metadata: AppshotRecordMetadata,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotCopyResponse {
+    pub timestamp: String,
+    pub protocol_text: String,
+    pub copied: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotReadRecordsRequest {
+    pub timestamps: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotPendingAutoAcceptRequest {
+    pub preview_id: String,
+    pub held: bool,
+    pub resume_in_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotRecordListItem {
+    pub timestamp: String,
+    pub record_dir: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotRecordDetail {
+    pub timestamp: String,
+    pub metadata: AppshotRecordMetadata,
+    pub context_preview: String,
+    pub snapshot_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotRecordMetadata {
+    pub timestamp: String,
+    pub captured_at: String,
+    pub platform: AppshotPlatform,
+    pub app_name: String,
+    pub bundle_id: Option<String>,
+    pub process_id: Option<u32>,
+    pub window_title: Option<String>,
+    pub window_id: Option<String>,
+    pub quality: AppshotQuality,
+    pub record_dir: String,
+    pub snapshot_path: String,
+    pub context_path: String,
+    pub metadata_path: String,
+    pub screenshot: AppshotScreenshotMetadata,
+    pub warnings: Vec<String>,
+    pub context_bytes: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotScreenshotMetadata {
+    pub available: bool,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub media_type: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AppshotPermissionName {
+    Accessibility,
+    ScreenRecording,
+    InputMonitoring,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AppshotSettingsTarget {
+    Accessibility,
+    ScreenRecording,
+    InputMonitoring,
+    PrivacySecurity,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotPermissionRecoveryAction {
+    pub label: String,
+    pub target: AppshotSettingsTarget,
+    pub manual_steps: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotPermissionState {
+    pub name: AppshotPermissionName,
+    pub display_name: String,
+    pub granted: bool,
+    pub required_for: Vec<String>,
+    pub recovery_action: Option<AppshotPermissionRecoveryAction>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotOpenPermissionsRequest {
+    pub target: AppshotSettingsTarget,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AppshotTriggerMode {
+    MacosModifierGesture,
+    RegularHotkeyFallback,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppshotTriggerStatus {
+    pub mode: AppshotTriggerMode,
+    pub enabled: bool,
+    pub required_modifiers: Vec<String>,
+    pub last_error: Option<String>,
+    pub permissions: Vec<AppshotPermissionState>,
+}
+```
+
+`context.md` is Markdown rather than JSON so a human or agent can read it directly:
+
+```markdown
+# Appshot Context
+
+- App: Cursor
+- Window: Cursor Agents
+- Captured at: 2026-05-28T10:24:00Z
+- Quality: screenshot_and_accessibility
+
+## Focused Element
+
+...
+
+## Accessibility Tree
+
+- window "Cursor Agents"
+  - group "HTML content"
+    - button "New Chat"
+
+## Warnings
+
+- Some secure text fields were redacted.
+```
+
+`metadata.json` is for UI and automation. It should not duplicate the full accessibility tree; it points to `context.md` and `snapshot.png`.
+
+TypeScript mirrors in `apps/web/src/features/appshot/types.ts`. Keep names aligned through serde `snake_case` JSON rather than inventing a second shape.
+
+Supported composer serialized state:
+
+```ts
+type AppshotComposerRef = {
+  timestamp: string;
+  token: `[#appshot:${string}]`;
+};
+```
+
+## Transport
+
+### Native events and Tauri invoke
+
+Native emits preview events to the main WebView:
+
+```ts
+type AppshotPreviewEvent = {
+  preview_id: string;
+  app_name: string;
+  window_title?: string;
+  captured_at: string;
+  quality: string;
+  screenshot_preview_base64?: string;
+  permissions: AppshotPermissionState[];
+  warnings: string[];
+  expires_in_ms: 6000;
+};
+```
+
+Preview controls:
+
+```ts
+await invoke<AppshotAcceptResponse>("appshot_accept_pending", { previewId });
+await invoke<void>("appshot_discard_pending", { previewId });
+await invoke<void>("appshot_set_pending_auto_accept", { req: { preview_id, held, resume_in_ms } });
+```
+
+History controls:
+
+```ts
+const list = await invoke<AppshotRecordListItem[]>("appshot_list_records");
+const rows = await invoke<AppshotRecordDetail[]>("appshot_read_records", {
+  req: { timestamps: list.slice(0, 10).map((item) => item.timestamp) },
+});
+await invoke<AppshotCopyResponse>("appshot_copy_record", { timestamp });
+await invoke<void>("appshot_delete_record", { timestamp });
+```
+
+### Agent prompt
+
+No new Agent WebSocket message is required. Welcome submit expands `[#appshot:<timestamp>]` into:
+
+```text
+atmos://appshots/{timestamp}
+Appshot record is stored locally at ~/.atmos/appshots/records/{timestamp}/. Read metadata.json, context.md, and snapshot.png in that directory before answering. Inspect snapshot.png when visual context matters.
+```
+
+### REST
+
+No new REST endpoint.
+
+## Security & permissions
+
+- Capture is user-triggered only.
+- The modifier listener must observe only modifier state changes needed for the Appshot gesture. It must not collect typed characters or persist raw keyboard events.
+- Appshot content must not be included in `write_log`, tracing logs, desktop logs, or API logs.
+- Secure text fields are redacted when the platform exposes secure field semantics.
+- Permission-denied responses are normal results with `status.permissions`, not internal errors. Every required denied permission must include a recovery action or explicit manual steps.
+- The clipboard protocol text is plain text; users can paste it anywhere. Atmos consumers should show a compact label only in surfaces that explicitly support Appshot parsing.
+- Welcome and Automation setup composers must show a compact chip before submit and allow deletion.
+- Hosted web, relay web, and non-Tauri browser sessions must not show a working capture control.
+- `snapshot.png`, `context.md`, and `metadata.json` can contain sensitive screen content. Delete must remove the whole record directory.
+- Remote relay clients must not trigger native capture on a remote machine through the API. Appshots are local Desktop-only in v1.
+
+## Rollout plan
+
+1. Add the appshot Rust module and unsupported status stubs for all platforms.
+2. Implement macOS permission preflight, settings-opening commands, manual fallback instructions, and status refresh after returning from System Settings.
+3. Implement the macOS modifier-only trigger listener in `shortcut.rs`, including latch, cooldown, disabled-state reporting, and event tap re-enable handling.
+4. Implement macOS window tracking for the last non-Atmos foreground window.
+5. Implement macOS screenshot capture with structured fallback when Screen Recording is missing.
+6. Implement macOS accessibility traversal with depth/node/text caps and secure-field redaction.
+7. Add `protocol.rs`, `records.rs`, and clipboard write support for `atmos://appshots/{timestamp}` prompt text.
+8. Add pending capture state, 6-second auto-accept, and accept/delete commands.
+9. Add the right-top `AppshotCapturePreview` UI.
+10. Add `apps/web/src/features/appshot` client/protocol/history helpers and unit tests.
+11. Add the Header Appshots button immediately left of Open in Web, plus paged history popover.
+12. Extend Welcome `PromptComposer` paste handling and Appshot chip rendering.
+13. Extend Welcome submit-time placeholder resolution so agent prompts receive protocol prompt text.
+14. Run dogfood on common native, Electron, Tauri, browser, and self-drawn app cases.
+15. Remove or keep the feature flag based on dogfood results.
+
+## Risks & tradeoffs
+
+- **Tradeoff**: Capture lives in Tauri instead of `apps/api` because only the foreground native app process can reliably observe OS window state and request desktop permissions.
+- **Tradeoff**: macOS ships first because its accessibility and screen capture APIs are the most predictable for this workflow.
+- **Tradeoff**: macOS uses a modifier-state listener instead of a normal hotkey registration because `Fn + Option + Command` has no non-modifier key.
+- **Risk**: Accessibility trees vary by target app. The UI and prompt must label partial capture quality clearly.
+- **Risk**: `Fn` / Globe may be intercepted by macOS settings or unavailable on some external keyboards. `appshot_status` must surface this explicitly and product review should decide whether a configurable fallback chord is needed.
+- **Risk**: Global event taps can be disabled by permission changes, secure input modes, or OS behavior. The listener must recover once, then expose a disabled/degraded state rather than silently failing.
+- **Risk**: Active-window detection can still pick the wrong target on fast focus changes. The preview must include app/window title so users can delete bad captures before persistence.
+- **Risk**: Appshot records can grow large over time. The history UI ships delete controls in v1; retention policy can be a follow-up.
+- **Risk**: Hidden composer state can drift from visible chip tokens. Submit-time resolution must treat missing IDs as recoverable and avoid sending dangling tokens silently.
+- **Risk**: Native timeout and UI Copy/Delete can race. Pending state must resolve exactly once, with Delete winning if it arrives before auto-accept starts.
+- **Rollback path**: Disable the feature flag and leave native commands/PromptComposer Appshot parsing unused. Existing Welcome, Automation, and Agent Chat flows keep working.
+
+## Dependencies & compatibility
+
+- Depends on Desktop Tauri runtime from `APP-009_desktop-tauri`.
+- Integrates first with `apps/web/src/features/welcome/components/PromptComposer.tsx` consumers: Welcome page and Automation setup.
+- Still works with agent execution because Welcome submit expands the Appshot chip into protocol prompt text before `queueAgentRun`, and Automation setup expands the same chip before saving instructions used by terminal automation runs.
+- Minimum v1 platform: macOS Desktop.
+- Windows and Linux compile with unsupported status until their backends are implemented.
+
+## Open questions
+
+- [ ] Exact macOS screenshot API choice: ScreenCaptureKit vs. CoreGraphics per-window image, based on OS support and permission behavior during implementation.
+- [ ] Whether `Fn` / Globe is observable reliably enough across built-in and common external keyboards, or needs a configurable fallback chord.
+- [ ] Whether timeout auto-accept should show a notification after the preview disappears.
+- [ ] Final `context.md` size caps after dogfood with real accessibility trees.

--- a/specs/APP/APP-021_appshots-cross-app-snapshot/TEST.md
+++ b/specs/APP/APP-021_appshots-cross-app-snapshot/TEST.md
@@ -1,0 +1,193 @@
+# TEST · APP-021: Appshots Cross-App Snapshot
+
+> Test Plan · how we verify global-shortcut Appshots, local records, protocol copy, history, and supported composer labels. References PRD APP-021 and TECH APP-021.
+
+## Test strategy
+
+- Unit / integration: Validate protocol formatting/parsing, record file layout, prompt expansion, payload caps, redaction, unsupported-platform responses, and permission state mapping without real OS capture.
+- Desktop integration: Exercise Tauri commands with mocked or platform-gated backends where possible.
+- End-to-end: Verify global shortcut capture, right-top preview, record persistence, clipboard protocol, Header history, and supported composer paste behavior in a Desktop build.
+- Manual-only: Real macOS global shortcut, Screen Recording, Accessibility, and possible Input Monitoring permission flows, because OS permission dialogs and cross-app capture are not stable in headless automation.
+
+## Coverage map
+
+| PRD item | Scenario IDs |
+|----------|--------------|
+| M1       | S1, S10 |
+| M2       | S1, S2, S3 |
+| M3       | S2, S3 |
+| M4       | S3, S5 |
+| M5       | S3, S5, S8 |
+| M6       | S3, S4, S8 |
+| M7       | S6 |
+| M8       | S6 |
+| M9       | S7 |
+| M10      | S7 |
+| M11      | S7 |
+| M12      | S7 |
+| M13      | S8 |
+| M14      | S9 |
+| M15      | S10 |
+| M16      | S11 |
+| M17      | S12 |
+
+## Scenarios
+
+### S1 - Global shortcut captures from another app
+
+- **Level**: Manual macOS Desktop plus native integration.
+- **Given**: Atmos Desktop is running with required permissions and another app is focused.
+- **When**: the user presses the configured global shortcut.
+- **Then**: Atmos captures the focused external app, not Atmos, and emits a pending preview event.
+- **Signals**: preview event has `preview_id`, app/window metadata, screenshot preview when available, and `expires_in_ms: 6000`.
+
+### S2 - Preview popover resolves by delete
+
+- **Level**: E2E / native integration.
+- **Given**: a pending Appshot preview is visible in the right-top popover.
+- **When**: the user clicks Delete before 6 seconds elapse.
+- **Then**: the pending capture is discarded, no record directory is written, and clipboard content is unchanged.
+- **Signals**: `appshot_discard_pending` succeeds; `~/.atmos/appshots/records/{timestamp}/` is absent; popover disappears.
+
+### S3 - Preview popover resolves by copy or timeout
+
+- **Level**: E2E / native integration.
+- **Given**: a pending Appshot preview is visible.
+- **When**: the user clicks Copy, or takes no action for 6 seconds.
+- **Then**: Atmos writes a timestamped record directory and copies protocol prompt text.
+- **Signals**: record path is `~/.atmos/appshots/records/{13-digit timestamp}/`; clipboard starts with `atmos://appshots/{timestamp}`; popover disappears.
+
+### S4 - Protocol parser accepts only Appshot first-line references
+
+- **Level**: Unit.
+- **Given**: plain text payloads with `atmos://appshots/{timestamp}` on the first line, later in the body, malformed timestamps, and unrelated text.
+- **When**: `parseAppshotProtocol` runs.
+- **Then**: only payloads whose first line matches `atmos://appshots/<13 digits>` are treated as Appshots.
+- **Signals**: accepted payload returns timestamp and prompt text; rejected payload remains ordinary pasted text.
+
+### S5 - Record directory contains canonical files
+
+- **Level**: Native integration.
+- **Given**: an accepted happy-path Appshot.
+- **When**: the record is written.
+- **Then**: the record directory contains `snapshot.png`, `context.md`, and `metadata.json`.
+- **Signals**: `snapshot.png` is a readable PNG; `context.md` includes app/window metadata and non-empty accessibility/text content; `metadata.json` includes paths, quality, warnings, and screenshot dimensions.
+
+### S6 - Supported composer paste collapses protocol into a label
+
+- **Level**: E2E / component integration.
+- **Given**: the clipboard contains valid protocol prompt text for an existing Appshot record.
+- **When**: the user pastes into the Welcome page composer or Automation setup composer.
+- **Then**: the visible composer shows one compact Appshot label, while submit text preserves the protocol reference and fixed instruction.
+- **Signals**: DOM contains an Appshot chip/token; serialized composer text contains `[#appshot:<timestamp>]`; submit resolver expands it to `atmos://appshots/{timestamp}` plus instruction.
+
+### S7 - Header history pages recent records
+
+- **Level**: E2E / component integration.
+- **Given**: at least 12 record directories exist under `~/.atmos/appshots/records/`.
+- **When**: the user opens the Header Appshots popover.
+- **Then**: the button appears immediately left of Open in Web; the popover explains Appshots; records are sorted newest first; only the first 10 records have details loaded until More is clicked.
+- **Signals**: first page renders 10 rows with app, time, thumbnail, truncated context, Copy, and Delete; More reveals rows 11-20 by reading additional details.
+
+### S8 - History copy and delete
+
+- **Level**: E2E / native integration.
+- **Given**: a record row is visible in the Header Appshots history.
+- **When**: the user clicks Copy.
+- **Then**: clipboard contains the same `atmos://appshots/{timestamp}` plus fixed instruction.
+- **When**: the user clicks Delete.
+- **Then**: the entire record directory is removed and the row disappears.
+- **Signals**: `appshot_copy_record` returns `copied: true`; `appshot_delete_record` removes `snapshot.png`, `context.md`, `metadata.json`, and the parent directory.
+
+### S9 - Security: secure text values are redacted
+
+- **Level**: Unit / native integration.
+- **Given**: an accessibility node representing a secure text field or password-like role is returned by the platform backend.
+- **When**: the record files are written.
+- **Then**: the node remains structurally present only if useful, but its value is omitted or replaced with a redaction marker.
+- **Signals**: `context.md` does not contain the original secure value; `metadata.json` does not contain the secure value; logs do not contain the secure value.
+
+### S10 - Explicit user action only
+
+- **Level**: Unit / E2E.
+- **Given**: Atmos is open and the user types or pastes ordinary text into Welcome composer.
+- **When**: the user does not click Appshot or invoke a configured capture action.
+- **Then**: no native capture command runs, no pending preview appears, and no record directory is written.
+- **Signals**: no preview event; records directory unchanged; submitted prompt contains only user-entered text and regular placeholders.
+
+### S11 - Unsupported runtime or platform
+
+- **Level**: Unit / integration.
+- **Given**: the web app runs outside Tauri, or the native backend reports unsupported on Windows/Linux v1.
+- **When**: the Appshots Header button renders or `appshot_status` is called.
+- **Then**: Appshot controls are hidden or disabled with an unsupported state, and no capture attempt is made.
+- **Signals**: `isTauriRuntime()` gates the web action; native status returns `supported: false`.
+
+### S12 - Permission recovery
+
+- **Level**: Manual macOS Desktop.
+- **Given**: one or more required macOS permissions are missing: Accessibility, Screen Recording / Screen & System Audio Recording, or Input Monitoring.
+- **When**: the user opens the Header Appshots popover or attempts Appshot capture.
+- **Then**: Atmos shows the missing permission name, why Appshots need it, and an Open System Settings action.
+- **And when**: the user clicks Open System Settings.
+- **Then**: Atmos opens the relevant macOS System Settings pane, or opens Privacy & Security and shows exact manual steps when a direct pane cannot be opened.
+- **And when**: the user grants permission and returns to Atmos.
+- **Then**: Atmos refreshes `appshot_status` and removes the missing-permission state without requiring an app restart.
+- **Signals**: `appshot_status` returns denied permissions with `recovery_action`; `appshot_open_permissions` succeeds or returns manual steps; UI updates after focus returns.
+
+## Performance & load budgets
+
+- Accessibility traversal defaults to no more than 420 nodes, depth 8, 24 KB raw accessibility text, and 28 KB final `context.md` in macOS v1.
+- A happy-path macOS capture should show the preview popover within 2 seconds at p50 and 5 seconds at p95 in dogfood testing.
+- Accepting a pending Appshot should write all three canonical files and copy protocol text within 500 ms at p50 after capture is complete.
+- Header history should list filenames without parsing all details; first 10 detail rows should render within 300 ms for normal record sizes.
+
+## Regression checklist
+
+- [ ] Appshot capture does not run in browser, hosted web, or relay web mode.
+- [ ] Triggering the global shortcut captures the focused external app, not Atmos.
+- [ ] Long or complex target app pages still produce app/window metadata and `snapshot.png` even if Accessibility tree capture times out.
+- [ ] Permission-denied results are recoverable UI states with an Open System Settings action, not unhandled exceptions.
+- [ ] Secure text is redacted in `context.md`, `metadata.json`, prompts, and logs.
+- [ ] Welcome and Automation setup composers still support ordinary text paste, image paste, `@file` chips, and `/skill` chips.
+- [ ] Appshot labels are removable and do not leave hidden protocol state behind.
+- [ ] Delete removes the whole record directory.
+
+## Acceptance criteria
+
+- [ ] All Must Have PRD items map to passing scenarios above.
+- [ ] macOS Desktop happy path shows a right-top preview after global shortcut capture.
+- [ ] Accepted records create `snapshot.png`, `context.md`, and `metadata.json` under `~/.atmos/appshots/records/{timestamp}/`.
+- [ ] Clipboard text starts with `atmos://appshots/{timestamp}` and includes the fixed instruction pointing at the record directory.
+- [ ] Missing permission states identify the exact permission, explain why it is needed, open System Settings or show manual steps, and refresh after authorization.
+- [ ] Welcome and Automation setup composers render pasted Appshot protocol text as compact labels and submit the protocol reference/instruction.
+- [ ] Header Appshots history can page, copy, and delete records.
+- [ ] The agent receives Appshot context through the existing Welcome submit/queue flow, without a new Appshot REST endpoint.
+- [ ] Captured content is excluded from logs.
+- [ ] The feature is gated off outside supported Desktop runtimes.
+- [ ] `bun test` covers protocol parsing, Welcome paste handling, submit-time expansion, Header history UI, and web gating.
+- [ ] `cargo test -p atmos-desktop` or the relevant Tauri crate test target covers native normalization helpers where available.
+
+## Manual verification steps
+
+1. On macOS Desktop, revoke one Appshots permission, open the Header Appshots popover, and confirm it shows the missing permission with an Open System Settings action.
+2. Click Open System Settings, grant the permission, return to Atmos, and confirm the permission state refreshes without restarting.
+3. Grant Screen Recording, Accessibility, and Input Monitoring if required by the chosen trigger listener; focus an Electron or browser window and press the global Appshot gesture.
+4. Confirm the right-top preview appears with a screenshot, Copy, Delete, and a live countdown; hover it and confirm the countdown pauses; move the mouse out and confirm the countdown resumes and creates a record directory on timeout.
+5. Inspect `~/.atmos/appshots/records/{timestamp}/` and confirm `snapshot.png`, `context.md`, and `metadata.json` exist.
+6. Paste the clipboard into a plain text editor and confirm the first line is `atmos://appshots/{timestamp}` and the instruction points at the record directory.
+7. Paste the same clipboard into the Welcome composer and confirm it becomes a compact Appshot label.
+8. Create a workspace from the Welcome page and confirm the resulting requirement/queued prompt includes the protocol reference and instruction.
+9. Paste the same clipboard into Automation setup and confirm saved automation instructions include the protocol reference and instruction.
+10. Paste an image into Automation setup and confirm the saved automation instruction points at an attachment under `~/.atmos/automations/definitions/{automation_guid}/attachments/`.
+11. Open the Header Appshots popover next to Open in Web and confirm recent records show thumbnails, app/time, truncated context, Copy, Delete, and More pagination.
+12. Delete a record from history and confirm its directory is removed.
+13. Focus a long Electron/browser page and capture; confirm `metadata.json` does not degrade to `app_name: "Unknown App"` and `snapshot.png` is a real window image even if `quality` is `screenshot_only`.
+14. Focus a password field in a target app, capture, and confirm `context.md`, `metadata.json`, submitted prompt, and logs do not contain the password value.
+15. Run the web app in a regular browser and confirm Appshot controls are not available.
+
+## Non-coverage
+
+- Windows UI Automation and Linux AT-SPI2 backends are not covered until N4 moves into scope.
+- OCR or model-based visual fallback is deferred until N2 moves into scope.
+- Automated validation of macOS System Settings dialogs is manual-only because OS dialogs are not reliable in CI.

--- a/specs/APP/APP-021_appshots-cross-app-snapshot/TEST.md
+++ b/specs/APP/APP-021_appshots-cross-app-snapshot/TEST.md
@@ -38,8 +38,8 @@
 - **Level**: Manual macOS Desktop plus native integration.
 - **Given**: Atmos Desktop is running with required permissions and another app is focused.
 - **When**: the user presses the configured global shortcut.
-- **Then**: Atmos captures the focused external app, not Atmos, and emits a pending preview event.
-- **Signals**: preview event has `preview_id`, app/window metadata, screenshot preview when available, and `expires_in_ms: 6000`.
+- **Then**: Atmos highlights the focused external app with a blue capture border/flash, captures that app instead of Atmos, and emits a pending preview event.
+- **Signals**: preview event has `preview_id`, app/window metadata, `source_bounds` when known, screenshot preview when available, and `expires_in_ms: 6000`.
 
 ### S2 - Preview popover resolves by delete
 
@@ -87,7 +87,7 @@
 - **Given**: at least 12 record directories exist under `~/.atmos/appshots/records/`.
 - **When**: the user opens the Header Appshots popover.
 - **Then**: the button appears immediately left of Open in Web; the popover explains Appshots; records are sorted newest first; only the first 10 records have details loaded until More is clicked.
-- **Signals**: first page renders 10 rows with app, time, thumbnail, truncated context, Copy, and Delete; More reveals rows 11-20 by reading additional details.
+- **Signals**: first page renders 10 rows with app, time, thumbnail, truncated context, Copy, and Delete; clicking a thumbnail opens the shared image preview overlay; More reveals rows 11-20 by reading additional details.
 
 ### S8 - History copy and delete
 
@@ -173,14 +173,14 @@
 1. On macOS Desktop, revoke one Appshots permission, open the Header Appshots popover, and confirm it shows the missing permission with an Open System Settings action.
 2. Click Open System Settings, grant the permission, return to Atmos, and confirm the permission state refreshes without restarting.
 3. Grant Screen Recording and Accessibility; focus an Electron or browser window and press the global Appshot gesture.
-4. Confirm the right-top preview appears with a screenshot, Copy, Delete, and a live countdown; hover it and confirm the countdown pauses; move the mouse out and confirm the countdown resumes and creates a record directory on timeout.
+4. Confirm the target app briefly shows a blue capture border/flash, then the right-top preview appears with a screenshot, Copy, Delete, a live countdown, and a movement animation into Atmos; hover it and confirm the countdown pauses; move the mouse out and confirm the countdown resumes and creates a record directory on timeout.
 5. Inspect `~/.atmos/appshots/records/{timestamp}/` and confirm `snapshot.png`, `context.md`, and `metadata.json` exist.
 6. Paste the clipboard into a plain text editor and confirm the first line is `atmos://appshots/{timestamp}` and the instruction points at the record directory.
 7. Paste the same clipboard into the Welcome composer and confirm it becomes a compact Appshot label.
 8. Create a workspace from the Welcome page and confirm the resulting requirement/queued prompt includes the protocol reference and instruction.
 9. Paste the same clipboard into Automation setup and confirm saved automation instructions include the protocol reference and instruction.
 10. Paste an image into Automation setup and confirm the saved automation instruction points at an attachment under `~/.atmos/automations/definitions/{automation_guid}/attachments/`.
-11. Open the Header Appshots popover next to Open in Web and confirm recent records show thumbnails, app/time, truncated context, Copy, Delete, and More pagination.
+11. Open the Header Appshots popover next to Open in Web and confirm recent records show thumbnails, app/time, truncated context, Copy, Delete, and More pagination. Click a thumbnail and confirm it opens in the same full-screen image preview overlay used by composer attachments.
 12. Delete a record from history and confirm its directory is removed.
 13. Focus a long Electron/browser page and capture; confirm `metadata.json` does not degrade to `app_name: "Unknown App"` and `snapshot.png` is a real window image even if `quality` is `screenshot_only`.
 14. Focus a password field in a target app, capture, and confirm `context.md`, `metadata.json`, submitted prompt, and logs do not contain the password value.

--- a/specs/APP/APP-021_appshots-cross-app-snapshot/TEST.md
+++ b/specs/APP/APP-021_appshots-cross-app-snapshot/TEST.md
@@ -7,7 +7,7 @@
 - Unit / integration: Validate protocol formatting/parsing, record file layout, prompt expansion, payload caps, redaction, unsupported-platform responses, and permission state mapping without real OS capture.
 - Desktop integration: Exercise Tauri commands with mocked or platform-gated backends where possible.
 - End-to-end: Verify global shortcut capture, right-top preview, record persistence, clipboard protocol, Header history, and supported composer paste behavior in a Desktop build.
-- Manual-only: Real macOS global shortcut, Screen Recording, Accessibility, and possible Input Monitoring permission flows, because OS permission dialogs and cross-app capture are not stable in headless automation.
+- Manual-only: Real macOS global shortcut, Screen Recording, and Accessibility permission flows, because OS permission dialogs and cross-app capture are not stable in headless automation.
 
 ## Coverage map
 
@@ -126,7 +126,7 @@
 ### S12 - Permission recovery
 
 - **Level**: Manual macOS Desktop.
-- **Given**: one or more required macOS permissions are missing: Accessibility, Screen Recording / Screen & System Audio Recording, or Input Monitoring.
+- **Given**: one or more required macOS permissions are missing: Accessibility or Screen Recording / Screen & System Audio Recording.
 - **When**: the user opens the Header Appshots popover or attempts Appshot capture.
 - **Then**: Atmos shows the missing permission name, why Appshots need it, and an Open System Settings action.
 - **And when**: the user clicks Open System Settings.
@@ -172,7 +172,7 @@
 
 1. On macOS Desktop, revoke one Appshots permission, open the Header Appshots popover, and confirm it shows the missing permission with an Open System Settings action.
 2. Click Open System Settings, grant the permission, return to Atmos, and confirm the permission state refreshes without restarting.
-3. Grant Screen Recording, Accessibility, and Input Monitoring if required by the chosen trigger listener; focus an Electron or browser window and press the global Appshot gesture.
+3. Grant Screen Recording and Accessibility; focus an Electron or browser window and press the global Appshot gesture.
 4. Confirm the right-top preview appears with a screenshot, Copy, Delete, and a live countdown; hover it and confirm the countdown pauses; move the mouse out and confirm the countdown resumes and creates a record directory on timeout.
 5. Inspect `~/.atmos/appshots/records/{timestamp}/` and confirm `snapshot.png`, `context.md`, and `metadata.json` exist.
 6. Paste the clipboard into a plain text editor and confirm the first line is `atmos://appshots/{timestamp}` and the instruction points at the record directory.

--- a/specs/README.md
+++ b/specs/README.md
@@ -98,6 +98,7 @@ These files are not requirements sources. Requirements live in `PRD.md`, archite
 | **APP-018** | ACP Protocol Upgrade | `PRD.md` |
 | **APP-019** | GitHub Automation Triggers | `specs/APP/APP-019_github-automation-triggers/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`, `REVIEW.md`) |
 | **APP-020** | Relay Stable Tenant Identity | `specs/APP/APP-020_relay-stable-tenant-identity/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`, `REVIEW.md`) |
+| **APP-021** | Appshots Cross-App Snapshot | `specs/APP/APP-021_appshots-cross-app-snapshot/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`, `REVIEW.md`) |
 
 ### Landing
 


### PR DESCRIPTION
## Summary

- Add cross-app Appshots capture for the desktop app: modifier-only global shortcut, macOS screenshot/accessibility collection, local record storage, pending preview, clipboard protocol references, and header history management.
- Reuse the shared composer behavior across Welcome and Automation setup so Appshot references, `@` files, `/` skills, and pasted images flow consistently into agent prompts.
- Harden capture and UX behavior around long app content, permission recovery, preview countdown hover pause, Appshots history pagination, and APP-021 specs/tests.

## Related Issue

None

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] Additional checks (describe below)

Additional checks:

- `cargo test -p atmos-desktop appshot`
- `cargo check -p atmos-desktop`
- `cargo test -p core-service resolves_written_attachment_tokens_to_paths`
- `cargo check -p api`
- `bun --filter web typecheck`
- Focused Appshot/Welcome web tests: `bun test apps/web/src/features/appshot/__tests__/appshot-payload.test.ts apps/web/src/features/appshot/__tests__/appshot-protocol.test.ts apps/web/src/features/appshot/__tests__/appshot-client-runtime.test.ts apps/web/src/features/appshot/__tests__/appshots-history-popover.test.tsx apps/web/src/features/welcome/lib/__tests__/welcome-appshot-placeholders.test.ts apps/web/src/features/welcome/components/__tests__/prompt-composer-appshot-paste.test.tsx`
- Focused web lint: `bun --filter web lint -- src/features/appshot/components/AppshotCapturePreview.tsx src/features/appshot/components/AppshotsHeaderButton.tsx src/features/appshot/lib/appshot-client.ts src/features/appshot/types.ts src/features/appshot/__tests__/appshot-payload.test.ts src/features/appshot/__tests__/appshots-history-popover.test.tsx`
- `git diff --check`

## Checklist

- [x] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cross-app Appshots to the desktop: a macOS global shortcut captures another app, shows a short preview, saves a local record, and copies an `atmos://appshots/{timestamp}` reference. Integrates Appshots into the header, Welcome, and Automation composers; adds atomic writes, attachment handling, hardened shortcut restart, clearer macOS permission guidance, and removes the Input Monitoring permission.

- **New Features**
  - macOS capture via modifier-only global shortcut with Screen Recording/Accessibility flows.
  - Short preview (hover-pause, accept/discard, optional auto-accept); hides oversized inline images.
  - Local records at `~/.atmos/appshots/records/{timestamp}/` plus clipboard protocol; atomic writes via temp dir.
  - Header history and desktop runtime on launch; composers parse `atmos://appshots/{timestamp}`; Automation composer resolves tokens and uploads attachments.

- **Bug Fixes**
  - Hardened shortcut runtime restart for reliable capture.
  - Clearer permission drift guidance and recovery flows; removed Input Monitoring permission from requirements and UI.

<sup>Written for commit f9ae632a6a30d097796d85384c9007eff825b94d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/124?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Appshots feature for macOS: capture other app windows via global shortcut, preview with auto-accept timeout, and persist captured context locally.
  * Added Appshots history popover with pagination, copy, delete, and screenshot preview.
  * Added Appshot reference support in Welcome and Automation composers via paste detection and token rendering.
  * Added permission management UI for Accessibility and Screen Recording access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AruNi-01/atmos/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->