### PR TITLE
refactor: address daily quality findings for 2026-06-18

### DIFF
--- a/apps/web/src/app-shell/sidebar/CommitActions.tsx
+++ b/apps/web/src/app-shell/sidebar/CommitActions.tsx
@@ -55,6 +55,7 @@ import {
   CommitActionsPanelChanges,
   CommitActionsPanelHeader,
 } from "@/app-shell/sidebar/CommitActionsPanelParts";
+import { basenameFromPath } from "@/app-shell/sidebar/commit-actions-paths";
 
 export function resolveGitCommitLlmProvider(
   config: LlmProvidersFile,
@@ -542,7 +543,7 @@ Report back which files were resolved and whether any conflicts still need user 
     const skillPath = "~/.atmos/skills/.system/git-commit/SKILL.md";
     const prompt = `Read the skill instructions at ${skillPath} and follow the full workflow: analyze the diff, generate a conventional commit message, and execute the git commit. Do not ask for confirmation.`;
     const contextName =
-      currentWorkspace?.localPath?.split("/").pop() ??
+      basenameFromPath(currentWorkspace?.localPath) ??
       currentProject?.name ??
       "Project";
     const now = new Date();

--- a/apps/web/src/app-shell/sidebar/CommitActions.tsx
+++ b/apps/web/src/app-shell/sidebar/CommitActions.tsx
@@ -32,8 +32,6 @@ import {
 } from "@workspace/ui";
 import {
   CloudSync,
-  FileText,
-  GitBranch,
   MessageCircleReply,
   Sparkles,
 } from "lucide-react";
@@ -53,7 +51,10 @@ import { useWebSocketStore } from "@/features/connection/hooks/use-websocket";
 import type { AgentChatMode } from "@/features/agent/types/index";
 import type { QueuedAgentPrompt } from "@/app-shell/state/use-dialog-store";
 import { agentCliRouteLabel } from "@/app-shell/llm-providers-modal-utils";
-import { ChangeSection } from "@/app-shell/sidebar/ChangeSection";
+import {
+  CommitActionsPanelChanges,
+  CommitActionsPanelHeader,
+} from "@/app-shell/sidebar/CommitActionsPanelParts";
 
 export function resolveGitCommitLlmProvider(
   config: LlmProvidersFile,
@@ -594,45 +595,6 @@ Report back which files were resolved and whether any conflicts still need user 
     (hasMergeConflicts && conflictedFiles.length === 0) ||
     (!hasMergeConflicts && !hasPrimaryGitAction && isCommitDisabled);
   const isPanel = variant === "panel";
-  const repositoryLabel =
-    currentWorkspace?.name?.trim() ||
-    currentProject?.name?.trim() ||
-    currentProjectPath?.split("/").filter(Boolean).pop() ||
-    "Repository";
-  const branchLabel = gitStatus?.current_branch || "No branch";
-  const panelChangedFiles = [
-    ...stagedFiles,
-    ...unstagedFiles,
-    ...untrackedFiles,
-  ];
-  const totalAdditions = panelChangedFiles.reduce((sum, file) => sum + file.additions, 0);
-  const totalDeletions = panelChangedFiles.reduce((sum, file) => sum + file.deletions, 0);
-  const panelStats = [
-    {
-      label: "changed",
-      value: gitStatus?.uncommitted_count ?? panelChangedFiles.length,
-      className: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300",
-      valueClassName: "text-amber-800 dark:text-amber-200",
-    },
-    {
-      label: "staged",
-      value: stagedFiles.length,
-      className: "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300",
-      valueClassName: "text-sky-800 dark:text-sky-200",
-    },
-    {
-      label: "new",
-      value: untrackedFiles.length,
-      className: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
-      valueClassName: "text-emerald-800 dark:text-emerald-200",
-    },
-    {
-      label: "unpushed",
-      value: gitStatus?.unpushed_count ?? 0,
-      className: "border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-300",
-      valueClassName: "text-violet-800 dark:text-violet-200",
-    },
-  ];
 
   return (
     <div
@@ -644,28 +606,15 @@ Report back which files were resolved and whether any conflicts still need user 
       )}
     >
       {isPanel ? (
-        <div className="flex shrink-0 items-center justify-between gap-4 px-4 pb-3 pt-4">
-          <div className="min-w-0">
-            <p className="truncate text-sm font-semibold text-foreground">{repositoryLabel}</p>
-            <div className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
-              <GitBranch className="size-3.5 shrink-0" />
-              <span className="truncate">{branchLabel}</span>
-            </div>
-          </div>
-          <div className="flex shrink-0 flex-wrap justify-end gap-1.5">
-            {panelStats.map((item) => (
-              <span
-                key={item.label}
-                className={cn(
-                  "rounded-md border px-2 py-1 text-[11px]",
-                  item.className,
-                )}
-              >
-                <span className={cn("font-mono", item.valueClassName)}>{item.value}</span> {item.label}
-              </span>
-            ))}
-          </div>
-        </div>
+        <CommitActionsPanelHeader
+          currentProjectName={currentProject?.name}
+          currentProjectPath={currentProjectPath}
+          currentWorkspaceName={currentWorkspace?.name}
+          gitStatus={gitStatus}
+          stagedFiles={stagedFiles}
+          unstagedFiles={unstagedFiles}
+          untrackedFiles={untrackedFiles}
+        />
       ) : null}
 
       <div
@@ -938,52 +887,12 @@ Report back which files were resolved and whether any conflicts still need user 
         </div>
 
         {isPanel ? (
-          <aside
-            className="order-1 flex min-h-0 flex-none flex-col overflow-hidden rounded-lg border border-border/70 bg-muted/25"
-            style={{ width: "calc(60% - 0.5rem)" }}
-          >
-            <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border/60 px-3 py-2">
-              <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                <FileText className="size-3.5" />
-                Changes
-              </div>
-              <span className="font-mono text-[11px]">
-                <span className="text-emerald-600 dark:text-emerald-400">+{totalAdditions}</span>
-                <span className="ml-2 text-red-600 dark:text-red-400">-{totalDeletions}</span>
-              </span>
-            </div>
-            <div className="min-h-0 flex-1 overflow-y-auto p-2">
-              {panelChangedFiles.length > 0 ? (
-                <div className="space-y-1">
-                  <ChangeSection
-                    kind="staged"
-                    title="Staged Changes"
-                    files={stagedFiles}
-                    workspaceId={workspaceId ?? null}
-                    readOnly
-                  />
-                  <ChangeSection
-                    kind="unstaged"
-                    title="Unstaged Changes"
-                    files={unstagedFiles}
-                    workspaceId={workspaceId ?? null}
-                    readOnly
-                  />
-                  <ChangeSection
-                    kind="untracked"
-                    title="Untracked Changes"
-                    files={untrackedFiles}
-                    workspaceId={workspaceId ?? null}
-                    readOnly
-                  />
-                </div>
-              ) : (
-                <div className="flex h-full items-center justify-center px-3 text-center text-xs text-muted-foreground">
-                  No changed files.
-                </div>
-              )}
-            </div>
-          </aside>
+          <CommitActionsPanelChanges
+            stagedFiles={stagedFiles}
+            unstagedFiles={unstagedFiles}
+            untrackedFiles={untrackedFiles}
+            workspaceId={workspaceId}
+          />
         ) : null}
       </div>
     </div>

--- a/apps/web/src/app-shell/sidebar/CommitActionsPanelParts.tsx
+++ b/apps/web/src/app-shell/sidebar/CommitActionsPanelParts.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { FileText, GitBranch } from 'lucide-react';
+import type { GitChangedFile, GitStatusResponse } from '@/api/ws-api';
+import { cn } from '@/shared/lib/utils';
+import { ChangeSection } from '@/app-shell/sidebar/ChangeSection';
+
+interface CommitActionsPanelHeaderProps {
+  currentProjectName?: string;
+  currentProjectPath: string | null;
+  currentWorkspaceName?: string;
+  gitStatus: GitStatusResponse | null;
+  stagedFiles: GitChangedFile[];
+  unstagedFiles: GitChangedFile[];
+  untrackedFiles: GitChangedFile[];
+}
+
+interface CommitActionsPanelChangesProps {
+  stagedFiles: GitChangedFile[];
+  unstagedFiles: GitChangedFile[];
+  untrackedFiles: GitChangedFile[];
+  workspaceId: string | null | undefined;
+}
+
+export function CommitActionsPanelHeader({
+  currentProjectName,
+  currentProjectPath,
+  currentWorkspaceName,
+  gitStatus,
+  stagedFiles,
+  unstagedFiles,
+  untrackedFiles,
+}: CommitActionsPanelHeaderProps) {
+  const repositoryLabel =
+    currentWorkspaceName?.trim() ||
+    currentProjectName?.trim() ||
+    currentProjectPath?.split('/').filter(Boolean).pop() ||
+    'Repository';
+  const branchLabel = gitStatus?.current_branch || 'No branch';
+  const changedFiles = [
+    ...stagedFiles,
+    ...unstagedFiles,
+    ...untrackedFiles,
+  ];
+  const panelStats = [
+    {
+      label: 'changed',
+      value: gitStatus?.uncommitted_count ?? changedFiles.length,
+      className: 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300',
+      valueClassName: 'text-amber-800 dark:text-amber-200',
+    },
+    {
+      label: 'staged',
+      value: stagedFiles.length,
+      className: 'border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300',
+      valueClassName: 'text-sky-800 dark:text-sky-200',
+    },
+    {
+      label: 'new',
+      value: untrackedFiles.length,
+      className: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300',
+      valueClassName: 'text-emerald-800 dark:text-emerald-200',
+    },
+    {
+      label: 'unpushed',
+      value: gitStatus?.unpushed_count ?? 0,
+      className: 'border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-300',
+      valueClassName: 'text-violet-800 dark:text-violet-200',
+    },
+  ];
+
+  return (
+    <div className="flex shrink-0 items-center justify-between gap-4 px-4 pb-3 pt-4">
+      <div className="min-w-0">
+        <p className="truncate text-sm font-semibold text-foreground">{repositoryLabel}</p>
+        <div className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+          <GitBranch className="size-3.5 shrink-0" />
+          <span className="truncate">{branchLabel}</span>
+        </div>
+      </div>
+      <div className="flex shrink-0 flex-wrap justify-end gap-1.5">
+        {panelStats.map((item) => (
+          <span
+            key={item.label}
+            className={cn(
+              'rounded-md border px-2 py-1 text-[11px]',
+              item.className,
+            )}
+          >
+            <span className={cn('font-mono', item.valueClassName)}>{item.value}</span> {item.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function CommitActionsPanelChanges({
+  stagedFiles,
+  unstagedFiles,
+  untrackedFiles,
+  workspaceId,
+}: CommitActionsPanelChangesProps) {
+  const changedFiles = [
+    ...stagedFiles,
+    ...unstagedFiles,
+    ...untrackedFiles,
+  ];
+  const totalAdditions = changedFiles.reduce((sum, file) => sum + file.additions, 0);
+  const totalDeletions = changedFiles.reduce((sum, file) => sum + file.deletions, 0);
+
+  return (
+    <aside
+      className="order-1 flex min-h-0 flex-none flex-col overflow-hidden rounded-lg border border-border/70 bg-muted/25"
+      style={{ width: 'calc(60% - 0.5rem)' }}
+    >
+      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border/60 px-3 py-2">
+        <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <FileText className="size-3.5" />
+          Changes
+        </div>
+        <span className="font-mono text-[11px]">
+          <span className="text-emerald-600 dark:text-emerald-400">+{totalAdditions}</span>
+          <span className="ml-2 text-red-600 dark:text-red-400">-{totalDeletions}</span>
+        </span>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        {changedFiles.length > 0 ? (
+          <div className="space-y-1">
+            <ChangeSection
+              kind="staged"
+              title="Staged Changes"
+              files={stagedFiles}
+              workspaceId={workspaceId ?? null}
+              readOnly
+            />
+            <ChangeSection
+              kind="unstaged"
+              title="Unstaged Changes"
+              files={unstagedFiles}
+              workspaceId={workspaceId ?? null}
+              readOnly
+            />
+            <ChangeSection
+              kind="untracked"
+              title="Untracked Changes"
+              files={untrackedFiles}
+              workspaceId={workspaceId ?? null}
+              readOnly
+            />
+          </div>
+        ) : (
+          <div className="flex h-full items-center justify-center px-3 text-center text-xs text-muted-foreground">
+            No changed files.
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/app-shell/sidebar/CommitActionsPanelParts.tsx
+++ b/apps/web/src/app-shell/sidebar/CommitActionsPanelParts.tsx
@@ -4,6 +4,7 @@ import { FileText, GitBranch } from 'lucide-react';
 import type { GitChangedFile, GitStatusResponse } from '@/api/ws-api';
 import { cn } from '@/shared/lib/utils';
 import { ChangeSection } from '@/app-shell/sidebar/ChangeSection';
+import { basenameFromPath } from '@/app-shell/sidebar/commit-actions-paths';
 
 interface CommitActionsPanelHeaderProps {
   currentProjectName?: string;
@@ -34,7 +35,7 @@ export function CommitActionsPanelHeader({
   const repositoryLabel =
     currentWorkspaceName?.trim() ||
     currentProjectName?.trim() ||
-    currentProjectPath?.split('/').filter(Boolean).pop() ||
+    basenameFromPath(currentProjectPath) ||
     'Repository';
   const branchLabel = gitStatus?.current_branch || 'No branch';
   const changedFiles = [

--- a/apps/web/src/app-shell/sidebar/commit-actions-paths.test.ts
+++ b/apps/web/src/app-shell/sidebar/commit-actions-paths.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+
+import { basenameFromPath } from "./commit-actions-paths";
+
+describe("basenameFromPath", () => {
+  it("returns the final segment for POSIX paths", () => {
+    expect(basenameFromPath("/Users/aarynlu/OpenSource/atmos")).toBe("atmos");
+  });
+
+  it("returns the final segment for Windows paths", () => {
+    expect(basenameFromPath("C:\\Users\\aarynlu\\OpenSource\\atmos")).toBe("atmos");
+  });
+
+  it("ignores trailing separators", () => {
+    expect(basenameFromPath("C:\\Users\\aarynlu\\OpenSource\\atmos\\")).toBe("atmos");
+    expect(basenameFromPath("/Users/aarynlu/OpenSource/atmos/")).toBe("atmos");
+  });
+
+  it("returns undefined for blank paths", () => {
+    expect(basenameFromPath("   ")).toBeUndefined();
+    expect(basenameFromPath(null)).toBeUndefined();
+  });
+});

--- a/apps/web/src/app-shell/sidebar/commit-actions-paths.ts
+++ b/apps/web/src/app-shell/sidebar/commit-actions-paths.ts
@@ -1,0 +1,6 @@
+export function basenameFromPath(path: string | null | undefined): string | undefined {
+  const normalized = path?.trim().replace(/[\\/]+$/, '');
+  if (!normalized) return undefined;
+
+  return normalized.split(/[\\/]/).filter(Boolean).pop();
+}

--- a/apps/web/src/features/settings/components/HeaderLayoutSettingsSection.tsx
+++ b/apps/web/src/features/settings/components/HeaderLayoutSettingsSection.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  Switch,
+} from '@workspace/ui';
+import { ChevronDown, GitCommit, ListTodo, PanelTop, StickyNote } from 'lucide-react';
+
+interface HeaderLayoutSettingsSectionProps {
+  expanded: boolean;
+  onExpandedChange: (expanded: boolean) => void;
+  showHeaderSummary: boolean;
+  showHeaderSummaryTask: boolean;
+  showHeaderSummaryNote: boolean;
+  showHeaderSummaryCommit: boolean;
+  setHeaderShowSummary: (value: boolean) => Promise<void>;
+  setHeaderShowSummaryTask: (value: boolean) => Promise<void>;
+  setHeaderShowSummaryNote: (value: boolean) => Promise<void>;
+  setHeaderShowSummaryCommit: (value: boolean) => Promise<void>;
+}
+
+export function HeaderLayoutSettingsSection({
+  expanded,
+  onExpandedChange,
+  showHeaderSummary,
+  showHeaderSummaryTask,
+  showHeaderSummaryNote,
+  showHeaderSummaryCommit,
+  setHeaderShowSummary,
+  setHeaderShowSummaryTask,
+  setHeaderShowSummaryNote,
+  setHeaderShowSummaryCommit,
+}: HeaderLayoutSettingsSectionProps) {
+  const enabledCount =
+    Number(showHeaderSummaryTask) +
+    Number(showHeaderSummaryNote) +
+    Number(showHeaderSummaryCommit);
+
+  return (
+    <Collapsible
+      open={expanded}
+      onOpenChange={onExpandedChange}
+      className="overflow-hidden rounded-2xl border border-border"
+    >
+      <div className="flex items-start justify-between gap-4 px-6 py-5">
+        <CollapsibleTrigger className="group min-w-0 flex-1 cursor-pointer text-left">
+          <div className="flex items-start gap-3">
+            <span className="relative mt-0.5 size-5 shrink-0">
+              <PanelTop className="absolute inset-0 size-5 transition-opacity duration-150 group-hover:opacity-0" />
+              <ChevronDown className="absolute inset-0 size-5 opacity-0 transition-all duration-150 group-hover:opacity-100 group-data-[state=closed]:-rotate-90" />
+            </span>
+            <div className="min-w-0">
+              <p className="text-base font-medium text-foreground">Header layout</p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                Choose which workspace utilities appear to the left of global search.
+              </p>
+            </div>
+          </div>
+        </CollapsibleTrigger>
+        <div className="pt-1 text-xs text-muted-foreground">
+          {showHeaderSummary ? `${enabledCount} enabled` : 'Hidden'}
+        </div>
+      </div>
+
+      <CollapsibleContent>
+        <div className="border-t border-border px-4">
+          <div className="border-b border-border px-2 py-4 last:border-b-0">
+            <div className="grid grid-cols-[minmax(0,1fr)_100px] gap-8">
+              <div>
+                <p className="text-sm font-medium text-foreground">Workspace summary button</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Show one compact icon button before global search with project, task, note, and commit shortcuts.
+                </p>
+              </div>
+              <div className="flex items-center justify-end">
+                <Switch
+                  checked={showHeaderSummary}
+                  onCheckedChange={(checked) => void setHeaderShowSummary(!!checked)}
+                />
+              </div>
+            </div>
+          </div>
+          <div className="border-b border-border px-2 py-4 last:border-b-0">
+            <div className="grid grid-cols-[minmax(0,1fr)_100px] gap-8">
+              <div className="flex gap-3">
+                <ListTodo className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                <div>
+                  <p className="text-sm font-medium text-foreground">TASK section</p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Show task counts in the summary popover and expose the full task panel as a nested popover.
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center justify-end">
+                <Switch
+                  checked={showHeaderSummaryTask}
+                  disabled={!showHeaderSummary}
+                  onCheckedChange={(checked) => void setHeaderShowSummaryTask(!!checked)}
+                />
+              </div>
+            </div>
+          </div>
+          <div className="border-b border-border px-2 py-4 last:border-b-0">
+            <div className="grid grid-cols-[minmax(0,1fr)_100px] gap-8">
+              <div className="flex gap-3">
+                <StickyNote className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                <div>
+                  <p className="text-sm font-medium text-foreground">NOTE section</p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Show a note preview row and expose the markdown editor/preview as a nested popover.
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center justify-end">
+                <Switch
+                  checked={showHeaderSummaryNote}
+                  disabled={!showHeaderSummary}
+                  onCheckedChange={(checked) => void setHeaderShowSummaryNote(!!checked)}
+                />
+              </div>
+            </div>
+          </div>
+          <div className="px-2 py-4">
+            <div className="grid grid-cols-[minmax(0,1fr)_100px] gap-8">
+              <div className="flex gap-3">
+                <GitCommit className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                <div>
+                  <p className="text-sm font-medium text-foreground">Commit & Push section</p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Show repository change status and expose the shared Commit & Push controls as a nested popover.
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center justify-end">
+                <Switch
+                  checked={showHeaderSummaryCommit}
+                  disabled={!showHeaderSummary}
+                  onCheckedChange={(checked) => void setHeaderShowSummaryCommit(!!checked)}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/apps/web/src/features/settings/components/LayoutSettingsSection.tsx
+++ b/apps/web/src/features/settings/components/LayoutSettingsSection.tsx
@@ -10,10 +10,11 @@ import {
   Switch,
   cn,
 } from '@workspace/ui';
-import { ChevronDown, Columns2, GitCommit, ListTodo, PanelBottom, PanelTop, StickyNote } from 'lucide-react';
+import { ChevronDown, Columns2, PanelBottom } from 'lucide-react';
 import { useExperimentSettingsStore } from '@/features/settings/store/experiment-settings-store';
 import { useLayoutSettingsStore } from '@/features/settings/store/layout-settings-store';
 import { settingsModalParams } from '@/shared/lib/nuqs/searchParams';
+import { HeaderLayoutSettingsSection } from '@/features/settings/components/HeaderLayoutSettingsSection';
 
 export function LayoutSettingsSection() {
   const {
@@ -57,8 +58,6 @@ export function LayoutSettingsSection() {
     workspaceSidebarTwoColumn || workspaceSidebarTimeTwoColumn || workspaceSidebarStatusTwoColumn;
   const footerEnabledCount =
     Number(showWsConnection) + Number(showLocalServices) + Number(showUsageCarousel) + Number(showAgentStatus);
-  const headerEnabledCount =
-    Number(showHeaderSummaryTask) + Number(showHeaderSummaryNote) + Number(showHeaderSummaryCommit);
 
   React.useEffect(() => {
     loadSettings();
@@ -221,112 +220,18 @@ export function LayoutSettingsSection() {
         </CollapsibleContent>
       </Collapsible>
 
-      <Collapsible
-        open={headerLayoutExpanded}
-        onOpenChange={setHeaderLayoutExpanded}
-        className="overflow-hidden rounded-2xl border border-border"
-      >
-        <div className="flex items-start justify-between gap-4 px-6 py-5">
-          <CollapsibleTrigger className="group min-w-0 flex-1 cursor-pointer text-left">
-            <div className="flex items-start gap-3">
-              <span className="relative mt-0.5 size-5 shrink-0">
-                <PanelTop className="absolute inset-0 size-5 transition-opacity duration-150 group-hover:opacity-0" />
-                <ChevronDown className="absolute inset-0 size-5 opacity-0 transition-all duration-150 group-hover:opacity-100 group-data-[state=closed]:-rotate-90" />
-              </span>
-              <div className="min-w-0">
-                <p className="text-base font-medium text-foreground">Header layout</p>
-                <p className="mt-2 text-sm leading-6 text-muted-foreground">
-                  Choose which workspace utilities appear to the left of global search.
-                </p>
-              </div>
-            </div>
-          </CollapsibleTrigger>
-          <div className="pt-1 text-xs text-muted-foreground">
-            {showHeaderSummary ? `${headerEnabledCount} enabled` : 'Hidden'}
-          </div>
-        </div>
-
-        <CollapsibleContent>
-          <div className="border-t border-border px-4">
-            <div className="border-b border-border px-2 py-4 last:border-b-0">
-              <div className="grid grid-cols-[minmax(0,1fr)_100px] gap-8">
-                <div>
-                  <p className="text-sm font-medium text-foreground">Workspace summary button</p>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    Show one compact icon button before global search with project, task, note, and commit shortcuts.
-                  </p>
-                </div>
-                <div className="flex items-center justify-end">
-                  <Switch
-                    checked={showHeaderSummary}
-                    onCheckedChange={(checked) => void setHeaderShowSummary(!!checked)}
-                  />
-                </div>
-              </div>
-            </div>
-            <div className="border-b border-border px-2 py-4 last:border-b-0">
-              <div className="grid grid-cols-[minmax(0,1fr)_100px] gap-8">
-                <div className="flex gap-3">
-                  <ListTodo className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-                  <div>
-                    <p className="text-sm font-medium text-foreground">TASK section</p>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      Show task counts in the summary popover and expose the full task panel as a nested popover.
-                    </p>
-                  </div>
-                </div>
-                <div className="flex items-center justify-end">
-                  <Switch
-                    checked={showHeaderSummaryTask}
-                    disabled={!showHeaderSummary}
-                    onCheckedChange={(checked) => void setHeaderShowSummaryTask(!!checked)}
-                  />
-                </div>
-              </div>
-            </div>
-            <div className="border-b border-border px-2 py-4 last:border-b-0">
-              <div className="grid grid-cols-[minmax(0,1fr)_100px] gap-8">
-                <div className="flex gap-3">
-                  <StickyNote className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-                  <div>
-                    <p className="text-sm font-medium text-foreground">NOTE section</p>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      Show a note preview row and expose the markdown editor/preview as a nested popover.
-                    </p>
-                  </div>
-                </div>
-                <div className="flex items-center justify-end">
-                  <Switch
-                    checked={showHeaderSummaryNote}
-                    disabled={!showHeaderSummary}
-                    onCheckedChange={(checked) => void setHeaderShowSummaryNote(!!checked)}
-                  />
-                </div>
-              </div>
-            </div>
-            <div className="px-2 py-4">
-              <div className="grid grid-cols-[minmax(0,1fr)_100px] gap-8">
-                <div className="flex gap-3">
-                  <GitCommit className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-                  <div>
-                    <p className="text-sm font-medium text-foreground">Commit & Push section</p>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      Show repository change status and expose the shared Commit & Push controls as a nested popover.
-                    </p>
-                  </div>
-                </div>
-                <div className="flex items-center justify-end">
-                  <Switch
-                    checked={showHeaderSummaryCommit}
-                    disabled={!showHeaderSummary}
-                    onCheckedChange={(checked) => void setHeaderShowSummaryCommit(!!checked)}
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </CollapsibleContent>
-      </Collapsible>
+      <HeaderLayoutSettingsSection
+        expanded={headerLayoutExpanded}
+        onExpandedChange={setHeaderLayoutExpanded}
+        showHeaderSummary={showHeaderSummary}
+        showHeaderSummaryTask={showHeaderSummaryTask}
+        showHeaderSummaryNote={showHeaderSummaryNote}
+        showHeaderSummaryCommit={showHeaderSummaryCommit}
+        setHeaderShowSummary={setHeaderShowSummary}
+        setHeaderShowSummaryTask={setHeaderShowSummaryTask}
+        setHeaderShowSummaryNote={setHeaderShowSummaryNote}
+        setHeaderShowSummaryCommit={setHeaderShowSummaryCommit}
+      />
 
       <Collapsible
         open={footerLayoutExpanded}

--- a/apps/web/src/features/settings/store/layout-settings-store.ts
+++ b/apps/web/src/features/settings/store/layout-settings-store.ts
@@ -77,173 +77,120 @@ function readHeaderLayout(layout: Record<string, unknown> | undefined): HeaderLa
   };
 }
 
-export const useLayoutSettingsStore = create<LayoutSettingsState>((set, get) => ({
-  projectFilesSide: 'left',
-  workspaceSidebarTwoColumn: false,
-  workspaceSidebarTwoColumnShowPinned: false,
-  workspaceSidebarSecondColumnKanban: false,
-  workspaceSidebarTimeTwoColumn: false,
-  workspaceSidebarStatusTwoColumn: false,
-  showWsConnection: true,
-  showLocalServices: true,
-  showUsageCarousel: true,
-  showAgentStatus: true,
-  showHeaderSummary: true,
-  showHeaderSummaryTask: true,
-  showHeaderSummaryNote: true,
-  showHeaderSummaryCommit: true,
-  loaded: false,
-
-  loadSettings: async (force = false) => {
-    if (!force && get().loaded) return;
+export const useLayoutSettingsStore = create<LayoutSettingsState>((set, get) => {
+  const updateLayoutSetting = async (
+    patch: Partial<LayoutSettingsState>,
+    key: string,
+    value: unknown,
+  ) => {
+    set(patch);
     try {
-      if (force) {
-        useFunctionSettingsStore.getState().invalidate();
+      await functionSettingsApi.update('layout', key, value);
+    } catch {
+      await get().loadSettings(true);
+    }
+  };
+
+  return {
+    projectFilesSide: 'left',
+    workspaceSidebarTwoColumn: false,
+    workspaceSidebarTwoColumnShowPinned: false,
+    workspaceSidebarSecondColumnKanban: false,
+    workspaceSidebarTimeTwoColumn: false,
+    workspaceSidebarStatusTwoColumn: false,
+    showWsConnection: true,
+    showLocalServices: true,
+    showUsageCarousel: true,
+    showAgentStatus: true,
+    showHeaderSummary: true,
+    showHeaderSummaryTask: true,
+    showHeaderSummaryNote: true,
+    showHeaderSummaryCommit: true,
+    loaded: false,
+
+    loadSettings: async (force = false) => {
+      if (!force && get().loaded) return;
+      try {
+        if (force) {
+          useFunctionSettingsStore.getState().invalidate();
+        }
+        const settings = await useFunctionSettingsStore.getState().load();
+        const layout = settings.layout as Record<string, unknown> | undefined;
+        const side = layout?.project_files_side;
+        const footer = readFooterLayout(layout);
+        const header = readHeaderLayout(layout);
+        set({
+          projectFilesSide: side === 'right' ? 'right' : 'left',
+          workspaceSidebarTwoColumn: layout?.workspace_sidebar_two_column === true,
+          workspaceSidebarTwoColumnShowPinned: layout?.workspace_sidebar_two_column_show_pinned === true,
+          workspaceSidebarSecondColumnKanban: layout?.workspace_sidebar_second_column_kanban === true,
+          workspaceSidebarTimeTwoColumn: layout?.workspace_sidebar_time_two_column === true,
+          workspaceSidebarStatusTwoColumn: layout?.workspace_sidebar_status_two_column === true,
+          ...footer,
+          ...header,
+          loaded: true,
+        });
+      } catch {
+        set({ loaded: true });
       }
-      const settings = await useFunctionSettingsStore.getState().load();
-      const layout = settings.layout as Record<string, unknown> | undefined;
-      const side = layout?.project_files_side;
-      const footer = readFooterLayout(layout);
-      const header = readHeaderLayout(layout);
-      set({
-        projectFilesSide: side === 'right' ? 'right' : 'left',
-        workspaceSidebarTwoColumn: layout?.workspace_sidebar_two_column === true,
-        workspaceSidebarTwoColumnShowPinned: layout?.workspace_sidebar_two_column_show_pinned === true,
-        workspaceSidebarSecondColumnKanban: layout?.workspace_sidebar_second_column_kanban === true,
-        workspaceSidebarTimeTwoColumn: layout?.workspace_sidebar_time_two_column === true,
-        workspaceSidebarStatusTwoColumn: layout?.workspace_sidebar_status_two_column === true,
-        ...footer,
-        ...header,
-        loaded: true,
-      });
-    } catch {
-      set({ loaded: true });
-    }
-  },
+    },
 
-  setProjectFilesSide: async (value) => {
-    set({ projectFilesSide: value });
-    try {
-      await functionSettingsApi.update('layout', 'project_files_side', value);
-    } catch {
-      await get().loadSettings(true);
-    }
-  },
+    setProjectFilesSide: (value) =>
+      updateLayoutSetting({ projectFilesSide: value }, 'project_files_side', value),
 
-  setWorkspaceSidebarTwoColumn: async (value) => {
-    set({ workspaceSidebarTwoColumn: value });
-    try {
-      await functionSettingsApi.update('layout', 'workspace_sidebar_two_column', value);
-    } catch {
-      await get().loadSettings(true);
-    }
-  },
+    setWorkspaceSidebarTwoColumn: (value) =>
+      updateLayoutSetting({ workspaceSidebarTwoColumn: value }, 'workspace_sidebar_two_column', value),
 
-  setWorkspaceSidebarTwoColumnShowPinned: async (value) => {
-    set({ workspaceSidebarTwoColumnShowPinned: value });
-    try {
-      await functionSettingsApi.update('layout', 'workspace_sidebar_two_column_show_pinned', value);
-    } catch {
-      await get().loadSettings(true);
-    }
-  },
+    setWorkspaceSidebarTwoColumnShowPinned: (value) =>
+      updateLayoutSetting(
+        { workspaceSidebarTwoColumnShowPinned: value },
+        'workspace_sidebar_two_column_show_pinned',
+        value,
+      ),
 
-  setWorkspaceSidebarSecondColumnKanban: async (value) => {
-    set({ workspaceSidebarSecondColumnKanban: value });
-    try {
-      await functionSettingsApi.update('layout', 'workspace_sidebar_second_column_kanban', value);
-    } catch {
-      await get().loadSettings(true);
-    }
-  },
+    setWorkspaceSidebarSecondColumnKanban: (value) =>
+      updateLayoutSetting(
+        { workspaceSidebarSecondColumnKanban: value },
+        'workspace_sidebar_second_column_kanban',
+        value,
+      ),
 
-  setWorkspaceSidebarTimeTwoColumn: async (value) => {
-    set({ workspaceSidebarTimeTwoColumn: value });
-    try {
-      await functionSettingsApi.update('layout', 'workspace_sidebar_time_two_column', value);
-    } catch {
-      await get().loadSettings(true);
-    }
-  },
+    setWorkspaceSidebarTimeTwoColumn: (value) =>
+      updateLayoutSetting(
+        { workspaceSidebarTimeTwoColumn: value },
+        'workspace_sidebar_time_two_column',
+        value,
+      ),
 
-  setWorkspaceSidebarStatusTwoColumn: async (value) => {
-    set({ workspaceSidebarStatusTwoColumn: value });
-    try {
-      await functionSettingsApi.update('layout', 'workspace_sidebar_status_two_column', value);
-    } catch {
-      await get().loadSettings(true);
-    }
-  },
+    setWorkspaceSidebarStatusTwoColumn: (value) =>
+      updateLayoutSetting(
+        { workspaceSidebarStatusTwoColumn: value },
+        'workspace_sidebar_status_two_column',
+        value,
+      ),
 
-  setFooterShowWsConnection: async (value) => {
-    set({ showWsConnection: value });
-    try {
-      await functionSettingsApi.update('layout', 'footer_show_ws_connection', value);
-    } catch {
-      await get().loadSettings(true);
-    }
-  },
+    setFooterShowWsConnection: (value) =>
+      updateLayoutSetting({ showWsConnection: value }, 'footer_show_ws_connection', value),
 
-  setFooterShowLocalServices: async (value) => {
-    set({ showLocalServices: value });
-    try {
-      await functionSettingsApi.update('layout', 'footer_show_local_services', value);
-    } catch {
-      await get().loadSettings(true);
-    }
-  },
+    setFooterShowLocalServices: (value) =>
+      updateLayoutSetting({ showLocalServices: value }, 'footer_show_local_services', value),
 
-  setFooterShowUsageCarousel: async (value) => {
-    set({ showUsageCarousel: value });
-    try {
-      await functionSettingsApi.update('layout', 'footer_show_usage_carousel', value);
-    } catch {
-      await get().loadSettings(true);
-    }
-  },
+    setFooterShowUsageCarousel: (value) =>
+      updateLayoutSetting({ showUsageCarousel: value }, 'footer_show_usage_carousel', value),
 
-  setFooterShowAgentStatus: async (value) => {
-    set({ showAgentStatus: value });
-    try {
-      await functionSettingsApi.update('layout', 'footer_show_agent_status', value);
-    } catch {
-      await get().loadSettings(true);
-    }
-  },
+    setFooterShowAgentStatus: (value) =>
+      updateLayoutSetting({ showAgentStatus: value }, 'footer_show_agent_status', value),
 
-  setHeaderShowSummary: async (value) => {
-    set({ showHeaderSummary: value });
-    try {
-      await functionSettingsApi.update('layout', 'header_summary_enabled', value);
-    } catch {
-      await get().loadSettings(true);
-    }
-  },
+    setHeaderShowSummary: (value) =>
+      updateLayoutSetting({ showHeaderSummary: value }, 'header_summary_enabled', value),
 
-  setHeaderShowSummaryTask: async (value) => {
-    set({ showHeaderSummaryTask: value });
-    try {
-      await functionSettingsApi.update('layout', 'header_summary_show_task', value);
-    } catch {
-      await get().loadSettings(true);
-    }
-  },
+    setHeaderShowSummaryTask: (value) =>
+      updateLayoutSetting({ showHeaderSummaryTask: value }, 'header_summary_show_task', value),
 
-  setHeaderShowSummaryNote: async (value) => {
-    set({ showHeaderSummaryNote: value });
-    try {
-      await functionSettingsApi.update('layout', 'header_summary_show_note', value);
-    } catch {
-      await get().loadSettings(true);
-    }
-  },
+    setHeaderShowSummaryNote: (value) =>
+      updateLayoutSetting({ showHeaderSummaryNote: value }, 'header_summary_show_note', value),
 
-  setHeaderShowSummaryCommit: async (value) => {
-    set({ showHeaderSummaryCommit: value });
-    try {
-      await functionSettingsApi.update('layout', 'header_summary_show_commit', value);
-    } catch {
-      await get().loadSettings(true);
-    }
-  },
-}));
+    setHeaderShowSummaryCommit: (value) =>
+      updateLayoutSetting({ showHeaderSummaryCommit: value }, 'header_summary_show_commit', value),
+  };
+});

--- a/automations/code/result/2026-06-19_08-12-03_score-84_ATMOS_CODE_QUALITY_REVIEW.md
+++ b/automations/code/result/2026-06-19_08-12-03_score-84_ATMOS_CODE_QUALITY_REVIEW.md
@@ -1,0 +1,85 @@
+# Atmos Main 每日代码质量评分
+
+## 1. 审查范围
+
+- 昨日时间窗口：2026-06-18 00:00:00 到 2026-06-18 23:59:59（UTC+8，Asia/Shanghai）。
+- 被审查提交：
+  - `6ac73b10` Refactor runtime and UI session flow，作者 AarynLu
+  - `4ce15d0f` Reorder header workspace summary button，作者 AarynLu
+  - `e6394751` fix: preserve workspace overlay and build handling，作者 AarynLu
+  - `5d86ee61` Merge pull request #126 from AruNi-01/codex/quality-fix/2026-06-11，作者 AruNi_Lu；仅审查真实代码变更，忽略随 merge 带入的历史结果文件
+- 排除提交：
+  - `883da527` docs: add code quality review result 2026-06-18 no commits
+  - `bef068d7` docs: finalize code quality review result 2026-06-18 no commits
+
+## 2. 一份好代码应该是什么样
+
+本次评分把“维护者能否快速定位职责、理解控制流、在正确层次继续演进”作为核心标准。好的代码应让 app-shell 只做组合和编排，feature/store 持有各自领域逻辑；大组件应及时拆出稳定子职责；重复的设置写入、状态合并和 UI 片段应收敛成明确接口，而不是靠复制维持一致。
+
+## 3. 评分方法
+
+- 100 分制：设计与分层 30 分，可读性与复杂度 25 分，体量与内聚 20 分，可维护性与复用 15 分，工程卫生 10 分。
+- 高严重度通常扣 8-15 分；中严重度扣 3-7 分；低严重度扣 1-2 分。
+- 体量阈值作为 review 信号：文件超过 500 行需重点看职责，超过 800 行通常高风险；函数超过 80 行需检查阶段混杂；UI 组件超过 250 行需检查是否混合数据、状态、渲染和副作用。
+
+## 4. 总分
+
+- 总分：84/100
+- 总体判断：良好。主要代码方向可工作且有一些正向拆分，但 `6ac73b10` 继续扩大了几个前端高体量组件和 store 的维护面，需要及时收口。
+
+## 5. 分项评分
+
+- 设计与分层：24/30。`CommitActionsContainer` 抽出 store wiring 是正向变化，但 `CommitActions.tsx` 又承载 sidebar/panel 两种布局、提交控制流和 changes 列表；`LayoutSettingsSection.tsx` 直接吞入 header layout 配置块。
+- 可读性与复杂度：20/25。`CommitActions.tsx` 的主路径仍被 AI 提交、冲突处理、publish/sync/push、panel 变体共同拉长；`WorkspaceNotePanel.tsx` 的 autosave 生命周期可理解但依赖多个 ref 和 effect。
+- 体量与内聚：16/20。`CommitActions.tsx` 达到 991 行，`LayoutSettingsSection.tsx` 达到 458 行，`header-workspace-widgets.tsx` 新增 359 行，均已越过需要拆分的信号线。
+- 可维护性与复用：14/15。`layout-settings-store.ts` 新增 header setters 时继续复制 optimistic update + API update + reload 回退模式。
+- 工程卫生：10/10。未发现明显调试残留、临时开关或无关改动。
+
+## 6. 主要问题清单
+
+### 高
+
+1. `6ac73b10`，`apps/web/src/app-shell/sidebar/CommitActions.tsx`，`CommitActions`：panel 模式把仓库标题、统计 chips、changes 列表和 sidebar 提交动作塞回同一个 991 行组件。问题是同一组件同时负责数据动作、提交输入、冲突处理、两种布局和文件列表展示，后续改 panel 或 sidebar 都容易互相影响。优化建议：抽出 panel 专属 chrome 和 changes 列表，例如 `CommitActionsPanelHeader`、`CommitActionsPanelChanges`，让 `CommitActions` 只保留提交输入与动作分派；后续若继续演进，再把 AI commit composer 和 primary action group 分成独立组件。
+
+### 中
+
+2. `6ac73b10`，`apps/web/src/features/settings/components/LayoutSettingsSection.tsx`，`LayoutSettingsSection`：新增 header layout 配置块后，settings section 继续增长到 458 行，并混合 project files、workspace sidebar、header、footer 四组配置。问题是页面级 section 变成所有 layout 表单的容器，局部配置的图标、文案和开关逻辑难以独立 review。优化建议：将 header 配置拆到 `HeaderLayoutSettingsSection`，由父组件只负责读取 store、维护展开状态并传递 setter。
+
+3. `6ac73b10`，`apps/web/src/features/settings/store/layout-settings-store.ts`，layout setters：新增 `setHeaderShowSummary*` 方法继续复制 `set -> functionSettingsApi.update -> catch reload` 模式。问题是设置键和本地字段越多，重复 catch/reload 逻辑越容易分叉。优化建议：在 store create callback 内集中一个 `updateLayoutSetting(patch, key, value)` helper，所有 layout setter 只传本地 patch 和远端 key。
+
+## 7. 正向观察
+
+- `6ac73b10` 把 `RightSidebar` 的 commit store/dialog wiring 收敛到 `CommitActionsContainer`，减少了右侧栏直接知道 agent chat 和 git action 细节的范围。
+- `e6394751` 的 build 脚本修复把子进程失败从直接 `process.exit` 改为抛错并进入 `finally`，有利于恢复临时移动的 API/proxy 文件。
+- `5d86ee61` 带入的 selection popover 拆分和 workspace bootstrap bounded concurrency 属于明确的维护性改善。
+
+## 8. Review 建议
+
+人工 review 今天重点看三类问题：一是 app-shell 大组件是否继续承载多种布局变体；二是 settings UI 是否能按配置域拆分；三是 store setter/API key 是否集中管理，避免复制写入协议。
+
+## 9. 自动修复与 PR
+
+- 触发原因：总分 84，小于 90，按规则进入自动修复。
+- 修复分支：`codex/quality-fix/2026-06-18`
+- 修复摘要：
+  - 新增 `apps/web/src/app-shell/sidebar/CommitActionsPanelParts.tsx`，抽出 panel header 统计和 changes 列表。
+  - 新增 `apps/web/src/features/settings/components/HeaderLayoutSettingsSection.tsx`，从 `LayoutSettingsSection.tsx` 拆出 header layout 配置块。
+  - 在 `apps/web/src/features/settings/store/layout-settings-store.ts` 增加 `updateLayoutSetting`，收敛重复 setter 写入逻辑。
+- 验证：
+  - `bun --filter web lint --fix <changed files>`：通过
+  - `bun --filter web lint <changed files>`：通过
+  - `bun --filter web typecheck`：通过
+  - `git diff --check`：通过
+  - `bun --filter web lint`：失败，失败来自本次未改文件的既有问题，例如 `apps/web/src/app-shell/HostedAppShellGate.tsx`、`apps/web/src/features/canvas/components/CanvasAgentIsland.tsx`、`apps/web/src/features/diff/components/ChangesCodeView.tsx`、`apps/web/src/features/github/components/PRFilesTab.tsx`、`apps/web/src/features/settings/hooks/use-updater.ts`
+- 修复提交 hash：待提交
+- PR URL：待创建
+
+## 10. 结果文件
+
+- 本次 Markdown 结果文件路径：`automations/code/result/2026-06-19_08-12-03_score-84_ATMOS_CODE_QUALITY_REVIEW.md`
+
+## 11. 结果提交与推送
+
+- 结果文件提交 hash：待提交
+- 推送目标分支：`codex/quality-fix/2026-06-18`
+- PR URL：待创建

--- a/automations/code/result/2026-06-19_08-12-03_score-84_ATMOS_CODE_QUALITY_REVIEW.md
+++ b/automations/code/result/2026-06-19_08-12-03_score-84_ATMOS_CODE_QUALITY_REVIEW.md
@@ -71,8 +71,9 @@
   - `bun --filter web typecheck`：通过
   - `git diff --check`：通过
   - `bun --filter web lint`：失败，失败来自本次未改文件的既有问题，例如 `apps/web/src/app-shell/HostedAppShellGate.tsx`、`apps/web/src/features/canvas/components/CanvasAgentIsland.tsx`、`apps/web/src/features/diff/components/ChangesCodeView.tsx`、`apps/web/src/features/github/components/PRFilesTab.tsx`、`apps/web/src/features/settings/hooks/use-updater.ts`
-- 修复提交 hash：待提交
-- PR URL：待创建
+- 修复提交 hash：`6cadb3c3`
+- PR URL：https://github.com/AruNi-01/atmos/pull/127
+- PR labels：已添加 `codex`；仓库当前没有 `codex-automation` label，已跳过
 
 ## 10. 结果文件
 
@@ -80,6 +81,6 @@
 
 ## 11. 结果提交与推送
 
-- 结果文件提交 hash：待提交
+- 结果文件提交 hash：`6cadb3c3`（初始结果文件随修复提交进入分支；PR URL 补写会随本 PR 分支最新提交推送）
 - 推送目标分支：`codex/quality-fix/2026-06-18`
-- PR URL：待创建
+- PR URL：https://github.com/AruNi-01/atmos/pull/127


### PR DESCRIPTION
## Summary

- Original daily quality score: 84/100 for the 2026-06-18 UTC+8 main window.
- Addressed the main maintainability findings by extracting commit panel-only UI from `CommitActions` and moving header layout settings into a focused settings component.
- Consolidated duplicated layout setting writes behind `updateLayoutSetting`.
- Includes the daily review report at `automations/code/result/2026-06-19_08-12-03_score-84_ATMOS_CODE_QUALITY_REVIEW.md`.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] Additional checks (describe below)

Additional checks:

- `bun --filter web lint --fix <changed files>`: passed
- `bun --filter web lint <changed files>`: passed
- `bun --filter web typecheck`: passed
- `git diff --check`: passed
- `bun --filter web lint`: failed on pre-existing errors outside this PR, including `apps/web/src/app-shell/HostedAppShellGate.tsx`, `apps/web/src/features/canvas/components/CanvasAgentIsland.tsx`, `apps/web/src/features/diff/components/ChangesCodeView.tsx`, `apps/web/src/features/github/components/PRFilesTab.tsx`, and `apps/web/src/features/settings/hooks/use-updater.ts`.

Remaining risk:

- `CommitActions.tsx` is still large after this low-risk extraction. The riskiest panel-only responsibilities are now outside the file, but a future pass should split the AI commit composer and primary action group if this area keeps changing.

## Checklist

- [x] I updated documentation if behavior changed
- [ ] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the commit panel and settings layout to reduce component size and centralize layout writes. Added a shared `basenameFromPath` for cross-platform repo labels with tests.

- **Refactors**
  - Extracted panel header and changes list into `CommitActionsPanelParts` and integrated in `CommitActions`; replaced ad‑hoc path splits with shared `basenameFromPath` (plus unit tests).
  - Introduced `HeaderLayoutSettingsSection` and delegated header config from `LayoutSettingsSection`.
  - Consolidated layout store setters via `updateLayoutSetting` to remove duplicated write logic.
  - Added the daily code quality report at `automations/code/result/2026-06-19_08-12-03_score-84_ATMOS_CODE_QUALITY_REVIEW.md`.

<sup>Written for commit af761cb1ddda01fc6a21175b6208a20223881c6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added header layout settings controls to customize visibility of task, note, and commit summary elements in the header.

* **Refactor**
  * Reorganized commit actions sidebar components for improved code maintainability.
  * Consolidated layout settings persistence logic for better state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->