### PR TITLE
refactor: address daily quality findings for 2026-06-22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "atmos-desktop"
-version = "1.2.0-beta.15"
+version = "1.2.0-beta.16"
 dependencies = [
  "chrono",
  "core-foundation 0.10.1",

--- a/apps/web/src/features/diff/components/ChangesCodeView.tsx
+++ b/apps/web/src/features/diff/components/ChangesCodeView.tsx
@@ -2,11 +2,10 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CodeView, type CodeViewHandle } from '@pierre/diffs/react';
-import type { CodeViewItem, DiffLineAnnotation, SelectedLineRange } from '@pierre/diffs';
+import type { CodeViewItem, SelectedLineRange } from '@pierre/diffs';
 import { parseDiffFromFile } from '@pierre/diffs';
 import { useTheme } from 'next-themes';
-import { ChevronRight, Copy, Loader2, MessageSquareText } from 'lucide-react';
-import { getFileIconProps, toastManager } from '@workspace/ui';
+import { Loader2 } from 'lucide-react';
 import { gitApi } from '@/api/ws-api';
 import { useGitStore } from '@/features/git/store/use-git-store';
 import { useEditorStore } from '@/features/editor/store/use-editor-store';
@@ -20,17 +19,14 @@ import {
 import { useDiffWorkerPoolReady } from '@/features/diff/components/DiffWorkerPoolProvider';
 import { DiffCodeViewSettingsMenu } from '@/features/diff/components/DiffCodeViewSettingsMenu';
 import { DiffCodeViewScaffold } from '@/features/diff/components/DiffCodeViewScaffold';
-import { DiffCopyAnnotation } from '@/features/diff/components/DiffCopyAnnotation';
+import {
+  useDiffPromptStash,
+  type LoadedDiffContents,
+} from '@/features/diff/components/useDiffPromptStash';
 import { sortByDiffTreePath } from '@/features/diff/lib/diff-file-order';
 import {
   applyCollapseModeToItems,
-  buildDiffSelectionInfo,
-  filePathFromHeaderContext,
-  formatSelectedRangeLabel,
-  isCopyAnnotation,
   type CopyAnnotationMeta,
-  toggleItemCollapsed,
-  updateViewerDiffItem,
 } from '@/features/diff/lib/diff-code-view-shared';
 import {
   ATMOS_DIFF_THEME,
@@ -40,35 +36,15 @@ import {
 } from '@/features/diff/lib/diff-view-constants';
 import {
   findDiffItemIdForViewport,
+  renderDiffHeaderPrefix,
   scrollCodeViewToItem,
 } from '@/features/diff/lib/code-view-ui';
-import { formatDiffSelectionForAI } from '@/shared/lib/format-selection-for-ai';
-import { cn } from '@/shared/lib/utils';
 
 const CODE_VIEW_BATCH_SIZE = 25;
 
 function yieldToBrowser(): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, 0));
 }
-
-type StashedDiffPrompt = {
-  itemId: string;
-  key: string;
-  prompt: string;
-};
-
-type StashedDiffPromptState = {
-  scope: string;
-  prompts: StashedDiffPrompt[];
-};
-
-type DraftPromptNoteState = {
-  scope: string;
-  notes: Record<string, string>;
-};
-
-const EMPTY_STASHED_PROMPTS: StashedDiffPrompt[] = [];
-const EMPTY_DRAFT_NOTES: Record<string, string> = {};
 
 interface ChangesCodeViewProps {
   repoPath: string;
@@ -105,30 +81,6 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
     [],
   );
   const stashedPromptScope = `${repoPath}:${groupPath}`;
-  const [stashedPromptState, setStashedPromptState] =
-    useState<StashedDiffPromptState>(() => ({
-      scope: stashedPromptScope,
-      prompts: [],
-    }));
-  const stashedPrompts = useMemo(
-    () =>
-      stashedPromptState.scope === stashedPromptScope
-        ? stashedPromptState.prompts
-        : EMPTY_STASHED_PROMPTS,
-    [stashedPromptScope, stashedPromptState],
-  );
-  const [draftNoteState, setDraftNoteState] =
-    useState<DraftPromptNoteState>(() => ({
-      scope: stashedPromptScope,
-      notes: EMPTY_DRAFT_NOTES,
-    }));
-  const draftNotes = useMemo(
-    () =>
-      draftNoteState.scope === stashedPromptScope
-        ? draftNoteState.notes
-        : EMPTY_DRAFT_NOTES,
-    [draftNoteState, stashedPromptScope],
-  );
   const [pathByFileName, setPathByFileName] = useState<Map<string, string>>(
     () => new Map(),
   );
@@ -156,11 +108,14 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
   const itemIdsRef = useRef<string[]>([]);
   const pendingAppendRef = useRef<CodeViewItem<CopyAnnotationMeta>[]>([]);
   const scrollActiveIdRef = useRef<string | null>(null);
-  const loadedContentsRef = useRef<
-    Map<string, { oldContent: string; newContent: string }>
-  >(new Map());
-  const copyKeyRef = useRef(0);
+  const loadedContentsRef = useRef<Map<string, LoadedDiffContents>>(new Map());
   const collapseModeRef = useRef(collapseMode);
+  const { openCopyAnnotation, renderAnnotation, stashedPromptChip } =
+    useDiffPromptStash({
+      scope: stashedPromptScope,
+      viewerRef: codeViewRef,
+      loadedContentsRef,
+    });
 
   useEffect(() => {
     void loadDiffSettings();
@@ -209,350 +164,13 @@ export function ChangesCodeView({ repoPath, groupPath }: ChangesCodeViewProps) {
   const groupLabel = getDiffGroupTabLabel(groupPath);
 
   const renderHeaderPrefix = useCallback(
-    (item: CodeViewItem<CopyAnnotationMeta>) => {
-      if (item.type !== 'diff') return null;
-      const filePath = filePathFromHeaderContext(item.fileDiff, pathByFileName);
-      const collapsed = item.collapsed === true;
-      const baseName = filePath.split('/').pop() || filePath;
-      const iconProps = getFileIconProps({
-        name: baseName,
-        isDir: false,
-        className: 'size-4 shrink-0',
-      });
-      const isEmptyDiff =
-        item.fileDiff.splitLineCount === 0 &&
-        item.fileDiff.unifiedLineCount === 0;
-
-      return (
-        <span className="inline-flex items-center gap-1">
-          <button
-            type="button"
-            disabled={isEmptyDiff}
-            aria-expanded={!isEmptyDiff && !collapsed}
-            aria-label={
-              isEmptyDiff
-                ? undefined
-                : collapsed
-                  ? 'Expand diff'
-                  : 'Collapse diff'
-            }
-            className={cn(
-              'inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors',
-              'hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-50',
-            )}
-            onClick={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-              if (isEmptyDiff) return;
-              toggleItemCollapsed(codeViewRef, item.id);
-            }}
-          >
-            <ChevronRight
-              className={cn(
-                'size-4 transition-transform',
-                !isEmptyDiff && !collapsed && 'rotate-90',
-              )}
-            />
-          </button>
-          {/* eslint-disable-next-line @next/next/no-img-element -- file icons are local UI asset descriptors from getFileIconProps */}
-          <img {...iconProps} alt="" />
-        </span>
-      );
-    },
+    (item: CodeViewItem<CopyAnnotationMeta>) =>
+      renderDiffHeaderPrefix({
+        item,
+        viewerRef: codeViewRef,
+        pathByFileName,
+      }),
     [pathByFileName],
-  );
-
-  const removeCopyAnnotation = useCallback((itemId: string, key: string) => {
-    updateViewerDiffItem(codeViewRef.current, itemId, (item) => {
-      if (!item.annotations?.length) return false;
-      const next = item.annotations.filter((a) => a.metadata?.key !== key);
-      if (next.length === item.annotations.length) return false;
-      item.annotations = next;
-      return true;
-    });
-  }, []);
-
-  const removeStashedPrompt = useCallback(
-    (itemId: string, key: string) => {
-      setStashedPromptState((current) => {
-        if (current.scope !== stashedPromptScope) return current;
-        return {
-          scope: current.scope,
-          prompts: current.prompts.filter(
-            (entry) => entry.itemId !== itemId || entry.key !== key,
-          ),
-        };
-      });
-    },
-    [stashedPromptScope],
-  );
-
-  const removeDraftNote = useCallback(
-    (key: string) => {
-      setDraftNoteState((current) => {
-        if (current.scope !== stashedPromptScope || !(key in current.notes)) {
-          return current;
-        }
-        const notes = { ...current.notes };
-        delete notes[key];
-        return { scope: current.scope, notes };
-      });
-    },
-    [stashedPromptScope],
-  );
-
-  const handleDraftNoteChange = useCallback(
-    (key: string, note: string) => {
-      setDraftNoteState((current) => ({
-        scope: stashedPromptScope,
-        notes: {
-          ...(current.scope === stashedPromptScope ? current.notes : EMPTY_DRAFT_NOTES),
-          [key]: note,
-        },
-      }));
-    },
-    [stashedPromptScope],
-  );
-
-  const handleDismissAnnotation = useCallback(
-    (itemId: string, key: string) => {
-      removeStashedPrompt(itemId, key);
-      removeDraftNote(key);
-      removeCopyAnnotation(itemId, key);
-    },
-    [removeCopyAnnotation, removeDraftNote, removeStashedPrompt],
-  );
-
-  const buildPromptForAnnotation = useCallback(
-    (itemId: string, key: string, note: string) => {
-      const viewer = codeViewRef.current;
-      const item = viewer?.getItem(itemId);
-      const contents = loadedContentsRef.current.get(itemId);
-      if (item?.type !== 'diff' || !contents) return null;
-
-      const annotation = item.annotations?.find(
-        (a) => isCopyAnnotation(a) && a.metadata.key === key,
-      );
-      if (!annotation || !isCopyAnnotation(annotation)) return null;
-
-      const selectionInfo = buildDiffSelectionInfo({
-        filePath: annotation.metadata.filePath,
-        fileDiff: item.fileDiff,
-        contents,
-        range: annotation.metadata.range,
-      });
-      return selectionInfo
-        ? formatDiffSelectionForAI(selectionInfo, note)
-        : null;
-    },
-    [],
-  );
-
-  const handleCopyAnnotation = useCallback(
-    (itemId: string, key: string, note: string) => {
-      const prompt = buildPromptForAnnotation(itemId, key, note);
-      if (!prompt) {
-        toastManager.add({
-          title: 'Nothing to copy',
-          type: 'error',
-        });
-        return;
-      }
-
-      void navigator.clipboard.writeText(prompt).catch(() =>
-        toastManager.add({
-          title: 'Failed to copy prompt',
-          type: 'error',
-        }),
-      );
-      removeStashedPrompt(itemId, key);
-      removeDraftNote(key);
-      removeCopyAnnotation(itemId, key);
-    },
-    [
-      buildPromptForAnnotation,
-      removeCopyAnnotation,
-      removeDraftNote,
-      removeStashedPrompt,
-    ],
-  );
-
-  const handleStashAnnotation = useCallback(
-    (itemId: string, key: string, note: string) => {
-      const prompt = buildPromptForAnnotation(itemId, key, note);
-      if (!prompt) {
-        toastManager.add({
-          title: 'Nothing to stash',
-          type: 'error',
-        });
-        return;
-      }
-
-      setStashedPromptState((current) => ({
-        scope: stashedPromptScope,
-        prompts:
-          current.scope === stashedPromptScope
-            ? [
-                ...current.prompts.filter(
-                  (entry) => entry.itemId !== itemId || entry.key !== key,
-                ),
-                { itemId, key, prompt },
-              ]
-            : [{ itemId, key, prompt }],
-      }));
-    },
-    [buildPromptForAnnotation, stashedPromptScope],
-  );
-
-  const handleCopyStashedPrompts = useCallback(() => {
-    if (stashedPrompts.length === 0) return;
-    const prompt = stashedPrompts
-      .map((entry, index) => `# Comment ${index + 1}\n\n${entry.prompt}`)
-      .join('\n\n---\n\n');
-
-    void navigator.clipboard.writeText(prompt).then(
-      () => {
-        const copiedKeys = new Set(stashedPrompts.map((entry) => entry.key));
-        for (const entry of stashedPrompts) {
-          removeCopyAnnotation(entry.itemId, entry.key);
-        }
-        setDraftNoteState((current) => {
-          if (current.scope !== stashedPromptScope) return current;
-          return {
-            scope: current.scope,
-            notes: Object.fromEntries(
-              Object.entries(current.notes).filter(([key]) => !copiedKeys.has(key)),
-            ),
-          };
-        });
-        setStashedPromptState({ scope: stashedPromptScope, prompts: [] });
-      },
-      () =>
-        toastManager.add({
-          title: 'Failed to copy prompt',
-          type: 'error',
-        }),
-    );
-  }, [removeCopyAnnotation, stashedPromptScope, stashedPrompts]);
-
-  const stashedPromptChip = useMemo(() => {
-    if (stashedPrompts.length === 0) return null;
-    return (
-      <button
-        type="button"
-        onClick={handleCopyStashedPrompts}
-        className={cn(
-          'group/comment-chip inline-flex h-7 max-w-[58px] shrink-0 items-center justify-start overflow-hidden rounded-md border border-foreground bg-foreground px-2 text-xs font-semibold text-background shadow-sm',
-          'transition-[max-width,background-color,border-color,color,box-shadow] duration-300 ease-out hover:max-w-[132px] hover:bg-background hover:text-foreground hover:shadow-md',
-          'dark:border-foreground dark:bg-foreground dark:text-background dark:hover:bg-background dark:hover:text-foreground',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
-        )}
-        aria-label={`Copy ${stashedPrompts.length} stashed prompt comment${stashedPrompts.length === 1 ? '' : 's'}`}
-        title="Copy Prompt"
-      >
-        <span className="relative mr-1.5 flex size-3.5 shrink-0 items-center justify-center">
-          <MessageSquareText className="absolute size-3.5 transition-all duration-300 ease-out group-hover/comment-chip:scale-75 group-hover/comment-chip:opacity-0" />
-          <Copy className="absolute size-3.5 scale-75 opacity-0 transition-all duration-300 ease-out group-hover/comment-chip:scale-100 group-hover/comment-chip:opacity-100" />
-        </span>
-        <span className="w-4 overflow-hidden text-center text-xs tabular-nums transition-[width,opacity,transform] duration-300 ease-out group-hover/comment-chip:w-0 group-hover/comment-chip:-translate-x-1 group-hover/comment-chip:opacity-0">
-          {stashedPrompts.length}
-        </span>
-        <span className="ml-0 max-w-0 whitespace-nowrap opacity-0 transition-[max-width,opacity,margin-left] duration-300 ease-out group-hover/comment-chip:max-w-24 group-hover/comment-chip:opacity-100">
-          Copy Prompt
-        </span>
-      </button>
-    );
-  }, [handleCopyStashedPrompts, stashedPrompts.length]);
-
-  const openCopyAnnotation = useCallback(
-    (itemId: string, range: SelectedLineRange) => {
-      const viewer = codeViewRef.current;
-      if (viewer == null) return;
-
-      const side = range.endSide ?? range.side;
-      if (!side) return;
-
-      const lineNumber = range.end;
-      const key = `copy-${copyKeyRef.current++}`;
-
-      updateViewerDiffItem(viewer, itemId, (item) => {
-        const removedEmptyKeys: string[] = [];
-        const stashedKeys = new Set(stashedPrompts.map((entry) => entry.key));
-        const existingAnnotations = (item.annotations ?? []).filter((annotation) => {
-          if (!isCopyAnnotation(annotation)) return true;
-          if (stashedKeys.has(annotation.metadata.key)) return true;
-          if ((draftNotes[annotation.metadata.key] ?? '').trim()) return true;
-          removedEmptyKeys.push(annotation.metadata.key);
-          return false;
-        });
-
-        const hasExistingRange = existingAnnotations.some((annotation) => {
-          if (!isCopyAnnotation(annotation)) return false;
-          const existingRange = annotation.metadata.range;
-          return (
-            annotation.side === side &&
-            existingRange.side === range.side &&
-            existingRange.endSide === range.endSide &&
-            existingRange.start === range.start &&
-            existingRange.end === range.end
-          );
-        });
-        if (hasExistingRange) return false;
-
-        const nextAnnotation: DiffLineAnnotation<CopyAnnotationMeta> = {
-          side,
-          lineNumber,
-          metadata: { kind: 'copy', key, filePath: itemId, range },
-        };
-        item.annotations = [...existingAnnotations, nextAnnotation];
-        if (removedEmptyKeys.length > 0) {
-          setDraftNoteState((current) => {
-            if (current.scope !== stashedPromptScope) return current;
-            const removed = new Set(removedEmptyKeys);
-            return {
-              scope: current.scope,
-              notes: Object.fromEntries(
-                Object.entries(current.notes).filter(([entryKey]) => !removed.has(entryKey)),
-              ),
-            };
-          });
-        }
-        return true;
-      });
-    },
-    [draftNotes, stashedPromptScope, stashedPrompts],
-  );
-
-  const renderAnnotation = useCallback(
-    (annotation: DiffLineAnnotation<CopyAnnotationMeta>) => {
-      if (!isCopyAnnotation(annotation)) return null;
-      const isStashed = stashedPrompts.some(
-        (entry) =>
-          entry.itemId === annotation.metadata.filePath &&
-          entry.key === annotation.metadata.key,
-      );
-      return (
-        <DiffCopyAnnotation
-          annotation={annotation}
-          itemId={annotation.metadata.filePath}
-          isStashed={isStashed}
-          note={draftNotes[annotation.metadata.key] ?? ''}
-          onNoteChange={handleDraftNoteChange}
-          onCopy={handleCopyAnnotation}
-          onStash={handleStashAnnotation}
-          onDismiss={handleDismissAnnotation}
-          lineLabel={formatSelectedRangeLabel(annotation.metadata.range)}
-        />
-      );
-    },
-    [
-      handleCopyAnnotation,
-      handleDismissAnnotation,
-      handleDraftNoteChange,
-      handleStashAnnotation,
-      draftNotes,
-      stashedPrompts,
-    ],
   );
 
   useEffect(() => {

--- a/apps/web/src/features/diff/components/useDiffPromptStash.tsx
+++ b/apps/web/src/features/diff/components/useDiffPromptStash.tsx
@@ -1,0 +1,389 @@
+'use client';
+
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type MutableRefObject,
+} from 'react';
+import type { DiffLineAnnotation, SelectedLineRange } from '@pierre/diffs';
+import type { CodeViewHandle } from '@pierre/diffs/react';
+import { Copy, MessageSquareText } from 'lucide-react';
+import { toastManager } from '@workspace/ui';
+import { DiffCopyAnnotation } from '@/features/diff/components/DiffCopyAnnotation';
+import {
+  buildDiffSelectionInfo,
+  formatSelectedRangeLabel,
+  isCopyAnnotation,
+  type CopyAnnotationMeta,
+  updateViewerDiffItem,
+} from '@/features/diff/lib/diff-code-view-shared';
+import { formatDiffSelectionForAI } from '@/shared/lib/format-selection-for-ai';
+import { cn } from '@/shared/lib/utils';
+
+export type LoadedDiffContents = {
+  oldContent: string;
+  newContent: string;
+};
+
+type StashedDiffPrompt = {
+  itemId: string;
+  key: string;
+  prompt: string;
+};
+
+type StashedDiffPromptState = {
+  scope: string;
+  prompts: StashedDiffPrompt[];
+};
+
+type DraftPromptNoteState = {
+  scope: string;
+  notes: Record<string, string>;
+};
+
+const EMPTY_STASHED_PROMPTS: StashedDiffPrompt[] = [];
+const EMPTY_DRAFT_NOTES: Record<string, string> = {};
+
+type UseDiffPromptStashArgs = {
+  scope: string;
+  viewerRef: MutableRefObject<CodeViewHandle<CopyAnnotationMeta> | null>;
+  loadedContentsRef: MutableRefObject<Map<string, LoadedDiffContents>>;
+};
+
+export function useDiffPromptStash({
+  scope,
+  viewerRef,
+  loadedContentsRef,
+}: UseDiffPromptStashArgs) {
+  const copyKeyRef = useRef(0);
+  const [stashedPromptState, setStashedPromptState] =
+    useState<StashedDiffPromptState>(() => ({
+      scope,
+      prompts: [],
+    }));
+  const stashedPrompts = useMemo(
+    () =>
+      stashedPromptState.scope === scope
+        ? stashedPromptState.prompts
+        : EMPTY_STASHED_PROMPTS,
+    [scope, stashedPromptState],
+  );
+  const [draftNoteState, setDraftNoteState] =
+    useState<DraftPromptNoteState>(() => ({
+      scope,
+      notes: EMPTY_DRAFT_NOTES,
+    }));
+  const draftNotes = useMemo(
+    () =>
+      draftNoteState.scope === scope ? draftNoteState.notes : EMPTY_DRAFT_NOTES,
+    [draftNoteState, scope],
+  );
+
+  const removeCopyAnnotation = useCallback(
+    (itemId: string, key: string) => {
+      updateViewerDiffItem(viewerRef.current, itemId, (item) => {
+        if (!item.annotations?.length) return false;
+        const next = item.annotations.filter((a) => a.metadata?.key !== key);
+        if (next.length === item.annotations.length) return false;
+        item.annotations = next;
+        return true;
+      });
+    },
+    [viewerRef],
+  );
+
+  const removeStashedPrompt = useCallback(
+    (itemId: string, key: string) => {
+      setStashedPromptState((current) => {
+        if (current.scope !== scope) return current;
+        return {
+          scope: current.scope,
+          prompts: current.prompts.filter(
+            (entry) => entry.itemId !== itemId || entry.key !== key,
+          ),
+        };
+      });
+    },
+    [scope],
+  );
+
+  const removeDraftNote = useCallback(
+    (key: string) => {
+      setDraftNoteState((current) => {
+        if (current.scope !== scope || !(key in current.notes)) {
+          return current;
+        }
+        const notes = { ...current.notes };
+        delete notes[key];
+        return { scope: current.scope, notes };
+      });
+    },
+    [scope],
+  );
+
+  const handleDraftNoteChange = useCallback(
+    (key: string, note: string) => {
+      setDraftNoteState((current) => ({
+        scope,
+        notes: {
+          ...(current.scope === scope ? current.notes : EMPTY_DRAFT_NOTES),
+          [key]: note,
+        },
+      }));
+    },
+    [scope],
+  );
+
+  const handleDismissAnnotation = useCallback(
+    (itemId: string, key: string) => {
+      removeStashedPrompt(itemId, key);
+      removeDraftNote(key);
+      removeCopyAnnotation(itemId, key);
+    },
+    [removeCopyAnnotation, removeDraftNote, removeStashedPrompt],
+  );
+
+  const buildPromptForAnnotation = useCallback(
+    (itemId: string, key: string, note: string) => {
+      const item = viewerRef.current?.getItem(itemId);
+      const contents = loadedContentsRef.current.get(itemId);
+      if (item?.type !== 'diff' || !contents) return null;
+
+      const annotation = item.annotations?.find(
+        (a) => isCopyAnnotation(a) && a.metadata.key === key,
+      );
+      if (!annotation || !isCopyAnnotation(annotation)) return null;
+
+      const selectionInfo = buildDiffSelectionInfo({
+        filePath: annotation.metadata.filePath,
+        fileDiff: item.fileDiff,
+        contents,
+        range: annotation.metadata.range,
+      });
+      return selectionInfo ? formatDiffSelectionForAI(selectionInfo, note) : null;
+    },
+    [loadedContentsRef, viewerRef],
+  );
+
+  const handleCopyAnnotation = useCallback(
+    (itemId: string, key: string, note: string) => {
+      const prompt = buildPromptForAnnotation(itemId, key, note);
+      if (!prompt) {
+        toastManager.add({
+          title: 'Nothing to copy',
+          type: 'error',
+        });
+        return;
+      }
+
+      void navigator.clipboard.writeText(prompt).catch(() =>
+        toastManager.add({
+          title: 'Failed to copy prompt',
+          type: 'error',
+        }),
+      );
+      removeStashedPrompt(itemId, key);
+      removeDraftNote(key);
+      removeCopyAnnotation(itemId, key);
+    },
+    [
+      buildPromptForAnnotation,
+      removeCopyAnnotation,
+      removeDraftNote,
+      removeStashedPrompt,
+    ],
+  );
+
+  const handleStashAnnotation = useCallback(
+    (itemId: string, key: string, note: string) => {
+      const prompt = buildPromptForAnnotation(itemId, key, note);
+      if (!prompt) {
+        toastManager.add({
+          title: 'Nothing to stash',
+          type: 'error',
+        });
+        return;
+      }
+
+      setStashedPromptState((current) => ({
+        scope,
+        prompts:
+          current.scope === scope
+            ? [
+                ...current.prompts.filter(
+                  (entry) => entry.itemId !== itemId || entry.key !== key,
+                ),
+                { itemId, key, prompt },
+              ]
+            : [{ itemId, key, prompt }],
+      }));
+    },
+    [buildPromptForAnnotation, scope],
+  );
+
+  const handleCopyStashedPrompts = useCallback(() => {
+    if (stashedPrompts.length === 0) return;
+    const prompt = stashedPrompts
+      .map((entry, index) => `# Comment ${index + 1}\n\n${entry.prompt}`)
+      .join('\n\n---\n\n');
+
+    void navigator.clipboard.writeText(prompt).then(
+      () => {
+        const copiedKeys = new Set(stashedPrompts.map((entry) => entry.key));
+        for (const entry of stashedPrompts) {
+          removeCopyAnnotation(entry.itemId, entry.key);
+        }
+        setDraftNoteState((current) => {
+          if (current.scope !== scope) return current;
+          return {
+            scope: current.scope,
+            notes: Object.fromEntries(
+              Object.entries(current.notes).filter(
+                ([key]) => !copiedKeys.has(key),
+              ),
+            ),
+          };
+        });
+        setStashedPromptState({ scope, prompts: [] });
+      },
+      () =>
+        toastManager.add({
+          title: 'Failed to copy prompt',
+          type: 'error',
+        }),
+    );
+  }, [removeCopyAnnotation, scope, stashedPrompts]);
+
+  const stashedPromptChip = useMemo(() => {
+    if (stashedPrompts.length === 0) return null;
+    return (
+      <button
+        type="button"
+        onClick={handleCopyStashedPrompts}
+        className={cn(
+          'group/comment-chip inline-flex h-7 max-w-[58px] shrink-0 items-center justify-start overflow-hidden rounded-md border border-foreground bg-foreground px-2 text-xs font-semibold text-background shadow-sm',
+          'transition-[max-width,background-color,border-color,color,box-shadow] duration-300 ease-out hover:max-w-[132px] hover:bg-background hover:text-foreground hover:shadow-md',
+          'dark:border-foreground dark:bg-foreground dark:text-background dark:hover:bg-background dark:hover:text-foreground',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+        )}
+        aria-label={`Copy ${stashedPrompts.length} stashed prompt comment${stashedPrompts.length === 1 ? '' : 's'}`}
+        title="Copy Prompt"
+      >
+        <span className="relative mr-1.5 flex size-3.5 shrink-0 items-center justify-center">
+          <MessageSquareText className="absolute size-3.5 transition-all duration-300 ease-out group-hover/comment-chip:scale-75 group-hover/comment-chip:opacity-0" />
+          <Copy className="absolute size-3.5 scale-75 opacity-0 transition-all duration-300 ease-out group-hover/comment-chip:scale-100 group-hover/comment-chip:opacity-100" />
+        </span>
+        <span className="w-4 overflow-hidden text-center text-xs tabular-nums transition-[width,opacity,transform] duration-300 ease-out group-hover/comment-chip:w-0 group-hover/comment-chip:-translate-x-1 group-hover/comment-chip:opacity-0">
+          {stashedPrompts.length}
+        </span>
+        <span className="ml-0 max-w-0 whitespace-nowrap opacity-0 transition-[max-width,opacity,margin-left] duration-300 ease-out group-hover/comment-chip:max-w-24 group-hover/comment-chip:opacity-100">
+          Copy Prompt
+        </span>
+      </button>
+    );
+  }, [handleCopyStashedPrompts, stashedPrompts.length]);
+
+  const openCopyAnnotation = useCallback(
+    (itemId: string, range: SelectedLineRange) => {
+      const viewer = viewerRef.current;
+      if (viewer == null) return;
+
+      const side = range.endSide ?? range.side;
+      if (!side) return;
+
+      const lineNumber = range.end;
+      const key = `copy-${copyKeyRef.current++}`;
+
+      updateViewerDiffItem(viewer, itemId, (item) => {
+        const removedEmptyKeys: string[] = [];
+        const stashedKeys = new Set(stashedPrompts.map((entry) => entry.key));
+        const existingAnnotations = (item.annotations ?? []).filter((annotation) => {
+          if (!isCopyAnnotation(annotation)) return true;
+          if (stashedKeys.has(annotation.metadata.key)) return true;
+          if ((draftNotes[annotation.metadata.key] ?? '').trim()) return true;
+          removedEmptyKeys.push(annotation.metadata.key);
+          return false;
+        });
+
+        const hasExistingRange = existingAnnotations.some((annotation) => {
+          if (!isCopyAnnotation(annotation)) return false;
+          const existingRange = annotation.metadata.range;
+          return (
+            annotation.side === side &&
+            existingRange.side === range.side &&
+            existingRange.endSide === range.endSide &&
+            existingRange.start === range.start &&
+            existingRange.end === range.end
+          );
+        });
+        if (hasExistingRange) return false;
+
+        item.annotations = [
+          ...existingAnnotations,
+          {
+            side,
+            lineNumber,
+            metadata: { kind: 'copy', key, filePath: itemId, range },
+          },
+        ];
+
+        if (removedEmptyKeys.length > 0) {
+          setDraftNoteState((current) => {
+            if (current.scope !== scope) return current;
+            const removed = new Set(removedEmptyKeys);
+            return {
+              scope: current.scope,
+              notes: Object.fromEntries(
+                Object.entries(current.notes).filter(
+                  ([entryKey]) => !removed.has(entryKey),
+                ),
+              ),
+            };
+          });
+        }
+        return true;
+      });
+    },
+    [draftNotes, scope, stashedPrompts, viewerRef],
+  );
+
+  const renderAnnotation = useCallback(
+    (annotation: DiffLineAnnotation<CopyAnnotationMeta>) => {
+      if (!isCopyAnnotation(annotation)) return null;
+      const isStashed = stashedPrompts.some(
+        (entry) =>
+          entry.itemId === annotation.metadata.filePath &&
+          entry.key === annotation.metadata.key,
+      );
+      return (
+        <DiffCopyAnnotation
+          annotation={annotation}
+          itemId={annotation.metadata.filePath}
+          isStashed={isStashed}
+          note={draftNotes[annotation.metadata.key] ?? ''}
+          onNoteChange={handleDraftNoteChange}
+          onCopy={handleCopyAnnotation}
+          onStash={handleStashAnnotation}
+          onDismiss={handleDismissAnnotation}
+          lineLabel={formatSelectedRangeLabel(annotation.metadata.range)}
+        />
+      );
+    },
+    [
+      handleCopyAnnotation,
+      handleDismissAnnotation,
+      handleDraftNoteChange,
+      handleStashAnnotation,
+      draftNotes,
+      stashedPrompts,
+    ],
+  );
+
+  return {
+    openCopyAnnotation,
+    renderAnnotation,
+    stashedPromptChip,
+  };
+}

--- a/apps/web/src/features/diff/components/useDiffPromptStash.tsx
+++ b/apps/web/src/features/diff/components/useDiffPromptStash.tsx
@@ -178,15 +178,18 @@ export function useDiffPromptStash({
         return;
       }
 
-      void navigator.clipboard.writeText(prompt).catch(() =>
-        toastManager.add({
-          title: 'Failed to copy prompt',
-          type: 'error',
-        }),
+      void navigator.clipboard.writeText(prompt).then(
+        () => {
+          removeStashedPrompt(itemId, key);
+          removeDraftNote(key);
+          removeCopyAnnotation(itemId, key);
+        },
+        () =>
+          toastManager.add({
+            title: 'Failed to copy prompt',
+            type: 'error',
+          }),
       );
-      removeStashedPrompt(itemId, key);
-      removeDraftNote(key);
-      removeCopyAnnotation(itemId, key);
     },
     [
       buildPromptForAnnotation,

--- a/apps/web/src/features/diff/lib/code-view-ui.tsx
+++ b/apps/web/src/features/diff/lib/code-view-ui.tsx
@@ -18,55 +18,64 @@ export function createDiffHeaderPrefixRenderer<LAnnotation>(args: {
   return function renderDiffCodeViewHeaderPrefix(
     item: CodeViewItem<LAnnotation>,
   ) {
-    if (item.type !== 'diff') return null;
-    const fileDiff = item.fileDiff;
-    const filePath = filePathFromHeaderContext(fileDiff, args.pathByFileName);
-    const collapsed = item.collapsed === true;
-    const baseName = filePath.split('/').pop() || filePath;
-    const iconProps = getFileIconProps({
-      name: baseName,
-      isDir: false,
-      className: 'size-4 shrink-0',
-    });
-
-    const isEmptyDiff =
-      fileDiff.splitLineCount === 0 && fileDiff.unifiedLineCount === 0;
-
-    return (
-      <span className="inline-flex items-center gap-1">
-        <button
-          type="button"
-          disabled={isEmptyDiff}
-          aria-expanded={!isEmptyDiff && !collapsed}
-          aria-label={
-            isEmptyDiff
-              ? undefined
-              : collapsed
-                ? 'Expand diff'
-                : 'Collapse diff'
-          }
-          className={cn(
-            'inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors',
-            'hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-50',
-          )}
-          onClick={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            if (isEmptyDiff) return;
-            toggleItemCollapsed(args.viewerRef, item.id);
-          }}
-        >
-          <ChevronRight
-            className={cn(
-              'size-4 transition-transform',
-              !isEmptyDiff && !collapsed && 'rotate-90',
-            )}
-          />
-        </button>
-        <img {...iconProps} alt="" />
-      </span>
-    );
+    return renderDiffHeaderPrefix({ ...args, item });
   };
+}
+
+export function renderDiffHeaderPrefix<LAnnotation>(args: {
+  item: CodeViewItem<LAnnotation>;
+  viewerRef: MutableRefObject<CodeViewHandle<LAnnotation> | null>;
+  pathByFileName: Map<string, string>;
+}) {
+  if (args.item.type !== 'diff') return null;
+  const fileDiff = args.item.fileDiff;
+  const filePath = filePathFromHeaderContext(fileDiff, args.pathByFileName);
+  const collapsed = args.item.collapsed === true;
+  const baseName = filePath.split('/').pop() || filePath;
+  const iconProps = getFileIconProps({
+    name: baseName,
+    isDir: false,
+    className: 'size-4 shrink-0',
+  });
+
+  const isEmptyDiff =
+    fileDiff.splitLineCount === 0 && fileDiff.unifiedLineCount === 0;
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      <button
+        type="button"
+        disabled={isEmptyDiff}
+        aria-expanded={!isEmptyDiff && !collapsed}
+        aria-label={
+          isEmptyDiff
+            ? undefined
+            : collapsed
+              ? 'Expand diff'
+              : 'Collapse diff'
+        }
+        className={cn(
+          'inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors',
+          'hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-50',
+        )}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          if (isEmptyDiff) return;
+          toggleItemCollapsed(args.viewerRef, args.item.id);
+        }}
+      >
+        <ChevronRight
+          className={cn(
+            'size-4 transition-transform',
+            !isEmptyDiff && !collapsed && 'rotate-90',
+          )}
+        />
+      </button>
+      {/* eslint-disable-next-line @next/next/no-img-element -- file icons are local UI asset descriptors from getFileIconProps */}
+      <img {...iconProps} alt="" />
+    </span>
+  );
 }
 
 export function scrollCodeViewToItem<LAnnotation = undefined>(
@@ -93,7 +102,7 @@ export function scrollCodeViewToItem<LAnnotation = undefined>(
 }
 
 /** File whose diff occupies the viewport center, with a top-of-viewport fallback. */
-export function findDiffItemIdForViewport<LAnnotation>(
+export function findDiffItemIdForViewport(
   viewer: {
     getTopForItem(id: string): number | undefined;
     getWindowSpecs(): { top: number; bottom: number };
@@ -128,7 +137,7 @@ export function findDiffItemIdForViewport<LAnnotation>(
   return activeId ?? itemIds[0];
 }
 
-export function findDiffItemIdAtScrollTop<LAnnotation>(
+export function findDiffItemIdAtScrollTop(
   viewer: {
     getTopForItem(id: string): number | undefined;
     getWindowSpecs(): { top: number; bottom: number };

--- a/automations/review/quality/result/2026-06/06-23_score-88_RESULT.md
+++ b/automations/review/quality/result/2026-06/06-23_score-88_RESULT.md
@@ -1,0 +1,132 @@
+# Atmos main 每日代码质量评分 - 2026-06-23
+
+## 1. 审查范围
+
+- 审查时间窗口：2026-06-22 00:00:00 +0800 至 2026-06-22 23:59:59 +0800。
+- 审查分支：`main`。
+- 已排除纯 automation 结果归档提交：`5f66ecb3 docs: record quality review PR link`。
+- 说明：`facf535c`、`1bc03600`、`26bbea10` 同时包含结果文件和真实代码变更，因此只按真实代码变更部分纳入审查；`6e4c7f55` 是 merge commit，无独立 diff，仅记录合并事实。
+
+被审查提交：
+
+| Commit | Author | Message |
+| --- | --- | --- |
+| `26bbea10` | AarynLu | `refactor: address daily quality findings for 2026-06-21` |
+| `facf535c` | AarynLu | `fix: avoid node_modules script path in video scaffold` |
+| `1bc03600` | AarynLu | `fix: ignore generated gsap runtime asset` |
+| `6e4c7f55` | AruNi_Lu | `Merge pull request #129 from AruNi-01/codex/quality-fix/2026-06-22` |
+| `ef02b724` | AarynLu | `Support Hermes prompt flag query syntax` |
+| `7feb4da4` | AarynLu | `Add prompt stashing to diff annotations` |
+| `ab28ac51` | AarynLu | `chore(local-runtime): bump version to 0.2.0-beta.10` |
+| `03c5933a` | AarynLu | `chore(desktop): release 1.2.0-beta.15` |
+| `7128d21f` | AarynLu | `Guard Hermes executable permissions on non-Unix` |
+| `81a3bb4d` | AarynLu | `Bump atmos-desktop to 1.2.0-beta.15` |
+| `3021e1c7` | AarynLu | `Remove local runtime alias and add JSON CLI output` |
+| `e8b5b340` | AarynLu | `chore(cli): release 0.2.0` |
+| `15792de7` | AarynLu | `chore(local-runtime): release 0.2.0-beta.11` |
+| `6bb8aa5a` | AarynLu | `chore(desktop): release 1.2.0-beta.16` |
+| `ec76931b` | AarynLu | `fix(web): keep local retry button in header row` |
+| `48e91373` | AarynLu | `chore(local-runtime): release 0.2.0` |
+| `6b73e7c6` | AarynLu | `fix(web): preserve hosted local detection on reconnect failure` |
+| `c5c596de` | AarynLu | `fix(local-runtime): publish npm prereleases with dist tag` |
+| `49f2c836` | AarynLu | `fix(local-runtime): keep npm publish opt-in` |
+| `9f8c0250` | AarynLu | `fix(local-runtime): stabilize latest installer distribution` |
+
+## 2. 一份好代码应该是什么样
+
+本次采用的标准是：改动应放在清楚的归属层里，单个组件或模块只承担它自然拥有的职责；复杂交互要通过贴合当前问题的抽象拆开，而不是把状态、IO、渲染和副作用都塞进一个入口文件。代码应让维护者能顺着主路径理解行为，版本、配置、manifest、锁文件等工程元数据必须保持一致，避免靠隐式记忆维持正确性。
+
+## 3. 评分方法
+
+- 100 分制。
+- 设计与分层 30 分：职责边界、模块耦合、分层方向、抽象是否贴合。
+- 可读性与复杂度 25 分：控制流、状态管理、分支复杂度、理解成本。
+- 体量与内聚 20 分：文件、函数、组件体量是否与职责匹配。
+- 可维护性与复用 15 分：重复逻辑、共享规则、配置和协议是否集中管理。
+- 工程卫生 10 分：命名、注释、错误处理、日志、调试残留、锁文件和 release 元数据一致性。
+- 高严重度问题通常单项扣 8-15 分；中严重度问题扣 3-7 分；低严重度问题扣 1-2 分。体量阈值只作为信号，只有体量超出且职责确实变差时扣分。
+
+## 4. 总分
+
+**88 / 100。总体判断：良好。**
+
+当天多数改动沿既有边界推进，Hermes manifest、发布 workflow、runtime installer 和 generated asset 处理都有正向收口。但 `ChangesCodeView.tsx` 新增 prompt stash 后把多个交互职责继续集中到一个 900+ 行组件里，形成明确的维护风险；另有一次 desktop release bump 未同步 `Cargo.lock`。
+
+## 5. 分项评分
+
+| 维度 | 得分 | 扣分原因 |
+| --- | ---: | --- |
+| 设计与分层 | 26 / 30 | `7feb4da4` 将 prompt stash 状态机、annotation mutation、prompt 构造、toolbar chip 渲染继续放进 `apps/web/src/features/diff/components/ChangesCodeView.tsx`，让 diff 加载/导航组件承担新的交互子系统职责。 |
+| 可读性与复杂度 | 22 / 25 | `ChangesCodeView.tsx` 同时维护加载批次、滚动导航、collapse、path map、draft notes、stashed prompts 和 clipboard 行为，主路径阅读成本上升。 |
+| 体量与内聚 | 17 / 20 | 同一组件从 479 行增长到 964 行，超过高风险 UI 组件阈值；新增代码有清晰拆分点但未在提交中拆出。 |
+| 可维护性与复用 | 14 / 15 | 多数跨端 manifest 变更有测试同步；但 prompt stash 行为没有形成独立 hook/component，后续扩展会继续扩大主组件。 |
+| 工程卫生 | 9 / 10 | `6bb8aa5a` 将 `apps/desktop/src-tauri/Cargo.toml` bump 到 `1.2.0-beta.16`，但 `Cargo.lock` 仍记录 `atmos-desktop` 为 `1.2.0-beta.15`。 |
+
+## 6. 主要问题清单
+
+### 高：prompt stash 让 diff 主组件职责继续膨胀
+
+- 提交：`7feb4da4 Add prompt stashing to diff annotations`
+- 文件：`apps/web/src/features/diff/components/ChangesCodeView.tsx:107`、`apps/web/src/features/diff/components/ChangesCodeView.tsx:265`
+- 问题：新增的 `stashedPromptState`、`draftNoteState`、copy/stash/dismiss handler、prompt 构造、批量复制 chip 和 annotation 渲染全部内联在 `ChangesCodeView` 中。该文件已经同时承担 diff 文件加载、CodeView 装配、滚动定位、collapse、active file 同步和 selection handling，新增功能把组件推到 964 行。
+- 为什么是质量问题：这不是单纯行数问题，而是新的 prompt annotation 子系统和原 diff viewer 生命周期交织在一个组件里。后续要调整 prompt 文案、stash 交互、annotation 去重或 clipboard 失败行为时，都必须穿过加载和导航逻辑，回归风险变高。
+- 优化建议：把 prompt stash 相关状态和 UI 提取到 `apps/web/src/features/diff/components/useDiffPromptStash.tsx` 或同级 feature-local hook/component 中。主组件只传入 `codeViewRef`、`loadedContentsRef` 和 scope，并接收 `openCopyAnnotation`、`renderAnnotation`、`stashedPromptChip`。这样 `ChangesCodeView` 保持 diff viewer orchestration 职责，prompt annotation 子系统独立演进。
+
+### 中：desktop release bump 未同步 Cargo.lock
+
+- 提交：`6bb8aa5a chore(desktop): release 1.2.0-beta.16`
+- 文件：`apps/desktop/src-tauri/Cargo.toml:3`、`Cargo.lock:530`
+- 问题：`apps/desktop/src-tauri/Cargo.toml` 中 `atmos-desktop` 已是 `1.2.0-beta.16`，但同一 main 状态下 `Cargo.lock` 仍记录 `1.2.0-beta.15`。
+- 为什么是质量问题：release bump 属于工程元数据变更，锁文件与 manifest 不一致会让后续 `cargo test` / `cargo build` 在本地自动改写锁文件，给下一位维护者留下不必要的脏 diff，也可能遮蔽真正的 dependency 变化。
+- 优化建议：release bump 后运行对应 cargo 命令或显式更新锁文件，并把 `Cargo.lock` 同步提交。对桌面 release 流程可补一条检查：release PR 中 `apps/desktop/src-tauri/Cargo.toml` 改版本时，`Cargo.lock` 的 `atmos-desktop` entry 必须同版本。
+
+## 7. 正向观察
+
+- `ef02b724` 修改 Hermes prompt flag 语义时，同步更新了 `resources/terminal-agents/builtin_agents.json`、Rust automation resolver 测试和 Web AgentSelect 测试，符合 terminal-agent manifest 双端消费规则。
+- `7128d21f` 用 `#[cfg(unix)]` / `#[cfg(not(unix))]` 收口 Hermes executable permission 处理，避免非 Unix 平台引入不可编译路径。
+- `facf535c` / `1bc03600` 把 GSAP runtime asset 从已提交文件调整为安装后同步生成，减少 generated artifact 污染。
+- local runtime 发布 workflow 的 npm publish 被改为显式 opt-in，并按 prerelease 推导 npm tag，发布边界比默认自动发布更清楚。
+- Hosted welcome 的本地检测重试入口是局部 UI 改动，没有引入新的 transport 或绕开现有 hosted connection store。
+
+## 8. Review 建议
+
+人工 review 最值得盯：
+
+1. Diff viewer 相关改动是否继续把新交互状态塞进 `ChangesCodeView.tsx`，尤其是 selection、annotation、clipboard、toolbar 类逻辑。
+2. Release/version bump 是否同步更新对应 lockfile、package manifest、Tauri config 和 release notes。
+3. Terminal agent manifest 变更是否仍同时覆盖 TS UI adapter 和 Rust automation resolver。
+
+## 9. 自动修复与 PR
+
+已触发自动修复，因为总分 **88 < 90**。
+
+- 修复分支：`codex/quality-fix/2026-06-22-0807`
+- 修复提交：`e7a967d6 refactor: address daily quality findings for 2026-06-22`
+- PR：https://github.com/AruNi-01/atmos/pull/130
+- 标签：已添加 `codex`；仓库中未找到 `codex-automation`，因此跳过该标签。
+- 修复内容：
+  - 新增 `apps/web/src/features/diff/components/useDiffPromptStash.tsx`，承接 prompt stash 状态、annotation mutation、prompt 构造、chip UI 和 copy/stash/dismiss 行为。
+  - `apps/web/src/features/diff/components/ChangesCodeView.tsx` 改为只调用 hook 返回的 `openCopyAnnotation`、`renderAnnotation` 和 `stashedPromptChip`，主组件从 964 行降至 582 行。
+  - `apps/web/src/features/diff/lib/code-view-ui.tsx` 增加 direct header renderer，避免本次组件在 render 阶段通过工厂传 ref 触发 React lint。
+  - `Cargo.lock` 中 `atmos-desktop` 版本同步为 `1.2.0-beta.16`。
+- 验证：
+  - `bun --filter web lint -- src/features/diff/components/ChangesCodeView.tsx src/features/diff/components/useDiffPromptStash.tsx src/features/diff/lib/code-view-ui.tsx` 通过。
+  - `bun --filter web typecheck` 通过。
+  - `bun test apps/web/src/features/wiki/components/__tests__/agent-select.test.ts` 通过，5 tests passed。
+  - `cargo test -p atmos` 通过，当前 crate 无单元测试。
+  - `cargo test -p core-service s11_supported_builtin_agent_commands_use_declared_prompt_strategies` 通过；存在既有 `resolve_interactive_automation_agent` dead code warning。
+  - `bash -n install-local-web-runtime.sh` 通过。
+  - `node --check packages/local-installer/bin/atmos-local.mjs && node --check marketing/creative/projects/atmos-intro/hyperframes/scripts/sync-runtime-assets.mjs && node --check .agents/skills/atmos-video-gen/scripts/scaffold-atmos-video-project.mjs` 通过。
+  - `git diff --check` 通过。
+- 剩余风险：`ChangesCodeView.tsx` 仍有 582 行，后续若继续扩展 diff loading、导航或 toolbar 行为，建议再拆出加载/导航 hook；本次 PR 只修复昨天新增 prompt stash 导致的职责膨胀。
+
+## 10. 结果文件
+
+本次结果文件路径：`automations/review/quality/result/2026-06/06-23_score-88_RESULT.md`
+
+## 11. 结果提交与推送
+
+- 结果文件随修复 PR 分支 `codex/quality-fix/2026-06-22-0807` 推送到 `origin`。
+- 修复代码提交 hash：`e7a967d6`
+- PR URL：https://github.com/AruNi-01/atmos/pull/130
+- 结果文件提交 hash：本文件提交后由最终回复记录。


### PR DESCRIPTION
## Summary

- Original daily quality score: 88/100 for the 2026-06-22 UTC+8 main-branch review window.
- Extracted diff prompt stashing state and UI from `ChangesCodeView.tsx` into a feature-local hook.
- Synchronized the `atmos-desktop` entry in `Cargo.lock` with the 1.2.0-beta.16 release bump.
- Kept the existing diff header renderer behavior while avoiding React ref lint issues in the changed component.

## Related Issue

N/A - daily quality automation follow-up.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [x] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] Additional checks (describe below)

Additional checks:
- `bun --filter web lint -- src/features/diff/components/ChangesCodeView.tsx src/features/diff/components/useDiffPromptStash.tsx src/features/diff/lib/code-view-ui.tsx`
- `bun --filter web typecheck`
- `bun test apps/web/src/features/wiki/components/__tests__/agent-select.test.ts`
- `cargo test -p atmos`
- `cargo test -p core-service s11_supported_builtin_agent_commands_use_declared_prompt_strategies`
- `bash -n install-local-web-runtime.sh`
- `node --check packages/local-installer/bin/atmos-local.mjs && node --check marketing/creative/projects/atmos-intro/hyperframes/scripts/sync-runtime-assets.mjs && node --check .agents/skills/atmos-video-gen/scripts/scaffold-atmos-video-project.mjs`
- `git diff --check`

## Checklist

- [x] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

## Quality Findings Addressed

- `7feb4da4` put prompt stash state, annotation mutation, prompt construction, and toolbar chip rendering into `apps/web/src/features/diff/components/ChangesCodeView.tsx`, pushing the component to 964 lines and mixing interaction state with diff loading/navigation.
- `6bb8aa5a` bumped `apps/desktop/src-tauri/Cargo.toml` to 1.2.0-beta.16 without updating the corresponding `Cargo.lock` package entry.

## Remaining Risk

- `ChangesCodeView.tsx` is still moderately large because it owns incremental diff loading and navigation. This PR removes the new prompt-stash responsibility without broadening into a larger diff-view refactor.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted prompt-stash logic into `useDiffPromptStash` and centralized diff header rendering to reduce `ChangesCodeView` size. Also fixed copy-failure behavior to keep stashed prompts, synced `Cargo.lock` to `atmos-desktop` 1.2.0-beta.16, and added the 2026-06-23 quality review doc.

- **Refactors**
  - Moved prompt-stash state, actions, and annotation UI to `useDiffPromptStash`.
  - Centralized header prefix via `renderDiffHeaderPrefix` in `code-view-ui` to fix ref/lint warnings.
  - Trimmed ~400 lines from `ChangesCodeView.tsx`; diff loading/navigation unchanged.

- **Bug Fixes**
  - Keep stashed prompts on clipboard copy failure; only clear on successful copy.

<sup>Written for commit 943b8881f68428f3bf7840d26380d0a7afa3844d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

