### PR TITLE
refactor: address daily quality findings for 2026-06-25

### DIFF
--- a/apps/api/src/api/system/cli.rs
+++ b/apps/api/src/api/system/cli.rs
@@ -90,7 +90,7 @@ pub async fn install_cli(
 
     Ok(Json(ApiResponse::success(CliInstallResponse {
         success: true,
-        version: install.version,
+        version: Some(install.version),
         message,
         path_modified: Some(path_modified),
         path_modified_file,

--- a/apps/api/src/api/system/diagnostics.rs
+++ b/apps/api/src/api/system/diagnostics.rs
@@ -105,7 +105,7 @@ pub fn get_pty_process_summary() -> Vec<Value> {
                 .into_iter()
                 .map(|(cmd, devices)| (cmd, devices.len() as u32))
                 .collect();
-            sorted.sort_by(|a, b| b.1.cmp(&a.1));
+            sorted.sort_by_key(|item| std::cmp::Reverse(item.1));
             sorted.truncate(10);
 
             sorted

--- a/apps/api/src/api/system/diagnostics.rs
+++ b/apps/api/src/api/system/diagnostics.rs
@@ -167,18 +167,6 @@ pub fn get_orphaned_processes() -> Vec<Value> {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::normalized_shell_basename;
-
-    #[test]
-    fn normalizes_login_shell_basenames() {
-        assert_eq!(normalized_shell_basename("-bash --login"), "bash");
-        assert_eq!(normalized_shell_basename("/bin/-zsh -l"), "zsh");
-        assert_eq!(normalized_shell_basename("/usr/bin/fish"), "fish");
-    }
-}
-
 /// Gather tmux server information (socket, PID, uptime, total sessions/windows).
 pub fn get_tmux_server_info(tmux_engine: &core_engine::TmuxEngine) -> Value {
     let socket_path = tmux_engine.socket_file_path();
@@ -330,5 +318,17 @@ pub fn get_pty_device_details() -> Vec<Value> {
             warn!("Failed to get PTY device details: {}", e);
             vec![]
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalized_shell_basename;
+
+    #[test]
+    fn normalizes_login_shell_basenames() {
+        assert_eq!(normalized_shell_basename("-bash --login"), "bash");
+        assert_eq!(normalized_shell_basename("/bin/-zsh -l"), "zsh");
+        assert_eq!(normalized_shell_basename("/usr/bin/fish"), "fish");
     }
 }

--- a/apps/api/src/api/ws/router/github.rs
+++ b/apps/api/src/api/ws/router/github.rs
@@ -45,11 +45,13 @@ impl WsMessageService {
             .list_issues(
                 &req.owner,
                 &req.repo,
-                &req.state,
-                req.limit,
-                &req.sort,
-                &req.direction,
-                req.search.as_deref(),
+                core_engine::github::GithubIssueListOptions {
+                    state: &req.state,
+                    limit: req.limit,
+                    sort: &req.sort,
+                    direction: &req.direction,
+                    search: req.search.as_deref(),
+                },
             )
             .await
             .map_err(|error| {

--- a/apps/api/src/api/ws/router/local_model.rs
+++ b/apps/api/src/api/ws/router/local_model.rs
@@ -233,8 +233,8 @@ impl WsMessageService {
             .stop()
             .await
             .map_err(|e| ServiceError::Processing(e.to_string()))?;
-        if let Some(ref mgr) = ws_manager {
-            let state_json = serde_json::to_value(&manager.state()).unwrap_or(json!(null));
+        if let Some(mgr) = ws_manager {
+            let state_json = serde_json::to_value(manager.state()).unwrap_or(json!(null));
             let notification = WsMessage::notification(
                 WsEvent::LocalModelStateChanged,
                 json!({ "state": state_json }),
@@ -259,8 +259,8 @@ impl WsMessageService {
             tracing::warn!("[LocalModel] failed to delete provider config: {e}");
         }
 
-        if let Some(ref mgr) = self.ws_manager.get() {
-            let state_json = serde_json::to_value(&manager.state()).unwrap_or(json!(null));
+        if let Some(mgr) = self.ws_manager.get() {
+            let state_json = serde_json::to_value(manager.state()).unwrap_or(json!(null));
             let notification = WsMessage::notification(
                 WsEvent::LocalModelStateChanged,
                 json!({ "state": state_json }),
@@ -280,8 +280,8 @@ impl WsMessageService {
             .delete_runtime()
             .await
             .map_err(|e| ServiceError::Processing(e.to_string()))?;
-        if let Some(ref mgr) = self.ws_manager.get() {
-            let state_json = serde_json::to_value(&manager.state()).unwrap_or(json!(null));
+        if let Some(mgr) = self.ws_manager.get() {
+            let state_json = serde_json::to_value(manager.state()).unwrap_or(json!(null));
             let notification = WsMessage::notification(
                 WsEvent::LocalModelStateChanged,
                 json!({ "state": state_json }),
@@ -316,11 +316,12 @@ impl WsMessageService {
         let resolved = resolve_hf_model_url(&http, &req.url).await.map_err(|e| {
             ServiceError::Processing(format!("Failed to resolve Hugging Face URL: {e}"))
         })?;
-        let HfResolveResult::Model { mut model } = resolved else {
+        let HfResolveResult::Model { model } = resolved else {
             return Err(ServiceError::Validation(
                 "Choose a specific GGUF file before adding the custom model".to_string(),
             ));
         };
+        let mut model = *model;
 
         if let Some(display_name) = req
             .display_name

--- a/apps/api/src/api/ws/router/mod.rs
+++ b/apps/api/src/api/ws/router/mod.rs
@@ -66,6 +66,7 @@ pub struct WsMessageService {
 }
 
 impl WsMessageService {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         project_service: Arc<ProjectService>,
         workspace_service: Arc<WorkspaceService>,

--- a/apps/api/src/api/ws/router/support.rs
+++ b/apps/api/src/api/ws/router/support.rs
@@ -59,20 +59,11 @@ pub(super) fn function_settings_path() -> std::path::PathBuf {
 }
 
 /// Workspace deletion settings read from function_settings.json.
+#[derive(Default)]
 pub(super) struct WorkspaceDeleteSettings {
     pub(super) close_pr_on_delete: bool,
     pub(super) close_issue_on_delete: bool,
     pub(super) delete_remote_branch: bool,
-}
-
-impl Default for WorkspaceDeleteSettings {
-    fn default() -> Self {
-        Self {
-            close_pr_on_delete: false,
-            close_issue_on_delete: false,
-            delete_remote_branch: false,
-        }
-    }
 }
 
 impl WorkspaceDeleteSettings {

--- a/apps/api/src/api/ws/router/workspace.rs
+++ b/apps/api/src/api/ws/router/workspace.rs
@@ -69,7 +69,7 @@ impl WsMessageService {
                 );
             }
 
-            return Err(error.into());
+            return Err(error);
         }
 
         if !req.attachments.is_empty() {
@@ -241,13 +241,15 @@ impl WsMessageService {
             let workspace = self
                 .workspace_service
                 .create_issue_only_workspace(
-                    req.project_guid.clone(),
-                    Some(issue.title.clone()),
-                    issue.url.clone(),
-                    issue_data,
-                    req.workflow_status.clone(),
-                    req.priority.clone(),
-                    Some(label_guids),
+                    core_service::service::workspace::CreateIssueOnlyWorkspaceInput {
+                        project_guid: req.project_guid.clone(),
+                        display_name: Some(issue.title.clone()),
+                        github_issue_url: issue.url.clone(),
+                        github_issue_data: issue_data,
+                        workflow_status: req.workflow_status.clone(),
+                        priority: req.priority.clone(),
+                        labels: Some(label_guids),
+                    },
                 )
                 .await?;
 

--- a/apps/api/src/api/ws/router/workspace_setup.rs
+++ b/apps/api/src/api/ws/router/workspace_setup.rs
@@ -166,6 +166,7 @@ impl WsMessageService {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn send_setup_failure(
         manager: &Arc<WsManager>,
         conn_id: &str,

--- a/apps/api/src/api/ws/terminal_handler.rs
+++ b/apps/api/src/api/ws/terminal_handler.rs
@@ -59,6 +59,7 @@ pub struct TerminalWsQuery {
 /// Terminal message from client
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[allow(clippy::enum_variant_names)]
 enum ClientTerminalMessage {
     TerminalCreate {
         #[allow(dead_code)]

--- a/apps/api/src/relay/ingest.rs
+++ b/apps/api/src/relay/ingest.rs
@@ -199,7 +199,7 @@ pub async fn run(
         interval.tick().await;
         loop {
             interval.tick().await;
-            if ping_tx.send(Message::Ping(Vec::new().into())).is_err() {
+            if ping_tx.send(Message::Ping(Vec::new())).is_err() {
                 break;
             }
         }
@@ -259,7 +259,7 @@ pub async fn run(
                             "body": response_body,
                         })
                         .to_string();
-                        if let Err(error) = relay_out.send(Message::Text(outbound.into())) {
+                        if let Err(error) = relay_out.send(Message::Text(outbound)) {
                             warn!(
                                 target: "atmos_relay",
                                 error = %error,
@@ -299,7 +299,7 @@ pub async fn run(
                             "body": ack_body,
                         })
                         .to_string();
-                        if let Err(error) = relay_out.send(Message::Text(outbound.into())) {
+                        if let Err(error) = relay_out.send(Message::Text(outbound)) {
                             warn!(
                                 target: "atmos_relay",
                                 error = %error,
@@ -376,7 +376,7 @@ pub async fn run(
                         "body": reply,
                     })
                     .to_string();
-                    let _ = out_tx.send(Message::Text(outbound.into()));
+                    let _ = out_tx.send(Message::Text(outbound));
                 }
             }
             Some(Ok(Message::Ping(payload))) => {
@@ -462,7 +462,7 @@ async fn ensure_session(
                 "body": msg,
             })
             .to_string();
-            if relay_out_clone.send(Message::Text(frame.into())).is_err() {
+            if relay_out_clone.send(Message::Text(frame)).is_err() {
                 break;
             }
         }

--- a/apps/api/src/relay/terminal.rs
+++ b/apps/api/src/relay/terminal.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 
-use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
 use core_engine::GitEngine;
 use core_service::{
     AttachSessionParams, CreateSessionParams, CreateSimpleSessionParams, TerminalResponse,
 };
 use serde::{Deserialize, Serialize};
-use tokio::sync::{RwLock, mpsc};
+use tokio::sync::{mpsc, RwLock};
 use tokio_tungstenite::tungstenite::Message;
 use tracing::{debug, error, warn};
 
@@ -23,6 +23,7 @@ pub struct RelayTerminalSession {
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[allow(clippy::enum_variant_names)]
 enum RelayTerminalClientMessage {
     TerminalOpen {
         session_id: String,
@@ -424,7 +425,7 @@ fn send_terminal_response_to_sid<T: Serialize>(
         "body": body,
     })
     .to_string();
-    let _ = relay_out.send(Message::Text(outbound.into()));
+    let _ = relay_out.send(Message::Text(outbound));
 }
 
 fn relay_terminal_output(session_id: &str, data: &[u8]) -> RelayTerminalServerMessage {

--- a/apps/cli/src/commands/runtime.rs
+++ b/apps/cli/src/commands/runtime.rs
@@ -84,6 +84,5 @@ async fn stop(args: StopArgs) -> Result<Value, String> {
 
 async fn status() -> Result<Value, String> {
     let status = runtime_manager::supervisor::runtime_status().await?;
-    Ok(serde_json::to_value(status)
-        .map_err(|e| format!("Failed to serialize runtime status: {e}"))?)
+    serde_json::to_value(status).map_err(|e| format!("Failed to serialize runtime status: {e}"))
 }

--- a/apps/cli/src/commands/update.rs
+++ b/apps/cli/src/commands/update.rs
@@ -1,20 +1,13 @@
 use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use clap::Args;
+use runtime_manager::{fetch_latest_cli_release, install_latest_cli, version_gt, LatestCliRelease};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-const GITHUB_RELEASES_URL: &str = "https://api.github.com/repos/AruNi-01/atmos/releases";
-const GITHUB_RELEASES_ATOM_URL: &str = "https://github.com/AruNi-01/atmos/releases.atom";
-const GITHUB_TAGS_ATOM_URL: &str = "https://github.com/AruNi-01/atmos/tags.atom";
-const ATMOS_DOWNLOAD_BASE_URL: &str = "https://install.atmos.land";
-const UPDATE_MANIFEST_ENV: &str = "ATMOS_CLI_UPDATE_MANIFEST_URL";
-const CLI_RELEASE_TAG_PREFIX: &str = "cli-v";
-const ALT_CLI_RELEASE_TAG_PREFIX: &str = "atmos-cli-v";
 const CHECK_INTERVAL_HOURS: i64 = 24;
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -25,55 +18,12 @@ pub struct UpdateArgs {
     pub check: bool,
 }
 
-#[derive(Debug, Clone, Deserialize)]
-struct GithubRelease {
-    tag_name: String,
-    html_url: String,
-    draft: bool,
-    prerelease: bool,
-    #[serde(default)]
-    assets: Vec<GithubAsset>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct GithubAsset {
-    name: String,
-    browser_download_url: String,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct CliUpdateManifest {
-    version: Option<String>,
-    tag: String,
-    #[serde(default)]
-    release_url: Option<String>,
-    #[serde(default)]
-    assets: Vec<CliUpdateManifestAsset>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct CliUpdateManifestAsset {
-    name: String,
-    #[serde(default)]
-    target: Option<String>,
-    #[serde(default)]
-    url: Option<String>,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct UpdateCheckCache {
     checked_at: String,
     latest_version: String,
     latest_tag: String,
     release_url: String,
-}
-
-#[derive(Debug, Clone)]
-struct LatestRelease {
-    version: String,
-    tag: String,
-    url: String,
-    asset_url: Option<String>,
 }
 
 pub async fn execute(args: UpdateArgs) -> Result<Value, String> {
@@ -103,15 +53,7 @@ pub async fn execute(args: UpdateArgs) -> Result<Value, String> {
         }));
     }
 
-    let installed_path = installed_cli_path()?;
-    let install_method = if let Some(asset_url) = latest.asset_url {
-        let target = current_target_triple()?;
-        download_and_install_cli(&asset_url, &target, &installed_path).await?;
-        "release_asset"
-    } else {
-        install_from_git().await?;
-        "cargo_install_git"
-    };
+    let install = install_latest_cli().await?;
 
     Ok(json!({
         "ok": true,
@@ -119,8 +61,8 @@ pub async fn execute(args: UpdateArgs) -> Result<Value, String> {
         "from_version": CURRENT_VERSION,
         "to_version": latest.version,
         "latest_tag": latest.tag,
-        "installed_path": installed_path.to_string_lossy(),
-        "install_method": install_method,
+        "installed_path": install.install_path.to_string_lossy(),
+        "install_method": "release_asset",
     }))
 }
 
@@ -130,7 +72,7 @@ pub async fn update_hint_if_needed() -> Option<String> {
     }
 
     let latest = match read_fresh_update_cache() {
-        Some(cache) => LatestRelease {
+        Some(cache) => LatestCliRelease {
             version: cache.latest_version,
             tag: cache.latest_tag,
             url: cache.release_url,
@@ -156,404 +98,6 @@ pub async fn update_hint_if_needed() -> Option<String> {
     ))
 }
 
-async fn fetch_latest_cli_release() -> Result<LatestRelease, String> {
-    match fetch_latest_cli_release_from_manifest().await {
-        Ok(release) => Ok(release),
-        Err(manifest_error) => match fetch_latest_cli_release_from_api().await {
-            Ok(release) => Ok(release),
-            Err(api_error) => match fetch_latest_cli_release_from_atom(GITHUB_RELEASES_ATOM_URL)
-                .await
-            {
-                Ok(release) => Ok(release),
-                Err(releases_atom_error) => fetch_latest_cli_release_from_atom(GITHUB_TAGS_ATOM_URL)
-                    .await
-                    .map_err(|tags_atom_error| {
-                        format!(
-                            "{}; GitHub API fallback failed: {}; releases feed fallback failed: {}; tags feed fallback failed: {}",
-                            manifest_error, api_error, releases_atom_error, tags_atom_error
-                        )
-                    }),
-            },
-        },
-    }
-}
-
-async fn fetch_latest_cli_release_from_manifest() -> Result<LatestRelease, String> {
-    let manifest_url = update_manifest_url();
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(10))
-        .user_agent("atmos-cli")
-        .build()
-        .map_err(|error| format!("Failed to create HTTP client: {}", error))?;
-    let manifest = client
-        .get(&manifest_url)
-        .send()
-        .await
-        .map_err(|error| format!("Failed to check Atmos update manifest: {}", error))?
-        .error_for_status()
-        .map_err(|error| format!("Failed to check Atmos update manifest: {}", error))?
-        .json::<CliUpdateManifest>()
-        .await
-        .map_err(|error| format!("Failed to parse Atmos update manifest: {}", error))?;
-
-    latest_release_from_manifest(manifest)
-}
-
-async fn fetch_latest_cli_release_from_api() -> Result<LatestRelease, String> {
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(10))
-        .user_agent("atmos-cli")
-        .build()
-        .map_err(|error| format!("Failed to create HTTP client: {}", error))?;
-    let releases = client
-        .get(format!("{}?per_page=100", GITHUB_RELEASES_URL))
-        .send()
-        .await
-        .map_err(|error| format!("Failed to check Atmos releases: {}", error))?
-        .error_for_status()
-        .map_err(|error| format!("Failed to check Atmos releases: {}", error))?
-        .json::<Vec<GithubRelease>>()
-        .await
-        .map_err(|error| format!("Failed to parse Atmos releases: {}", error))?;
-
-    let target = current_target_triple().ok();
-    releases
-        .into_iter()
-        .find(|release| {
-            !release.draft && !release.prerelease && is_cli_release_tag(&release.tag_name)
-        })
-        .map(|release| {
-            let asset_url = target.as_ref().and_then(|target| {
-                release
-                    .assets
-                    .iter()
-                    .find(|asset| is_cli_asset_for_target(&asset.name, target))
-                    .map(|asset| asset.browser_download_url.clone())
-            });
-            LatestRelease {
-                version: release_version(&release.tag_name),
-                tag: release.tag_name,
-                url: release.html_url,
-                asset_url,
-            }
-        })
-        .ok_or_else(|| "No published Atmos CLI release was found".to_string())
-}
-
-async fn fetch_latest_cli_release_from_atom(feed_url: &str) -> Result<LatestRelease, String> {
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(10))
-        .user_agent("atmos-cli")
-        .build()
-        .map_err(|error| format!("Failed to create HTTP client: {}", error))?;
-    let feed = client
-        .get(feed_url)
-        .send()
-        .await
-        .map_err(|error| format!("Failed to check Atmos releases feed: {}", error))?
-        .error_for_status()
-        .map_err(|error| format!("Failed to check Atmos releases feed: {}", error))?
-        .text()
-        .await
-        .map_err(|error| format!("Failed to read Atmos releases feed: {}", error))?;
-    let tag = find_latest_cli_tag_in_atom(&feed)
-        .ok_or_else(|| "No cli-v release was found in Atmos releases feed".to_string())?;
-    Ok(LatestRelease {
-        version: release_version(&tag),
-        url: format!("https://github.com/AruNi-01/atmos/releases/tag/{}", tag),
-        tag,
-        asset_url: None,
-    })
-}
-
-async fn download_and_install_cli(
-    asset_url: &str,
-    target: &str,
-    installed_path: &Path,
-) -> Result<(), String> {
-    ensure_https_download_url(asset_url)?;
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(120))
-        .user_agent("atmos-cli")
-        .build()
-        .map_err(|error| format!("Failed to create HTTP client: {}", error))?;
-    let bytes = client
-        .get(asset_url)
-        .send()
-        .await
-        .map_err(|error| format!("Failed to download Atmos update: {}", error))?
-        .error_for_status()
-        .map_err(|error| format!("Failed to download Atmos update: {}", error))?
-        .bytes()
-        .await
-        .map_err(|error| format!("Failed to read Atmos update: {}", error))?;
-
-    let temp_root = std::env::temp_dir().join(format!(
-        "atmos-update-{}-{}",
-        std::process::id(),
-        Utc::now().timestamp_millis()
-    ));
-    fs::create_dir_all(&temp_root)
-        .map_err(|error| format!("Failed to create {}: {}", temp_root.display(), error))?;
-    let archive_path = temp_root.join("runtime.tar.gz");
-    fs::write(&archive_path, &bytes)
-        .map_err(|error| format!("Failed to write {}: {}", archive_path.display(), error))?;
-
-    let status = Command::new("tar")
-        .args(["-xzf"])
-        .arg(&archive_path)
-        .arg("-C")
-        .arg(&temp_root)
-        .status()
-        .map_err(|error| format!("Failed to run tar: {}", error))?;
-    if !status.success() {
-        return Err("Failed to extract Atmos update archive".to_string());
-    }
-
-    let source = find_extracted_cli_binary(&temp_root, target)
-        .ok_or_else(|| format!("Update archive did not contain {}", binary_name()))?;
-    if !source.is_file() {
-        return Err(format!(
-            "Update archive did not contain {}",
-            source.display()
-        ));
-    }
-
-    let parent = installed_path.parent().ok_or_else(|| {
-        format!(
-            "Cannot determine install directory for {}",
-            installed_path.display()
-        )
-    })?;
-    fs::create_dir_all(parent)
-        .map_err(|error| format!("Failed to create {}: {}", parent.display(), error))?;
-    let staged_path = installed_path.with_extension("new");
-    fs::copy(&source, &staged_path).map_err(|error| {
-        format!(
-            "Failed to copy {} to {}: {}",
-            source.display(),
-            staged_path.display(),
-            error
-        )
-    })?;
-    set_executable_if_needed(&staged_path)?;
-    fs::rename(&staged_path, installed_path).map_err(|error| {
-        format!(
-            "Failed to replace {} with {}: {}",
-            installed_path.display(),
-            staged_path.display(),
-            error
-        )
-    })?;
-    let _ = fs::remove_dir_all(&temp_root);
-    Ok(())
-}
-
-async fn install_from_git() -> Result<(), String> {
-    Err(
-        "The latest CLI release does not include a compatible binary asset for this platform."
-            .to_string(),
-    )
-}
-
-fn current_target_triple() -> Result<String, String> {
-    target_triple_for(std::env::consts::OS, std::env::consts::ARCH).map(str::to_string)
-}
-
-fn target_triple_for(os: &str, arch: &str) -> Result<&'static str, String> {
-    Ok(match (os, arch) {
-        ("macos", "aarch64") => "aarch64-apple-darwin",
-        ("macos", "x86_64") => "x86_64-apple-darwin",
-        ("linux", "aarch64") => "aarch64-unknown-linux-gnu",
-        ("linux", "x86_64") => "x86_64-unknown-linux-gnu",
-        ("windows", "x86_64") => "x86_64-pc-windows-msvc",
-        (os, arch) => {
-            return Err(format!(
-                "Atmos updates are not available for {}-{}",
-                os, arch
-            ))
-        }
-    })
-}
-
-fn installed_cli_path() -> Result<PathBuf, String> {
-    dirs::home_dir()
-        .map(|home| home.join(".atmos").join("bin").join(binary_name()))
-        .ok_or_else(|| "Cannot determine home directory".to_string())
-}
-
-fn binary_name() -> &'static str {
-    #[cfg(windows)]
-    {
-        "atmos.exe"
-    }
-    #[cfg(not(windows))]
-    {
-        "atmos"
-    }
-}
-
-fn set_executable_if_needed(path: &Path) -> Result<(), String> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-
-        let metadata = fs::metadata(path)
-            .map_err(|error| format!("Failed to stat {}: {}", path.display(), error))?;
-        let mut permissions = metadata.permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(path, permissions)
-            .map_err(|error| format!("Failed to chmod {}: {}", path.display(), error))?;
-    }
-
-    Ok(())
-}
-
-fn is_cli_asset_for_target(name: &str, target: &str) -> bool {
-    let normalized = name.to_ascii_lowercase();
-    normalized.contains("atmos")
-        && normalized.contains("cli")
-        && normalized.contains(&target.to_ascii_lowercase())
-        && (normalized.ends_with(".tar.gz") || normalized.ends_with(".tgz"))
-}
-
-fn latest_release_from_manifest(manifest: CliUpdateManifest) -> Result<LatestRelease, String> {
-    if !is_stable_cli_release_tag(&manifest.tag) {
-        return Err(format!(
-            "Atmos update manifest does not describe a stable CLI release: {}",
-            manifest.tag
-        ));
-    }
-
-    let target = current_target_triple().ok();
-    let asset_url = if let Some(target) = target.as_ref() {
-        manifest
-            .assets
-            .iter()
-            .find(|asset| {
-                asset.target.as_deref() == Some(target)
-                    || is_cli_asset_for_target(&asset.name, target)
-            })
-            .map(|asset| manifest_asset_url(asset, &manifest.tag))
-            .transpose()?
-    } else {
-        None
-    };
-
-    Ok(LatestRelease {
-        version: manifest
-            .version
-            .unwrap_or_else(|| release_version(&manifest.tag)),
-        tag: manifest.tag.clone(),
-        url: manifest.release_url.unwrap_or_else(|| {
-            format!(
-                "https://github.com/AruNi-01/atmos/releases/tag/{}",
-                manifest.tag
-            )
-        }),
-        asset_url,
-    })
-}
-
-fn manifest_asset_url(asset: &CliUpdateManifestAsset, tag: &str) -> Result<String, String> {
-    manifest_asset_url_with_base(asset, tag, &download_base_url())
-}
-
-fn manifest_asset_url_with_base(
-    asset: &CliUpdateManifestAsset,
-    tag: &str,
-    base: &str,
-) -> Result<String, String> {
-    if let Some(url) = asset
-        .url
-        .as_ref()
-        .map(|value| value.trim())
-        .filter(|value| !value.is_empty())
-    {
-        if is_absolute_url(url) {
-            ensure_https_download_url(url)?;
-            return Ok(url.to_string());
-        }
-        let resolved = if url.starts_with('/') {
-            format!("{}{}", base.trim_end_matches('/'), url)
-        } else {
-            format!("{}/{}", base.trim_end_matches('/'), url)
-        };
-        ensure_https_download_url(&resolved)?;
-        return Ok(resolved);
-    }
-    let resolved = format!("{}/cli/{}/{}", base.trim_end_matches('/'), tag, asset.name);
-    ensure_https_download_url(&resolved)?;
-    Ok(resolved)
-}
-
-fn update_manifest_url() -> String {
-    std::env::var(UPDATE_MANIFEST_ENV)
-        .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| format!("{}/cli/latest.json", download_base_url()))
-}
-
-fn download_base_url() -> String {
-    std::env::var("ATMOS_DOWNLOAD_BASE_URL")
-        .ok()
-        .map(|value| value.trim_end_matches('/').to_string())
-        .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| ATMOS_DOWNLOAD_BASE_URL.to_string())
-}
-
-fn is_absolute_url(value: &str) -> bool {
-    value.contains("://")
-}
-
-fn ensure_https_download_url(url: &str) -> Result<(), String> {
-    if url
-        .get(..8)
-        .is_some_and(|scheme| scheme.eq_ignore_ascii_case("https://"))
-    {
-        return Ok(());
-    }
-    Err(format!("Atmos CLI asset downloads must use HTTPS: {}", url))
-}
-
-fn find_extracted_cli_binary(root: &Path, target: &str) -> Option<PathBuf> {
-    let direct_candidates = [
-        root.join(binary_name()),
-        root.join("bin").join(binary_name()),
-        root.join(format!("atmos-cli-{}", target))
-            .join(binary_name()),
-        root.join(format!("atmos-cli-{}", target))
-            .join("bin")
-            .join(binary_name()),
-    ];
-    for candidate in direct_candidates {
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    find_file_named(root, binary_name(), 4)
-}
-
-fn find_file_named(dir: &Path, file_name: &str, depth: usize) -> Option<PathBuf> {
-    if depth == 0 {
-        return None;
-    }
-    let entries = fs::read_dir(dir).ok()?;
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_file() && path.file_name().and_then(|name| name.to_str()) == Some(file_name) {
-            return Some(path);
-        }
-        if path.is_dir() {
-            if let Some(found) = find_file_named(&path, file_name, depth - 1) {
-                return Some(found);
-            }
-        }
-    }
-    None
-}
-
 fn cache_path() -> Option<PathBuf> {
     dirs::home_dir().map(|home| home.join(".atmos").join("cli").join("update-check.json"))
 }
@@ -571,7 +115,7 @@ fn read_fresh_update_cache() -> Option<UpdateCheckCache> {
     None
 }
 
-fn write_update_cache(latest: &LatestRelease) {
+fn write_update_cache(latest: &LatestCliRelease) {
     let Some(path) = cache_path() else {
         return;
     };
@@ -591,139 +135,4 @@ fn write_update_cache(latest: &LatestRelease) {
         return;
     };
     let _ = fs::write(path, content);
-}
-
-fn release_version(tag: &str) -> String {
-    tag.strip_prefix(CLI_RELEASE_TAG_PREFIX)
-        .or_else(|| tag.strip_prefix(ALT_CLI_RELEASE_TAG_PREFIX))
-        .or_else(|| tag.strip_prefix('v'))
-        .unwrap_or(tag)
-        .to_string()
-}
-
-fn is_cli_release_tag(tag: &str) -> bool {
-    tag.starts_with(CLI_RELEASE_TAG_PREFIX) || tag.starts_with(ALT_CLI_RELEASE_TAG_PREFIX)
-}
-
-fn is_stable_cli_release_tag(tag: &str) -> bool {
-    if !is_cli_release_tag(tag) {
-        return false;
-    }
-    let version = release_version(tag);
-    !version.contains('-')
-}
-
-fn find_latest_cli_tag_in_atom(feed: &str) -> Option<String> {
-    for entry in feed.split("<entry").skip(1) {
-        if let Some(tag) = extract_between(entry, "/releases/tag/", "\"")
-            .or_else(|| extract_between(entry, "<title>", "</title>"))
-        {
-            let tag = tag.trim().to_string();
-            if is_stable_cli_release_tag(&tag) {
-                return Some(tag);
-            }
-        }
-    }
-    None
-}
-
-fn extract_between(value: &str, start: &str, end: &str) -> Option<String> {
-    let start_index = value.find(start)? + start.len();
-    let rest = &value[start_index..];
-    let end_index = rest.find(end)?;
-    Some(rest[..end_index].to_string())
-}
-
-fn version_gt(candidate: &str, current: &str) -> bool {
-    let candidate_parts = version_parts(candidate);
-    let current_parts = version_parts(current);
-    for index in 0..candidate_parts.len().max(current_parts.len()) {
-        let candidate_part = *candidate_parts.get(index).unwrap_or(&0);
-        let current_part = *current_parts.get(index).unwrap_or(&0);
-        if candidate_part != current_part {
-            return candidate_part > current_part;
-        }
-    }
-    false
-}
-
-fn version_parts(version: &str) -> Vec<u64> {
-    version
-        .split(['+', '-'])
-        .next()
-        .unwrap_or(version)
-        .split('.')
-        .map(|part| part.parse::<u64>().unwrap_or(0))
-        .collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn manifest_asset_url_resolves_relative_paths() {
-        let asset = CliUpdateManifestAsset {
-            name: "atmos-cli-aarch64-apple-darwin.tar.gz".to_string(),
-            target: Some("aarch64-apple-darwin".to_string()),
-            url: Some("cli/cli-v0.2.1/atmos-cli-aarch64-apple-darwin.tar.gz".to_string()),
-        };
-
-        assert_eq!(
-            manifest_asset_url_with_base(&asset, "cli-v0.2.1", "https://install.atmos.land")
-                .unwrap(),
-            "https://install.atmos.land/cli/cli-v0.2.1/atmos-cli-aarch64-apple-darwin.tar.gz"
-        );
-    }
-
-    #[test]
-    fn manifest_without_asset_url_uses_tag_path() {
-        let asset = CliUpdateManifestAsset {
-            name: "atmos-cli-x86_64-unknown-linux-gnu.tar.gz".to_string(),
-            target: Some("x86_64-unknown-linux-gnu".to_string()),
-            url: None,
-        };
-
-        assert_eq!(
-            manifest_asset_url_with_base(&asset, "cli-v0.2.1", "https://install.atmos.land")
-                .unwrap(),
-            "https://install.atmos.land/cli/cli-v0.2.1/atmos-cli-x86_64-unknown-linux-gnu.tar.gz"
-        );
-    }
-
-    #[test]
-    fn manifest_asset_url_rejects_insecure_http_urls() {
-        let asset = CliUpdateManifestAsset {
-            name: "atmos-cli-x86_64-unknown-linux-gnu.tar.gz".to_string(),
-            target: Some("x86_64-unknown-linux-gnu".to_string()),
-            url: Some("http://example.com/atmos-cli-x86_64-unknown-linux-gnu.tar.gz".to_string()),
-        };
-
-        assert!(
-            manifest_asset_url_with_base(&asset, "cli-v0.2.1", "https://install.atmos.land")
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn manifest_asset_url_rejects_insecure_relative_base() {
-        let asset = CliUpdateManifestAsset {
-            name: "atmos-cli-x86_64-unknown-linux-gnu.tar.gz".to_string(),
-            target: Some("x86_64-unknown-linux-gnu".to_string()),
-            url: Some("cli/cli-v0.2.1/atmos-cli-x86_64-unknown-linux-gnu.tar.gz".to_string()),
-        };
-
-        assert!(
-            manifest_asset_url_with_base(&asset, "cli-v0.2.1", "http://install.atmos.land")
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn linux_aarch64_target_is_supported() {
-        assert_eq!(
-            target_triple_for("linux", "aarch64").unwrap(),
-            "aarch64-unknown-linux-gnu"
-        );
-    }
 }

--- a/apps/cli/src/commands/update.rs
+++ b/apps/cli/src/commands/update.rs
@@ -4,7 +4,9 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use clap::Args;
-use runtime_manager::{fetch_latest_cli_release, install_latest_cli, version_gt, LatestCliRelease};
+use runtime_manager::{
+    fetch_latest_cli_release, install_cli_release, version_gt, LatestCliRelease,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
@@ -53,16 +55,16 @@ pub async fn execute(args: UpdateArgs) -> Result<Value, String> {
         }));
     }
 
-    let install = install_latest_cli().await?;
+    let install = install_cli_release(&latest).await?;
 
     Ok(json!({
         "ok": true,
         "action": "updated",
         "from_version": CURRENT_VERSION,
-        "to_version": latest.version,
+        "to_version": install.version,
         "latest_tag": latest.tag,
         "installed_path": install.install_path.to_string_lossy(),
-        "install_method": "release_asset",
+        "install_method": install.install_method,
     }))
 }
 

--- a/automations/review/quality/result/2026-06/06-25_score-88_RESULT.md
+++ b/automations/review/quality/result/2026-06/06-25_score-88_RESULT.md
@@ -1,0 +1,116 @@
+# Atmos main 每日代码质量评分 - 2026-06-25
+
+## 1. 审查范围
+
+- 审查时间窗口：2026-06-24 00:00:00 +0800 至 2026-06-24 23:59:59 +0800。
+- 审查分支：`main`。
+- 已排除纯 automation 结果归档提交：`32d7efb7 docs: add code quality review result 2026-06-24 score 88`。
+- 说明：`2341fc59` 是 merge commit；其合入的真实代码改动已通过对应子提交纳入审查，不重复计分。
+
+被审查提交：
+
+| Commit | Author | Message |
+| --- | --- | --- |
+| `86e2054b` | AarynLu | `refactor: move cli update logic into runtime manager` |
+| `58b99192` | AarynLu | `fix: harden cli updater asset selection` |
+| `2341fc59` | AruNi_Lu | `Merge pull request #131 from AruNi-01/codex/quality-fix/2026-06-24` |
+| `0a1ae42e` | AarynLu | `Add multi-value GitHub trigger filters` |
+| `c6fb9af2` | AarynLu | `feat: harden relay automation limits` |
+| `ee4d6528` | AarynLu | `chore: publish local runtime under atmos-land scope` |
+| `ef4b891c` | AarynLu | `chore: remove local runtime npm installer` |
+| `f7b82b87` | AarynLu | `Handle manual-only desktop updates with GitHub links` |
+
+## 2. 一份好代码应该是什么样
+
+本次采用的质量标准是：代码应放在自然归属层里，主机/runtime 能力不应散落在多个调用端；跨语言协议和策略可以重复适配，但核心规则要尽量有单一来源或至少有清楚的同步边界。复杂功能可以有较大体量，但文件职责要内聚，维护者应能快速判断哪里负责 release 解析、哪里负责 UI 输入、哪里负责 Relay 策略。
+
+## 3. 评分方法
+
+- 100 分制。
+- 设计与分层 30 分：职责边界、模块耦合、分层方向、抽象是否贴合。
+- 可读性与复杂度 25 分：控制流、状态管理、分支复杂度、理解成本。
+- 体量与内聚 20 分：文件、函数、组件体量是否与职责匹配。
+- 可维护性与复用 15 分：重复逻辑、共享规则、配置和协议是否集中管理。
+- 工程卫生 10 分：命名、注释、错误处理、日志、调试残留、锁文件和 release 元数据一致性。
+- 高严重度问题通常单项扣 8-15 分；中严重度问题扣 3-7 分；低严重度问题扣 1-2 分。体量阈值只作为信号，只有体量超出且职责确实变差时扣分。
+
+## 4. 总分
+
+**88 / 100。总体判断：良好。**
+
+当天大部分改动都在收口边界：API 的 CLI install endpoint 被压回薄 handler，runtime-manager 承接主机安装能力，Relay 限流有 schema 和测试，local runtime release 也去掉了 npm 包装器这一条额外分发路径。但 CLI 命令侧仍保留了一份平行 updater 实现，导致同一 release discovery、asset 匹配、版本比较和安装规则同时存在于 `apps/cli` 与 `crates/runtime-manager`；GitHub trigger 策略也在 Rust、Relay TypeScript 和 UI option list 中继续重复维护。因此低于 90 并触发自动修复。
+
+## 5. 分项评分
+
+| 维度 | 得分 | 扣分原因 |
+| --- | ---: | --- |
+| 设计与分层 | 26 / 30 | `86e2054b` 正确把 API 中的 CLI install 能力下沉到 `runtime-manager`，但 `58b99192` 之后 `apps/cli/src/commands/update.rs` 仍维护平行 release/update 能力，没有复用共享模块。 |
+| 可读性与复杂度 | 22 / 25 | CLI update 文件在当天仍有 729 行，混合命令输出、缓存、manifest 解析、GitHub fallback、Atom fallback、tar 解包、递归找二进制和 version compare；GitHub trigger 的多值输入也让多个大文件继续增长。 |
+| 体量与内聚 | 18 / 20 | `apps/cli/src/commands/update.rs`、`crates/runtime-manager/src/cli_update.rs` 分别承载相近能力；`packages/relay/src/event-routes.ts` 和 `crates/core-service/src/service/automation/github_trigger.rs` 已超过 1000 行，但本次新增仍基本围绕同一领域。 |
+| 可维护性与复用 | 13 / 15 | CLI updater 规则和 GitHub trigger policy 都需要跨文件手动保持一致；尤其 CLI updater 已经有共享归属层却仍复制实现，未来 release 命名或 target alias 变化容易分叉。 |
+| 工程卫生 | 9 / 10 | 未发现 token/secret 泄露或明显调试残留；release 文档和 workflow 大体同步，但 updater/GitHub policy 的重复测试位置增加了维护成本。 |
+
+## 6. 主要问题清单
+
+### 高：CLI updater 共享能力存在后，CLI 仍保留平行实现
+
+- 提交：`86e2054b refactor: move cli update logic into runtime manager`、`58b99192 fix: harden cli updater asset selection`
+- 文件：`apps/cli/src/commands/update.rs:159`、`apps/cli/src/commands/update.rs:412`、`apps/cli/src/commands/update.rs:420`、`apps/cli/src/commands/update.rs:637`；对照 `crates/runtime-manager/src/cli_update.rs:256`、`crates/runtime-manager/src/cli_update.rs:430`、`crates/runtime-manager/src/cli_update.rs:343`、`crates/runtime-manager/src/cli_update.rs:610`
+- 问题：同一 CLI release discovery / manifest parsing / GitHub API fallback / asset URL 解析 / target triple / version comparison / archive install 规则同时存在于 CLI command 和 runtime-manager。当天修复还需要在两边各补 HTTPS 校验、Linux aarch64 target、manifest asset URL 测试，说明规则已经进入“改一处要记得改另一处”的状态。
+- 为什么是质量问题：`runtime-manager` 已经是 local host/runtime 能力归属层，CLI 应只是命令入口和输出适配。继续在 `apps/cli` 中保留 700+ 行平行 updater 实现，会让后续 release 命名、R2 manifest、target alias、archive layout 和 version compare 的变更产生分叉风险；维护者也必须阅读两套实现才能确认 CLI/API/Desktop startup 的 updater 行为是否一致。
+- 优化建议：让 `apps/cli/src/commands/update.rs` 调用 `runtime_manager::fetch_latest_cli_release()`、`runtime_manager::install_latest_cli()` 和 `runtime_manager::version_gt()`；CLI 文件只保留 `UpdateArgs`、JSON 输出、24 小时 update hint cache。把 manifest URL、asset 选择、archive install、target alias 和版本比较测试都留在 `crates/runtime-manager/src/cli_update.rs`。
+
+### 中：GitHub trigger policy 在 Rust、Relay 和 UI 中继续重复
+
+- 提交：`0a1ae42e Add multi-value GitHub trigger filters`、`c6fb9af2 feat: harden relay automation limits`
+- 文件：`crates/core-service/src/service/automation/github_trigger.rs:594`、`packages/relay/src/event-routes.ts:849`、`apps/web/src/features/automations/components/AutomationGithubTriggerPanel.tsx:81`、`apps/web/src/features/automations/hooks/use-github-trigger-setup.ts:444`
+- 问题：issue action allowlist、push 必须指定 branch、comment 必须指定 sender、sender login 规范、comment contains 合并规则在 Rust core-service、Relay Worker 和 Web UI 中分别实现。当前测试能覆盖一部分分叉，但规则来源仍靠人工同步。
+- 为什么是质量问题：GitHub trigger 是跨 Relay 与本地 automation 的协议边界。策略重复不是纯风格问题，一旦 Relay 接受但 core-service 拒绝，或 UI 展示了某个后端不再接受的 action，用户会看到 setup 成功但运行时不触发或被本地拒绝的隐性故障。
+- 优化建议：把事件 family、action allowlist、必填 filter、branch wildcard 规则和 workflow conclusion allowlist 收敛到一个轻量 policy artifact，例如 `resources/github-triggers/policy.json`；Rust 用 `include_str!` 解析并暴露校验，Relay/Web 直接 import JSON 或通过小生成脚本产出 typed constants。短期至少增加一组跨语言 fixture，要求 Rust `GithubTriggerConfig::canonicalize` 与 Relay `validateGithubEventRoutePolicy` 对同一输入返回同类结果。
+
+## 7. 正向观察
+
+- `86e2054b` 把 `apps/api/src/api/system/cli.rs` 从 695 行以上压到薄 handler，API 层只保留 DTO 和 response mapping，方向符合 `apps/api/AGENTS.md`。
+- `crates/runtime-manager/src/cli_update.rs` 承接 standalone CLI release discovery、archive install、shell config 修改等主机能力，层次归属比 API handler 更合理。
+- `c6fb9af2` 的 Relay route limit、monthly delivery limit 和 computer app device id 都有测试，且限制常量集中在 Relay 边界。
+- `ef4b891c` 删除 local runtime npm installer，改用 `resources/local-runtime/version.json` 作为 release version source，减少一条分发路径和一组版本同步点。
+- `f7b82b87` 对 manual-only desktop prerelease update 使用显式 `manualDownloadOnly` / `releaseUrl` 状态，避免 UI 展示不可执行的 Install 按钮。
+
+## 8. Review 建议
+
+人工 review 最值得盯：
+
+1. CLI updater 是否完全通过 `runtime-manager` 共享能力执行，避免 `apps/cli` 再长出 release parsing 或 archive install 逻辑。
+2. GitHub trigger policy 的 Rust/Relay/UI 三处规则是否一致，尤其是 issue action、sender login、branch wildcard 和 comment contains 多值匹配。
+3. Relay 限流 SQL 与 migration 是否适合 D1 查询规模，`github_webhook_deliveries` 的 installation/month 索引是否覆盖实际查询。
+4. local runtime release workflow 去掉 npm 后，文档、skill、installer 和 R2 sync 是否没有残留 npm wrapper 路径。
+
+## 9. 自动修复与 PR
+
+已触发自动修复，因为总分 **88 < 90**。
+
+- 修复分支：`codex/quality-fix/2026-06-25`
+- 修复提交：`60519e7f refactor: share cli updater logic`
+- PR：https://github.com/AruNi-01/atmos/pull/136
+- 标签：已添加 `codex`；仓库中未找到 `codex-automation`，因此跳过该标签。
+- 修复内容：
+  - `apps/cli/src/commands/update.rs` 改为调用 `runtime_manager::{fetch_latest_cli_release, install_latest_cli, version_gt}`。
+  - CLI 文件只保留命令 JSON 输出和 update hint cache，从 729 行降到 140 行。
+  - 删除 CLI 内重复的 manifest schema、GitHub release fallback、Atom feed parser、asset URL resolver、target triple、archive install、binary lookup、version compare 和重复测试。
+- 验证：
+  - `cargo fmt --package atmos` 通过。
+  - `cargo test -p atmos --quiet` 通过，当前 crate 无单元测试。
+  - `cargo test -p runtime-manager --quiet` 通过，13 tests passed。
+  - `git diff --check` 通过。
+- 剩余风险：`crates/runtime-manager/src/cli_update.rs` 仍有 807 行；它现在是正确归属层，但后续若继续扩展 release 策略，建议再拆为 release discovery、archive install、shell config 三个子模块。GitHub trigger policy 重复问题未在本 PR 中修复，建议作为下一轮专项处理。
+
+## 10. 结果文件
+
+本次结果文件路径：`automations/review/quality/result/2026-06/06-25_score-88_RESULT.md`
+
+## 11. 结果提交与推送
+
+- 结果文件随修复 PR 分支 `codex/quality-fix/2026-06-25` 推送到 `origin`。
+- 修复代码提交 hash：`60519e7f`
+- PR URL：https://github.com/AruNi-01/atmos/pull/136
+- 结果文件提交 hash：本文件提交后由最终回复记录。

--- a/crates/ai-usage/src/providers/cursor.rs
+++ b/crates/ai-usage/src/providers/cursor.rs
@@ -215,7 +215,7 @@ pub(crate) async fn fetch_cursor_live(client: &Client) -> Result<LiveFetchResult
         .as_ref()
         .map(|value| {
             let is_team = value.limit_type.as_deref() == Some("team");
-            let individual_used = value.individual_used.or_else(|| {
+            let individual_used = value.individual_used.or({
                 match (value.individual_limit, value.individual_remaining) {
                     (Some(limit), Some(remaining)) => Some(limit - remaining),
                     _ => None,

--- a/crates/ai-usage/src/providers/factory/mod.rs
+++ b/crates/ai-usage/src/providers/factory/mod.rs
@@ -622,38 +622,6 @@ fn normalize_factory_timestamp(raw: i64) -> Option<u64> {
     })
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{
-        factory_bearer_from_cookie_header, filter_cookie_header, is_method_not_allowed_error,
-    };
-    use crate::models::ProviderError;
-
-    #[test]
-    fn extracts_factory_bearer_from_cookie_header() {
-        let header = "foo=bar; access-token=abc.def.ghi; session=xyz";
-        assert_eq!(
-            factory_bearer_from_cookie_header(header).as_deref(),
-            Some("abc.def.ghi")
-        );
-    }
-
-    #[test]
-    fn filters_stale_factory_cookie_names() {
-        let header = "foo=bar; access-token=abc; __recent_auth=1; session=xyz";
-        assert_eq!(
-            filter_cookie_header(header, &["access-token", "__recent_auth"]),
-            "foo=bar; session=xyz"
-        );
-    }
-
-    #[test]
-    fn detects_method_not_allowed_error() {
-        let error = ProviderError::Fetch("Factory endpoint returned 405 Method Not Allowed".into());
-        assert!(is_method_not_allowed_error(&error));
-    }
-}
-
 fn format_short_date(timestamp: u64) -> String {
     let Some(date) = time::OffsetDateTime::from_unix_timestamp(timestamp as i64).ok() else {
         return timestamp.to_string();
@@ -691,4 +659,36 @@ fn titleize(raw: String) -> String {
 
 fn is_method_not_allowed_error(error: &ProviderError) -> bool {
     error.to_string().contains("405 Method Not Allowed")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        factory_bearer_from_cookie_header, filter_cookie_header, is_method_not_allowed_error,
+    };
+    use crate::models::ProviderError;
+
+    #[test]
+    fn extracts_factory_bearer_from_cookie_header() {
+        let header = "foo=bar; access-token=abc.def.ghi; session=xyz";
+        assert_eq!(
+            factory_bearer_from_cookie_header(header).as_deref(),
+            Some("abc.def.ghi")
+        );
+    }
+
+    #[test]
+    fn filters_stale_factory_cookie_names() {
+        let header = "foo=bar; access-token=abc; __recent_auth=1; session=xyz";
+        assert_eq!(
+            filter_cookie_header(header, &["access-token", "__recent_auth"]),
+            "foo=bar; session=xyz"
+        );
+    }
+
+    #[test]
+    fn detects_method_not_allowed_error() {
+        let error = ProviderError::Fetch("Factory endpoint returned 405 Method Not Allowed".into());
+        assert!(is_method_not_allowed_error(&error));
+    }
 }

--- a/crates/core-engine/src/agent_hooks/claude_code.rs
+++ b/crates/core-engine/src/agent_hooks/claude_code.rs
@@ -211,7 +211,7 @@ pub(super) fn check() -> AgentHookToolStatus {
         .get("hooks")
         .and_then(|h| h.get("Stop"))
         .and_then(|arr| arr.as_array())
-        .map(|arr| arr.iter().any(|entry| is_atmos_hook(entry)))
+        .map(|arr| arr.iter().any(is_atmos_hook))
         .unwrap_or(false);
 
     AgentHookToolStatus {

--- a/crates/core-engine/src/agent_hooks/codex.rs
+++ b/crates/core-engine/src/agent_hooks/codex.rs
@@ -192,7 +192,7 @@ pub(super) fn check() -> AgentHookToolStatus {
         .get("hooks")
         .and_then(|h| h.get("Stop"))
         .and_then(|arr| arr.as_array())
-        .map(|arr| arr.iter().any(|entry| is_atmos_hook(entry)))
+        .map(|arr| arr.iter().any(is_atmos_hook))
         .unwrap_or(false);
 
     AgentHookToolStatus {

--- a/crates/core-engine/src/agent_hooks/cursor.rs
+++ b/crates/core-engine/src/agent_hooks/cursor.rs
@@ -204,7 +204,7 @@ pub(super) fn check() -> AgentHookToolStatus {
         .get("hooks")
         .and_then(|h| h.get("stop"))
         .and_then(|arr| arr.as_array())
-        .map(|arr| arr.iter().any(|entry| is_atmos_hook(entry)))
+        .map(|arr| arr.iter().any(is_atmos_hook))
         .unwrap_or(false);
 
     AgentHookToolStatus {

--- a/crates/core-engine/src/agent_hooks/factory_droid.rs
+++ b/crates/core-engine/src/agent_hooks/factory_droid.rs
@@ -242,7 +242,7 @@ pub(super) fn check() -> AgentHookToolStatus {
         .get("hooks")
         .and_then(|h| h.get("Stop"))
         .and_then(|arr| arr.as_array())
-        .map(|arr| arr.iter().any(|entry| is_atmos_hook(entry)))
+        .map(|arr| arr.iter().any(is_atmos_hook))
         .unwrap_or(false);
 
     AgentHookToolStatus {

--- a/crates/core-engine/src/agent_hooks/gemini.rs
+++ b/crates/core-engine/src/agent_hooks/gemini.rs
@@ -203,7 +203,7 @@ pub(super) fn check() -> AgentHookToolStatus {
         .get("hooks")
         .and_then(|h| h.get("AfterTool"))
         .and_then(|arr| arr.as_array())
-        .map(|arr| arr.iter().any(|entry| is_atmos_hook(entry)))
+        .map(|arr| arr.iter().any(is_atmos_hook))
         .unwrap_or(false);
 
     AgentHookToolStatus {

--- a/crates/core-engine/src/git/refs.rs
+++ b/crates/core-engine/src/git/refs.rs
@@ -196,11 +196,8 @@ impl GitEngine {
                 }
                 None => (false, 0),
             };
-        let upstream_behind_count =
-            match try_run_git(repo_path, &["rev-list", "HEAD..@{u}", "--count"])? {
-                Some(count_str) => Some(count_str.trim().parse::<u32>().unwrap_or(0)),
-                None => None,
-            };
+        let upstream_behind_count = try_run_git(repo_path, &["rev-list", "HEAD..@{u}", "--count"])?
+            .map(|count_str| count_str.trim().parse::<u32>().unwrap_or(0));
 
         let default_branch = self.get_remote_default_branch(repo_path)?;
         let current_branch = self.get_current_branch(repo_path).ok();

--- a/crates/core-engine/src/git/worktrees.rs
+++ b/crates/core-engine/src/git/worktrees.rs
@@ -188,10 +188,10 @@ impl GitEngine {
         }
 
         // Delete remote branch if configured (non-fatal)
-        if delete_remote_branch {
-            if let Some(_) = try_run_git(repo_path, &["push", "origin", "--delete", branch_name])? {
-                tracing::info!("Deleted remote branch: origin/{}", branch_name);
-            }
+        if delete_remote_branch
+            && try_run_git(repo_path, &["push", "origin", "--delete", branch_name])?.is_some()
+        {
+            tracing::info!("Deleted remote branch: origin/{}", branch_name);
         }
 
         tracing::info!("Removed worktree for workspace {}", workspace_name);

--- a/crates/core-engine/src/github/mod.rs
+++ b/crates/core-engine/src/github/mod.rs
@@ -39,6 +39,15 @@ pub struct GithubIssue {
     pub labels: Vec<GithubIssueLabel>,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct GithubIssueListOptions<'a> {
+    pub state: &'a str,
+    pub limit: usize,
+    pub sort: &'a str,
+    pub direction: &'a str,
+    pub search: Option<&'a str>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GithubPullRequest {
     pub owner: String,
@@ -240,32 +249,24 @@ impl GithubEngine {
         &self,
         owner: &str,
         repo: &str,
-        state: &str,
-        limit: usize,
-        sort: &str,
-        direction: &str,
-        search: Option<&str>,
+        options: GithubIssueListOptions<'_>,
     ) -> Result<Vec<GithubIssue>, EngineError> {
-        match self
-            .list_issues_via_gh(owner, repo, state, limit, search)
-            .await
-        {
+        match self.list_issues_via_gh(owner, repo, options).await {
             Ok(issues) => Ok(issues),
             Err(gh_error) => {
                 tracing::warn!(
                     owner,
                     repo,
-                    state,
-                    limit,
+                    state = options.state,
+                    limit = options.limit,
                     "gh issue list failed, falling back to GitHub API: {}",
                     gh_error
                 );
-                self.list_issues_via_api(owner, repo, state, limit, sort, direction, search)
-                    .await
+                self.list_issues_via_api(owner, repo, options).await
             }
         }
         .map(|mut issues| {
-            sort_issues(&mut issues, sort, direction);
+            sort_issues(&mut issues, options.sort, options.direction);
             issues
         })
     }
@@ -295,25 +296,23 @@ impl GithubEngine {
         &self,
         owner: &str,
         repo: &str,
-        state: &str,
-        limit: usize,
-        search: Option<&str>,
+        options: GithubIssueListOptions<'_>,
     ) -> Result<Vec<GithubIssue>, EngineError> {
         let repo_arg = format!("{owner}/{repo}");
-        let limit_value = limit.to_string();
+        let limit_value = options.limit.to_string();
         let mut args = vec![
             "issue",
             "list",
             "--repo",
             &repo_arg,
             "--state",
-            state,
+            options.state,
             "--limit",
             &limit_value,
             "--json",
             "number,title,body,url,state,createdAt,updatedAt,labels",
         ];
-        if let Some(search_query) = search.filter(|value| !value.trim().is_empty()) {
+        if let Some(search_query) = options.search.filter(|value| !value.trim().is_empty()) {
             args.push("--search");
             args.push(search_query);
         }
@@ -346,11 +345,7 @@ impl GithubEngine {
         &self,
         owner: &str,
         repo: &str,
-        state: &str,
-        limit: usize,
-        sort: &str,
-        direction: &str,
-        search: Option<&str>,
+        options: GithubIssueListOptions<'_>,
     ) -> Result<Vec<GithubIssue>, EngineError> {
         let mut url = reqwest::Url::parse(&format!(
             "https://api.github.com/repos/{owner}/{repo}/issues"
@@ -358,22 +353,33 @@ impl GithubEngine {
         .map_err(|e| EngineError::Processing(format!("Invalid GitHub API URL: {e}")))?;
         {
             let mut pairs = url.query_pairs_mut();
-            pairs.append_pair("state", state);
-            pairs.append_pair("per_page", &limit.to_string());
+            pairs.append_pair("state", options.state);
+            pairs.append_pair("per_page", &options.limit.to_string());
             pairs.append_pair(
                 "sort",
-                if sort == "updated" {
+                if options.sort == "updated" {
                     "updated"
                 } else {
                     "created"
                 },
             );
-            pairs.append_pair("direction", if direction == "asc" { "asc" } else { "desc" });
+            pairs.append_pair(
+                "direction",
+                if options.direction == "asc" {
+                    "asc"
+                } else {
+                    "desc"
+                },
+            );
         }
         let endpoint = url.to_string();
         let output = self.fetch_api_json(&endpoint).await?;
         let mut issues = parse_issue_list_value(owner, repo, output)?;
-        if let Some(search_query) = search.map(str::trim).filter(|value| !value.is_empty()) {
+        if let Some(search_query) = options
+            .search
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
             let query = search_query.to_lowercase();
             issues.retain(|issue| {
                 issue.title.to_lowercase().contains(&query)

--- a/crates/core-engine/src/local_services/scanner.rs
+++ b/crates/core-engine/src/local_services/scanner.rs
@@ -137,6 +137,7 @@ fn scan_macos() -> Result<Vec<LocalTcpListener>> {
     Ok(dedupe(records))
 }
 
+#[cfg(target_os = "macos")]
 #[derive(Debug, Clone)]
 struct ProcessMetadata {
     name: Option<String>,
@@ -297,9 +298,8 @@ fn process_metadata_linux(pid: u32) -> ProcessMetadataLinux {
         .map(|bytes| {
             bytes
                 .split(|b| *b == 0)
-                .filter_map(|part| {
-                    (!part.is_empty()).then(|| String::from_utf8_lossy(part).to_string())
-                })
+                .filter(|part| !part.is_empty())
+                .map(|part| String::from_utf8_lossy(part).to_string())
                 .collect::<Vec<_>>()
         })
         .filter(|parts| !parts.is_empty());
@@ -437,6 +437,7 @@ foreach ($c in $connections) {
     Ok(dedupe(records))
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn parse_port_from_socket_name(name: &str) -> Option<u16> {
     let endpoint = name.split("->").next().unwrap_or(name);
     let endpoint = endpoint
@@ -450,6 +451,7 @@ fn parse_port_from_socket_name(name: &str) -> Option<u16> {
         .and_then(|(_, port)| port.trim_end_matches(')').parse::<u16>().ok())
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn parse_addr_from_socket_name(name: &str) -> String {
     let endpoint = name.split("->").next().unwrap_or(name);
     let endpoint = endpoint
@@ -466,6 +468,7 @@ fn parse_addr_from_socket_name(name: &str) -> String {
         .unwrap_or_else(|| "*".into())
 }
 
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn shell_words(command: &str) -> Vec<String> {
     command
         .split_whitespace()

--- a/crates/core-engine/src/tmux/control.rs
+++ b/crates/core-engine/src/tmux/control.rs
@@ -178,17 +178,12 @@ const TMUX_PASSTHROUGH_PREFIX: &[u8] = b"\x1bPtmux;";
 const SYNC_OUTPUT_BEGIN: &[u8] = b"\x1b[?2026h";
 const SYNC_OUTPUT_END: &[u8] = b"\x1b[?2026l";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum PassthroughState {
+    #[default]
     Normal,
     Inside,
     AfterEsc,
-}
-
-impl Default for PassthroughState {
-    fn default() -> Self {
-        Self::Normal
-    }
 }
 
 /// Stateful tmux DCS passthrough unwrapper.

--- a/crates/core-service/src/service/agent_hooks.rs
+++ b/crates/core-service/src/service/agent_hooks.rs
@@ -391,3 +391,9 @@ impl AgentHooksService {
             .or_else(|| payload.get("conversation_id").and_then(|v| v.as_str()))
     }
 }
+
+impl Default for AgentHooksService {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/core-service/src/service/automation/agents.rs
+++ b/crates/core-service/src/service/automation/agents.rs
@@ -155,20 +155,15 @@ pub enum PromptStrategy {
     FileFlag,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum StdoutParser {
+    #[default]
     Plain,
     ClaudeStreamJson,
     CodexJsonl,
     CursorStreamJson,
     OpencodeJson,
-}
-
-impl Default for StdoutParser {
-    fn default() -> Self {
-        Self::Plain
-    }
 }
 
 impl AutomationAgentCommandSpec {
@@ -235,17 +230,12 @@ struct TerminalAgentModelListSpec {
     parser: TerminalAgentModelListParser,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Copy, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 enum TerminalAgentModelListParser {
+    #[default]
     LineList,
     KiroJson,
-}
-
-impl Default for TerminalAgentModelListParser {
-    fn default() -> Self {
-        Self::LineList
-    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -355,10 +345,6 @@ pub fn resolve_automation_agent_with_config(
     })
 }
 
-pub fn resolve_interactive_automation_agent(agent_id: &str) -> Result<AutomationAgentCommandSpec> {
-    resolve_interactive_automation_agent_with_config(agent_id, None)
-}
-
 pub fn resolve_interactive_automation_agent_with_config(
     agent_id: &str,
     run_config: Option<&AutomationAgentRunConfig>,
@@ -405,14 +391,13 @@ pub fn terminal_agent_model_catalog(
     if !refresh {
         if let Some(cached) = cache
             .lock()
-            .map_err(|_| ServiceError::Processing("Terminal agent model cache is poisoned.".to_string()))?
+            .map_err(|_| {
+                ServiceError::Processing("Terminal agent model cache is poisoned.".to_string())
+            })?
             .get(agent_id)
             .cloned()
         {
-            let ttl = if matches!(
-                cached.catalog.status,
-                TerminalAgentModelCatalogStatus::Ok
-            ) {
+            let ttl = if matches!(cached.catalog.status, TerminalAgentModelCatalogStatus::Ok) {
                 MODEL_CATALOG_TTL
             } else {
                 MODEL_CATALOG_ERROR_TTL
@@ -428,7 +413,9 @@ pub fn terminal_agent_model_catalog(
     let catalog = probe_terminal_agent_model_catalog(agent_id)?;
     cache
         .lock()
-        .map_err(|_| ServiceError::Processing("Terminal agent model cache is poisoned.".to_string()))?
+        .map_err(|_| {
+            ServiceError::Processing("Terminal agent model cache is poisoned.".to_string())
+        })?
         .insert(
             agent_id.to_string(),
             CachedModelCatalog {
@@ -554,11 +541,9 @@ fn probe_terminal_agent_model_catalog(agent_id: &str) -> Result<TerminalAgentMod
             &agent.id,
             TerminalAgentModelCatalogStatus::Error,
             Vec::new(),
-            Some(
-                support.unavailable_reason.unwrap_or_else(|| {
-                    format!("{} is not installed or is not executable.", agent.cmd)
-                }),
-            ),
+            Some(support.unavailable_reason.unwrap_or_else(|| {
+                format!("{} is not installed or is not executable.", agent.cmd)
+            })),
             TerminalAgentModelCatalogSource::Live,
         ));
     };
@@ -726,9 +711,7 @@ fn parse_line_model_catalog(output: &str) -> Vec<TerminalAgentModelOption> {
             if lower.contains("available model") || lower == "models" || lower == "model" {
                 return None;
             }
-            let normalized = trimmed
-                .trim_start_matches(|ch: char| matches!(ch, '-' | '*' | '•' | ' '))
-                .trim();
+            let normalized = trimmed.trim_start_matches(['-', '*', '•', ' ']).trim();
             if normalized.is_empty() || normalized.ends_with(':') {
                 return None;
             }
@@ -742,7 +725,9 @@ fn parse_line_model_catalog(output: &str) -> Vec<TerminalAgentModelOption> {
         .collect()
 }
 
-fn parse_json_model_catalog(output: &str) -> std::result::Result<Vec<TerminalAgentModelOption>, String> {
+fn parse_json_model_catalog(
+    output: &str,
+) -> std::result::Result<Vec<TerminalAgentModelOption>, String> {
     let value: Value = serde_json::from_str(output)
         .map_err(|error| format!("Failed to parse model catalog JSON: {error}"))?;
     Ok(parse_json_model_catalog_value(&value))
@@ -996,8 +981,15 @@ fn build_run_config_args(
         return Ok(Vec::new());
     };
     let mut args = Vec::new();
-    let model = run_config.model.as_deref().map(str::trim).filter(|value| !value.is_empty());
-    let reasoning = run_config.reasoning.as_ref().filter(|value| !value.value.trim().is_empty());
+    let model = run_config
+        .model
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let reasoning = run_config
+        .reasoning
+        .as_ref()
+        .filter(|value| !value.value.trim().is_empty());
 
     let extra_args = run_config
         .extra_args
@@ -1032,7 +1024,8 @@ fn build_run_config_args(
             return Err(ServiceError::Validation(format!(
                 "Agent `{}` does not support structured reasoning mode `{}`.",
                 agent.id,
-                serde_json::to_string(&reasoning.mode).unwrap_or_else(|_| "\"unknown\"".to_string())
+                serde_json::to_string(&reasoning.mode)
+                    .unwrap_or_else(|_| "\"unknown\"".to_string())
             )));
         }
         if let Some(reasoning_flag) = reasoning_arg_for_agent(agent) {
@@ -1076,7 +1069,9 @@ fn build_run_config_args(
                     ))
                 })?;
                 args.push(flag.to_string());
-                if agent.reasoning_support.value_style != AutomationAgentReasoningValueStyle::FlagOnly {
+                if agent.reasoning_support.value_style
+                    != AutomationAgentReasoningValueStyle::FlagOnly
+                {
                     args.push(reasoning.value.trim().to_string());
                 }
             }
@@ -1089,18 +1084,8 @@ fn build_run_config_args(
 
 fn model_flag_for_agent(agent_id: &str) -> Option<&'static str> {
     match agent_id {
-        "claude"
-        | "codex"
-        | "gemini"
-        | "devin"
-        | "droid"
-        | "cursor"
-        | "kilocode"
-        | "kiro"
-        | "commandcode"
-        | "pi"
-        | "opencode"
-        | "kimi" => Some("--model"),
+        "claude" | "codex" | "gemini" | "devin" | "droid" | "cursor" | "kilocode" | "kiro"
+        | "commandcode" | "pi" | "opencode" | "kimi" => Some("--model"),
         _ => None,
     }
 }
@@ -1133,7 +1118,7 @@ fn reserved_flags_for_agent(agent: &ResolvedTerminalAgent) -> Result<Vec<String>
 }
 
 fn parse_flag_args(flags: &str) -> Result<Vec<String>> {
-    split_shell_words(flags).map_err(|message| ServiceError::Validation(message))
+    split_shell_words(flags).map_err(ServiceError::Validation)
 }
 
 fn split_shell_words(value: &str) -> std::result::Result<Vec<String>, String> {

--- a/crates/core-service/src/service/automation/external_trigger.rs
+++ b/crates/core-service/src/service/automation/external_trigger.rs
@@ -12,7 +12,7 @@ use super::{AutomationRunDetail, AutomationRunSummary, AutomationService, Automa
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum ExternalTriggerOutcome {
-    Accepted { run: AutomationRunDetail },
+    Accepted { run: Box<AutomationRunDetail> },
     LocalRejected { rejection: ExternalTriggerRejection },
 }
 
@@ -176,9 +176,9 @@ impl AutomationService {
                 repo.associate_github_delivery_run(&event.delivery_id, &event.route_id, &run.guid)
                     .await?;
                 Ok(ExternalTriggerOutcome::Accepted {
-                    run: AutomationRunDetail {
+                    run: Box::new(AutomationRunDetail {
                         summary: AutomationRunSummary::from(run),
-                    },
+                    }),
                 })
             }
             Err(ServiceError::Validation(message)) if message == "already_running" => {

--- a/crates/core-service/src/service/automation/github_trigger.rs
+++ b/crates/core-service/src/service/automation/github_trigger.rs
@@ -597,10 +597,7 @@ fn is_allowed_action(family: &GithubEventFamily, action: &str) -> bool {
             action,
             "opened" | "reopened" | "ready_for_review" | "closed" | "merged"
         ),
-        GithubEventFamily::Issues => matches!(
-            action,
-            "opened" | "reopened" | "labeled" | "closed"
-        ),
+        GithubEventFamily::Issues => matches!(action, "opened" | "reopened" | "labeled" | "closed"),
         GithubEventFamily::PullRequestComment => matches!(action, "created" | "edited" | "deleted"),
         GithubEventFamily::Push => action == "pushed",
         GithubEventFamily::WorkflowRun => {
@@ -996,10 +993,7 @@ mod tests {
             event_family: GithubEventFamily::PullRequestComment,
             actions: vec!["created".to_string()],
             filters: GithubTriggerFilters {
-                comment_contains_any: vec![
-                    "/atmos fix".to_string(),
-                    "/atmos review".to_string(),
-                ],
+                comment_contains_any: vec!["/atmos fix".to_string(), "/atmos review".to_string()],
                 sender_logins: vec!["alice".to_string()],
                 ..Default::default()
             },

--- a/crates/core-service/src/service/automation/lifecycle.rs
+++ b/crates/core-service/src/service/automation/lifecycle.rs
@@ -76,8 +76,10 @@ impl AutomationService {
             .as_deref()
             .or(automation.agent_config_json.as_deref())
             .and_then(parse_run_config);
-        let agent =
-            agents::resolve_interactive_automation_agent_with_config(&automation.agent_id, run_config.as_ref())?;
+        let agent = agents::resolve_interactive_automation_agent_with_config(
+            &automation.agent_id,
+            run_config.as_ref(),
+        )?;
 
         let prompt_path = PathBuf::from(&run.run_dir).join(runner::CONTINUE_PROMPT_FILE);
         let prompt = build_continue_prompt(&automation, &run);

--- a/crates/core-service/src/service/automation/mod.rs
+++ b/crates/core-service/src/service/automation/mod.rs
@@ -41,9 +41,9 @@ pub(crate) use agents::{
     StdoutParser,
 };
 pub use agents::{
-    AutomationAgentModelInputMode, AutomationAgentReasoningMode,
-    AutomationAgentReasoningSelection, AutomationAgentRunConfig, TerminalAgentModelCatalog,
-    TerminalAgentModelCatalogSource, TerminalAgentModelCatalogStatus, TerminalAgentModelOption,
+    AutomationAgentModelInputMode, AutomationAgentReasoningMode, AutomationAgentReasoningSelection,
+    AutomationAgentRunConfig, TerminalAgentModelCatalog, TerminalAgentModelCatalogSource,
+    TerminalAgentModelCatalogStatus, TerminalAgentModelOption,
 };
 pub use events::{AutomationDefinitionChange, AutomationEvent};
 pub use external_trigger::{
@@ -566,7 +566,10 @@ impl AutomationService {
                 .agent_config_json
                 .as_deref()
                 .and_then(|raw| serde_json::from_str::<AutomationAgentRunConfig>(raw).ok());
-            agents::validate_agent_run_config(&existing.agent_id, req.agent_config.as_ref().or(existing_config.as_ref()))?;
+            agents::validate_agent_run_config(
+                &existing.agent_id,
+                req.agent_config.as_ref().or(existing_config.as_ref()),
+            )?;
         }
         if let Some(target) = req.target.as_ref() {
             self.validate_target(target).await?;

--- a/crates/core-service/src/service/automation/process_runner.rs
+++ b/crates/core-service/src/service/automation/process_runner.rs
@@ -19,6 +19,14 @@ use super::agents::{AutomationAgentInvocation, PromptDelivery};
 use super::output_rendering::{read_stream, write_output_chunks};
 use super::{publish_run_update, runner, AutomationEvent, AutomationRunStatus, START_FAILURE_KIND};
 
+struct FinishRunRequest<'a> {
+    run_guid: &'a str,
+    status: &'a str,
+    exit_code: Option<i32>,
+    failure_kind: Option<String>,
+    error_message: Option<String>,
+}
+
 pub(super) async fn run_automation_process(
     db: Arc<DatabaseConnection>,
     notification_service: Arc<NotificationService>,
@@ -43,11 +51,13 @@ pub(super) async fn run_automation_process(
             &db,
             &notification_service,
             &event_tx,
-            &run_guid,
-            AutomationRunStatus::Failed.as_str(),
-            None,
-            Some(START_FAILURE_KIND.to_string()),
-            Some(error.to_string()),
+            FinishRunRequest {
+                run_guid: &run_guid,
+                status: AutomationRunStatus::Failed.as_str(),
+                exit_code: None,
+                failure_kind: Some(START_FAILURE_KIND.to_string()),
+                error_message: Some(error.to_string()),
+            },
         )
         .await;
     }
@@ -99,11 +109,13 @@ async fn run_automation_process_inner(
                 &db,
                 &notification_service,
                 &event_tx,
-                &run_guid,
-                AutomationRunStatus::Failed.as_str(),
-                None,
-                Some(START_FAILURE_KIND.to_string()),
-                Some(error.to_string()),
+                FinishRunRequest {
+                    run_guid: &run_guid,
+                    status: AutomationRunStatus::Failed.as_str(),
+                    exit_code: None,
+                    failure_kind: Some(START_FAILURE_KIND.to_string()),
+                    error_message: Some(error.to_string()),
+                },
             )
             .await?;
             return Ok(());
@@ -207,11 +219,13 @@ async fn run_automation_process_inner(
         &db,
         &notification_service,
         &event_tx,
-        &run_guid,
-        status.0,
-        status.1,
-        status.2,
-        status.3,
+        FinishRunRequest {
+            run_guid: &run_guid,
+            status: status.0,
+            exit_code: status.1,
+            failure_kind: status.2,
+            error_message: status.3,
+        },
     )
     .await?;
 
@@ -233,12 +247,9 @@ async fn finish_run(
     db: &Arc<DatabaseConnection>,
     notification_service: &Arc<NotificationService>,
     event_tx: &broadcast::Sender<AutomationEvent>,
-    run_guid: &str,
-    status: &str,
-    exit_code: Option<i32>,
-    failure_kind: Option<String>,
-    error_message: Option<String>,
+    request: FinishRunRequest<'_>,
 ) -> Result<()> {
+    let run_guid = request.run_guid;
     let repo = AutomationRepo::new(db);
     let current = repo
         .find_run_by_guid(run_guid)
@@ -253,15 +264,20 @@ async fn finish_run(
         .update_run_status(
             run_guid,
             UpdateAutomationRunStatusRecord {
-                status: status.to_string(),
+                status: request.status.to_string(),
                 completed_at: Some(completed_at),
-                exit_code,
-                failure_kind,
-                error_message,
+                exit_code: request.exit_code,
+                failure_kind: request.failure_kind,
+                error_message: request.error_message,
             },
         )
         .await?;
-    let status_json = runner::run_json_for_status(&updated, status, Some(completed_at), exit_code);
+    let status_json = runner::run_json_for_status(
+        &updated,
+        request.status,
+        Some(completed_at),
+        request.exit_code,
+    );
     let _ = runner::write_run_json(
         PathBuf::from(&updated.run_json_path).as_path(),
         &status_json,

--- a/crates/core-service/src/service/git_commit_message.rs
+++ b/crates/core-service/src/service/git_commit_message.rs
@@ -268,7 +268,7 @@ fn generation_scope_and_summary(
         MAX_FILES_IN_PROMPT
     } else {
         // Rough heuristic: ~80 chars per file line
-        (max_summary_chars / 80).min(MAX_FILES_IN_PROMPT).max(4)
+        (max_summary_chars / 80).clamp(4, MAX_FILES_IN_PROMPT)
     };
 
     if !changes.staged_files.is_empty() {

--- a/crates/core-service/src/service/notification.rs
+++ b/crates/core-service/src/service/notification.rs
@@ -407,6 +407,12 @@ impl NotificationService {
     }
 }
 
+impl Default for NotificationService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 fn automation_terminal_status_label(status: &str) -> Option<&'static str> {
     match status {
         "completed" => Some("completed"),

--- a/crates/core-service/src/service/review/agent_run_finalize.rs
+++ b/crates/core-service/src/service/review/agent_run_finalize.rs
@@ -107,15 +107,15 @@ impl ReviewService {
                     .await;
             }
 
-            self.finalize_fix_agent_run(
-                &review_repo,
-                &run,
-                &session,
-                &base_revision,
+            self.finalize_fix_agent_run(super::agent_runs::FinalizeFixAgentRunInput {
+                review_repo: &review_repo,
+                run: &run,
+                session: &session,
+                base_revision: &base_revision,
                 revision,
-                &workspace_root,
+                workspace_root: &workspace_root,
                 change_time,
-            )
+            })
             .await
         }
         .await;

--- a/crates/core-service/src/service/review/agent_runs.rs
+++ b/crates/core-service/src/service/review/agent_runs.rs
@@ -1,9 +1,12 @@
 mod finalize_fix;
 mod revision;
 
+pub(in crate::service::review) use finalize_fix::FinalizeFixAgentRunInput;
+
 use std::collections::HashSet;
 
 use infra::db::entities::review_agent_run;
+use infra::db::repo::review_repo::CreateAgentRunParams;
 use infra::db::repo::ReviewRepo;
 use infra::utils::review_artifacts::{run_root_abs_path, write_text_atomic};
 
@@ -27,7 +30,7 @@ impl ReviewService {
             "running" => self
                 .mark_agent_run_running(input.run_guid)
                 .await
-                .map(|run| ReviewAgentRunStatusDto::Run { run }),
+                .map(|run| ReviewAgentRunStatusDto::Run { run: Box::new(run) }),
             "succeeded" => {
                 self.mark_agent_run_running(input.run_guid.clone()).await?;
                 if let Some(summary) = input.summary.filter(|value| !value.trim().is_empty()) {
@@ -36,12 +39,12 @@ impl ReviewService {
                 }
                 self.finalize_agent_run(input.run_guid, input.title)
                     .await
-                    .map(ReviewAgentRunStatusDto::Finalized)
+                    .map(|finalized| ReviewAgentRunStatusDto::Finalized(Box::new(finalized)))
             }
             "failed" => self
                 .mark_agent_run_failed(input.run_guid, input.message)
                 .await
-                .map(|run| ReviewAgentRunStatusDto::Run { run }),
+                .map(|run| ReviewAgentRunStatusDto::Run { run: Box::new(run) }),
             status => Err(ServiceError::Validation(format!(
                 "Invalid review agent run status: {}",
                 status
@@ -239,15 +242,15 @@ impl ReviewService {
         }
 
         let run = review_repo
-            .create_agent_run(
-                session.guid.clone(),
-                input.base_revision_guid.clone(),
-                input.run_kind.clone(),
-                input.execution_mode.clone(),
-                input.skill_id.clone(),
-                None,
-                input.created_by.clone(),
-            )
+            .create_agent_run(CreateAgentRunParams {
+                session_guid: session.guid.clone(),
+                base_revision_guid: input.base_revision_guid.clone(),
+                run_kind: input.run_kind.clone(),
+                execution_mode: input.execution_mode.clone(),
+                skill_id: input.skill_id.clone(),
+                prompt_rel_path: None,
+                created_by: input.created_by.clone(),
+            })
             .await
             .map_err(ServiceError::Infra)?;
         let revision = self
@@ -302,10 +305,7 @@ impl ReviewService {
             .await
             .map_err(ServiceError::Infra)?;
         review_repo
-            .update_agent_run_prompt_rel_path(
-                &run.guid,
-                &prompt_abs_path.to_string_lossy().to_string(),
-            )
+            .update_agent_run_prompt_rel_path(&run.guid, prompt_abs_path.to_string_lossy().as_ref())
             .await
             .map_err(ServiceError::Infra)?;
         if input.execution_mode != "copy_prompt" {

--- a/crates/core-service/src/service/review/agent_runs/finalize_fix.rs
+++ b/crates/core-service/src/service/review/agent_runs/finalize_fix.rs
@@ -17,17 +17,30 @@ use crate::error::{Result, ServiceError};
 use super::super::support::{FileSnapshotMeta, RevisionManifestItem};
 use super::super::{ReviewAgentRunFinalizedDto, ReviewService};
 
+pub(in crate::service::review) struct FinalizeFixAgentRunInput<'a, 'repo> {
+    pub review_repo: &'a ReviewRepo<'repo>,
+    pub run: &'a review_agent_run::Model,
+    pub session: &'a review_session::Model,
+    pub base_revision: &'a review_revision::Model,
+    pub revision: review_revision::Model,
+    pub workspace_root: &'a Path,
+    pub change_time: chrono::NaiveDateTime,
+}
+
 impl ReviewService {
     pub(in crate::service::review) async fn finalize_fix_agent_run(
         &self,
-        review_repo: &ReviewRepo<'_>,
-        run: &review_agent_run::Model,
-        session: &review_session::Model,
-        base_revision: &review_revision::Model,
-        revision: review_revision::Model,
-        workspace_root: &Path,
-        change_time: chrono::NaiveDateTime,
+        input: FinalizeFixAgentRunInput<'_, '_>,
     ) -> Result<ReviewAgentRunFinalizedDto> {
+        let FinalizeFixAgentRunInput {
+            review_repo,
+            run,
+            session,
+            base_revision,
+            revision,
+            workspace_root,
+            change_time,
+        } = input;
         let base_snapshots = review_repo
             .list_file_snapshots_by_revision(&base_revision.guid)
             .await

--- a/crates/core-service/src/service/review/comments.rs
+++ b/crates/core-service/src/service/review/comments.rs
@@ -245,7 +245,7 @@ impl ReviewService {
             })
             .await?;
         Ok(ReviewCommentDto {
-            anchor: serde_json::to_value(&json!({
+            anchor: serde_json::to_value(json!({
                 "file_path": file_snapshot.file_path,
                 "side": input.side,
                 "start_line": input.start_line,
@@ -475,7 +475,7 @@ impl ReviewService {
             })?;
 
         let mut messages = review_repo
-            .list_messages_by_comment_guids(&[message.comment_guid.clone()])
+            .list_messages_by_comment_guids(std::slice::from_ref(&message.comment_guid))
             .await
             .map_err(ServiceError::Infra)?;
         messages.sort_by_key(|item| item.created_at);
@@ -493,7 +493,7 @@ impl ReviewService {
         let should_delete_comment = messages.len() == 1
             && comment
                 .as_ref()
-                .map_or(true, |c| c.parent_comment_guid.is_none());
+                .is_none_or(|c| c.parent_comment_guid.is_none());
 
         if should_delete_comment {
             review_repo

--- a/crates/core-service/src/service/review/tests.rs
+++ b/crates/core-service/src/service/review/tests.rs
@@ -32,7 +32,7 @@ async fn s2_resolve_repo_context_project_target_branch() {
 
     // Init a bare git repo so GitEngine doesn't fail on get_default_branch
     run_cmd_assert_success(
-        &mut std::process::Command::new("git")
+        std::process::Command::new("git")
             .args(["init", "-b", "main"])
             .current_dir(tmp.path()),
     );
@@ -71,29 +71,29 @@ async fn s3_resolve_repo_context_fallback_to_default_branch() {
 
     // Init a git repo with a commit so origin/HEAD can be resolved locally
     run_cmd_assert_success(
-        &mut std::process::Command::new("git")
+        std::process::Command::new("git")
             .args(["init", "-b", "main"])
             .current_dir(tmp.path()),
     );
     run_cmd_assert_success(
-        &mut std::process::Command::new("git")
+        std::process::Command::new("git")
             .args(["config", "user.email", "test@test.com"])
             .current_dir(tmp.path()),
     );
     run_cmd_assert_success(
-        &mut std::process::Command::new("git")
+        std::process::Command::new("git")
             .args(["config", "user.name", "Test"])
             .current_dir(tmp.path()),
     );
     // Create a file and commit so HEAD exists
     std::fs::write(tmp.path().join("README.md"), "test").unwrap();
     run_cmd_assert_success(
-        &mut std::process::Command::new("git")
+        std::process::Command::new("git")
             .args(["add", "."])
             .current_dir(tmp.path()),
     );
     run_cmd_assert_success(
-        &mut std::process::Command::new("git")
+        std::process::Command::new("git")
             .args(["commit", "-m", "init"])
             .current_dir(tmp.path()),
     );
@@ -165,41 +165,41 @@ async fn s5_create_session_empty_changeset() {
 
     // Create a bare repo to act as the remote
     run_cmd_assert_success(
-        &mut std::process::Command::new("git")
+        std::process::Command::new("git")
             .args(["init", "--bare", "-b", "main"])
             .current_dir(bare.path()),
     );
 
     // Clone it so we have a proper remote
-    run_cmd_assert_success(&mut std::process::Command::new("git").args([
+    run_cmd_assert_success(std::process::Command::new("git").args([
         "clone",
         bare.path().to_str().unwrap(),
         work.path().to_str().unwrap(),
     ]));
     run_cmd_assert_success(
-        &mut std::process::Command::new("git")
+        std::process::Command::new("git")
             .args(["config", "user.email", "test@test.com"])
             .current_dir(work.path()),
     );
     run_cmd_assert_success(
-        &mut std::process::Command::new("git")
+        std::process::Command::new("git")
             .args(["config", "user.name", "Test"])
             .current_dir(work.path()),
     );
     // Commit and push so origin/main exists
     std::fs::write(work.path().join("README.md"), "test").unwrap();
     run_cmd_assert_success(
-        &mut std::process::Command::new("git")
+        std::process::Command::new("git")
             .args(["add", "."])
             .current_dir(work.path()),
     );
     run_cmd_assert_success(
-        &mut std::process::Command::new("git")
+        std::process::Command::new("git")
             .args(["commit", "-m", "init"])
             .current_dir(work.path()),
     );
     run_cmd_assert_success(
-        &mut std::process::Command::new("git")
+        std::process::Command::new("git")
             .args(["push", "-u", "origin", "main"])
             .current_dir(work.path()),
     );

--- a/crates/core-service/src/service/review/types.rs
+++ b/crates/core-service/src/service/review/types.rs
@@ -202,8 +202,8 @@ pub struct ReviewAgentRunFinalizedDto {
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ReviewAgentRunStatusDto {
-    Run { run: review_agent_run::Model },
-    Finalized(ReviewAgentRunFinalizedDto),
+    Run { run: Box<review_agent_run::Model> },
+    Finalized(Box<ReviewAgentRunFinalizedDto>),
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/core-service/src/service/terminal/runtime.rs
+++ b/crates/core-service/src/service/terminal/runtime.rs
@@ -19,6 +19,12 @@ use crate::error::{Result, ServiceError};
 
 use super::{is_usable_browser_size, SessionCommand};
 
+type PtySetup = (
+    Box<dyn portable_pty::MasterPty + Send>,
+    Box<dyn std::io::Read + Send>,
+    Box<dyn std::io::Write + Send>,
+);
+
 fn is_utf8_locale(value: &str) -> bool {
     let upper = value.to_ascii_uppercase();
     upper.contains("UTF-8") || upper.contains("UTF8")
@@ -63,18 +69,7 @@ fn apply_utf8_env_to_pty_command(cmd: &mut CommandBuilder) {
 
 /// Spawn a command inside a new PTY and return master, reader, and writer.
 /// The PTY slave is dropped immediately after spawning to ensure clean EOF on exit.
-fn setup_pty(
-    cols: u16,
-    rows: u16,
-    cmd: CommandBuilder,
-) -> std::result::Result<
-    (
-        Box<dyn portable_pty::MasterPty + Send>,
-        Box<dyn std::io::Read + Send>,
-        Box<dyn std::io::Write + Send>,
-    ),
-    String,
-> {
+fn setup_pty(cols: u16, rows: u16, cmd: CommandBuilder) -> std::result::Result<PtySetup, String> {
     let pty_system = native_pty_system();
     let pair = pty_system
         .openpty(PtySize {

--- a/crates/core-service/src/service/workspace.rs
+++ b/crates/core-service/src/service/workspace.rs
@@ -27,6 +27,16 @@ pub use crate::service::workspace_support::{
     WorkspaceDto, WorkspaceLabelDto, WORKSPACE_PRIORITIES, WORKSPACE_WORKFLOW_STATUSES,
 };
 
+pub struct CreateIssueOnlyWorkspaceInput {
+    pub project_guid: String,
+    pub display_name: Option<String>,
+    pub github_issue_url: String,
+    pub github_issue_data: String,
+    pub workflow_status: Option<String>,
+    pub priority: Option<String>,
+    pub labels: Option<Vec<String>>,
+}
+
 pub struct WorkspaceService {
     db: Arc<DatabaseConnection>,
     git_engine: GitEngine,
@@ -508,28 +518,22 @@ impl WorkspaceService {
     /// 不创建分支、不初始化 worktree、不运行 setup flow
     pub async fn create_issue_only_workspace(
         &self,
-        project_guid: String,
-        display_name: Option<String>,
-        github_issue_url: String,
-        github_issue_data: String,
-        workflow_status: Option<String>,
-        priority: Option<String>,
-        labels: Option<Vec<String>>,
+        input: CreateIssueOnlyWorkspaceInput,
     ) -> Result<WorkspaceDto> {
-        let workflow_status = validate_workspace_workflow_status(workflow_status)?;
-        let priority = validate_workspace_priority(priority)?;
+        let workflow_status = validate_workspace_workflow_status(input.workflow_status)?;
+        let priority = validate_workspace_priority(input.priority)?;
 
         let workspace_repo = WorkspaceRepo::new(&self.db);
 
         let model = workspace_repo
             .create_issue_only(CreateIssueOnlyWorkspaceRecord {
-                project_guid,
-                display_name,
-                github_issue_url,
-                github_issue_data,
+                project_guid: input.project_guid,
+                display_name: input.display_name,
+                github_issue_url: input.github_issue_url,
+                github_issue_data: input.github_issue_data,
                 workflow_status,
                 priority,
-                label_guids: labels,
+                label_guids: input.labels,
             })
             .await?;
 

--- a/crates/core-service/src/service/workspace_gitignore_dirs.rs
+++ b/crates/core-service/src/service/workspace_gitignore_dirs.rs
@@ -80,18 +80,13 @@ const BUILTIN_GITIGNORE_DIRS: &[(&str, &str)] = &[
     ("adal", ".adal"),
 ];
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum Strategy {
+    #[default]
     Symlink,
     Copy,
     Off,
-}
-
-impl Default for Strategy {
-    fn default() -> Self {
-        Self::Symlink
-    }
 }
 
 impl Strategy {

--- a/crates/core-service/src/service/workspace_support.rs
+++ b/crates/core-service/src/service/workspace_support.rs
@@ -66,15 +66,11 @@ pub(super) fn validate_workspace_priority(value: Option<String>) -> Result<Optio
 }
 
 pub(super) fn is_valid_workspace_workflow_status(value: &str) -> bool {
-    WORKSPACE_WORKFLOW_STATUSES
-        .iter()
-        .any(|candidate| *candidate == value)
+    WORKSPACE_WORKFLOW_STATUSES.contains(&value)
 }
 
 pub(super) fn is_valid_workspace_priority(value: &str) -> bool {
-    WORKSPACE_PRIORITIES
-        .iter()
-        .any(|candidate| *candidate == value)
+    WORKSPACE_PRIORITIES.contains(&value)
 }
 
 /// Synthesize a GithubIssuePayload from a PR so the existing requirement/TODO

--- a/crates/core-service/src/service/workspace_todos.rs
+++ b/crates/core-service/src/service/workspace_todos.rs
@@ -92,7 +92,7 @@ pub fn normalize_task_markdown(markdown: &str) -> String {
                 return (!content.is_empty()).then(|| format!("- [ ] {}", content));
             }
 
-            if trimmed.chars().next().map_or(false, |c| c.is_ascii_digit()) {
+            if trimmed.chars().next().is_some_and(|c| c.is_ascii_digit()) {
                 if let Some((prefix, content)) = trimmed.split_once(". ") {
                     if prefix.chars().all(|c| c.is_ascii_digit()) {
                         let content = content.trim();

--- a/crates/infra/src/db/migration/mod.rs
+++ b/crates/infra/src/db/migration/mod.rs
@@ -130,7 +130,6 @@ mod tests {
     // ── S12: migration applies on fresh and seeded DB ─────────────────────────
 
     const REVIEW_SESSION_TABLE: &str = "review_session";
-    const OLD_WS_INDEX: &str = "idx-review_session-workspace-updated";
     const NEW_WS_INDEX: &str = "idx-review_session-workspace-status-updated";
     const NEW_PJ_INDEX: &str = "idx-review_session-project-status-updated";
 
@@ -139,7 +138,7 @@ mod tests {
         let db = Database::connect("sqlite::memory:").await?;
         let manager = SchemaManager::new(&db);
 
-        // Apply all migrations up to and including 000022
+        // Apply the baseline review schema before the no-op compatibility migration.
         m20260117_000001_create_test_message_table::Migration
             .up(&manager)
             .await?;
@@ -150,19 +149,13 @@ mod tests {
             .up(&manager)
             .await?;
 
-        // Old index should exist, new ones should not
         assert!(
             manager
-                .has_index(REVIEW_SESSION_TABLE, OLD_WS_INDEX)
-                .await?
-        );
-        assert!(
-            !manager
                 .has_index(REVIEW_SESSION_TABLE, NEW_WS_INDEX)
                 .await?
         );
         assert!(
-            !manager
+            manager
                 .has_index(REVIEW_SESSION_TABLE, NEW_PJ_INDEX)
                 .await?
         );
@@ -172,12 +165,7 @@ mod tests {
             .up(&manager)
             .await?;
 
-        // New indexes should exist, old one should be gone
-        assert!(
-            !manager
-                .has_index(REVIEW_SESSION_TABLE, OLD_WS_INDEX)
-                .await?
-        );
+        // New indexes should still exist after the no-op migration.
         assert!(
             manager
                 .has_index(REVIEW_SESSION_TABLE, NEW_WS_INDEX)

--- a/crates/infra/src/db/repo/review_repo.rs
+++ b/crates/infra/src/db/repo/review_repo.rs
@@ -9,6 +9,8 @@ mod file;
 mod revision;
 mod session;
 
+pub use agent_run::CreateAgentRunParams;
+
 pub struct ReviewRepo<'a> {
     db: &'a DatabaseConnection,
 }

--- a/crates/infra/src/db/repo/review_repo/agent_run.rs
+++ b/crates/infra/src/db/repo/review_repo/agent_run.rs
@@ -7,16 +7,20 @@ use crate::db::entities::base::BaseFields;
 use crate::db::entities::review_agent_run;
 use crate::error::{InfraError, Result};
 
+pub struct CreateAgentRunParams {
+    pub session_guid: String,
+    pub base_revision_guid: String,
+    pub run_kind: String,
+    pub execution_mode: String,
+    pub skill_id: Option<String>,
+    pub prompt_rel_path: Option<String>,
+    pub created_by: Option<String>,
+}
+
 impl<'a> ReviewRepo<'a> {
     pub async fn create_agent_run(
         &self,
-        session_guid: String,
-        base_revision_guid: String,
-        run_kind: String,
-        execution_mode: String,
-        skill_id: Option<String>,
-        prompt_rel_path: Option<String>,
-        created_by: Option<String>,
+        params: CreateAgentRunParams,
     ) -> Result<review_agent_run::Model> {
         let base = BaseFields::new();
         let model = review_agent_run::ActiveModel {
@@ -24,21 +28,21 @@ impl<'a> ReviewRepo<'a> {
             created_at: Set(base.created_at),
             updated_at: Set(base.updated_at),
             is_deleted: Set(false),
-            session_guid: Set(session_guid),
-            base_revision_guid: Set(base_revision_guid),
+            session_guid: Set(params.session_guid),
+            base_revision_guid: Set(params.base_revision_guid),
             result_revision_guid: Set(None),
-            run_kind: Set(run_kind),
-            execution_mode: Set(execution_mode),
+            run_kind: Set(params.run_kind),
+            execution_mode: Set(params.execution_mode),
             status: Set("pending".to_string()),
-            skill_id: Set(skill_id),
-            prompt_rel_path: Set(prompt_rel_path),
+            skill_id: Set(params.skill_id),
+            prompt_rel_path: Set(params.prompt_rel_path),
             result_rel_path: Set(None),
             patch_rel_path: Set(None),
             summary_rel_path: Set(None),
             agent_session_ref: Set(None),
             finalize_attempts: Set(0),
             failure_reason: Set(None),
-            created_by: Set(created_by),
+            created_by: Set(params.created_by),
             started_at: Set(None),
             finished_at: Set(None),
         };

--- a/crates/infra/src/utils/atmos_cli.rs
+++ b/crates/infra/src/utils/atmos_cli.rs
@@ -160,7 +160,7 @@ fn ensure_cli_in_shell_config(bin_dir: &Path) {
 
 fn get_shell_config_files(home: &Path, shell_name: &str) -> Vec<PathBuf> {
     let xdg_config_home = std::env::var("XDG_CONFIG_HOME")
-        .map(|path| PathBuf::from(path))
+        .map(PathBuf::from)
         .unwrap_or_else(|_| home.join(".config"));
 
     match shell_name {

--- a/crates/local-model-runtime/src/huggingface.rs
+++ b/crates/local-model-runtime/src/huggingface.rs
@@ -8,7 +8,7 @@ use crate::manifest::ModelEntry;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum HfResolveResult {
-    Model { model: ModelEntry },
+    Model { model: Box<ModelEntry> },
     Choices { choices: Vec<HfModelChoice> },
 }
 
@@ -62,7 +62,9 @@ pub async fn resolve_hf_model_url(client: &Client, raw_url: &str) -> Result<HfRe
     match parsed {
         ParsedHfUrl::File(file_ref) => {
             let model = resolve_file(file_ref).await?;
-            Ok(HfResolveResult::Model { model })
+            Ok(HfResolveResult::Model {
+                model: Box::new(model),
+            })
         }
         ParsedHfUrl::Repo {
             repo_id,
@@ -78,7 +80,9 @@ pub async fn resolve_hf_model_url(client: &Client, raw_url: &str) -> Result<HfRe
                     path: choices[0].filename.clone(),
                 };
                 let model = resolve_file(file_ref).await?;
-                Ok(HfResolveResult::Model { model })
+                Ok(HfResolveResult::Model {
+                    model: Box::new(model),
+                })
             } else if choices.is_empty() {
                 let discovered = discover_gguf_choices(client, &repo_id).await?;
                 if discovered.is_empty() {
@@ -349,7 +353,7 @@ async fn enrich_choice_metadata(choices: &mut [HfModelChoice], revision: &str) {
 }
 
 fn ram_footprint_mb(size_bytes: u64) -> u64 {
-    ((size_bytes + 1024 * 1024 - 1) / (1024 * 1024)).max(1)
+    size_bytes.div_ceil(1024 * 1024).max(1)
 }
 
 fn sort_choices(choices: &mut [HfModelChoice]) {

--- a/crates/local-model-runtime/src/manifest/mod.rs
+++ b/crates/local-model-runtime/src/manifest/mod.rs
@@ -112,7 +112,7 @@ pub async fn fetch_manifest(client: &Client, force_refresh: bool) -> Result<Mode
 
     // Fallback to bundled manifest
     debug!("Using bundled local model manifest");
-    Ok(fetch_bundled_manifest()?)
+    fetch_bundled_manifest()
 }
 
 /// Fetch manifest from a specific URL.
@@ -159,7 +159,7 @@ pub fn current_platform() -> &'static str {
 }
 
 /// Find the binary entry for the current platform.
-pub fn find_binary_for_platform<'a>(manifest: &'a ModelManifest) -> Option<&'a BinaryEntry> {
+pub fn find_binary_for_platform(manifest: &ModelManifest) -> Option<&BinaryEntry> {
     let platform = current_platform();
     manifest.binaries.iter().find(|b| b.platform == platform)
 }

--- a/crates/runtime-manager/src/cli_update.rs
+++ b/crates/runtime-manager/src/cli_update.rs
@@ -90,19 +90,26 @@ pub async fn install_cli_release(release: &LatestCliRelease) -> Result<CliInstal
             .map_err(|error| format!("Failed to create {}: {}", bin_dir.display(), error))?;
     }
 
-    let install_method = if let Some(asset_url) = release.asset_url.as_deref() {
-        info!("Downloading CLI from: {}", asset_url);
-        download_and_install_cli(asset_url, &cli_path).await?;
-        "release_asset"
-    } else {
-        install_from_git(release).await?;
-        "cargo_install_git"
+    let Some(asset_url) = release.asset_url.as_deref() else {
+        return Err(
+            "The latest CLI release does not include a compatible binary asset for this platform."
+                .to_string(),
+        );
     };
 
+    info!("Downloading CLI from: {}", asset_url);
+    download_and_install_cli(asset_url, &cli_path).await?;
+    let version = read_cli_version(&cli_path).ok_or_else(|| {
+        format!(
+            "Failed to determine installed CLI version at {}",
+            cli_path.display()
+        )
+    })?;
+
     Ok(CliInstallResult {
-        version: read_cli_version(&cli_path).unwrap_or_else(|| release.version.clone()),
+        version,
         install_path: cli_path,
-        install_method,
+        install_method: "release_asset",
     })
 }
 
@@ -140,13 +147,6 @@ pub async fn ensure_standalone_cli_on_startup() -> Result<Option<String>, String
     );
     download_and_install_cli(asset_url, &cli_path).await?;
     Ok(read_cli_version(&cli_path))
-}
-
-async fn install_from_git(_release: &LatestCliRelease) -> Result<(), String> {
-    Err(
-        "The latest CLI release does not include a compatible binary asset for this platform."
-            .to_string(),
-    )
 }
 
 async fn download_and_install_cli(asset_url: &str, cli_path: &Path) -> Result<(), String> {

--- a/crates/runtime-manager/src/cli_update.rs
+++ b/crates/runtime-manager/src/cli_update.rs
@@ -63,8 +63,9 @@ pub struct LatestCliRelease {
 
 #[derive(Debug, Clone)]
 pub struct CliInstallResult {
-    pub version: Option<String>,
+    pub version: String,
     pub install_path: PathBuf,
+    pub install_method: &'static str,
 }
 
 pub struct ShellConfigResult {
@@ -77,6 +78,11 @@ pub fn installed_cli_path() -> Option<PathBuf> {
 }
 
 pub async fn install_latest_cli() -> Result<CliInstallResult, String> {
+    let release = fetch_latest_cli_release().await?;
+    install_cli_release(&release).await
+}
+
+pub async fn install_cli_release(release: &LatestCliRelease) -> Result<CliInstallResult, String> {
     let cli_path =
         installed_cli_path().ok_or_else(|| "Cannot determine CLI install path".to_string())?;
     if let Some(bin_dir) = cli_path.parent() {
@@ -84,18 +90,19 @@ pub async fn install_latest_cli() -> Result<CliInstallResult, String> {
             .map_err(|error| format!("Failed to create {}: {}", bin_dir.display(), error))?;
     }
 
-    let release = fetch_latest_cli_release().await?;
-    let asset_url = release
-        .asset_url
-        .as_deref()
-        .ok_or_else(|| "No compatible CLI asset found for this platform".to_string())?;
-
-    info!("Downloading CLI from: {}", asset_url);
-    download_and_install_cli(asset_url, &cli_path).await?;
+    let install_method = if let Some(asset_url) = release.asset_url.as_deref() {
+        info!("Downloading CLI from: {}", asset_url);
+        download_and_install_cli(asset_url, &cli_path).await?;
+        "release_asset"
+    } else {
+        install_from_git(release).await?;
+        "cargo_install_git"
+    };
 
     Ok(CliInstallResult {
-        version: read_cli_version(&cli_path),
+        version: read_cli_version(&cli_path).unwrap_or_else(|| release.version.clone()),
         install_path: cli_path,
+        install_method,
     })
 }
 
@@ -133,6 +140,13 @@ pub async fn ensure_standalone_cli_on_startup() -> Result<Option<String>, String
     );
     download_and_install_cli(asset_url, &cli_path).await?;
     Ok(read_cli_version(&cli_path))
+}
+
+async fn install_from_git(_release: &LatestCliRelease) -> Result<(), String> {
+    Err(
+        "The latest CLI release does not include a compatible binary asset for this platform."
+            .to_string(),
+    )
 }
 
 async fn download_and_install_cli(asset_url: &str, cli_path: &Path) -> Result<(), String> {

--- a/crates/runtime-manager/src/computer_client_settings.rs
+++ b/crates/runtime-manager/src/computer_client_settings.rs
@@ -137,7 +137,7 @@ fn write_restricted_file(path: &Path, contents: &str) -> Result<(), String> {
             .map_err(|err| format!("Failed to write {}: {}", path.display(), err))?;
         file.write_all(contents.as_bytes())
             .map_err(|err| format!("Failed to write {}: {}", path.display(), err))?;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(unix))]

--- a/crates/runtime-manager/src/identity.rs
+++ b/crates/runtime-manager/src/identity.rs
@@ -88,7 +88,7 @@ fn write_identity_file_restricted(path: &std::path::Path, contents: &str) -> Res
             .map_err(|err| format!("Failed to write {}: {}", path.display(), err))?;
         file.write_all(contents.as_bytes())
             .map_err(|err| format!("Failed to write {}: {}", path.display(), err))?;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(unix))]

--- a/crates/runtime-manager/src/lib.rs
+++ b/crates/runtime-manager/src/lib.rs
@@ -17,9 +17,9 @@ mod registration_meta;
 pub mod supervisor;
 
 pub use cli_update::{
-    ensure_standalone_cli_on_startup, fetch_latest_cli_release, install_latest_cli,
-    installed_cli_path, modify_shell_config, read_cli_version, version_gt, CliInstallResult,
-    LatestCliRelease, ShellConfigResult,
+    ensure_standalone_cli_on_startup, fetch_latest_cli_release, install_cli_release,
+    install_latest_cli, installed_cli_path, modify_shell_config, read_cli_version, version_gt,
+    CliInstallResult, LatestCliRelease, ShellConfigResult,
 };
 pub use client_session::{
     clear_client_session, client_session_path, read_client_session, write_client_session,

--- a/crates/runtime-manager/src/supervisor.rs
+++ b/crates/runtime-manager/src/supervisor.rs
@@ -326,9 +326,9 @@ fn spawn_detached_api(
         }
 
         let pid_text = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        return pid_text
+        pid_text
             .parse::<u32>()
-            .map_err(|error| format!("Failed to parse API pid `{pid_text}`: {error}"));
+            .map_err(|error| format!("Failed to parse API pid `{pid_text}`: {error}"))
     }
 
     #[cfg(not(unix))]

--- a/crates/token-usage/src/service.rs
+++ b/crates/token-usage/src/service.rs
@@ -317,7 +317,7 @@ fn build_client_usage(graph: &tokscale_core::GraphResult) -> Vec<ClientTokenUsag
         })
         .collect::<Vec<_>>();
 
-    values.sort_by(|a, b| b.total_tokens.cmp(&a.total_tokens));
+    values.sort_by_key(|value| std::cmp::Reverse(value.total_tokens));
     values
 }
 

--- a/vendor/tokscale-core/src/parser.rs
+++ b/vendor/tokscale-core/src/parser.rs
@@ -178,7 +178,7 @@ mod tests {
 
         let mut file = File::create(&file_path).unwrap();
         writeln!(file, r#"{{"name": "a", "value": 1}}"#).unwrap();
-        writeln!(file, "").unwrap(); // Empty line
+        writeln!(file).unwrap(); // Empty line
         writeln!(file, "   ").unwrap(); // Whitespace only
         writeln!(file, r#"{{"name": "b", "value": 2}}"#).unwrap();
 

--- a/vendor/tokscale-core/src/sessions/opencode.rs
+++ b/vendor/tokscale-core/src/sessions/opencode.rs
@@ -676,7 +676,7 @@ mod tests {
             .filter(|msg| {
                 msg.dedup_key
                     .as_ref()
-                    .map_or(true, |key| seen.insert(key.clone()))
+                    .is_none_or(|key| seen.insert(key.clone()))
             })
             .collect();
 
@@ -750,7 +750,7 @@ mod tests {
         // Simulate the validity check from lib.rs
         let is_valid = cache.migration_complete
             && current_file_count == cache.json_file_count
-            && get_json_dir_mtime(&json_dir).map_or(false, |m| m <= cache.json_dir_mtime_secs);
+            && get_json_dir_mtime(&json_dir).is_some_and(|m| m <= cache.json_dir_mtime_secs);
 
         assert!(is_valid, "Cache should be valid when count and mtime match");
     }
@@ -776,7 +776,7 @@ mod tests {
         let current_file_count = 2u64; // changed
         let is_valid = cache.migration_complete
             && current_file_count == cache.json_file_count
-            && get_json_dir_mtime(&json_dir).map_or(false, |m| m <= cache.json_dir_mtime_secs);
+            && get_json_dir_mtime(&json_dir).is_some_and(|m| m <= cache.json_dir_mtime_secs);
 
         assert!(!is_valid, "Cache should be invalid when file count changes");
     }
@@ -802,7 +802,7 @@ mod tests {
 
         let is_valid = cache.migration_complete
             && 1u64 == cache.json_file_count
-            && get_json_dir_mtime(&json_dir).map_or(false, |m| m <= cache.json_dir_mtime_secs);
+            && get_json_dir_mtime(&json_dir).is_some_and(|m| m <= cache.json_dir_mtime_secs);
 
         assert!(
             !is_valid,
@@ -842,7 +842,7 @@ mod tests {
 
         let is_valid = cache.migration_complete
             && 1u64 == cache.json_file_count
-            && get_json_dir_mtime(&json_dir).map_or(false, |m| m <= cache.json_dir_mtime_secs);
+            && get_json_dir_mtime(&json_dir).is_some_and(|m| m <= cache.json_dir_mtime_secs);
 
         assert!(
             !is_valid,


### PR DESCRIPTION
## Summary

- Original quality score: 88 / 100 for the 2026-06-24 UTC+8 main review window.
- Main finding: `apps/cli/src/commands/update.rs` kept a parallel CLI release discovery, asset-selection, archive-install, and version-comparison implementation after the shared `runtime-manager` updater module existed.
- Refactors `atmos update` to call `runtime_manager::{fetch_latest_cli_release, install_latest_cli, version_gt}` while keeping CLI-specific JSON output and the 24-hour update hint cache in the CLI layer.
- Reduces `apps/cli/src/commands/update.rs` from 729 lines to 140 lines and removes duplicated updater tests whose coverage now lives in `runtime-manager`.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [x] `cargo fmt --package atmos`
- [x] Additional checks: `cargo test -p atmos --quiet`, `cargo test -p runtime-manager --quiet`, `git diff --check`

## Checklist

- [ ] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

## Remaining Risk

- `runtime-manager/src/cli_update.rs` remains an 807-line module. It now owns the updater behavior for API and CLI callers, but a future release-policy expansion should split release discovery, archive install, and shell profile editing into submodules.
- GitHub trigger policy is still duplicated across Rust core-service, Relay TypeScript, and UI option lists; this PR fixes the higher-impact CLI updater duplication only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the CLI updater to use the shared `runtime-manager` end-to-end and tightened install validation for reliable, exact-version updates. Adds the 2026-06-25 quality report and completes clippy/CI cleanups across crates.

- **Refactors**
  - Switched the `atmos update` flow to `runtime_manager::{fetch_latest_cli_release, install_cli_release, version_gt}` with `LatestCliRelease`; the 24-hour hint cache now serializes `LatestCliRelease`.
  - API install endpoint aligns types: wraps `version` as `Some(...)`, returns `install_method`, and uses `install.install_path`.
  - Cross-crate cleanups: introduced `GithubIssueListOptions`, added `CreateIssueOnlyWorkspaceInput`, boxed large DTOs/WS payloads, added `Default` derives, and scoped `clippy` allows.

- **Bug Fixes**
  - `atmos update` installs exactly the release returned by the update check and fails when no compatible asset exists or when the installed version cannot be determined.
  - Non-functional sorting tweaks (e.g., diagnostics, token usage) use key-based reverse ordering to satisfy clippy without changing behavior.
  - Updated infra migration test to reflect the no-op compatibility migration and assert the new review-session indexes.

<sup>Written for commit 7886d3f43d12eec8a6a8b160ef88d23045f0c865. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined the CLI update flow to use shared release discovery, version comparison, and installation logic.
  * Standardized the non-`--check` update path to always perform the same install step, while keeping cache freshness gating and existing `--check` reporting.

* **Bug Fixes**
  * Improved update/install results: consistent reported version plus an explicit install method.
  * API install responses now align the `version` field with its optional response type.
  * When no compatible CLI binary asset is available, installation now fails with a clear error instead of attempting an unexpected fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->