### PR TITLE
refactor: address daily quality findings for 2026-06-26

### DIFF
--- a/apps/web/src/features/agent-fix/hooks/use-agent-fix-context.ts
+++ b/apps/web/src/features/agent-fix/hooks/use-agent-fix-context.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useMemo } from "react";
+import { useContextParams } from "@/shared/hooks/use-context-params";
+import type { AgentFixContextRef } from "@/features/agent-fix/types";
+
+export function useAgentFixContext(): AgentFixContextRef | null {
+  const { currentView, effectiveContextId } = useContextParams();
+
+  return useMemo<AgentFixContextRef | null>(() => {
+    if (!effectiveContextId) return null;
+    if (currentView === "workspace") {
+      return { contextId: effectiveContextId, scope: "workspace" };
+    }
+    if (currentView === "project") {
+      return { contextId: effectiveContextId, scope: "project" };
+    }
+    return null;
+  }, [currentView, effectiveContextId]);
+}

--- a/apps/web/src/features/diff/components/useDiffPromptStash.tsx
+++ b/apps/web/src/features/diff/components/useDiffPromptStash.tsx
@@ -13,7 +13,8 @@ import { MessageSquareText } from 'lucide-react';
 import { toastManager } from '@workspace/ui';
 import { DiffCopyAnnotation } from '@/features/diff/components/DiffCopyAnnotation';
 import { AgentFixToolbar } from '@/features/agent-fix/components/AgentFixToolbar';
-import type { AgentFixContextRef, AgentFixPromptSource } from '@/features/agent-fix/types';
+import type { AgentFixPromptSource } from '@/features/agent-fix/types';
+import { useAgentFixContext } from '@/features/agent-fix/hooks/use-agent-fix-context';
 import {
   buildDiffSelectionInfo,
   formatSelectedRangeLabel,
@@ -22,7 +23,6 @@ import {
   updateViewerDiffItem,
 } from '@/features/diff/lib/diff-code-view-shared';
 import { formatDiffSelectionForAI } from '@/shared/lib/format-selection-for-ai';
-import { useContextParams } from '@/shared/hooks/use-context-params';
 
 export type LoadedDiffContents = {
   oldContent: string;
@@ -69,17 +69,7 @@ export function useDiffPromptStash({
   viewerRef,
   loadedContentsRef,
 }: UseDiffPromptStashArgs) {
-  const { currentView, effectiveContextId } = useContextParams();
-  const agentFixContext = useMemo<AgentFixContextRef | null>(() => {
-    if (!effectiveContextId) return null;
-    if (currentView === 'workspace') {
-      return { contextId: effectiveContextId, scope: 'workspace' };
-    }
-    if (currentView === 'project') {
-      return { contextId: effectiveContextId, scope: 'project' };
-    }
-    return null;
-  }, [currentView, effectiveContextId]);
+  const agentFixContext = useAgentFixContext();
   const copyKeyRef = useRef(0);
   const [stashedPromptState, setStashedPromptState] =
     useState<StashedDiffPromptState>(() => ({

--- a/apps/web/src/features/github/components/ActionsActionBar.tsx
+++ b/apps/web/src/features/github/components/ActionsActionBar.tsx
@@ -1,0 +1,195 @@
+import React from "react";
+import { Button } from "@workspace/ui";
+import { ExternalLink, LoaderCircle, RotateCw } from "lucide-react";
+import { cn } from "@/shared/lib/utils";
+
+export function ActionsActionBar({
+  actionLoading,
+  isCompleted,
+  isFailure,
+  onOpenGitHub,
+  onOpenBetterHub,
+  onRerunFailed,
+  onRerunAll,
+}: {
+  actionLoading: boolean;
+  isCompleted: boolean;
+  isFailure: boolean;
+  onOpenGitHub: () => void;
+  onOpenBetterHub: () => void;
+  onRerunFailed: () => void;
+  onRerunAll: () => void;
+}) {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [shouldRenderToolbar, setShouldRenderToolbar] = React.useState(false);
+  const [isToolbarHovered, setIsToolbarHovered] = React.useState(false);
+  const closeTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const openFrameRef = React.useRef<number | null>(null);
+
+  const cancelClose = React.useCallback(() => {
+    if (closeTimeoutRef.current) {
+      clearTimeout(closeTimeoutRef.current);
+      closeTimeoutRef.current = null;
+    }
+    if (openFrameRef.current != null) {
+      cancelAnimationFrame(openFrameRef.current);
+      openFrameRef.current = null;
+    }
+  }, []);
+
+  const scheduleOpenAfterMount = React.useCallback(() => {
+    openFrameRef.current = requestAnimationFrame(() => {
+      openFrameRef.current = requestAnimationFrame(() => {
+        setIsOpen(true);
+        openFrameRef.current = null;
+      });
+    });
+  }, []);
+
+  const openToolbar = React.useCallback(() => {
+    cancelClose();
+    if (shouldRenderToolbar) {
+      setIsOpen(true);
+      return;
+    }
+    setShouldRenderToolbar(true);
+    scheduleOpenAfterMount();
+  }, [cancelClose, scheduleOpenAfterMount, shouldRenderToolbar]);
+
+  const closeToolbar = React.useCallback(() => {
+    cancelClose();
+    setIsOpen(false);
+    closeTimeoutRef.current = setTimeout(() => {
+      setShouldRenderToolbar(false);
+      closeTimeoutRef.current = null;
+    }, 220);
+  }, [cancelClose]);
+
+  const scheduleClose = React.useCallback(() => {
+    closeToolbar();
+  }, [closeToolbar]);
+
+  React.useEffect(() => {
+    return () => {
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current);
+      }
+      if (openFrameRef.current != null) {
+        cancelAnimationFrame(openFrameRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <div className="pointer-events-none absolute bottom-6 left-1/2 z-10 flex -translate-x-1/2 justify-center">
+      <div className="pointer-events-auto relative flex items-end justify-center">
+        {shouldRenderToolbar && (
+          <div
+            onMouseEnter={() => {
+              setIsToolbarHovered(true);
+              cancelClose();
+            }}
+            onMouseLeave={() => {
+              setIsToolbarHovered(false);
+              scheduleClose();
+            }}
+            onBlur={(event) => {
+              if (
+                !event.currentTarget.contains(event.relatedTarget) &&
+                !isToolbarHovered
+              ) {
+                scheduleClose();
+              }
+            }}
+            aria-hidden={!isOpen}
+            className={cn(
+              "absolute bottom-full left-1/2 z-10 flex max-w-[calc(100vw-3rem)] -translate-x-1/2 items-center gap-6 whitespace-nowrap rounded-xl border border-dashed border-border/80 bg-background/90 px-4 py-2.5 shadow-xl backdrop-blur-md",
+              !isOpen
+                ? "pointer-events-none opacity-0 transition-opacity duration-220 ease-in"
+                : "pointer-events-auto opacity-100 transition-opacity duration-280 ease-[cubic-bezier(0.22,1,0.36,1)]",
+            )}
+          >
+            <div className="absolute left-1/2 top-full h-4 w-24 -translate-x-1/2" />
+            <div className="flex gap-2.5">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onOpenGitHub}
+                className="shadow-sm hover:shadow-md transition-shadow h-8 text-[11px] px-3 font-medium"
+              >
+                <ExternalLink className="mr-1.5 size-3.5" />
+                GitHub
+              </Button>
+
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onOpenBetterHub}
+                className="shadow-sm hover:shadow-md transition-shadow h-8 text-[11px] px-3 font-medium"
+              >
+                <ExternalLink className="mr-1.5 size-3.5" />
+                BetterHub
+              </Button>
+            </div>
+
+            {isCompleted && (
+              <>
+                <div className="w-px h-5 bg-border/40 shrink-0 mx-1" />
+
+                <div className="flex gap-2.5">
+                  {isFailure && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={onRerunFailed}
+                      disabled={actionLoading}
+                      className="shadow-sm hover:shadow-md transition-shadow h-8 text-[11px] px-3 font-medium"
+                    >
+                      {actionLoading ? (
+                        <LoaderCircle className="mr-1.5 size-3.5 animate-spin" />
+                      ) : (
+                        <RotateCw className="mr-1.5 size-3.5" />
+                      )}
+                      Re-run failed jobs
+                    </Button>
+                  )}
+
+                  <Button
+                    variant="default"
+                    size="sm"
+                    onClick={onRerunAll}
+                    disabled={actionLoading}
+                    className="shadow-sm hover:shadow-md transition-shadow h-8 text-[11px] px-3 font-medium"
+                  >
+                    {actionLoading ? (
+                      <LoaderCircle className="mr-1.5 size-3.5 animate-spin" />
+                    ) : (
+                      <RotateCw className="mr-1.5 size-3.5" />
+                    )}
+                    Re-run all jobs
+                  </Button>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        <button
+          type="button"
+          aria-label="Show workflow actions"
+          onClick={openToolbar}
+          onFocus={openToolbar}
+          onMouseEnter={openToolbar}
+          className={cn(
+            "h-1.5 w-40 rounded-full border-0 bg-foreground/20 p-0 shadow-[0_1px_8px_rgba(0,0,0,0.18)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+            !isOpen
+              ? "pointer-events-auto opacity-100 transition-opacity duration-220 ease-in"
+              : "pointer-events-none opacity-0 transition-opacity duration-280 ease-[cubic-bezier(0.22,1,0.36,1)]",
+          )}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/github/components/ActionsActionBar.tsx
+++ b/apps/web/src/features/github/components/ActionsActionBar.tsx
@@ -22,7 +22,6 @@ export function ActionsActionBar({
 }) {
   const [isOpen, setIsOpen] = React.useState(false);
   const [shouldRenderToolbar, setShouldRenderToolbar] = React.useState(false);
-  const [isToolbarHovered, setIsToolbarHovered] = React.useState(false);
   const closeTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
@@ -71,6 +70,15 @@ export function ActionsActionBar({
     closeToolbar();
   }, [closeToolbar]);
 
+  const handleControlBlur = React.useCallback(
+    (event: React.FocusEvent<HTMLDivElement>) => {
+      if (!event.currentTarget.contains(event.relatedTarget)) {
+        scheduleClose();
+      }
+    },
+    [scheduleClose],
+  );
+
   React.useEffect(() => {
     return () => {
       if (closeTimeoutRef.current) {
@@ -84,24 +92,18 @@ export function ActionsActionBar({
 
   return (
     <div className="pointer-events-none absolute bottom-6 left-1/2 z-10 flex -translate-x-1/2 justify-center">
-      <div className="pointer-events-auto relative flex items-end justify-center">
+      <div
+        className="pointer-events-auto relative flex items-end justify-center"
+        onBlur={handleControlBlur}
+        onMouseLeave={scheduleClose}
+      >
         {shouldRenderToolbar && (
           <div
             onMouseEnter={() => {
-              setIsToolbarHovered(true);
               cancelClose();
             }}
             onMouseLeave={() => {
-              setIsToolbarHovered(false);
               scheduleClose();
-            }}
-            onBlur={(event) => {
-              if (
-                !event.currentTarget.contains(event.relatedTarget) &&
-                !isToolbarHovered
-              ) {
-                scheduleClose();
-              }
             }}
             aria-hidden={!isOpen}
             className={cn(

--- a/apps/web/src/features/github/components/ActionsDetailModal.tsx
+++ b/apps/web/src/features/github/components/ActionsDetailModal.tsx
@@ -5,7 +5,6 @@ import {
   DialogHeader,
   DialogTitle,
   DialogDescription,
-  Button,
   DialogClose,
   Avatar,
   AvatarImage,
@@ -14,7 +13,6 @@ import {
 } from "@workspace/ui";
 import { useWebSocketStore } from "@/features/connection/hooks/use-websocket";
 import {
-  ExternalLink,
   XCircle,
   Expand,
   Shrink,
@@ -23,27 +21,18 @@ import {
   Rocket,
   X,
   Clock,
-  LoaderCircle,
-  RotateCw,
-  Box,
-  HelpCircle,
-  ChevronDown,
 } from "lucide-react";
 import { useGithubActionsDetail } from "@/features/github/hooks/use-github";
 import {
-  formatActionDuration,
   formatActionTimestamp,
   formatActionTimeAgo,
 } from "@/features/github/lib/action-run-time";
 import { cn } from "@/shared/lib/utils";
 import { type ActionRun } from "./ActionsPanel";
-import { useContextParams } from "@/shared/hooks/use-context-params";
-import type {
-  AgentFixContextRef,
-  AgentFixPromptSource,
-} from "@/features/agent-fix/types";
-import { AgentFixButton } from "@/features/agent-fix/components/AgentFixButton";
-import { buildGithubActionsJobFixPrompt } from "@/features/github/lib/agent-fix-prompts";
+import { useAgentFixContext } from "@/features/agent-fix/hooks/use-agent-fix-context";
+import { ActionsActionBar } from "./ActionsActionBar";
+import { ActionsJobsList } from "./ActionsJobsList";
+import type { ActionJob } from "./actions-detail-types";
 
 interface ActionsDetailModalProps {
   owner: string;
@@ -56,32 +45,6 @@ interface ActionsDetailModalProps {
   onOpenChange: (open: boolean) => void;
 }
 
-interface ActionStep {
-  name?: string;
-  status?: string;
-  conclusion?: string;
-  number?: number;
-  startedAt?: string;
-  started_at?: string;
-  completedAt?: string;
-  completed_at?: string;
-}
-
-interface ActionJob {
-  databaseId?: number;
-  id?: number;
-  name?: string;
-  status?: string;
-  conclusion?: string;
-  startedAt?: string;
-  started_at?: string;
-  completedAt?: string;
-  completed_at?: string;
-  url?: string;
-  html_url?: string;
-  steps?: ActionStep[];
-}
-
 export function ActionsDetailModal({
   owner,
   repo,
@@ -90,18 +53,10 @@ export function ActionsDetailModal({
   isOpen,
   onOpenChange,
 }: ActionsDetailModalProps) {
-  const { currentView, effectiveContextId } = useContextParams();
+  const agentFixContext = useAgentFixContext();
   const send = useWebSocketStore((s) => s.send);
   const [actionLoading, setActionLoading] = React.useState<boolean>(false);
   const [isFullscreen, setIsFullscreen] = React.useState(false);
-  const [expandedJobIds, setExpandedJobIds] = React.useState<Set<string>>(
-    () => new Set(),
-  );
-  const [selectedStepKey, setSelectedStepKey] = React.useState<string | null>(
-    null,
-  );
-  const [openAgentFixSettingsSourceId, setOpenAgentFixSettingsSourceId] =
-    React.useState<string | null>(null);
 
   const effectiveRunId = runId ?? run?.databaseId;
   const { data: detail, loading: detailLoading } = useGithubActionsDetail(
@@ -113,28 +68,6 @@ export function ActionsDetailModal({
     () => (Array.isArray(detail?.jobs) ? (detail.jobs as ActionJob[]) : []),
     [detail?.jobs],
   );
-  const agentFixContext = React.useMemo<AgentFixContextRef | null>(() => {
-    if (!effectiveContextId) return null;
-    if (currentView === "workspace") {
-      return { contextId: effectiveContextId, scope: "workspace" };
-    }
-    if (currentView === "project") {
-      return { contextId: effectiveContextId, scope: "project" };
-    }
-    return null;
-  }, [currentView, effectiveContextId]);
-
-  const toggleJob = React.useCallback((jobKey: string) => {
-    setExpandedJobIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(jobKey)) {
-        next.delete(jobKey);
-      } else {
-        next.add(jobKey);
-      }
-      return next;
-    });
-  }, []);
 
   // Merge: prefer the passed-in `run` object; fall back to `detail` (available after fetch on refresh)
   const effectiveRun: ActionRun | null =
@@ -201,28 +134,6 @@ export function ActionsDetailModal({
     window.open(effectiveRun.url, "_blank");
   };
 
-  React.useEffect(() => {
-    if (!isOpen || !effectiveRunId || jobs.length === 0) {
-      setExpandedJobIds(new Set());
-      setSelectedStepKey(null);
-      return;
-    }
-
-    setExpandedJobIds(
-      new Set(
-        jobs
-          .map((job, index) => ({ job, index }))
-          .filter(({ job }) => job.conclusion === "failure")
-          .map(({ job, index }) => getActionJobKey(job, index)),
-      ),
-    );
-    setSelectedStepKey(null);
-  }, [effectiveRunId, isOpen, jobs]);
-
-  React.useEffect(() => {
-    setOpenAgentFixSettingsSourceId(null);
-  }, [effectiveRunId, isOpen]);
-
   // Still loading initial data on refresh — show dialog with loading skeleton
   if (!effectiveRun) {
     if (!isOpen) return null;
@@ -249,28 +160,6 @@ export function ActionsDetailModal({
   const isCompleted = effectiveRun.status === "completed";
   const createdAtTimestamp = formatActionTimestamp(effectiveRun.createdAt);
   const createdAtTimeAgo = formatActionTimeAgo(effectiveRun.createdAt);
-  const buildJobAgentFixSource = (job: ActionJob): AgentFixPromptSource => {
-    const jobName = job.name || effectiveRun.workflowName || "job";
-    return {
-      id: `ci-job:${owner}/${repo}:${effectiveRun.databaseId}:${job.databaseId ?? job.id ?? jobName}`,
-      family: "ci_job",
-      context: agentFixContext,
-      label: `Fix CI: ${jobName}`,
-      disabledReason: agentFixContext
-        ? null
-        : "Open a workspace or project to run Agent Fix.",
-      getPrompt: () => ({
-        prompt: buildGithubActionsJobFixPrompt({
-          owner,
-          repo,
-          run: effectiveRun,
-          job,
-        }),
-        terminalTabTitle: `Fix CI: ${jobName}`,
-        terminalPaneLabel: `Fix ${jobName}`,
-      }),
-    };
-  };
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
@@ -436,363 +325,16 @@ export function ActionsDetailModal({
                 </div>
               </div>
 
-              {/* Jobs Summary Section */}
-              <div className="flex flex-col gap-3">
-                <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider flex items-center gap-2">
-                  <Box className="size-3.5" /> Jobs
-                </h4>
-                <div className="border rounded-xl flex flex-col divide-y divide-border overflow-hidden bg-background">
-                  {detailLoading ? (
-                    <div className="flex flex-col">
-                      {[1, 2].map((i) => (
-                        <div
-                          key={`skel-job-${i}`}
-                          className="flex flex-col border-b border-border/50 last:border-0"
-                        >
-                          <div className="px-4 py-3 flex items-center gap-3">
-                            <div className="shrink-0 flex items-center justify-center">
-                              <Skeleton className="size-4 rounded-full bg-muted-foreground/20" />
-                            </div>
-                            <div className="flex items-center gap-2 flex-1 min-w-0">
-                              <Skeleton className="h-4 w-28 rounded-md bg-muted-foreground/20" />
-                            </div>
-                            <Skeleton className="h-3 w-12 rounded-md hidden sm:block bg-muted-foreground/20" />
-                            <Skeleton className="h-3 w-24 rounded-md bg-muted-foreground/20" />
-                          </div>
-
-                          <div className="pl-11 pr-4 pb-4 flex flex-col gap-2">
-                            {[1, 2, 3, 4, 5].map((stepIdx) => (
-                              <div
-                                key={`skel-step-${i}-${stepIdx}`}
-                                className="flex items-center gap-2"
-                              >
-                                <Skeleton className="size-3.5 rounded-full bg-muted-foreground/10 shrink-0" />
-                                <Skeleton
-                                  className={cn(
-                                    "h-3 rounded-md bg-muted-foreground/10",
-                                    stepIdx === 1
-                                      ? "w-24"
-                                      : stepIdx === 2
-                                        ? "w-40"
-                                        : stepIdx === 3
-                                          ? "w-48"
-                                          : stepIdx === 4
-                                            ? "w-32"
-                                            : "w-20",
-                                  )}
-                                />
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  ) : jobs.length > 0 ? (
-                    jobs.map((job, jobIndex) => {
-                      const jobKey = getActionJobKey(job, jobIndex);
-                      const steps = Array.isArray(job.steps) ? job.steps : [];
-                      const jobSuccess = job.conclusion === "success";
-                      const jobFailure = job.conclusion === "failure";
-                      const jobSkipped = job.conclusion === "skipped";
-                      const jobCompleted = job.status === "completed";
-                      const jobStartedAtTimeAgo = formatActionTimeAgo(
-                        getStartedAt(job),
-                      );
-                      const isExpanded = expandedJobIds.has(jobKey);
-                      const canExpand = steps.length > 0;
-                      const agentFixSource = jobFailure
-                        ? buildJobAgentFixSource(job)
-                        : null;
-                      const agentFixSettingsOpen =
-                        !!agentFixSource &&
-                        openAgentFixSettingsSourceId === agentFixSource.id;
-                      const agentFixVisible = agentFixSettingsOpen;
-
-                      return (
-                        <div key={jobKey} className="flex flex-col">
-                          <div
-                            role="button"
-                            tabIndex={0}
-                            onClick={() => {
-                              if (canExpand) toggleJob(jobKey);
-                            }}
-                            onKeyDown={(event) => {
-                              if (!canExpand) return;
-                              if (event.key === "Enter" || event.key === " ") {
-                                event.preventDefault();
-                                toggleJob(jobKey);
-                              }
-                            }}
-                            aria-expanded={canExpand ? isExpanded : undefined}
-                            className={cn(
-                              "group px-4 py-3 flex w-full items-center gap-3 text-left transition-colors duration-180 ease-[cubic-bezier(0.22,1,0.36,1)]",
-                              canExpand
-                                ? "cursor-pointer hover:bg-muted/30"
-                                : "cursor-default",
-                              isExpanded && "bg-muted/20",
-                            )}
-                          >
-                            <ChevronDown
-                              className={cn(
-                                "size-3.5 shrink-0 text-muted-foreground/60 transition-transform duration-180 ease-[cubic-bezier(0.22,1,0.36,1)]",
-                                !isExpanded && "-rotate-90",
-                                !canExpand && "opacity-0",
-                              )}
-                            />
-                            <div className="shrink-0 flex items-center justify-center">
-                              {jobCompleted ? (
-                                jobSuccess ? (
-                                  <CheckCircle2 className="size-4 text-emerald-500" />
-                                ) : jobFailure ? (
-                                  <XCircle className="size-4 text-red-500" />
-                                ) : jobSkipped ? (
-                                  <div className="size-4 rounded-full border-2 border-muted-foreground/40 flex items-center justify-center" />
-                                ) : (
-                                  <HelpCircle className="size-4 text-muted-foreground" />
-                                )
-                              ) : (
-                                <Loader2 className="size-4 animate-spin text-blue-500" />
-                              )}
-                            </div>
-                            <div className="flex items-center gap-2 flex-1 min-w-0">
-                              <span className="font-semibold text-sm truncate">
-                                {job.name}
-                              </span>
-                              {jobSkipped && (
-                                <span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded-sm shrink-0">
-                                  skipped
-                                </span>
-                              )}
-                            </div>
-
-                            {steps.length > 0 && (
-                              <div className="hidden sm:flex text-[11px] text-muted-foreground/70 shrink-0 gap-1 opacity-70">
-                                <span>{steps.length} steps</span>
-                              </div>
-                            )}
-
-                            {jobCompleted && jobStartedAtTimeAgo && (
-                              <div className="shrink-0 whitespace-nowrap tabular-nums">
-                                {jobFailure ? (
-                                  <span className="relative inline-flex min-w-[92px] justify-end">
-                                    <span
-                                      className={cn(
-                                        "text-[11px] text-muted-foreground/80 group-hover:opacity-0 group-focus-visible:opacity-0",
-                                        agentFixVisible && "!opacity-0",
-                                      )}
-                                      style={
-                                        agentFixVisible
-                                          ? { opacity: 0 }
-                                          : undefined
-                                      }
-                                    >
-                                      {jobStartedAtTimeAgo}
-                                    </span>
-                                    <span
-                                      className={cn(
-                                        "invisible pointer-events-none absolute right-0 top-1/2 -translate-y-1/2 opacity-0",
-                                        "group-hover:visible group-hover:pointer-events-auto group-hover:opacity-100",
-                                        "group-focus-visible:visible group-focus-visible:pointer-events-auto group-focus-visible:opacity-100",
-                                        agentFixVisible &&
-                                          "!visible !pointer-events-auto !opacity-100",
-                                      )}
-                                      data-agent-fix-action-host="true"
-                                      style={
-                                        agentFixVisible
-                                          ? { opacity: 1 }
-                                          : undefined
-                                      }
-                                      onClick={(event) =>
-                                        event.stopPropagation()
-                                      }
-                                      onKeyDown={(event) =>
-                                        event.stopPropagation()
-                                      }
-                                    >
-                                      {agentFixSource ? (
-                                        <AgentFixButton
-                                          source={agentFixSource}
-                                          mode="label"
-                                          appearance="subtle"
-                                          onSettingsOpenChange={(open) => {
-                                            setOpenAgentFixSettingsSourceId(
-                                              (current) => {
-                                                if (open)
-                                                  return agentFixSource.id;
-                                                return current ===
-                                                  agentFixSource.id
-                                                  ? null
-                                                  : current;
-                                              },
-                                            );
-                                          }}
-                                        />
-                                      ) : null}
-                                    </span>
-                                  </span>
-                                ) : (
-                                  <span className="text-[11px] text-muted-foreground/80">
-                                    {jobStartedAtTimeAgo}
-                                  </span>
-                                )}
-                              </div>
-                            )}
-                          </div>
-
-                          {steps.length > 0 && (
-                            <div
-                              className={cn(
-                                "grid overflow-hidden transition-[grid-template-rows,opacity,border-color] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
-                                isExpanded
-                                  ? "grid-rows-[1fr] border-t border-border/40 opacity-100"
-                                  : "grid-rows-[0fr] border-t border-transparent opacity-0",
-                              )}
-                            >
-                              <div className="min-h-0 overflow-hidden">
-                                <div className="bg-muted/10 px-4 py-3">
-                                  <div className="ml-6 flex flex-col gap-1.5">
-                                    {steps.map((step, stepIndex) => {
-                                      const stepKey = getActionStepKey(
-                                        jobKey,
-                                        step,
-                                        stepIndex,
-                                      );
-                                      const isSelected =
-                                        selectedStepKey === stepKey;
-                                      const stepStatus =
-                                        step.conclusion ||
-                                        step.status ||
-                                        "unknown";
-                                      const stepStartedAt = getStartedAt(step);
-                                      const stepCompletedAt =
-                                        getCompletedAt(step);
-                                      const stepStartedLabel =
-                                        formatActionTimestamp(stepStartedAt);
-                                      const stepCompletedLabel =
-                                        formatActionTimestamp(stepCompletedAt);
-                                      const stepDuration = formatActionDuration(
-                                        stepStartedAt,
-                                        stepCompletedAt,
-                                      );
-
-                                      return (
-                                        <div
-                                          key={stepKey}
-                                          role="button"
-                                          tabIndex={isExpanded ? 0 : -1}
-                                          onClick={() =>
-                                            setSelectedStepKey(
-                                              isSelected ? null : stepKey,
-                                            )
-                                          }
-                                          onKeyDown={(event) => {
-                                            if (
-                                              event.key === "Enter" ||
-                                              event.key === " "
-                                            ) {
-                                              event.preventDefault();
-                                              setSelectedStepKey(
-                                                isSelected ? null : stepKey,
-                                              );
-                                            }
-                                          }}
-                                          className={cn(
-                                            "group/step flex cursor-pointer items-start gap-2 rounded-md border px-2 py-2 text-xs transition-colors duration-180 ease-[cubic-bezier(0.22,1,0.36,1)] outline-none",
-                                            isSelected
-                                              ? "border-border/70 bg-background shadow-sm"
-                                              : "border-transparent text-muted-foreground/85 hover:bg-background/70 focus-visible:border-ring/40",
-                                          )}
-                                        >
-                                          <div className="mt-0.5 shrink-0">
-                                            <StepStatusIcon
-                                              status={step.status}
-                                              conclusion={step.conclusion}
-                                            />
-                                          </div>
-                                          <div className="min-w-0 flex-1">
-                                            <div className="flex items-center justify-between gap-3">
-                                              <span
-                                                className={cn(
-                                                  "min-w-0 truncate font-medium",
-                                                  step.conclusion === "failure"
-                                                    ? "text-red-500"
-                                                    : "text-foreground/90",
-                                                )}
-                                              >
-                                                {step.name ||
-                                                  `Step ${stepIndex + 1}`}
-                                              </span>
-                                              <div className="flex shrink-0 items-center gap-2">
-                                                {stepDuration && (
-                                                  <span className="hidden font-mono text-[10px] text-muted-foreground/70 sm:inline">
-                                                    {stepDuration}
-                                                  </span>
-                                                )}
-                                                <button
-                                                  type="button"
-                                                  aria-label={`Open ${step.name || "step"} on GitHub`}
-                                                  tabIndex={isExpanded ? 0 : -1}
-                                                  onClick={(event) => {
-                                                    event.stopPropagation();
-                                                    openActionStepInGitHub(
-                                                      owner,
-                                                      repo,
-                                                      effectiveRun.databaseId,
-                                                      job,
-                                                      step,
-                                                    );
-                                                  }}
-                                                  className="flex size-6 items-center justify-center rounded-md text-muted-foreground/60 opacity-0 transition-all duration-180 ease-[cubic-bezier(0.22,1,0.36,1)] hover:bg-muted hover:text-foreground group-hover/step:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-                                                >
-                                                  <ExternalLink className="size-3" />
-                                                </button>
-                                              </div>
-                                            </div>
-
-                                            {isSelected && (
-                                              <div className="mt-2 grid grid-cols-1 gap-1.5 rounded-md border border-border/40 bg-muted/20 p-2 sm:grid-cols-2">
-                                                <StepMeta
-                                                  label="Status"
-                                                  value={stepStatus}
-                                                />
-                                                <StepMeta
-                                                  label="Duration"
-                                                  value={stepDuration ?? "-"}
-                                                />
-                                                <StepMeta
-                                                  label="Started"
-                                                  value={
-                                                    stepStartedLabel ?? "-"
-                                                  }
-                                                />
-                                                <StepMeta
-                                                  label="Completed"
-                                                  value={
-                                                    stepCompletedLabel ?? "-"
-                                                  }
-                                                />
-                                              </div>
-                                            )}
-                                          </div>
-                                        </div>
-                                      );
-                                    })}
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          )}
-                        </div>
-                      );
-                    })
-                  ) : (
-                    <div className="py-8 text-center text-xs text-muted-foreground/60 flex flex-col items-center">
-                      <Box className="size-8 opacity-20 mb-2" />
-                      No jobs found in this workflow run.
-                    </div>
-                  )}
-                </div>
-              </div>
+              <ActionsJobsList
+                agentFixContext={agentFixContext}
+                detailLoading={detailLoading}
+                isOpen={isOpen}
+                jobs={jobs}
+                owner={owner}
+                repo={repo}
+                run={effectiveRun}
+                runId={effectiveRunId}
+              />
             </div>
           </div>
         </div>
@@ -813,274 +355,6 @@ export function ActionsDetailModal({
         />
       </DialogContent>
     </Dialog>
-  );
-}
-
-function getStartedAt(value: { startedAt?: string; started_at?: string }) {
-  return value.startedAt ?? value.started_at ?? null;
-}
-
-function getCompletedAt(value: {
-  completedAt?: string;
-  completed_at?: string;
-}) {
-  return value.completedAt ?? value.completed_at ?? null;
-}
-
-function getActionJobKey(job: ActionJob, index: number) {
-  return String(job.databaseId ?? job.id ?? `${job.name ?? "job"}-${index}`);
-}
-
-function getActionStepKey(jobKey: string, step: ActionStep, index: number) {
-  return `${jobKey}:${step.number ?? step.name ?? index}`;
-}
-
-function openActionStepInGitHub(
-  owner: string,
-  repo: string,
-  runId: number,
-  job: ActionJob,
-  step: ActionStep,
-) {
-  const jobId = job.databaseId ?? job.id;
-  const rawJobUrl =
-    job.html_url ??
-    (job.url && !job.url.includes("api.github.com") ? job.url : undefined);
-  const jobUrl =
-    rawJobUrl ??
-    (jobId
-      ? `https://github.com/${owner}/${repo}/actions/runs/${runId}/job/${jobId}`
-      : `https://github.com/${owner}/${repo}/actions/runs/${runId}`);
-  const href =
-    jobId && step.number ? `${jobUrl}#step:${step.number}:1` : jobUrl;
-  window.open(href, "_blank");
-}
-
-function StepStatusIcon({
-  status,
-  conclusion,
-}: {
-  status?: string;
-  conclusion?: string;
-}) {
-  if (conclusion === "success") {
-    return <CheckCircle2 className="size-3.5 text-emerald-500" />;
-  }
-  if (conclusion === "failure") {
-    return <XCircle className="size-3.5 text-red-500" />;
-  }
-  if (conclusion === "skipped") {
-    return (
-      <div className="size-3.5 rounded-full border-2 border-muted-foreground/40" />
-    );
-  }
-  if (status === "in_progress" || status === "queued") {
-    return <Loader2 className="size-3.5 animate-spin text-blue-500" />;
-  }
-  return <HelpCircle className="size-3.5 text-muted-foreground" />;
-}
-
-function StepMeta({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="flex min-w-0 items-center justify-between gap-3">
-      <span className="shrink-0 text-[10px] font-semibold uppercase text-muted-foreground/70">
-        {label}
-      </span>
-      <span className="min-w-0 truncate text-right font-mono text-[10px] text-foreground/80 capitalize">
-        {value}
-      </span>
-    </div>
-  );
-}
-
-function ActionsActionBar({
-  actionLoading,
-  isCompleted,
-  isFailure,
-  onOpenGitHub,
-  onOpenBetterHub,
-  onRerunFailed,
-  onRerunAll,
-}: {
-  actionLoading: boolean;
-  isCompleted: boolean;
-  isFailure: boolean;
-  onOpenGitHub: () => void;
-  onOpenBetterHub: () => void;
-  onRerunFailed: () => void;
-  onRerunAll: () => void;
-}) {
-  const [isOpen, setIsOpen] = React.useState(false);
-  const [shouldRenderToolbar, setShouldRenderToolbar] = React.useState(false);
-  const [isToolbarHovered, setIsToolbarHovered] = React.useState(false);
-  const closeTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-  const openFrameRef = React.useRef<number | null>(null);
-
-  const cancelClose = React.useCallback(() => {
-    if (closeTimeoutRef.current) {
-      clearTimeout(closeTimeoutRef.current);
-      closeTimeoutRef.current = null;
-    }
-    if (openFrameRef.current != null) {
-      cancelAnimationFrame(openFrameRef.current);
-      openFrameRef.current = null;
-    }
-  }, []);
-
-  const scheduleOpenAfterMount = React.useCallback(() => {
-    openFrameRef.current = requestAnimationFrame(() => {
-      openFrameRef.current = requestAnimationFrame(() => {
-        setIsOpen(true);
-        openFrameRef.current = null;
-      });
-    });
-  }, []);
-
-  const openToolbar = React.useCallback(() => {
-    cancelClose();
-    if (shouldRenderToolbar) {
-      setIsOpen(true);
-      return;
-    }
-    setShouldRenderToolbar(true);
-    scheduleOpenAfterMount();
-  }, [cancelClose, scheduleOpenAfterMount, shouldRenderToolbar]);
-
-  const closeToolbar = React.useCallback(() => {
-    cancelClose();
-    setIsOpen(false);
-    closeTimeoutRef.current = setTimeout(() => {
-      setShouldRenderToolbar(false);
-      closeTimeoutRef.current = null;
-    }, 220);
-  }, [cancelClose]);
-
-  const scheduleClose = React.useCallback(() => {
-    closeToolbar();
-  }, [closeToolbar]);
-
-  React.useEffect(() => {
-    return () => {
-      if (closeTimeoutRef.current) {
-        clearTimeout(closeTimeoutRef.current);
-      }
-      if (openFrameRef.current != null) {
-        cancelAnimationFrame(openFrameRef.current);
-      }
-    };
-  }, []);
-
-  return (
-    <div className="pointer-events-none absolute bottom-6 left-1/2 z-10 flex -translate-x-1/2 justify-center">
-      <div className="pointer-events-auto relative flex items-end justify-center">
-        {shouldRenderToolbar && (
-          <div
-            onMouseEnter={() => {
-              setIsToolbarHovered(true);
-              cancelClose();
-            }}
-            onMouseLeave={() => {
-              setIsToolbarHovered(false);
-              scheduleClose();
-            }}
-            onBlur={(event) => {
-              if (
-                !event.currentTarget.contains(event.relatedTarget) &&
-                !isToolbarHovered
-              ) {
-                scheduleClose();
-              }
-            }}
-            aria-hidden={!isOpen}
-            className={cn(
-              "absolute bottom-full left-1/2 z-10 flex max-w-[calc(100vw-3rem)] -translate-x-1/2 items-center gap-6 whitespace-nowrap rounded-xl border border-dashed border-border/80 bg-background/90 px-4 py-2.5 shadow-xl backdrop-blur-md",
-              !isOpen
-                ? "pointer-events-none opacity-0 transition-opacity duration-220 ease-in"
-                : "pointer-events-auto opacity-100 transition-opacity duration-280 ease-[cubic-bezier(0.22,1,0.36,1)]",
-            )}
-          >
-            <div className="absolute left-1/2 top-full h-4 w-24 -translate-x-1/2" />
-            <div className="flex gap-2.5">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={onOpenGitHub}
-                className="shadow-sm hover:shadow-md transition-shadow h-8 text-[11px] px-3 font-medium"
-              >
-                <ExternalLink className="mr-1.5 size-3.5" />
-                GitHub
-              </Button>
-
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={onOpenBetterHub}
-                className="shadow-sm hover:shadow-md transition-shadow h-8 text-[11px] px-3 font-medium"
-              >
-                <ExternalLink className="mr-1.5 size-3.5" />
-                BetterHub
-              </Button>
-            </div>
-
-            {isCompleted && (
-              <>
-                <div className="w-px h-5 bg-border/40 shrink-0 mx-1" />
-
-                <div className="flex gap-2.5">
-                  {isFailure && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={onRerunFailed}
-                      disabled={actionLoading}
-                      className="shadow-sm hover:shadow-md transition-shadow h-8 text-[11px] px-3 font-medium"
-                    >
-                      {actionLoading ? (
-                        <LoaderCircle className="mr-1.5 size-3.5 animate-spin" />
-                      ) : (
-                        <RotateCw className="mr-1.5 size-3.5" />
-                      )}
-                      Re-run failed jobs
-                    </Button>
-                  )}
-
-                  <Button
-                    variant="default"
-                    size="sm"
-                    onClick={onRerunAll}
-                    disabled={actionLoading}
-                    className="shadow-sm hover:shadow-md transition-shadow h-8 text-[11px] px-3 font-medium"
-                  >
-                    {actionLoading ? (
-                      <LoaderCircle className="mr-1.5 size-3.5 animate-spin" />
-                    ) : (
-                      <RotateCw className="mr-1.5 size-3.5" />
-                    )}
-                    Re-run all jobs
-                  </Button>
-                </div>
-              </>
-            )}
-          </div>
-        )}
-
-        <button
-          type="button"
-          aria-label="Show workflow actions"
-          onClick={openToolbar}
-          onFocus={openToolbar}
-          onMouseEnter={openToolbar}
-          className={cn(
-            "h-1.5 w-40 rounded-full border-0 bg-foreground/20 p-0 shadow-[0_1px_8px_rgba(0,0,0,0.18)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
-            !isOpen
-              ? "pointer-events-auto opacity-100 transition-opacity duration-220 ease-in"
-              : "pointer-events-none opacity-0 transition-opacity duration-280 ease-[cubic-bezier(0.22,1,0.36,1)]",
-          )}
-        />
-      </div>
-    </div>
   );
 }
 

--- a/apps/web/src/features/github/components/ActionsJobsList.tsx
+++ b/apps/web/src/features/github/components/ActionsJobsList.tsx
@@ -1,0 +1,641 @@
+import React from "react";
+import { Skeleton } from "@workspace/ui";
+import {
+  Box,
+  CheckCircle2,
+  ChevronDown,
+  ExternalLink,
+  HelpCircle,
+  Loader2,
+  XCircle,
+} from "lucide-react";
+import { AgentFixButton } from "@/features/agent-fix/components/AgentFixButton";
+import type {
+  AgentFixContextRef,
+  AgentFixPromptSource,
+} from "@/features/agent-fix/types";
+import {
+  formatActionDuration,
+  formatActionTimestamp,
+  formatActionTimeAgo,
+} from "@/features/github/lib/action-run-time";
+import { buildGithubActionsJobFixPrompt } from "@/features/github/lib/agent-fix-prompts";
+import { cn } from "@/shared/lib/utils";
+import type { ActionRun } from "./ActionsPanel";
+import type { ActionJob, ActionStep } from "./actions-detail-types";
+
+export function ActionsJobsList({
+  agentFixContext,
+  detailLoading,
+  isOpen,
+  jobs,
+  owner,
+  repo,
+  run,
+  runId,
+}: {
+  agentFixContext: AgentFixContextRef | null;
+  detailLoading: boolean;
+  isOpen: boolean;
+  jobs: ActionJob[];
+  owner: string;
+  repo: string;
+  run: ActionRun;
+  runId: number | null | undefined;
+}) {
+  const [expandedJobIds, setExpandedJobIds] = React.useState<Set<string>>(
+    () => new Set(),
+  );
+  const [selectedStepKey, setSelectedStepKey] = React.useState<string | null>(
+    null,
+  );
+  const [openAgentFixSettingsSourceId, setOpenAgentFixSettingsSourceId] =
+    React.useState<string | null>(null);
+
+  const toggleJob = React.useCallback((jobKey: string) => {
+    setExpandedJobIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(jobKey)) {
+        next.delete(jobKey);
+      } else {
+        next.add(jobKey);
+      }
+      return next;
+    });
+  }, []);
+
+  React.useEffect(() => {
+    if (!isOpen || !runId || jobs.length === 0) {
+      setExpandedJobIds(new Set());
+      setSelectedStepKey(null);
+      return;
+    }
+
+    setExpandedJobIds(
+      new Set(
+        jobs
+          .map((job, index) => ({ job, index }))
+          .filter(({ job }) => job.conclusion === "failure")
+          .map(({ job, index }) => getActionJobKey(job, index)),
+      ),
+    );
+    setSelectedStepKey(null);
+  }, [isOpen, jobs, runId]);
+
+  React.useEffect(() => {
+    setOpenAgentFixSettingsSourceId(null);
+  }, [isOpen, runId]);
+
+  const buildJobAgentFixSource = React.useCallback(
+    (job: ActionJob) => {
+      const jobName = job.name || run.workflowName || "job";
+      return {
+        id: `ci-job:${owner}/${repo}:${run.databaseId}:${job.databaseId ?? job.id ?? jobName}`,
+        family: "ci_job" as const,
+        context: agentFixContext,
+        label: `Fix CI: ${jobName}`,
+        disabledReason: agentFixContext
+          ? null
+          : "Open a workspace or project to run Agent Fix.",
+        getPrompt: () => ({
+          prompt: buildGithubActionsJobFixPrompt({
+            owner,
+            repo,
+            run,
+            job,
+          }),
+          terminalTabTitle: `Fix CI: ${jobName}`,
+          terminalPaneLabel: `Fix ${jobName}`,
+        }),
+      };
+    },
+    [agentFixContext, owner, repo, run],
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider flex items-center gap-2">
+        <Box className="size-3.5" /> Jobs
+      </h4>
+      <div className="border rounded-xl flex flex-col divide-y divide-border overflow-hidden bg-background">
+        {detailLoading ? (
+          <ActionsJobsSkeleton />
+        ) : jobs.length > 0 ? (
+          jobs.map((job, jobIndex) => {
+            const jobKey = getActionJobKey(job, jobIndex);
+            const steps = Array.isArray(job.steps) ? job.steps : [];
+            const jobFailure = job.conclusion === "failure";
+            const agentFixSource = jobFailure
+              ? buildJobAgentFixSource(job)
+              : null;
+            const agentFixSettingsOpen =
+              !!agentFixSource &&
+              openAgentFixSettingsSourceId === agentFixSource.id;
+
+            return (
+              <ActionJobRow
+                key={jobKey}
+                agentFixSettingsOpen={agentFixSettingsOpen}
+                agentFixSource={agentFixSource}
+                job={job}
+                jobKey={jobKey}
+                owner={owner}
+                repo={repo}
+                runId={run.databaseId}
+                selectedStepKey={selectedStepKey}
+                steps={steps}
+                onAgentFixSettingsSourceChange={setOpenAgentFixSettingsSourceId}
+                onSelectedStepKeyChange={setSelectedStepKey}
+                isExpanded={expandedJobIds.has(jobKey)}
+                onToggleJob={toggleJob}
+              />
+            );
+          })
+        ) : (
+          <div className="py-8 text-center text-xs text-muted-foreground/60 flex flex-col items-center">
+            <Box className="size-8 opacity-20 mb-2" />
+            No jobs found in this workflow run.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ActionsJobsSkeleton() {
+  return (
+    <div className="flex flex-col">
+      {[1, 2].map((index) => (
+        <div
+          key={`skel-job-${index}`}
+          className="flex flex-col border-b border-border/50 last:border-0"
+        >
+          <div className="px-4 py-3 flex items-center gap-3">
+            <div className="shrink-0 flex items-center justify-center">
+              <Skeleton className="size-4 rounded-full bg-muted-foreground/20" />
+            </div>
+            <div className="flex items-center gap-2 flex-1 min-w-0">
+              <Skeleton className="h-4 w-28 rounded-md bg-muted-foreground/20" />
+            </div>
+            <Skeleton className="h-3 w-12 rounded-md hidden sm:block bg-muted-foreground/20" />
+            <Skeleton className="h-3 w-24 rounded-md bg-muted-foreground/20" />
+          </div>
+
+          <div className="pl-11 pr-4 pb-4 flex flex-col gap-2">
+            {[1, 2, 3, 4, 5].map((stepIndex) => (
+              <div
+                key={`skel-step-${index}-${stepIndex}`}
+                className="flex items-center gap-2"
+              >
+                <Skeleton className="size-3.5 rounded-full bg-muted-foreground/10 shrink-0" />
+                <Skeleton
+                  className={cn(
+                    "h-3 rounded-md bg-muted-foreground/10",
+                    stepIndex === 1
+                      ? "w-24"
+                      : stepIndex === 2
+                        ? "w-40"
+                        : stepIndex === 3
+                          ? "w-48"
+                          : stepIndex === 4
+                            ? "w-32"
+                            : "w-20",
+                  )}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ActionJobRow({
+  agentFixSettingsOpen,
+  agentFixSource,
+  isExpanded,
+  job,
+  jobKey,
+  onAgentFixSettingsSourceChange,
+  onSelectedStepKeyChange,
+  onToggleJob,
+  owner,
+  repo,
+  runId,
+  selectedStepKey,
+  steps,
+}: {
+  agentFixSettingsOpen: boolean;
+  agentFixSource: AgentFixPromptSource | null;
+  isExpanded: boolean;
+  job: ActionJob;
+  jobKey: string;
+  onAgentFixSettingsSourceChange: React.Dispatch<
+    React.SetStateAction<string | null>
+  >;
+  onSelectedStepKeyChange: React.Dispatch<React.SetStateAction<string | null>>;
+  onToggleJob: (jobKey: string) => void;
+  owner: string;
+  repo: string;
+  runId: number;
+  selectedStepKey: string | null;
+  steps: ActionStep[];
+}) {
+  const jobSuccess = job.conclusion === "success";
+  const jobFailure = job.conclusion === "failure";
+  const jobSkipped = job.conclusion === "skipped";
+  const jobCompleted = job.status === "completed";
+  const jobStartedAtTimeAgo = formatActionTimeAgo(getStartedAt(job));
+  const canExpand = steps.length > 0;
+
+  return (
+    <div className="flex flex-col">
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => {
+          if (canExpand) onToggleJob(jobKey);
+        }}
+        onKeyDown={(event) => {
+          if (!canExpand) return;
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            onToggleJob(jobKey);
+          }
+        }}
+        aria-expanded={canExpand ? isExpanded : undefined}
+        className={cn(
+          "group px-4 py-3 flex w-full items-center gap-3 text-left transition-colors duration-180 ease-[cubic-bezier(0.22,1,0.36,1)]",
+          canExpand ? "cursor-pointer hover:bg-muted/30" : "cursor-default",
+          isExpanded && "bg-muted/20",
+        )}
+      >
+        <ChevronDown
+          className={cn(
+            "size-3.5 shrink-0 text-muted-foreground/60 transition-transform duration-180 ease-[cubic-bezier(0.22,1,0.36,1)]",
+            !isExpanded && "-rotate-90",
+            !canExpand && "opacity-0",
+          )}
+        />
+        <div className="shrink-0 flex items-center justify-center">
+          <ActionJobStatusIcon
+            completed={jobCompleted}
+            failure={jobFailure}
+            skipped={jobSkipped}
+            success={jobSuccess}
+          />
+        </div>
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <span className="font-semibold text-sm truncate">{job.name}</span>
+          {jobSkipped && (
+            <span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded-sm shrink-0">
+              skipped
+            </span>
+          )}
+        </div>
+
+        {steps.length > 0 && (
+          <div className="hidden sm:flex text-[11px] text-muted-foreground/70 shrink-0 gap-1 opacity-70">
+            <span>{steps.length} steps</span>
+          </div>
+        )}
+
+        {jobCompleted && jobStartedAtTimeAgo && (
+          <ActionJobTrailingMeta
+            agentFixSettingsOpen={agentFixSettingsOpen}
+            agentFixSource={agentFixSource}
+            jobFailure={jobFailure}
+            jobStartedAtTimeAgo={jobStartedAtTimeAgo}
+            onAgentFixSettingsSourceChange={onAgentFixSettingsSourceChange}
+          />
+        )}
+      </div>
+
+      {steps.length > 0 && (
+        <ActionStepsList
+          isExpanded={isExpanded}
+          job={job}
+          jobKey={jobKey}
+          owner={owner}
+          repo={repo}
+          runId={runId}
+          selectedStepKey={selectedStepKey}
+          steps={steps}
+          onSelectedStepKeyChange={onSelectedStepKeyChange}
+        />
+      )}
+    </div>
+  );
+}
+
+function ActionJobTrailingMeta({
+  agentFixSettingsOpen,
+  agentFixSource,
+  jobFailure,
+  jobStartedAtTimeAgo,
+  onAgentFixSettingsSourceChange,
+}: {
+  agentFixSettingsOpen: boolean;
+  agentFixSource: AgentFixPromptSource | null;
+  jobFailure: boolean;
+  jobStartedAtTimeAgo: string;
+  onAgentFixSettingsSourceChange: React.Dispatch<
+    React.SetStateAction<string | null>
+  >;
+}) {
+  if (!jobFailure) {
+    return (
+      <div className="shrink-0 whitespace-nowrap tabular-nums">
+        <span className="text-[11px] text-muted-foreground/80">
+          {jobStartedAtTimeAgo}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="shrink-0 whitespace-nowrap tabular-nums">
+      <span className="relative inline-flex min-w-[92px] justify-end">
+        <span
+          className={cn(
+            "text-[11px] text-muted-foreground/80 group-hover:opacity-0 group-focus-visible:opacity-0",
+            agentFixSettingsOpen && "!opacity-0",
+          )}
+          style={agentFixSettingsOpen ? { opacity: 0 } : undefined}
+        >
+          {jobStartedAtTimeAgo}
+        </span>
+        <span
+          className={cn(
+            "invisible pointer-events-none absolute right-0 top-1/2 -translate-y-1/2 opacity-0",
+            "group-hover:visible group-hover:pointer-events-auto group-hover:opacity-100",
+            "group-focus-visible:visible group-focus-visible:pointer-events-auto group-focus-visible:opacity-100",
+            agentFixSettingsOpen &&
+              "!visible !pointer-events-auto !opacity-100",
+          )}
+          data-agent-fix-action-host="true"
+          style={agentFixSettingsOpen ? { opacity: 1 } : undefined}
+          onClick={(event) => event.stopPropagation()}
+          onKeyDown={(event) => event.stopPropagation()}
+        >
+          {agentFixSource ? (
+            <AgentFixButton
+              source={agentFixSource}
+              mode="label"
+              appearance="subtle"
+              onSettingsOpenChange={(open) => {
+                onAgentFixSettingsSourceChange((current) => {
+                  if (open) return agentFixSource.id;
+                  return current === agentFixSource.id ? null : current;
+                });
+              }}
+            />
+          ) : null}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+function ActionStepsList({
+  isExpanded,
+  job,
+  jobKey,
+  onSelectedStepKeyChange,
+  owner,
+  repo,
+  runId,
+  selectedStepKey,
+  steps,
+}: {
+  isExpanded: boolean;
+  job: ActionJob;
+  jobKey: string;
+  onSelectedStepKeyChange: React.Dispatch<React.SetStateAction<string | null>>;
+  owner: string;
+  repo: string;
+  runId: number;
+  selectedStepKey: string | null;
+  steps: ActionStep[];
+}) {
+  return (
+    <div
+      className={cn(
+        "grid overflow-hidden transition-[grid-template-rows,opacity,border-color] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
+        isExpanded
+          ? "grid-rows-[1fr] border-t border-border/40 opacity-100"
+          : "grid-rows-[0fr] border-t border-transparent opacity-0",
+      )}
+    >
+      <div className="min-h-0 overflow-hidden">
+        <div className="bg-muted/10 px-4 py-3">
+          <div className="ml-6 flex flex-col gap-1.5">
+            {steps.map((step, stepIndex) => {
+              const stepKey = getActionStepKey(jobKey, step, stepIndex);
+              const isSelected = selectedStepKey === stepKey;
+              const stepStatus = step.conclusion || step.status || "unknown";
+              const stepStartedAt = getStartedAt(step);
+              const stepCompletedAt = getCompletedAt(step);
+              const stepStartedLabel = formatActionTimestamp(stepStartedAt);
+              const stepCompletedLabel = formatActionTimestamp(stepCompletedAt);
+              const stepDuration = formatActionDuration(
+                stepStartedAt,
+                stepCompletedAt,
+              );
+
+              return (
+                <div
+                  key={stepKey}
+                  role="button"
+                  tabIndex={isExpanded ? 0 : -1}
+                  onClick={() =>
+                    onSelectedStepKeyChange(isSelected ? null : stepKey)
+                  }
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      onSelectedStepKeyChange(isSelected ? null : stepKey);
+                    }
+                  }}
+                  className={cn(
+                    "group/step flex cursor-pointer items-start gap-2 rounded-md border px-2 py-2 text-xs transition-colors duration-180 ease-[cubic-bezier(0.22,1,0.36,1)] outline-none",
+                    isSelected
+                      ? "border-border/70 bg-background shadow-sm"
+                      : "border-transparent text-muted-foreground/85 hover:bg-background/70 focus-visible:border-ring/40",
+                  )}
+                >
+                  <div className="mt-0.5 shrink-0">
+                    <StepStatusIcon
+                      status={step.status}
+                      conclusion={step.conclusion}
+                    />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center justify-between gap-3">
+                      <span
+                        className={cn(
+                          "min-w-0 truncate font-medium",
+                          step.conclusion === "failure"
+                            ? "text-red-500"
+                            : "text-foreground/90",
+                        )}
+                      >
+                        {step.name || `Step ${stepIndex + 1}`}
+                      </span>
+                      <div className="flex shrink-0 items-center gap-2">
+                        {stepDuration && (
+                          <span className="hidden font-mono text-[10px] text-muted-foreground/70 sm:inline">
+                            {stepDuration}
+                          </span>
+                        )}
+                        <button
+                          type="button"
+                          aria-label={`Open ${step.name || "step"} on GitHub`}
+                          tabIndex={isExpanded ? 0 : -1}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            openActionStepInGitHub(
+                              owner,
+                              repo,
+                              runId,
+                              job,
+                              step,
+                            );
+                          }}
+                          className="flex size-6 items-center justify-center rounded-md text-muted-foreground/60 opacity-0 transition-all duration-180 ease-[cubic-bezier(0.22,1,0.36,1)] hover:bg-muted hover:text-foreground group-hover/step:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                        >
+                          <ExternalLink className="size-3" />
+                        </button>
+                      </div>
+                    </div>
+
+                    {isSelected && (
+                      <div className="mt-2 grid grid-cols-1 gap-1.5 rounded-md border border-border/40 bg-muted/20 p-2 sm:grid-cols-2">
+                        <StepMeta label="Status" value={stepStatus} />
+                        <StepMeta label="Duration" value={stepDuration ?? "-"} />
+                        <StepMeta
+                          label="Started"
+                          value={stepStartedLabel ?? "-"}
+                        />
+                        <StepMeta
+                          label="Completed"
+                          value={stepCompletedLabel ?? "-"}
+                        />
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function getStartedAt(value: { startedAt?: string; started_at?: string }) {
+  return value.startedAt ?? value.started_at ?? null;
+}
+
+function getCompletedAt(value: {
+  completedAt?: string;
+  completed_at?: string;
+}) {
+  return value.completedAt ?? value.completed_at ?? null;
+}
+
+function getActionJobKey(job: ActionJob, index: number) {
+  return String(job.databaseId ?? job.id ?? `${job.name ?? "job"}-${index}`);
+}
+
+function getActionStepKey(jobKey: string, step: ActionStep, index: number) {
+  return `${jobKey}:${step.number ?? step.name ?? index}`;
+}
+
+function openActionStepInGitHub(
+  owner: string,
+  repo: string,
+  runId: number,
+  job: ActionJob,
+  step: ActionStep,
+) {
+  const jobId = job.databaseId ?? job.id;
+  const rawJobUrl =
+    job.html_url ??
+    (job.url && !job.url.includes("api.github.com") ? job.url : undefined);
+  const jobUrl =
+    rawJobUrl ??
+    (jobId
+      ? `https://github.com/${owner}/${repo}/actions/runs/${runId}/job/${jobId}`
+      : `https://github.com/${owner}/${repo}/actions/runs/${runId}`);
+  const href =
+    jobId && step.number ? `${jobUrl}#step:${step.number}:1` : jobUrl;
+  window.open(href, "_blank");
+}
+
+function ActionJobStatusIcon({
+  completed,
+  failure,
+  skipped,
+  success,
+}: {
+  completed: boolean;
+  failure: boolean;
+  skipped: boolean;
+  success: boolean;
+}) {
+  if (!completed) {
+    return <Loader2 className="size-4 animate-spin text-blue-500" />;
+  }
+  if (success) {
+    return <CheckCircle2 className="size-4 text-emerald-500" />;
+  }
+  if (failure) {
+    return <XCircle className="size-4 text-red-500" />;
+  }
+  if (skipped) {
+    return (
+      <div className="size-4 rounded-full border-2 border-muted-foreground/40 flex items-center justify-center" />
+    );
+  }
+  return <HelpCircle className="size-4 text-muted-foreground" />;
+}
+
+function StepStatusIcon({
+  status,
+  conclusion,
+}: {
+  status?: string;
+  conclusion?: string;
+}) {
+  if (conclusion === "success") {
+    return <CheckCircle2 className="size-3.5 text-emerald-500" />;
+  }
+  if (conclusion === "failure") {
+    return <XCircle className="size-3.5 text-red-500" />;
+  }
+  if (conclusion === "skipped") {
+    return (
+      <div className="size-3.5 rounded-full border-2 border-muted-foreground/40" />
+    );
+  }
+  if (status === "in_progress" || status === "queued") {
+    return <Loader2 className="size-3.5 animate-spin text-blue-500" />;
+  }
+  return <HelpCircle className="size-3.5 text-muted-foreground" />;
+}
+
+function StepMeta({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex min-w-0 items-center justify-between gap-3">
+      <span className="shrink-0 text-[10px] font-semibold uppercase text-muted-foreground/70">
+        {label}
+      </span>
+      <span className="min-w-0 truncate text-right font-mono text-[10px] text-foreground/80 capitalize">
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/features/github/components/ActionsJobsList.tsx
+++ b/apps/web/src/features/github/components/ActionsJobsList.tsx
@@ -493,6 +493,9 @@ function ActionStepsList({
                           type="button"
                           aria-label={`Open ${step.name || "step"} on GitHub`}
                           tabIndex={isExpanded ? 0 : -1}
+                          onKeyDown={(event) => {
+                            event.stopPropagation();
+                          }}
                           onClick={(event) => {
                             event.stopPropagation();
                             openActionStepInGitHub(
@@ -572,7 +575,7 @@ function openActionStepInGitHub(
       : `https://github.com/${owner}/${repo}/actions/runs/${runId}`);
   const href =
     jobId && step.number ? `${jobUrl}#step:${step.number}:1` : jobUrl;
-  window.open(href, "_blank");
+  window.open(href, "_blank", "noopener,noreferrer");
 }
 
 function ActionJobStatusIcon({

--- a/apps/web/src/features/github/components/PRDetailModal.tsx
+++ b/apps/web/src/features/github/components/PRDetailModal.tsx
@@ -51,12 +51,13 @@ import {
 import { formatDistanceToNow } from 'date-fns';
 import { cn } from '@/shared/lib/utils';
 import { MarkdownRenderer } from '@/shared/components/markdown/MarkdownRenderer';
-import { useContextParams } from '@/shared/hooks/use-context-params';
+import { useAgentFixContext } from '@/features/agent-fix/hooks/use-agent-fix-context';
 import { AgentFixButton } from '@/features/agent-fix/components/AgentFixButton';
-import type { AgentFixContextRef, AgentFixPromptSource } from '@/features/agent-fix/types';
+import type { AgentFixPromptSource } from '@/features/agent-fix/types';
 import { buildPrReviewFixPrompt, buildPrReviewThreadFixPrompt } from '@/features/github/lib/agent-fix-prompts';
 import { CommitList } from './CommitList';
 import { PRFilesTab } from './PRFilesTab';
+import { usePrContextHeader } from './use-pr-context-header';
 import { PRActionBar, type PRMergeStrategy } from '../lib/pr-detail-modal-actions';
 import {
   CommentBox,
@@ -82,11 +83,13 @@ interface PRDetailModalProps {
   onClosed?: () => void;
 }
 
+type PRMainTab = 'description' | 'discussion' | 'commits' | 'files';
+
 export function PRDetailModal({ owner, repo, branch, prNumber, isOpen, onOpenChange, onMerged, onClosed }: PRDetailModalProps) {
-  const { currentView, effectiveContextId } = useContextParams();
+  const agentFixContext = useAgentFixContext();
   const { data: pr, loading, fetch } = useGithubPRDetail(prNumber || 0, owner, repo);
   const { data: sidebarData, loading: sidebarLoading } = useGithubPRDetailSidebar(prNumber || 0, owner, repo);
-  const [activeMainTab, setActiveMainTab] = React.useState<'description' | 'discussion' | 'commits' | 'files'>('description');
+  const [activeMainTab, setActiveMainTab] = React.useState<PRMainTab>('description');
   const [hasVisitedDiscussion, setHasVisitedDiscussion] = React.useState(false);
   const [hasVisitedCommits, setHasVisitedCommits] = React.useState(false);
   const [hasVisitedFiles, setHasVisitedFiles] = React.useState(false);
@@ -103,22 +106,14 @@ export function PRDetailModal({ owner, repo, branch, prNumber, isOpen, onOpenCha
   const [mergeStrategy, setMergeStrategy] = React.useState<PRMergeStrategy>('merge');
   const [branchCopied, setBranchCopied] = React.useState(false);
   const [openReviewAgentFixSourceId, setOpenReviewAgentFixSourceId] = React.useState<string | null>(null);
-  const mainScrollRef = React.useRef<HTMLDivElement | null>(null);
-  const prContextRef = React.useRef<HTMLDivElement | null>(null);
-  const prContextHeightRef = React.useRef(64);
-  const prContextVisibleRef = React.useRef(true);
-  const lastMainScrollTopRef = React.useRef(0);
-  const agentFixContext = React.useMemo<AgentFixContextRef | null>(() => {
-    if (!effectiveContextId) return null;
-    if (currentView === 'workspace') {
-      return { contextId: effectiveContextId, scope: 'workspace' };
-    }
-    if (currentView === 'project') {
-      return { contextId: effectiveContextId, scope: 'project' };
-    }
-    return null;
-  }, [currentView, effectiveContextId]);
-
+  const {
+    handleFilesCodeViewTopBoundaryWheel,
+    handleMainScroll,
+    handleMainWheelCapture,
+    mainScrollRef,
+    prContextRef,
+    resetPrContext,
+  } = usePrContextHeader(activeMainTab);
   const buildThreadAgentFixSource = React.useCallback(
     (thread: ReviewCommentThread): AgentFixPromptSource | undefined => {
       if (!pr || !prNumber) return undefined;
@@ -190,34 +185,14 @@ export function PRDetailModal({ owner, repo, branch, prNumber, isOpen, onOpenCha
     [agentFixContext, branch, owner, pr, prNumber, repo],
   );
 
-  const setPrContextVisible = React.useCallback((visible: boolean) => {
-    if (prContextVisibleRef.current === visible) return;
-    prContextVisibleRef.current = visible;
-    const element = prContextRef.current;
-    if (!element) return;
-    element.style.transform = visible
-      ? 'translate3d(0, 0, 0)'
-      : 'translate3d(0, calc(-100% - 1px), 0)';
-  }, []);
-
-  const getPrContextMetrics = React.useCallback(() => {
-    const contextHeight = prContextHeightRef.current;
-    return {
-      contextHeight,
-      hideThreshold: Math.max(48, contextHeight * 0.7),
-    };
-  }, []);
-
   // Reset tab state when modal opens/closes or PR changes
   React.useEffect(() => {
     setActiveMainTab('description');
     setHasVisitedDiscussion(false);
     setHasVisitedCommits(false);
     setHasVisitedFiles(false);
-    setPrContextVisible(true);
-    lastMainScrollTopRef.current = 0;
-    mainScrollRef.current?.scrollTo({ top: 0 });
-  }, [prNumber, setPrContextVisible]);
+    resetPrContext();
+  }, [prNumber, resetPrContext]);
 
   React.useEffect(() => {
     if (!isOpen) {
@@ -225,28 +200,9 @@ export function PRDetailModal({ owner, repo, branch, prNumber, isOpen, onOpenCha
       setHasVisitedDiscussion(false);
       setHasVisitedCommits(false);
       setHasVisitedFiles(false);
-      setPrContextVisible(true);
+      resetPrContext();
     }
-  }, [isOpen, setPrContextVisible]);
-
-  React.useEffect(() => {
-    const element = prContextRef.current;
-    if (!element) return;
-
-    const updateHeight = () => {
-      prContextHeightRef.current = element.getBoundingClientRect().height || 64;
-    };
-
-    updateHeight();
-    if (typeof ResizeObserver === 'undefined') {
-      window.addEventListener('resize', updateHeight);
-      return () => window.removeEventListener('resize', updateHeight);
-    }
-
-    const resizeObserver = new ResizeObserver(updateHeight);
-    resizeObserver.observe(element);
-    return () => resizeObserver.disconnect();
-  }, [pr]);
+  }, [isOpen, resetPrContext]);
 
   const reviewComments = sidebarData?.review_comments;
   const reviewCommentThreadsByReviewId = React.useMemo(() => {
@@ -442,65 +398,17 @@ export function PRDetailModal({ owner, repo, branch, prNumber, isOpen, onOpenCha
     }
   };
 
-  const handleMainScroll = React.useCallback((event: React.UIEvent<HTMLDivElement>) => {
-    const nextTop = event.currentTarget.scrollTop;
-    const delta = nextTop - lastMainScrollTopRef.current;
-    const { hideThreshold } = getPrContextMetrics();
-
-    if (nextTop < 12) {
-      setPrContextVisible(true);
-    } else if (delta > 8 && nextTop > hideThreshold) {
-      setPrContextVisible(false);
-    } else if (delta < -8) {
-      setPrContextVisible(true);
-    }
-
-    lastMainScrollTopRef.current = nextTop;
-  }, [getPrContextMetrics, setPrContextVisible]);
-
-  const handleMainWheelCapture = React.useCallback((event: React.WheelEvent<HTMLDivElement>) => {
-    const scrollTop = mainScrollRef.current?.scrollTop ?? 0;
-    const { contextHeight, hideThreshold } = getPrContextMetrics();
-
-    if (activeMainTab === 'files' && event.deltaY > 8 && scrollTop <= hideThreshold) {
-      const nextTop = Math.max(contextHeight, hideThreshold + 1);
-      mainScrollRef.current?.scrollTo({ top: nextTop });
-      lastMainScrollTopRef.current = nextTop;
-      setPrContextVisible(false);
-      event.preventDefault();
-      event.stopPropagation();
-      return;
-    }
-
-    if (event.deltaY > 8 && scrollTop > hideThreshold) {
-      setPrContextVisible(false);
-    } else if (event.deltaY < -8) {
-      setPrContextVisible(true);
-    }
-  }, [activeMainTab, getPrContextMetrics, setPrContextVisible]);
-
-  const handleFilesCodeViewTopBoundaryWheel = React.useCallback((deltaY: number) => {
-    const scrollRoot = mainScrollRef.current;
-    if (!scrollRoot || deltaY >= 0) return;
-    const nextTop = Math.max(0, scrollRoot.scrollTop + deltaY);
-    scrollRoot.scrollTop = nextTop;
-    lastMainScrollTopRef.current = nextTop;
-    setPrContextVisible(true);
-  }, [setPrContextVisible]);
-
   const handleMainTabChange = React.useCallback((value: string) => {
-    const tab = value as typeof activeMainTab;
+    const tab = value as PRMainTab;
     setActiveMainTab(tab);
-    setPrContextVisible(true);
-    mainScrollRef.current?.scrollTo({ top: 0 });
-    lastMainScrollTopRef.current = 0;
+    resetPrContext();
     if (tab === 'discussion') setHasVisitedDiscussion(true);
     if (tab === 'commits') setHasVisitedCommits(true);
     if (tab === 'files') {
       setHasVisitedFiles(true);
       setIsSidebarCollapsed(true);
     }
-  }, [setPrContextVisible]);
+  }, [resetPrContext]);
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>

--- a/apps/web/src/features/github/components/actions-detail-types.ts
+++ b/apps/web/src/features/github/components/actions-detail-types.ts
@@ -1,0 +1,25 @@
+export interface ActionStep {
+  name?: string;
+  status?: string;
+  conclusion?: string;
+  number?: number;
+  startedAt?: string;
+  started_at?: string;
+  completedAt?: string;
+  completed_at?: string;
+}
+
+export interface ActionJob {
+  databaseId?: number;
+  id?: number;
+  name?: string;
+  status?: string;
+  conclusion?: string;
+  startedAt?: string;
+  started_at?: string;
+  completedAt?: string;
+  completed_at?: string;
+  url?: string;
+  html_url?: string;
+  steps?: ActionStep[];
+}

--- a/apps/web/src/features/github/components/use-pr-context-header.ts
+++ b/apps/web/src/features/github/components/use-pr-context-header.ts
@@ -1,0 +1,122 @@
+import React from "react";
+
+type PRMainTab = "description" | "discussion" | "commits" | "files";
+
+export function usePrContextHeader(activeMainTab: PRMainTab) {
+  const mainScrollRef = React.useRef<HTMLDivElement | null>(null);
+  const prContextRef = React.useRef<HTMLDivElement | null>(null);
+  const prContextHeightRef = React.useRef(64);
+  const prContextVisibleRef = React.useRef(true);
+  const lastMainScrollTopRef = React.useRef(0);
+
+  const setPrContextVisible = React.useCallback((visible: boolean) => {
+    if (prContextVisibleRef.current === visible) return;
+    prContextVisibleRef.current = visible;
+    const element = prContextRef.current;
+    if (!element) return;
+    element.style.transform = visible
+      ? "translate3d(0, 0, 0)"
+      : "translate3d(0, calc(-100% - 1px), 0)";
+  }, []);
+
+  const getPrContextMetrics = React.useCallback(() => {
+    const contextHeight = prContextHeightRef.current;
+    return {
+      contextHeight,
+      hideThreshold: Math.max(48, contextHeight * 0.7),
+    };
+  }, []);
+
+  const resetPrContext = React.useCallback(() => {
+    setPrContextVisible(true);
+    lastMainScrollTopRef.current = 0;
+    mainScrollRef.current?.scrollTo({ top: 0 });
+  }, [setPrContextVisible]);
+
+  React.useEffect(() => {
+    const element = prContextRef.current;
+    if (!element) return;
+
+    const updateHeight = () => {
+      prContextHeightRef.current = element.getBoundingClientRect().height || 64;
+    };
+
+    updateHeight();
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", updateHeight);
+      return () => window.removeEventListener("resize", updateHeight);
+    }
+
+    const resizeObserver = new ResizeObserver(updateHeight);
+    resizeObserver.observe(element);
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  const handleMainScroll = React.useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      const nextTop = event.currentTarget.scrollTop;
+      const delta = nextTop - lastMainScrollTopRef.current;
+      const { hideThreshold } = getPrContextMetrics();
+
+      if (nextTop < 12) {
+        setPrContextVisible(true);
+      } else if (delta > 8 && nextTop > hideThreshold) {
+        setPrContextVisible(false);
+      } else if (delta < -8) {
+        setPrContextVisible(true);
+      }
+
+      lastMainScrollTopRef.current = nextTop;
+    },
+    [getPrContextMetrics, setPrContextVisible],
+  );
+
+  const handleMainWheelCapture = React.useCallback(
+    (event: React.WheelEvent<HTMLDivElement>) => {
+      const scrollTop = mainScrollRef.current?.scrollTop ?? 0;
+      const { contextHeight, hideThreshold } = getPrContextMetrics();
+
+      if (
+        activeMainTab === "files" &&
+        event.deltaY > 8 &&
+        scrollTop <= hideThreshold
+      ) {
+        const nextTop = Math.max(contextHeight, hideThreshold + 1);
+        mainScrollRef.current?.scrollTo({ top: nextTop });
+        lastMainScrollTopRef.current = nextTop;
+        setPrContextVisible(false);
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
+      if (event.deltaY > 8 && scrollTop > hideThreshold) {
+        setPrContextVisible(false);
+      } else if (event.deltaY < -8) {
+        setPrContextVisible(true);
+      }
+    },
+    [activeMainTab, getPrContextMetrics, setPrContextVisible],
+  );
+
+  const handleFilesCodeViewTopBoundaryWheel = React.useCallback(
+    (deltaY: number) => {
+      const scrollRoot = mainScrollRef.current;
+      if (!scrollRoot || deltaY >= 0) return;
+      const nextTop = Math.max(0, scrollRoot.scrollTop + deltaY);
+      scrollRoot.scrollTop = nextTop;
+      lastMainScrollTopRef.current = nextTop;
+      setPrContextVisible(true);
+    },
+    [setPrContextVisible],
+  );
+
+  return {
+    handleFilesCodeViewTopBoundaryWheel,
+    handleMainScroll,
+    handleMainWheelCapture,
+    mainScrollRef,
+    prContextRef,
+    resetPrContext,
+  };
+}

--- a/apps/web/src/features/github/components/use-pr-context-header.ts
+++ b/apps/web/src/features/github/components/use-pr-context-header.ts
@@ -4,20 +4,40 @@ type PRMainTab = "description" | "discussion" | "commits" | "files";
 
 export function usePrContextHeader(activeMainTab: PRMainTab) {
   const mainScrollRef = React.useRef<HTMLDivElement | null>(null);
-  const prContextRef = React.useRef<HTMLDivElement | null>(null);
+  const prContextElementRef = React.useRef<HTMLDivElement | null>(null);
+  const [prContextElement, setPrContextElement] =
+    React.useState<HTMLDivElement | null>(null);
   const prContextHeightRef = React.useRef(64);
   const prContextVisibleRef = React.useRef(true);
   const lastMainScrollTopRef = React.useRef(0);
 
+  const applyPrContextVisibility = React.useCallback(
+    (element: HTMLDivElement, visible: boolean) => {
+      element.style.transform = visible
+        ? "translate3d(0, 0, 0)"
+        : "translate3d(0, calc(-100% - 1px), 0)";
+    },
+    [],
+  );
+
+  const prContextRef = React.useCallback(
+    (element: HTMLDivElement | null) => {
+      prContextElementRef.current = element;
+      setPrContextElement(element);
+      if (element) {
+        applyPrContextVisibility(element, prContextVisibleRef.current);
+      }
+    },
+    [applyPrContextVisibility],
+  );
+
   const setPrContextVisible = React.useCallback((visible: boolean) => {
     if (prContextVisibleRef.current === visible) return;
     prContextVisibleRef.current = visible;
-    const element = prContextRef.current;
+    const element = prContextElementRef.current;
     if (!element) return;
-    element.style.transform = visible
-      ? "translate3d(0, 0, 0)"
-      : "translate3d(0, calc(-100% - 1px), 0)";
-  }, []);
+    applyPrContextVisibility(element, visible);
+  }, [applyPrContextVisibility]);
 
   const getPrContextMetrics = React.useCallback(() => {
     const contextHeight = prContextHeightRef.current;
@@ -34,7 +54,7 @@ export function usePrContextHeader(activeMainTab: PRMainTab) {
   }, [setPrContextVisible]);
 
   React.useEffect(() => {
-    const element = prContextRef.current;
+    const element = prContextElement;
     if (!element) return;
 
     const updateHeight = () => {
@@ -50,7 +70,7 @@ export function usePrContextHeader(activeMainTab: PRMainTab) {
     const resizeObserver = new ResizeObserver(updateHeight);
     resizeObserver.observe(element);
     return () => resizeObserver.disconnect();
-  }, []);
+  }, [prContextElement]);
 
   const handleMainScroll = React.useCallback(
     (event: React.UIEvent<HTMLDivElement>) => {

--- a/automations/review/quality/result/2026-06/06-26_score-86_RESULT.md
+++ b/automations/review/quality/result/2026-06/06-26_score-86_RESULT.md
@@ -116,4 +116,5 @@
 
 - 修复分支已推送到 `origin/codex/quality-fix/2026-06-26`。
 - PR URL：https://github.com/AruNi-01/atmos/pull/137
-- 结果文件将随本报告提交到同一修复分支并推送；提交 hash 会在最终回复中给出，避免在报告内容中写入无法自指的提交 hash。
+- 结果文件提交：`1dacb680 docs: add code quality review result 2026-06-26 score 86`
+- 结果文件已随同一修复分支推送到 `origin/codex/quality-fix/2026-06-26`，并包含在 PR #137 中。

--- a/automations/review/quality/result/2026-06/06-26_score-86_RESULT.md
+++ b/automations/review/quality/result/2026-06/06-26_score-86_RESULT.md
@@ -1,0 +1,119 @@
+# Atmos main 每日代码质量评分：2026-06-26
+
+## 1. 审查范围
+
+- 时间窗口：UTC+8 2026-06-25 00:00:00 至 2026-06-25 23:59:59。
+- 分支：同步后的 `main`。
+- 排除提交：`743c8225 docs: add code quality review result 2026-06-25 score 88`，该提交只修改 `automations/review/quality/result/` 结果文件。
+
+被审查提交：
+
+| hash | author | message |
+| --- | --- | --- |
+| `60519e7f` | AarynLu | `refactor: share cli updater logic` |
+| `20374521` | AarynLu | `fix: install checked cli release` |
+| `31918cdc` | AarynLu | `fix: fail invalid cli install result` |
+| `a8de1d16` | AarynLu | `fix: satisfy rust ci` |
+| `4ab40737` | AarynLu | `fix: address linux clippy` |
+| `77de9546` | AarynLu | `fix: address token usage clippy` |
+| `f23e941f` | AarynLu | `fix: address diagnostics clippy` |
+| `7886d3f4` | AarynLu | `fix: update infra migration test` |
+| `57e91ba6` | AruNi_Lu | `Merge pull request #136 from AruNi-01/codex/quality-fix/2026-06-25` |
+| `ee79fe57` | AarynLu | `fix: refine pr modal file changes scrolling` |
+| `74a79424` | AarynLu | `feat: improve github modal interactions` |
+| `ac9fe4df` | AarynLu | `Refactor Atmos runtime and frontend integrations` |
+| `07d2701f` | AarynLu | `refactor: reuse agent fix toolbar in review actions` |
+
+备注：`57e91ba6` 是合并提交，本身没有额外文件 diff；相关代码内容已由其子提交覆盖审查。
+
+## 2. 一份好代码应该是什么样
+
+本次按“职责边界清楚、分层方向正确、控制流可追踪、体量与职责匹配、重复规则集中、工程卫生稳定”的标准评分。复杂功能可以有复杂实现，但新增代码应让维护者快速判断状态归属、UI 渲染归属、业务 prompt 组装归属，以及后续要修改哪一层。
+
+## 3. 评分方法
+
+- 100 分制。
+- 设计与分层 30 分，可读性与复杂度 25 分，体量与内聚 20 分，可维护性与复用 15 分，工程卫生 10 分。
+- 高严重度问题通常扣 8-15 分，中严重度扣 3-7 分，低严重度扣 1-2 分；同一问题不重复扣分。
+- 体量阈值作为风险信号使用：800 行以上 UI 文件通常需要重点关注；如果大文件继续混合数据、状态、渲染、DOM 协调和 prompt 构造，会进入扣分。
+
+## 4. 总分
+
+总分：86 / 100。
+
+总体判断：良好。Rust 侧多处改动在收敛接口和复用逻辑，质量方向正确；主要扣分来自 Web GitHub modal/Agent Fix 交互把新增状态协调和 prompt source 构造继续塞进已有大组件，后续维护成本被放大。
+
+## 5. 分项评分
+
+- 设计与分层：24 / 30。`ActionsDetailModal.tsx` 和 `PRDetailModal.tsx` 在 UI 渲染中直接承载 Agent Fix context、prompt source、滚动/hover 状态机；Rust CLI 更新逻辑迁到 `runtime-manager` 是正向分层。
+- 可读性与复杂度：21 / 25。GitHub Actions jobs/steps 渲染、PR sticky header wheel 边界处理和 Agent Fix settings 打开状态交织在 modal 主路径中，阅读时需要跨多个状态位追踪。
+- 体量与内聚：17 / 20。`ActionsDetailModal.tsx` 从 421 行放大到 1089 行，`PRDetailModal.tsx` 保持 1000 行以上，`PRFilesTab.tsx` 增至 572 行；其中部分增长来自合理功能，但拆分点明显。
+- 可维护性与复用：14 / 15。Agent Fix 基础组件有复用意识，`AgentFixToolbarPrimitive` 方向正确；但 workspace/project context 解析在多个调用方重复。
+- 工程卫生：10 / 10。已跑 `bun --filter web typecheck`、相关前端测试和 `cargo test -p runtime-manager -p atmos --lib`，未发现本次改动引入的明确工程卫生问题。
+
+## 6. 主要问题清单
+
+### 高：Actions detail modal 同时承载数据适配、job/step 展开、Agent Fix prompt source 和底部操作条
+
+- 提交：`74a79424`、`ac9fe4df`
+- 文件：`apps/web/src/features/github/components/ActionsDetailModal.tsx`
+- 证据：主组件内新增 `ActionJob`/`ActionStep` 类型、`expandedJobIds`、`selectedStepKey`、`openAgentFixSettingsSourceId`、`buildJobAgentFixSource`、完整 Jobs/Steps JSX，以及 `ActionsActionBar` hover/animation 状态；文件最终达到 1089 行。
+- 为什么是质量问题：这个 modal 的职责从“展示一个 Actions run”扩张为“run 数据适配 + job 树状态机 + step 元数据面板 + Agent Fix prompt 构造 + 底部 hover 工具条”。后续修改任一子行为都要进入同一个大文件，状态耦合点太多。
+- 优化建议：把 `ActionJob`/`ActionStep` 类型放到 feature-local 类型文件；把 Jobs 列表、step row、step meta、GitHub step URL 逻辑拆成 `ActionsJobsList`；把底部 hover action bar 拆成 `ActionsActionBar`；modal 只保留数据获取、run fallback 和顶层弹窗布局。
+
+### 中：PR detail modal 内联滚动头部控制和 Agent Fix prompt source 构造，继续放大巨型组件
+
+- 提交：`ee79fe57`、`ac9fe4df`
+- 文件：`apps/web/src/features/github/components/PRDetailModal.tsx`
+- 证据：`mainScrollRef`、`prContextRef`、`ResizeObserver`、`handleMainScroll`、`handleMainWheelCapture`、`handleFilesCodeViewTopBoundaryWheel` 与 PR timeline/rendering/merge/comment actions 同文件存在；文件最终约 1150 行。
+- 为什么是质量问题：滚动边界控制是独立 UI 行为，和 PR conversation/timeline 业务渲染无强绑定。把它留在主 modal 里会让后续调整 files tab、header sticky 行为或 timeline 渲染时互相干扰。
+- 优化建议：把 sticky PR context header 的 refs、height measurement、scroll/wheel handlers 和 reset 行为抽成 `usePrContextHeader(activeMainTab)`；主组件只接收 `mainScrollRef`、`prContextRef` 和三个 handler。后续可继续把 timeline row 渲染拆出。
+
+### 低：Agent Fix context 解析在多个调用方重复
+
+- 提交：`ac9fe4df`
+- 文件：`apps/web/src/features/github/components/ActionsDetailModal.tsx`、`apps/web/src/features/github/components/PRDetailModal.tsx`、`apps/web/src/features/diff/components/useDiffPromptStash.tsx`
+- 证据：三个位置都重复读取 `useContextParams()`，再把 `workspace`/`project` 映射为 `AgentFixContextRef`。
+- 为什么是质量问题：这是相同规则的重复实现，未来如果 Agent Fix 支持新的 context scope 或禁用语义变化，容易出现调用方分叉。
+- 优化建议：新增 `useAgentFixContext()`，把 `currentView`/`effectiveContextId` 到 `AgentFixContextRef | null` 的映射集中到 `features/agent-fix/hooks/`，调用方只消费结果。
+
+## 7. 正向观察
+
+- CLI 更新逻辑从 `apps/cli/src/commands/update.rs` 大幅迁出到 `crates/runtime-manager/src/cli_update.rs`，让 CLI 和 API 安装路径共享同一实现，方向正确。
+- `GithubIssueListOptions`、`CreateAgentRunParams`、`FinalizeFixAgentRunInput` 等参数对象减少了长参数列表，提升了调用端语义。
+- `AgentFixToolbarPrimitive`、`AgentFixToolbar`、`AgentFixButton` 的分层基本清楚，说明新增 Agent Fix 能力已有可复用基座。
+- 新增 prompt builder 测试覆盖了 PR review thread、完整 review 和 CI job prompt 三类核心场景。
+
+## 8. Review 建议
+
+人工 review 最值得看三点：
+
+- GitHub modal 是否还有可明显拆出的 timeline row、review thread 或 file comment 子组件。
+- Agent Fix prompt source 是否继续保持 source-owned，不要把 GitHub/Actions 特有数据下沉到通用组件。
+- `runtime-manager` CLI 安装结果校验是否满足所有平台，尤其是 release asset 缺失和安装后二进制版本读取失败路径。
+
+## 9. 自动修复与 PR
+
+已触发自动修复，因为总分低于 90。
+
+- 修复分支：`codex/quality-fix/2026-06-26`
+- 修复提交：`3e2c4cce refactor: improve daily quality findings`
+- PR：https://github.com/AruNi-01/atmos/pull/137
+- 标签：已添加 `codex`；仓库未发现 `codex-automation`，因此跳过。
+- 修复摘要：新增 `useAgentFixContext()`；拆出 `ActionsActionBar`、`ActionsJobsList`、`actions-detail-types`；新增 `usePrContextHeader()`；更新调用方使用共享 hook。
+- 验证：
+  - `bun --filter web typecheck` 通过。
+  - `bun test apps/web/src/features/github/lib/__tests__/agent-fix-prompts.test.ts apps/web/src/features/github/lib/__tests__/pr-review-thread-agent-fix.test.tsx apps/web/src/features/terminal/store/__tests__/terminal-store-new-tab.test.ts apps/web/src/features/wiki/components/__tests__/agent-select.test.ts` 通过，15 个测试。
+  - `bun run lint <本次改动的 7 个 Web 文件>` 通过。
+  - `git diff --check` 通过。
+  - `bun --filter web lint` 已尝试，但因本次范围外既有 lint 错误失败，涉及 `HostedAppShellGate.tsx`、`LocalModelDownloadProgress.tsx`、`CanvasAgentIsland.tsx`、`DiffWorkerPoolProvider.tsx`、`HostedWelcomeGate.tsx` 等文件。
+
+## 10. 结果文件
+
+本次结果文件路径：`automations/review/quality/result/2026-06/06-26_score-86_RESULT.md`
+
+## 11. 结果提交与推送
+
+- 修复分支已推送到 `origin/codex/quality-fix/2026-06-26`。
+- PR URL：https://github.com/AruNi-01/atmos/pull/137
+- 结果文件将随本报告提交到同一修复分支并推送；提交 hash 会在最终回复中给出，避免在报告内容中写入无法自指的提交 hash。


### PR DESCRIPTION
## Summary

- Original daily quality score: 86/100 for the UTC+8 2026-06-25 main-branch review window.
- Split GitHub Actions modal job rendering and action bar out of `ActionsDetailModal`, reducing the modal from 1089 lines to 363 lines.
- Centralized Agent Fix workspace/project context lookup in `useAgentFixContext` and reused it from Actions, PR detail, and diff prompt stash flows.
- Moved PR detail sticky-context scroll coordination into `usePrContextHeader` so the modal no longer owns the ResizeObserver/wheel boundary machinery inline.

## Related Issue

Daily automation: Atmos main 每日代码质量评分 (`atmos-main`).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] Additional checks:
  - `bun --filter web typecheck` passed.
  - `bun test apps/web/src/features/github/lib/__tests__/agent-fix-prompts.test.ts apps/web/src/features/github/lib/__tests__/pr-review-thread-agent-fix.test.tsx apps/web/src/features/terminal/store/__tests__/terminal-store-new-tab.test.ts apps/web/src/features/wiki/components/__tests__/agent-select.test.ts` passed, 15 tests.
  - `bun run lint src/features/github/components/ActionsDetailModal.tsx src/features/github/components/ActionsJobsList.tsx src/features/github/components/ActionsActionBar.tsx src/features/github/components/PRDetailModal.tsx src/features/github/components/use-pr-context-header.ts src/features/diff/components/useDiffPromptStash.tsx src/features/agent-fix/hooks/use-agent-fix-context.ts` passed.
  - `git diff --check` passed.
  - `bun --filter web lint` was attempted and failed on existing unrelated lint errors outside this PR, including `HostedAppShellGate.tsx`, `LocalModelDownloadProgress.tsx`, `CanvasAgentIsland.tsx`, `DiffWorkerPoolProvider.tsx`, and `HostedWelcomeGate.tsx`.

## Checklist

- [x] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

## Remaining Risk

- `PRDetailModal.tsx` remains a large component after this focused fix. This PR removes the scroll orchestration from the modal, but timeline rendering is still a good future extraction target.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the GitHub Actions modal into focused components and centralized shared hooks for Agent Fix context and PR header scroll. Added the 2026-06-26 quality report and tightened toolbar/links behavior.

- **Refactors**
  - Extracted `ActionsJobsList` and `ActionsActionBar` from `ActionsDetailModal`; added `actions-detail-types`. Reduced the modal from ~1089 lines to ~363.
  - Introduced `useAgentFixContext` and used it in Actions, `PRDetailModal`, and `useDiffPromptStash`.
  - Moved sticky PR context header logic into `usePrContextHeader` and wired it into `PRDetailModal`.

- **Bug Fixes**
  - Improved the workflow action toolbar’s focus/hover/blur handling to avoid accidental hiding.
  - Opened job step links with `noopener,noreferrer` for safer external navigation.

<sup>Written for commit d6e1c9d0abeba0f3fdc43b0087edd092640c74a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

