### PR TITLE
Refresh landing feature showcase

### DIFF
--- a/apps/landing/messages/en.json
+++ b/apps/landing/messages/en.json
@@ -1,4 +1,98 @@
 {
+  "featureShowcase": {
+    "features": {
+      "agent": {
+        "title": "AI Agent Workspace",
+        "label": "Agent",
+        "description": "Streaming responses, tool-call updates, permissions, and custom ACP agents in one workspace."
+      },
+      "wiki": {
+        "title": "Project Wiki",
+        "label": "Wiki",
+        "description": "URL-synced project knowledge that agents can generate, refresh, and use as working context."
+      },
+      "search": {
+        "title": "Global Search",
+        "label": "Search",
+        "description": "A command surface for jumping between workspaces, files, actions, and app-level tools."
+      },
+      "git": {
+        "title": "Integrated Git Workflow",
+        "label": "Git",
+        "description": "Diff review, branch state, AI-assisted commits, and PR context stay in the same cockpit."
+      },
+      "review": {
+        "title": "Review Workflow",
+        "label": "Review",
+        "description": "Inline review comments, threaded revisions, and terminal fix runners for agent handoff."
+      },
+      "run": {
+        "title": "Run Preview",
+        "label": "Run",
+        "description": "Run scripts, preview output, and verify changes without leaving the development surface."
+      },
+      "terminal": {
+        "title": "Terminal & Tmux",
+        "label": "Terminal",
+        "description": "Persistent tmux-backed terminals survive reloads, reconnect cleanly, and keep agent work alive."
+      },
+      "usage": {
+        "title": "Usage Analytics",
+        "label": "Usage",
+        "description": "Provider-specific token usage, subscription quota tracking, and cost estimates for AI work."
+      },
+      "auto": {
+        "title": "Local Automations",
+        "label": "Auto",
+        "description": "Scheduled and manual terminal-agent runs with artifacts, notifications, and issue automation."
+      },
+      "remote": {
+        "title": "Atmos Computer",
+        "label": "Remote",
+        "description": "Register remote machines, connect from Desktop or Hosted Web, and run terminals anywhere."
+      },
+      "models": {
+        "title": "Local Model Runtime",
+        "label": "Models",
+        "description": "Run lightweight llama-server models locally for TODO extraction and commit-message help."
+      },
+      "hooks": {
+        "title": "Agent Hooks",
+        "label": "Hooks",
+        "description": "Hook-based lifecycle sync shows running, idle, waiting, and done states across the UI."
+      },
+      "kanban": {
+        "title": "Workspace Kanban",
+        "label": "Kanban",
+        "description": "Drag workspace cards through status, priority, labels, issues, and PR-linked workflows."
+      },
+      "canvas": {
+        "title": "Canvas Workbench",
+        "label": "Canvas",
+        "description": "Pin terminals, notes, and diagrams from multiple projects onto a persistent working board."
+      },
+      "mobile": {
+        "title": "Mobile Companion",
+        "label": "Mobile",
+        "description": "Expo mobile surfaces keep remote workspaces, git state, and terminal follow-up within reach."
+      },
+      "files": {
+        "title": "Live File Tree",
+        "label": "Files",
+        "description": "Live file status, inline previews, and quick edits keep manual coding close to agent work."
+      },
+      "skills": {
+        "title": "Skill Management",
+        "label": "Skills",
+        "description": "Discover, enable, disable, and tune skills and custom agent definitions from settings."
+      },
+      "work": {
+        "title": "Multi-Workspace Isolation",
+        "label": "Work",
+        "description": "Git worktree isolation lets multiple agents operate in parallel without trampling changes."
+      }
+    }
+  },
   "changelog": {
     "heroTitle": "Catch up on the latest from Atmos",
     "heroDescription": "We're constantly shipping shiny new features, squashing bugs, and making things faster so you can build better.",

--- a/apps/landing/messages/zh.json
+++ b/apps/landing/messages/zh.json
@@ -1,4 +1,98 @@
 {
+  "featureShowcase": {
+    "features": {
+      "agent": {
+        "title": "AI Agent Workspace",
+        "label": "智能体",
+        "description": "在同一个工作区查看流式回复、工具调用更新、权限控制和自定义 ACP 智能体。"
+      },
+      "wiki": {
+        "title": "项目 Wiki",
+        "label": "Wiki",
+        "description": "和 URL 同步的项目知识库，智能体可以生成、刷新，并作为工作上下文使用。"
+      },
+      "search": {
+        "title": "全局搜索",
+        "label": "搜索",
+        "description": "在工作区、文件、动作和应用级工具之间快速跳转的命令入口。"
+      },
+      "git": {
+        "title": "集成 Git 工作流",
+        "label": "Git",
+        "description": "Diff 审阅、分支状态、AI 辅助提交和 PR 上下文都保留在同一个工作台里。"
+      },
+      "review": {
+        "title": "审阅工作流",
+        "label": "审阅",
+        "description": "通过内联审阅评论、线程化修改和终端修复任务完成智能体交接。"
+      },
+      "run": {
+        "title": "运行预览",
+        "label": "运行",
+        "description": "不离开开发界面即可运行脚本、查看预览输出并验证改动。"
+      },
+      "terminal": {
+        "title": "终端与 Tmux",
+        "label": "终端",
+        "description": "基于 tmux 的持久终端可以跨刷新保留状态，重连后继续保持智能体任务运行。"
+      },
+      "usage": {
+        "title": "用量分析",
+        "label": "用量",
+        "description": "按供应商追踪 token 用量、订阅额度和 AI 工作的成本估算。"
+      },
+      "auto": {
+        "title": "本地自动化",
+        "label": "自动",
+        "description": "支持定时或手动运行终端智能体，并管理产物、通知和 issue 自动化。"
+      },
+      "remote": {
+        "title": "Atmos Computer",
+        "label": "远程",
+        "description": "注册远程机器，从桌面端或托管 Web 连接，并在任何位置运行终端。"
+      },
+      "models": {
+        "title": "本地模型运行时",
+        "label": "模型",
+        "description": "本地运行轻量 llama-server 模型，用于 TODO 提取和提交信息辅助。"
+      },
+      "hooks": {
+        "title": "智能体 Hooks",
+        "label": "Hooks",
+        "description": "基于 hook 的生命周期同步会在界面中展示运行、空闲、等待和完成状态。"
+      },
+      "kanban": {
+        "title": "工作区看板",
+        "label": "看板",
+        "description": "通过状态、优先级、标签、issue 和 PR 关联工作流拖拽管理工作区卡片。"
+      },
+      "canvas": {
+        "title": "画布工作台",
+        "label": "画布",
+        "description": "把多个项目的终端、笔记和图表固定到一个持久工作画布上。"
+      },
+      "mobile": {
+        "title": "移动端伴侣",
+        "label": "移动",
+        "description": "Expo 移动端界面让远程工作区、Git 状态和终端跟进随时可用。"
+      },
+      "files": {
+        "title": "实时文件树",
+        "label": "文件",
+        "description": "通过实时文件状态、内联预览和快速编辑，让手动编码紧贴智能体工作流。"
+      },
+      "skills": {
+        "title": "技能管理",
+        "label": "技能",
+        "description": "在设置中发现、启用、停用并调整技能和自定义智能体定义。"
+      },
+      "work": {
+        "title": "多工作区隔离",
+        "label": "工作",
+        "description": "Git worktree 隔离让多个智能体并行工作，避免互相覆盖改动。"
+      }
+    }
+  },
   "changelog": {
     "heroTitle": "了解 Atmos 的最新动态",
     "heroDescription": "我们持续推出新功能、修复问题并提升性能，帮助你更好地构建应用。",

--- a/apps/landing/src/components/blocks/feature-showcase.tsx
+++ b/apps/landing/src/components/blocks/feature-showcase.tsx
@@ -283,7 +283,7 @@ export default function FeatureShowcase() {
                   })}
                 </div>
 
-                <div className="grid min-h-0 grid-cols-[3.875rem_minmax(0,1fr)_3.875rem] gap-2">
+                <div className="grid min-h-0 grid-cols-[3rem_minmax(0,1fr)_3rem] gap-2">
                   <div className="grid grid-rows-3 gap-2">
                     {leftFeatures.map((feature) => {
                       return (

--- a/apps/landing/src/components/blocks/feature-showcase.tsx
+++ b/apps/landing/src/components/blocks/feature-showcase.tsx
@@ -1,48 +1,197 @@
 'use client'
 
 import { useState, useEffect, useRef } from 'react'
-import { motion, AnimatePresence } from 'motion/react'
+import { motion } from 'motion/react'
+import {
+  BarChart3Icon,
+  BellRingIcon,
+  BookOpenIcon,
+  BotIcon,
+  CalendarClockIcon,
+  Columns3Icon,
+  CpuIcon,
+  FileCodeIcon,
+  GitBranchIcon,
+  GitPullRequestIcon,
+  LayersIcon,
+  MonitorIcon,
+  PanelsTopLeftIcon,
+  PlayIcon,
+  SearchIcon,
+  SmartphoneIcon,
+  TerminalIcon,
+  WorkflowIcon,
+  type LucideIcon,
+} from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { MotionPreset } from '@workspace/ui/components/ui/motion-preset'
 import { Badge } from '@workspace/ui/components/ui/badge'
 
+type FeaturePlacement = 'top-left' | 'top' | 'top-right' | 'right' | 'bottom-right' | 'bottom' | 'bottom-left' | 'left'
+
+type Feature = {
+  title: string
+  label: string
+  description: string
+  icon: LucideIcon
+  placement: FeaturePlacement
+  gridAreaClass: string
+}
+
+const FEATURE_VIDEO_URL = '/videos/atmos-intro-editorial.mp4'
+const FEATURE_POSTER_URL = '/videos/atmos-intro-editorial-poster.jpg'
+
 const features = [
   {
     title: 'AI Agent Workspace',
-    description: 'Agent panel with streaming responses, tool call updates, and custom ACP agent support.',
-    videoUrl: 'https://www.pexels.com/zh-cn/download/video/34312649/',
+    label: 'Agent',
+    description: 'Streaming responses, tool-call updates, permissions, and custom ACP agents in one workspace.',
+    icon: BotIcon,
+    placement: 'top-left',
+    gridAreaClass: 'col-start-1 row-start-1',
   },
   {
     title: 'Project Wiki',
-    description: 'A URL-synced Wiki tab with automated generation integrated with terminal automation.',
-    videoUrl: 'https://www.pexels.com/zh-cn/download/video/34312649/',
+    label: 'Wiki',
+    description: 'URL-synced project knowledge that agents can generate, refresh, and use as working context.',
+    icon: BookOpenIcon,
+    placement: 'top',
+    gridAreaClass: 'col-start-2 row-start-1',
   },
   {
     title: 'Global Search',
-    description: 'Unified command surface for navigation, file/code search, and app quick actions.',
-    videoUrl: 'https://www.pexels.com/zh-cn/download/video/34312649/',
+    label: 'Search',
+    description: 'A command surface for jumping between workspaces, files, actions, and app-level tools.',
+    icon: SearchIcon,
+    placement: 'top',
+    gridAreaClass: 'col-start-3 row-start-1',
   },
   {
-    title: 'Git Intelligence',
-    description: 'AI-assisted commits, code-review workflows, and detailed PR context parsing.',
-    videoUrl: 'https://www.pexels.com/zh-cn/download/video/34312649/',
+    title: 'Integrated Git Workflow',
+    label: 'Git',
+    description: 'Diff review, branch state, AI-assisted commits, and PR context stay in the same cockpit.',
+    icon: GitBranchIcon,
+    placement: 'top',
+    gridAreaClass: 'col-start-4 row-start-1',
+  },
+  {
+    title: 'Review Workflow',
+    label: 'Review',
+    description: 'Inline review comments, threaded revisions, and terminal fix runners for agent handoff.',
+    icon: GitPullRequestIcon,
+    placement: 'top',
+    gridAreaClass: 'col-start-5 row-start-1',
   },
   {
     title: 'Run Preview',
-    description: 'Built-in Run Preview panel for rapid "run-and-verify" script workflows.',
-    videoUrl: 'https://www.pexels.com/zh-cn/download/video/34312649/',
+    label: 'Run',
+    description: 'Run scripts, preview output, and verify changes without leaving the development surface.',
+    icon: PlayIcon,
+    placement: 'top-right',
+    gridAreaClass: 'col-start-6 row-start-1',
   },
   {
     title: 'Terminal & Tmux',
-    description: 'Persistent, tmux-backed terminals that preserve logic and reattach cleanly.',
-    videoUrl: 'https://www.pexels.com/zh-cn/download/video/34312649/',
+    label: 'Terminal',
+    description: 'Persistent tmux-backed terminals survive reloads, reconnect cleanly, and keep agent work alive.',
+    icon: TerminalIcon,
+    placement: 'right',
+    gridAreaClass: 'col-start-6 row-start-2',
   },
   {
-    title: 'Usage Observability',
-    description: 'Provider-specific token visualization to keep an eye on active AI expenses.',
-    videoUrl: 'https://www.pexels.com/zh-cn/download/video/34312649/',
+    title: 'Usage Analytics',
+    label: 'Usage',
+    description: 'Provider-specific token usage, subscription quota tracking, and cost estimates for AI work.',
+    icon: BarChart3Icon,
+    placement: 'right',
+    gridAreaClass: 'col-start-6 row-start-3',
   },
-]
+  {
+    title: 'Local Automations',
+    label: 'Auto',
+    description: 'Scheduled and manual terminal-agent runs with artifacts, notifications, and issue automation.',
+    icon: CalendarClockIcon,
+    placement: 'right',
+    gridAreaClass: 'col-start-6 row-start-4',
+  },
+  {
+    title: 'Atmos Computer',
+    label: 'Remote',
+    description: 'Register remote machines, connect from Desktop or Hosted Web, and run terminals anywhere.',
+    icon: MonitorIcon,
+    placement: 'bottom-right',
+    gridAreaClass: 'col-start-6 row-start-5',
+  },
+  {
+    title: 'Local Model Runtime',
+    label: 'Models',
+    description: 'Run lightweight llama-server models locally for TODO extraction and commit-message help.',
+    icon: CpuIcon,
+    placement: 'bottom',
+    gridAreaClass: 'col-start-5 row-start-5',
+  },
+  {
+    title: 'Agent Hooks',
+    label: 'Hooks',
+    description: 'Hook-based lifecycle sync shows running, idle, waiting, and done states across the UI.',
+    icon: BellRingIcon,
+    placement: 'bottom',
+    gridAreaClass: 'col-start-4 row-start-5',
+  },
+  {
+    title: 'Workspace Kanban',
+    label: 'Kanban',
+    description: 'Drag workspace cards through status, priority, labels, issues, and PR-linked workflows.',
+    icon: Columns3Icon,
+    placement: 'bottom',
+    gridAreaClass: 'col-start-3 row-start-5',
+  },
+  {
+    title: 'Canvas Workbench',
+    label: 'Canvas',
+    description: 'Pin terminals, notes, and diagrams from multiple projects onto a persistent working board.',
+    icon: PanelsTopLeftIcon,
+    placement: 'bottom',
+    gridAreaClass: 'col-start-2 row-start-5',
+  },
+  {
+    title: 'Mobile Companion',
+    label: 'Mobile',
+    description: 'Expo mobile surfaces keep remote workspaces, git state, and terminal follow-up within reach.',
+    icon: SmartphoneIcon,
+    placement: 'bottom-left',
+    gridAreaClass: 'col-start-1 row-start-5',
+  },
+  {
+    title: 'Live File Tree',
+    label: 'Files',
+    description: 'Live file status, inline previews, and quick edits keep manual coding close to agent work.',
+    icon: FileCodeIcon,
+    placement: 'left',
+    gridAreaClass: 'col-start-1 row-start-4',
+  },
+  {
+    title: 'Skill Management',
+    label: 'Skills',
+    description: 'Discover, enable, disable, and tune skills and custom agent definitions from settings.',
+    icon: LayersIcon,
+    placement: 'left',
+    gridAreaClass: 'col-start-1 row-start-3',
+  },
+  {
+    title: 'Multi-Workspace Isolation',
+    label: 'Work',
+    description: 'Git worktree isolation lets multiple agents operate in parallel without trampling changes.',
+    icon: WorkflowIcon,
+    placement: 'left',
+    gridAreaClass: 'col-start-1 row-start-2',
+  },
+] satisfies Feature[]
+
+const topFeatures = features.filter((feature) => getFeatureEdgePlacement(feature.placement) === 'top')
+const rightFeatures = features.filter((feature) => getFeatureEdgePlacement(feature.placement) === 'right')
+const bottomFeatures = features.filter((feature) => getFeatureEdgePlacement(feature.placement) === 'bottom').reverse()
+const leftFeatures = features.filter((feature) => getFeatureEdgePlacement(feature.placement) === 'left').reverse()
 
 const DURATION = 5000 // 5 seconds per slide
 
@@ -100,7 +249,7 @@ export default function FeatureShowcase() {
       >
         <div className='m-6 w-full shrink-2 max-xl:hidden'></div>
 
-        <div className='mx-auto w-full max-w-6xl shrink-0 space-y-8 px-4 py-8 min-[1158px]:border-x sm:space-y-16 sm:px-6 sm:py-16 lg:px-8'>
+        <div className='mx-auto w-full max-w-7xl shrink-0 space-y-8 px-4 py-8 min-[1158px]:border-x sm:space-y-16 sm:px-6 sm:py-16 lg:px-8'>
           <div className='space-y-2.5'>
             <MotionPreset fade blur slide={{ direction: 'down', offset: 50 }} transition={{ duration: 0.5 }}>
               <Badge variant='outline' className='rounded-none'>
@@ -115,83 +264,100 @@ export default function FeatureShowcase() {
           </div>
 
           {/* Container for Video & Nav */}
-          <MotionPreset fade slide blur transition={{ duration: 0.5 }} delay={0.4}>
-            <div className="flex flex-col rounded-3xl border border-border/50 bg-muted/20 p-2 md:p-3 ring-1 ring-white/5">
-              {/* Main Video Display */}
-              <div
-                className="relative aspect-video w-full rounded-2xl overflow-hidden border border-border/50shadow-2xl group"
-                onMouseEnter={() => setIsHovering(true)}
-                onMouseLeave={() => setIsHovering(false)}
-              >
-                <AnimatePresence mode="wait">
-                  <motion.div
-                    key={activeIndex}
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    exit={{ opacity: 0 }}
-                    transition={{ duration: 0.2 }}
-                    className="absolute inset-0 size-full"
-                  >
-                    <video
-                      ref={videoRef}
-                      src={features[activeIndex].videoUrl}
-                      autoPlay
-                      muted
-                      loop
-                      className="size-full object-cover"
-                      playsInline
-                      suppressHydrationWarning
-                    />
-                    {/* Overlay Content */}
-                    <div className="absolute inset-0 bg-muted/50 dark:bg-black/50 p-8 flex flex-col justify-end items-start pointer-events-none">
-                      <motion.div
-                        initial={{ y: 20, opacity: 0 }}
-                        animate={{ y: 0, opacity: 1 }}
-                        transition={{ delay: 0.5, duration: 2 }}
-                      >
-                        <h3 className="text-3xl font-bold text-white mb-2">{features[activeIndex].title}</h3>
-                        <p className="text-white/80 text-lg max-w-2xl">{features[activeIndex].description}</p>
-                      </motion.div>
-                    </div>
-                  </motion.div>
-                </AnimatePresence>
+          <MotionPreset fade slide blur transition={{ duration: 0.5 }} delay={0.4} inView={false}>
+            <div>
+              <div className="hidden gap-2 lg:flex lg:flex-col">
+                <div className="grid grid-cols-6 gap-2">
+                  {topFeatures.map((feature) => {
+                    const index = features.indexOf(feature)
+
+                    return (
+                      <FeatureActionButton
+                        key={feature.title}
+                        feature={feature}
+                        isActive={index === activeIndex}
+                        progress={progress}
+                        onClick={() => handleManualChange(index)}
+                      />
+                    )
+                  })}
+                </div>
+
+                <div className="grid min-h-0 grid-cols-[3.875rem_minmax(0,1fr)_3.875rem] gap-2">
+                  <div className="grid grid-rows-3 gap-2">
+                    {leftFeatures.map((feature) => {
+                      const index = features.indexOf(feature)
+
+                      return (
+                        <FeatureActionButton
+                          key={feature.title}
+                          feature={feature}
+                          isActive={index === activeIndex}
+                          progress={progress}
+                          onClick={() => handleManualChange(index)}
+                        />
+                      )
+                    })}
+                  </div>
+
+                  <FeaturePreview
+                    videoRef={videoRef}
+                    onMouseEnter={() => setIsHovering(true)}
+                    onMouseLeave={() => setIsHovering(false)}
+                  />
+
+                  <div className="grid grid-rows-3 gap-2">
+                    {rightFeatures.map((feature) => {
+                      const index = features.indexOf(feature)
+
+                      return (
+                        <FeatureActionButton
+                          key={feature.title}
+                          feature={feature}
+                          isActive={index === activeIndex}
+                          progress={progress}
+                          onClick={() => handleManualChange(index)}
+                        />
+                      )
+                    })}
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-6 gap-2">
+                  {bottomFeatures.map((feature) => {
+                    const index = features.indexOf(feature)
+
+                    return (
+                      <FeatureActionButton
+                        key={feature.title}
+                        feature={feature}
+                        isActive={index === activeIndex}
+                        progress={progress}
+                        onClick={() => handleManualChange(index)}
+                      />
+                    )
+                  })}
+                </div>
               </div>
 
-              {/* Navigation Bar */}
-              <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-2 pt-2">
-                {features.map((feature, index) => {
-                  const isActive = index === activeIndex;
-                  return (
-                    <button
-                      key={index}
+              <div className="lg:hidden">
+                <FeaturePreview
+                  videoRef={videoRef}
+                  onMouseEnter={() => setIsHovering(true)}
+                  onMouseLeave={() => setIsHovering(false)}
+                />
+                <div className="-mx-2 mt-2 flex snap-x gap-2 overflow-x-auto px-2 pb-1">
+                  {features.map((feature, index) => (
+                    <FeatureActionButton
+                      key={feature.title}
+                      feature={feature}
+                      isActive={index === activeIndex}
+                      progress={progress}
                       onClick={() => handleManualChange(index)}
-                      className={cn(
-                        "relative flex flex-col items-start p-3 rounded-lg text-left transition-all duration-300 group/btn h-full overflow-hidden cursor-pointer",
-                        isActive ? "bg-muted" : "hover:bg-muted/50"
-                      )}
-                    >
-                      {/* Progress Bar Background */}
-                      {isActive && (
-                        <div className="absolute top-0 left-0 h-1 w-full bg-border">
-                          <motion.div
-                            className="h-full bg-primary"
-                            style={{ width: `${progress}%` }}
-                            transition={{ duration: 0, ease: "linear" }}
-                          />
-                        </div>
-                      )}
-
-                      <div className="flex items-center gap-2 w-full">
-                        <span className={cn(
-                          "text-sm font-semibold whitespace-nowrap",
-                          isActive ? "text-foreground" : "text-muted-foreground group-hover/btn:text-foreground"
-                        )}>
-                          {feature.title}
-                        </span>
-                      </div>
-                    </button>
-                  )
-                })}
+                      isMobile
+                    />
+                  ))}
+                </div>
               </div>
             </div>
           </MotionPreset>
@@ -201,4 +367,124 @@ export default function FeatureShowcase() {
       </MotionPreset>
     </section>
   )
+}
+
+function FeaturePreview({
+  videoRef,
+  onMouseEnter,
+  onMouseLeave,
+}: {
+  videoRef: React.RefObject<HTMLVideoElement | null>
+  onMouseEnter: () => void
+  onMouseLeave: () => void
+}) {
+  return (
+    <div
+      className="relative aspect-video min-h-0 w-full overflow-hidden rounded-2xl border border-border/60 bg-background shadow-2xl shadow-black/10 group"
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      <video
+        ref={videoRef}
+        src={FEATURE_VIDEO_URL}
+        poster={FEATURE_POSTER_URL}
+        autoPlay
+        muted
+        loop
+        className="size-full object-cover"
+        playsInline
+        suppressHydrationWarning
+      />
+    </div>
+  )
+}
+
+function FeatureActionButton({
+  feature,
+  isActive,
+  progress,
+  onClick,
+  isMobile = false,
+}: {
+  feature: Feature
+  isActive: boolean
+  progress: number
+  onClick: () => void
+  isMobile?: boolean
+}) {
+  const Icon = feature.icon
+  const edgePlacement = getFeatureEdgePlacement(feature.placement)
+  const isLeftSide = edgePlacement === 'left' && !isMobile
+  const isRightSide = edgePlacement === 'right' && !isMobile
+  const isSide = isLeftSide || isRightSide
+  const toneClass = 'bg-background text-foreground shadow-sm dark:bg-zinc-900'
+
+  return (
+    <button
+      type="button"
+      aria-label={feature.title}
+      aria-pressed={isActive}
+      onClick={onClick}
+      className={cn(
+        'relative isolate flex cursor-pointer overflow-hidden border-0 text-left transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/30',
+        toneClass,
+        !isActive && 'hover:bg-muted/60 dark:hover:bg-white/[0.07]',
+        isMobile
+          ? 'h-12 min-w-[10.5rem] snap-start items-center gap-2 rounded-lg px-3'
+          : cn(
+            'min-h-0',
+            isSide
+              ? 'h-full w-full items-center justify-center rounded-xl px-0'
+              : 'h-12 items-center justify-center gap-2 rounded-xl px-3'
+          )
+      )}
+    >
+      {isActive && (
+        <span className="absolute inset-0">
+          <motion.span
+            className={cn('block bg-foreground/[0.08] dark:bg-white/[0.08]', isSide ? 'w-full' : 'h-full')}
+            style={isSide ? { height: `${progress}%` } : { width: `${progress}%` }}
+            transition={{ duration: 0, ease: 'linear' }}
+          />
+        </span>
+      )}
+
+      <span
+        className={cn(
+          'relative z-10 flex items-center gap-1.5',
+          isSide ? 'w-24 justify-center' : 'min-w-0',
+          isLeftSide && 'rotate-90',
+          isRightSide && 'rotate-90'
+        )}
+      >
+        <span
+          className="flex size-6 shrink-0 items-center justify-center rounded-md bg-muted/50"
+        >
+          <Icon className="size-3.5" aria-hidden="true" />
+        </span>
+        <span className={cn('text-xs font-semibold leading-none', isSide ? 'shrink-0' : 'min-w-0 truncate')}>
+          {feature.label}
+        </span>
+      </span>
+    </button>
+  )
+}
+
+function getFeatureEdgePlacement(placement: FeaturePlacement): 'top' | 'right' | 'bottom' | 'left' {
+  switch (placement) {
+    case 'top-left':
+    case 'top-right':
+    case 'top':
+      return 'top'
+    case 'bottom-right':
+    case 'bottom-left':
+    case 'bottom':
+      return 'bottom'
+    case 'right':
+      return 'right'
+    case 'left':
+      return 'left'
+    default:
+      return placement
+  }
 }

--- a/apps/landing/src/components/blocks/feature-showcase.tsx
+++ b/apps/landing/src/components/blocks/feature-showcase.tsx
@@ -251,7 +251,7 @@ export default function FeatureShowcase() {
       >
         <div className='m-6 w-full shrink-2 max-xl:hidden'></div>
 
-        <div className='mx-auto w-full max-w-7xl shrink-0 space-y-8 px-4 py-8 min-[1158px]:border-x sm:space-y-16 sm:px-6 sm:py-16 lg:px-8'>
+        <div className='mx-auto w-full max-w-6xl shrink-0 space-y-8 px-4 py-8 min-[1158px]:border-x sm:space-y-16 sm:px-6 sm:py-16 lg:px-8'>
           <div className='space-y-2.5'>
             <MotionPreset fade blur slide={{ direction: 'down', offset: 50 }} transition={{ duration: 0.5 }}>
               <Badge variant='outline' className='rounded-none'>

--- a/apps/landing/src/components/blocks/feature-showcase.tsx
+++ b/apps/landing/src/components/blocks/feature-showcase.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { motion } from 'motion/react'
+import { useTranslations } from 'next-intl'
 import {
   BarChart3Icon,
   BellRingIcon,
@@ -26,10 +27,40 @@ import {
 import { cn } from '@/lib/utils'
 import { MotionPreset } from '@workspace/ui/components/ui/motion-preset'
 import { Badge } from '@workspace/ui/components/ui/badge'
+import { Button } from '@workspace/ui/components/ui/button'
 
 type FeaturePlacement = 'top-left' | 'top' | 'top-right' | 'right' | 'bottom-right' | 'bottom' | 'bottom-left' | 'left'
 
+type FeatureKey =
+  | 'agent'
+  | 'wiki'
+  | 'search'
+  | 'git'
+  | 'review'
+  | 'run'
+  | 'terminal'
+  | 'usage'
+  | 'auto'
+  | 'remote'
+  | 'models'
+  | 'hooks'
+  | 'kanban'
+  | 'canvas'
+  | 'mobile'
+  | 'files'
+  | 'skills'
+  | 'work'
+
+type FeatureDefinition = {
+  key: FeatureKey
+  icon: LucideIcon
+  placement: FeaturePlacement
+  gridAreaClass: string
+}
+
 type Feature = {
+  key: FeatureKey
+  index: number
   title: string
   label: string
   description: string
@@ -41,161 +72,121 @@ type Feature = {
 const FEATURE_VIDEO_URL = '/videos/atmos-intro-editorial.mp4'
 const FEATURE_POSTER_URL = '/videos/atmos-intro-editorial-poster.jpg'
 
-const features = [
+const featureDefinitions = [
   {
-    title: 'AI Agent Workspace',
-    label: 'Agent',
-    description: 'Streaming responses, tool-call updates, permissions, and custom ACP agents in one workspace.',
+    key: 'agent',
     icon: BotIcon,
     placement: 'top-left',
     gridAreaClass: 'col-start-1 row-start-1',
   },
   {
-    title: 'Project Wiki',
-    label: 'Wiki',
-    description: 'URL-synced project knowledge that agents can generate, refresh, and use as working context.',
+    key: 'wiki',
     icon: BookOpenIcon,
     placement: 'top',
     gridAreaClass: 'col-start-2 row-start-1',
   },
   {
-    title: 'Global Search',
-    label: 'Search',
-    description: 'A command surface for jumping between workspaces, files, actions, and app-level tools.',
+    key: 'search',
     icon: SearchIcon,
     placement: 'top',
     gridAreaClass: 'col-start-3 row-start-1',
   },
   {
-    title: 'Integrated Git Workflow',
-    label: 'Git',
-    description: 'Diff review, branch state, AI-assisted commits, and PR context stay in the same cockpit.',
+    key: 'git',
     icon: GitBranchIcon,
     placement: 'top',
     gridAreaClass: 'col-start-4 row-start-1',
   },
   {
-    title: 'Review Workflow',
-    label: 'Review',
-    description: 'Inline review comments, threaded revisions, and terminal fix runners for agent handoff.',
+    key: 'review',
     icon: GitPullRequestIcon,
     placement: 'top',
     gridAreaClass: 'col-start-5 row-start-1',
   },
   {
-    title: 'Run Preview',
-    label: 'Run',
-    description: 'Run scripts, preview output, and verify changes without leaving the development surface.',
+    key: 'run',
     icon: PlayIcon,
     placement: 'top-right',
     gridAreaClass: 'col-start-6 row-start-1',
   },
   {
-    title: 'Terminal & Tmux',
-    label: 'Terminal',
-    description: 'Persistent tmux-backed terminals survive reloads, reconnect cleanly, and keep agent work alive.',
+    key: 'terminal',
     icon: TerminalIcon,
     placement: 'right',
     gridAreaClass: 'col-start-6 row-start-2',
   },
   {
-    title: 'Usage Analytics',
-    label: 'Usage',
-    description: 'Provider-specific token usage, subscription quota tracking, and cost estimates for AI work.',
+    key: 'usage',
     icon: BarChart3Icon,
     placement: 'right',
     gridAreaClass: 'col-start-6 row-start-3',
   },
   {
-    title: 'Local Automations',
-    label: 'Auto',
-    description: 'Scheduled and manual terminal-agent runs with artifacts, notifications, and issue automation.',
+    key: 'auto',
     icon: CalendarClockIcon,
     placement: 'right',
     gridAreaClass: 'col-start-6 row-start-4',
   },
   {
-    title: 'Atmos Computer',
-    label: 'Remote',
-    description: 'Register remote machines, connect from Desktop or Hosted Web, and run terminals anywhere.',
+    key: 'remote',
     icon: MonitorIcon,
     placement: 'bottom-right',
     gridAreaClass: 'col-start-6 row-start-5',
   },
   {
-    title: 'Local Model Runtime',
-    label: 'Models',
-    description: 'Run lightweight llama-server models locally for TODO extraction and commit-message help.',
+    key: 'models',
     icon: CpuIcon,
     placement: 'bottom',
     gridAreaClass: 'col-start-5 row-start-5',
   },
   {
-    title: 'Agent Hooks',
-    label: 'Hooks',
-    description: 'Hook-based lifecycle sync shows running, idle, waiting, and done states across the UI.',
+    key: 'hooks',
     icon: BellRingIcon,
     placement: 'bottom',
     gridAreaClass: 'col-start-4 row-start-5',
   },
   {
-    title: 'Workspace Kanban',
-    label: 'Kanban',
-    description: 'Drag workspace cards through status, priority, labels, issues, and PR-linked workflows.',
+    key: 'kanban',
     icon: Columns3Icon,
     placement: 'bottom',
     gridAreaClass: 'col-start-3 row-start-5',
   },
   {
-    title: 'Canvas Workbench',
-    label: 'Canvas',
-    description: 'Pin terminals, notes, and diagrams from multiple projects onto a persistent working board.',
+    key: 'canvas',
     icon: PanelsTopLeftIcon,
     placement: 'bottom',
     gridAreaClass: 'col-start-2 row-start-5',
   },
   {
-    title: 'Mobile Companion',
-    label: 'Mobile',
-    description: 'Expo mobile surfaces keep remote workspaces, git state, and terminal follow-up within reach.',
+    key: 'mobile',
     icon: SmartphoneIcon,
     placement: 'bottom-left',
     gridAreaClass: 'col-start-1 row-start-5',
   },
   {
-    title: 'Live File Tree',
-    label: 'Files',
-    description: 'Live file status, inline previews, and quick edits keep manual coding close to agent work.',
+    key: 'files',
     icon: FileCodeIcon,
     placement: 'left',
     gridAreaClass: 'col-start-1 row-start-4',
   },
   {
-    title: 'Skill Management',
-    label: 'Skills',
-    description: 'Discover, enable, disable, and tune skills and custom agent definitions from settings.',
+    key: 'skills',
     icon: LayersIcon,
     placement: 'left',
     gridAreaClass: 'col-start-1 row-start-3',
   },
   {
-    title: 'Multi-Workspace Isolation',
-    label: 'Work',
-    description: 'Git worktree isolation lets multiple agents operate in parallel without trampling changes.',
+    key: 'work',
     icon: WorkflowIcon,
     placement: 'left',
     gridAreaClass: 'col-start-1 row-start-2',
   },
-] satisfies Feature[]
-
-const topFeatures = features.filter((feature) => getFeatureEdgePlacement(feature.placement) === 'top')
-const rightFeatures = features.filter((feature) => getFeatureEdgePlacement(feature.placement) === 'right')
-const bottomFeatures = features.filter((feature) => getFeatureEdgePlacement(feature.placement) === 'bottom').reverse()
-const leftFeatures = features.filter((feature) => getFeatureEdgePlacement(feature.placement) === 'left').reverse()
+] satisfies FeatureDefinition[]
 
 const DURATION = 5000 // 5 seconds per slide
 
 export default function FeatureShowcase() {
+  const t = useTranslations('featureShowcase')
   const [activeIndex, setActiveIndex] = useState(0)
   const [progress, setProgress] = useState(0)
   const [isHovering, setIsHovering] = useState(false)
@@ -203,6 +194,17 @@ export default function FeatureShowcase() {
 
   // Track the actual video element to control playback if needed
   const videoRef = useRef<HTMLVideoElement>(null)
+  const features = featureDefinitions.map((feature, index) => ({
+    ...feature,
+    index,
+    title: t(`features.${feature.key}.title`),
+    label: t(`features.${feature.key}.label`),
+    description: t(`features.${feature.key}.description`),
+  })) satisfies Feature[]
+  const topFeatures = features.filter((feature) => getFeatureEdgePlacement(feature.placement) === 'top')
+  const rightFeatures = features.filter((feature) => getFeatureEdgePlacement(feature.placement) === 'right')
+  const bottomFeatures = features.filter((feature) => getFeatureEdgePlacement(feature.placement) === 'bottom').reverse()
+  const leftFeatures = features.filter((feature) => getFeatureEdgePlacement(feature.placement) === 'left').reverse()
 
   // Combined effect: manage timer and auto-advance slides
   useEffect(() => {
@@ -217,7 +219,7 @@ export default function FeatureShowcase() {
         if (nextProgress >= 100) {
           // Use setTimeout to defer state update and avoid cascading renders
           setTimeout(() => {
-            setActiveIndex((idx) => (idx + 1) % features.length)
+            setActiveIndex((idx) => (idx + 1) % featureDefinitions.length)
           }, 0)
           return 0
         }
@@ -269,15 +271,13 @@ export default function FeatureShowcase() {
               <div className="hidden gap-2 lg:flex lg:flex-col">
                 <div className="grid grid-cols-6 gap-2">
                   {topFeatures.map((feature) => {
-                    const index = features.indexOf(feature)
-
                     return (
                       <FeatureActionButton
-                        key={feature.title}
+                        key={feature.key}
                         feature={feature}
-                        isActive={index === activeIndex}
+                        isActive={feature.index === activeIndex}
                         progress={progress}
-                        onClick={() => handleManualChange(index)}
+                        onClick={() => handleManualChange(feature.index)}
                       />
                     )
                   })}
@@ -286,15 +286,13 @@ export default function FeatureShowcase() {
                 <div className="grid min-h-0 grid-cols-[3.875rem_minmax(0,1fr)_3.875rem] gap-2">
                   <div className="grid grid-rows-3 gap-2">
                     {leftFeatures.map((feature) => {
-                      const index = features.indexOf(feature)
-
                       return (
                         <FeatureActionButton
-                          key={feature.title}
+                          key={feature.key}
                           feature={feature}
-                          isActive={index === activeIndex}
+                          isActive={feature.index === activeIndex}
                           progress={progress}
-                          onClick={() => handleManualChange(index)}
+                          onClick={() => handleManualChange(feature.index)}
                         />
                       )
                     })}
@@ -308,15 +306,13 @@ export default function FeatureShowcase() {
 
                   <div className="grid grid-rows-3 gap-2">
                     {rightFeatures.map((feature) => {
-                      const index = features.indexOf(feature)
-
                       return (
                         <FeatureActionButton
-                          key={feature.title}
+                          key={feature.key}
                           feature={feature}
-                          isActive={index === activeIndex}
+                          isActive={feature.index === activeIndex}
                           progress={progress}
-                          onClick={() => handleManualChange(index)}
+                          onClick={() => handleManualChange(feature.index)}
                         />
                       )
                     })}
@@ -325,15 +321,13 @@ export default function FeatureShowcase() {
 
                 <div className="grid grid-cols-6 gap-2">
                   {bottomFeatures.map((feature) => {
-                    const index = features.indexOf(feature)
-
                     return (
                       <FeatureActionButton
-                        key={feature.title}
+                        key={feature.key}
                         feature={feature}
-                        isActive={index === activeIndex}
+                        isActive={feature.index === activeIndex}
                         progress={progress}
-                        onClick={() => handleManualChange(index)}
+                        onClick={() => handleManualChange(feature.index)}
                       />
                     )
                   })}
@@ -347,13 +341,13 @@ export default function FeatureShowcase() {
                   onMouseLeave={() => setIsHovering(false)}
                 />
                 <div className="-mx-2 mt-2 flex snap-x gap-2 overflow-x-auto px-2 pb-1">
-                  {features.map((feature, index) => (
+                  {features.map((feature) => (
                     <FeatureActionButton
-                      key={feature.title}
+                      key={feature.key}
                       feature={feature}
-                      isActive={index === activeIndex}
+                      isActive={feature.index === activeIndex}
                       progress={progress}
-                      onClick={() => handleManualChange(index)}
+                      onClick={() => handleManualChange(feature.index)}
                       isMobile
                     />
                   ))}
@@ -420,8 +414,10 @@ function FeatureActionButton({
   const toneClass = 'bg-background text-foreground shadow-sm dark:bg-zinc-900'
 
   return (
-    <button
+    <Button
       type="button"
+      variant="ghost"
+      size="sm"
       aria-label={feature.title}
       aria-pressed={isActive}
       onClick={onClick}
@@ -466,7 +462,7 @@ function FeatureActionButton({
           {feature.label}
         </span>
       </span>
-    </button>
+    </Button>
   )
 }
 


### PR DESCRIPTION
## Summary

Refresh the landing page feature showcase so the product video remains the primary focus:

- Replaces the old bottom action strip with a perimeter action layout around the video.
- Adds project-specific feature actions with icons for agent, wiki, search, git, review, run, terminal, usage, automations, mobile, canvas, kanban, hooks, models, remote, files, skills, and workspaces.
- Uses the local Atmos editorial video/poster and removes in-video overlay copy so the video is not visually polluted.
- Removes the outer showcase frame and item borders, widens the section, and uses an in-item background overlay to show playback progress.
- Keeps side items vertical, with the right-side labels reading from top to bottom.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] Additional checks (describe below)

Additional checks:

- [x] `bun run lint -- src/components/blocks/feature-showcase.tsx`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] Playwright production preview checks for visible desktop items, no video overlays, no horizontal overflow, no console/network errors, and right-side item rotation.

## Checklist

- [ ] I updated documentation if behavior changed
- [ ] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the landing page feature showcase to keep the product video as the main focus, with a clean perimeter action layout and no in-video copy. Adds localized feature text (EN/ZH) and improves clarity, navigation, and responsiveness across desktop and mobile.

- New Features
  - Perimeter action layout on all sides with rotated side labels.
  - 18 project-specific actions with `lucide-react` icons and an in-button progress overlay.
  - Local editorial video and poster, no overlay text on the video.
  - Responsive: desktop perimeter grid; mobile video with a horizontal action scroller.
  - Localization: feature titles, labels, and descriptions via `next-intl` with `en` and `zh` messages.
  - Visual polish: remove outer frame/borders, adjust section max width, and align side-rail widths.

- Refactors
  - Extracted `FeaturePreview` and `FeatureActionButton` components and centralized placement mapping via `getFeatureEdgePlacement`.
  - Unified to a single shared video source; removed `AnimatePresence` overlay content.
  - Added a11y improvements: `aria-label`, `aria-pressed`, and visible focus states.

<sup>Written for commit 1bdff0fc9e1b00f8f513a95b88010b47bb9d887c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the feature showcase with a new, more interactive layout for browsing featured items.
  * Added a cleaner desktop grid experience and a mobile-friendly horizontal selector.
  * Improved the preview area with a consistent video display and clearer active-state indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->