### PR TITLE
refactor: address daily quality findings for 2026-06-29

### DIFF
--- a/apps/web/src/app-shell/RightSidebar.tsx
+++ b/apps/web/src/app-shell/RightSidebar.tsx
@@ -14,20 +14,12 @@ import { useProjectStore } from "@/features/project/store/use-project-store";
 import {
   Check,
   Button,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
-  DropdownMenuTrigger,
   Tabs,
   TabsList,
   TabsTab,
 } from "@workspace/ui";
 import {
   Play,
-  ChevronDown,
   GitPullRequest,
   GitPullRequestCreate,
   GitPullRequestClosed,
@@ -57,14 +49,15 @@ import { useGitInfoStore } from "@/features/git/store/use-git-info-store";
 import { PRPanel, type PRPanelHandle } from "@/features/github/components/PRPanel";
 import { CommitsPanel } from "@/features/github/components/CommitsPanel";
 import { ActionsPanel } from "@/features/github/components/ActionsPanel";
-import { useGitLog, type GitCommit } from "@/features/github/hooks/use-github";
 import { isWorkspaceSetupBlocking } from "@/features/workspace/lib/workspace-setup";
 import { useLayoutSettingsStore } from "@/features/settings/store/layout-settings-store";
 import { FileTreePanel } from "@/features/files/components/FileTreePanel";
 
 import { ChangeSection } from "@/app-shell/sidebar/ChangeSection";
+import { ChangesScopeMenu } from "@/app-shell/sidebar/ChangesScopeMenu";
 import { CommitActionsContainer } from "@/app-shell/sidebar/CommitActionsContainer";
 import { RightSidebarDialogs } from "@/app-shell/sidebar/RightSidebarDialogs";
+import { useRightSidebarChangesScope } from "@/app-shell/sidebar/useRightSidebarChangesScope";
 import { ReviewContextProvider } from "@/features/diff/components/review/ReviewContextProvider";
 import type { ReviewTarget } from "@/api/ws-api";
 import { ReviewActions } from "@/features/diff/components/review/ReviewActions";
@@ -99,175 +92,6 @@ const BASE_TABS: Array<{
 ];
 
 const FILES_TAB = { value: "files" as RightSidebarTab, labelKey: "common.files", Icon: FolderTree };
-
-type ChangesDiffScope = "branch" | "unstaged" | "staged" | "commit";
-
-interface ChangesScopeState {
-  key: string;
-  scope: ChangesDiffScope;
-  selectedCommitHash: string | null;
-  menuOpen: boolean;
-}
-
-function defaultChangesScopeState(key: string): ChangesScopeState {
-  return {
-    key,
-    scope: "branch",
-    selectedCommitHash: null,
-    menuOpen: false,
-  };
-}
-
-interface ChangesScopeMenuProps {
-  scope: ChangesDiffScope;
-  selectedCommitHash: string | null;
-  commits: GitCommit[];
-  loadingCommits: boolean;
-  stagedCount: number;
-  unstagedCount: number;
-  open: boolean;
-  isVisible: boolean;
-  onOpenChange: (open: boolean) => void;
-  onSelectScope: (scope: Exclude<ChangesDiffScope, "commit">) => void;
-  onSelectCommit: (commitHash: string) => void;
-}
-
-function formatCommitScopeLabel(commit: GitCommit | undefined, fallbackHash: string | null) {
-  if (commit) return commit.short_hash;
-  return fallbackHash ? fallbackHash.slice(0, 7) : null;
-}
-
-function ChangesScopeMenu({
-  scope,
-  selectedCommitHash,
-  commits,
-  loadingCommits,
-  stagedCount,
-  unstagedCount,
-  open,
-  isVisible,
-  onOpenChange,
-  onSelectScope,
-  onSelectCommit,
-}: ChangesScopeMenuProps) {
-  const t = useTranslations("AppShell.chrome");
-  const selectedCommit = commits.find((commit) => commit.hash === selectedCommitHash);
-  const label =
-    scope === "commit"
-      ? formatCommitScopeLabel(selectedCommit, selectedCommitHash) ??
-        t("rightSidebar.changes.scope.commit")
-      : scope === "branch"
-        ? t("rightSidebar.changes.scope.branch")
-        : scope === "staged"
-          ? t("rightSidebar.changes.scope.staged")
-          : t("rightSidebar.changes.scope.unstaged");
-
-  const renderTrailingCheck = (checked: boolean) =>
-    checked ? <Check className="size-3.5 shrink-0" /> : null;
-  const renderCountBadge = (count: number) =>
-    count > 0 ? (
-      <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium tabular-nums text-muted-foreground">
-        {count}
-      </span>
-    ) : null;
-
-  return (
-    <DropdownMenu open={open} onOpenChange={onOpenChange}>
-      <DropdownMenuTrigger asChild>
-        <span
-          role="button"
-          title={t("rightSidebar.changes.selectScope")}
-          aria-label={t("rightSidebar.changes.selectScope")}
-          tabIndex={isVisible ? 0 : -1}
-          onPointerDown={(event) => {
-            event.stopPropagation();
-          }}
-          onMouseDown={(event) => {
-            event.stopPropagation();
-          }}
-          onClick={(event) => {
-            event.stopPropagation();
-          }}
-          onKeyDown={(event) => {
-            event.stopPropagation();
-          }}
-          className="flex h-full min-w-0 max-w-24 cursor-pointer items-center justify-center gap-1 border-l border-sidebar-border/60 px-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-foreground"
-        >
-          <span className="truncate">{label}</span>
-          <ChevronDown className="size-3 shrink-0" />
-        </span>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-48">
-        <DropdownMenuItem
-          className="cursor-pointer"
-          onSelect={() => onSelectScope("unstaged")}
-        >
-          <span>{t("rightSidebar.changes.scope.unstaged")}</span>
-          {renderCountBadge(unstagedCount)}
-          <span className="flex-1" />
-          {renderTrailingCheck(scope === "unstaged")}
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          className="cursor-pointer"
-          onSelect={() => onSelectScope("staged")}
-        >
-          <span>{t("rightSidebar.changes.scope.staged")}</span>
-          {renderCountBadge(stagedCount)}
-          <span className="flex-1" />
-          {renderTrailingCheck(scope === "staged")}
-        </DropdownMenuItem>
-        <DropdownMenuSub>
-          <DropdownMenuSubTrigger
-            className={cn(
-              "group/commit-scope cursor-pointer",
-              scope === "commit" &&
-                "[&>svg:last-child]:hidden hover:[&>svg:last-child]:block data-[state=open]:[&>svg:last-child]:block",
-            )}
-          >
-            <span className="flex-1">{t("rightSidebar.changes.scope.commit")}</span>
-            {scope === "commit" ? (
-              <Check className="size-3.5 shrink-0 group-hover/commit-scope:hidden group-data-[state=open]/commit-scope:hidden" />
-            ) : null}
-          </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent className="max-h-72 w-80 overflow-y-auto">
-            {loadingCommits && commits.length === 0 ? (
-              <DropdownMenuItem disabled>
-                {t("rightSidebar.changes.loadingCommits")}
-              </DropdownMenuItem>
-            ) : commits.length === 0 ? (
-              <DropdownMenuItem disabled>
-                {t("rightSidebar.changes.noCommitsOnBranch")}
-              </DropdownMenuItem>
-            ) : (
-              commits.map((commit) => (
-                <DropdownMenuItem
-                  key={commit.hash}
-                  className="min-w-0 cursor-pointer"
-                  onSelect={() => onSelectCommit(commit.hash)}
-                >
-                  <span className="w-14 shrink-0 font-mono text-[11px] text-muted-foreground">
-                    {commit.short_hash}
-                  </span>
-                  <span className="min-w-0 flex-1 truncate">{commit.subject}</span>
-                  {renderTrailingCheck(
-                    scope === "commit" && selectedCommitHash === commit.hash,
-                  )}
-                </DropdownMenuItem>
-              ))
-            )}
-          </DropdownMenuSubContent>
-        </DropdownMenuSub>
-        <DropdownMenuItem
-          className="cursor-pointer"
-          onSelect={() => onSelectScope("branch")}
-        >
-          <span className="flex-1">{t("rightSidebar.changes.scope.branch")}</span>
-          {renderTrailingCheck(scope === "branch")}
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
 
 function buildWikiChatPrompt(
   prompt: string,
@@ -407,57 +231,42 @@ const RightSidebar: React.FC<RightSidebarProps> = () => {
     currentProjectPath &&
     (workspaceId || projectIdFromUrl)
   );
-  const changesScopeKey = `${currentProjectPath ?? ""}:${currentBranch ?? ""}`;
-  const [changesScopeState, setChangesScopeState] = useState<ChangesScopeState>(
-    () => defaultChangesScopeState(changesScopeKey),
-  );
-  const activeChangesScopeState =
-    changesScopeState.key === changesScopeKey
-      ? changesScopeState
-      : defaultChangesScopeState(changesScopeKey);
-  const changesScope = activeChangesScopeState.scope;
-  const selectedCommitHash = activeChangesScopeState.selectedCommitHash;
-  const changesScopeMenuOpen = activeChangesScopeState.menuOpen;
-  useEffect(() => {
-    resetCompareMode();
-    if (hasWorkingContext) {
-      void refreshRepositoryState({ fetchRemote: true });
-    }
-  }, [changesScopeKey, hasWorkingContext, refreshRepositoryState, resetCompareMode]);
-  const setChangesScopeMenuOpen = useCallback(
-    (open: boolean) => {
-      setChangesScopeState((current) => ({
-        ...(current.key === changesScopeKey
-          ? current
-          : defaultChangesScopeState(changesScopeKey)),
-        menuOpen: open,
-      }));
-    },
-    [changesScopeKey],
-  );
-
-  const commitLog = useGitLog({
-    repoPath: hasWorkingContext ? currentProjectPath ?? null : null,
-    branchKey: hasWorkingContext ? currentBranch ?? null : null,
+  const markCommitsVisited = useCallback(() => {
+    setHasVisitedCommits(true);
+  }, []);
+  const {
+    changesScope,
+    selectedCommitHash,
+    selectedCommitLabel,
+    emptyCompareLabel,
+    changesScopeMenuOpen,
+    setChangesScopeMenuOpen,
+    commitLog,
+    displayedComparedFiles,
+    displayedStagedFiles,
+    displayedUnstagedFiles,
+    displayedUntrackedFiles,
+    hasDisplayedChanges,
+    defaultBranchFallback,
+    handleSelectChangesScope,
+    handleSelectCommitScope,
+    handleChangesRefresh,
+  } = useRightSidebarChangesScope({
+    currentProjectPath,
+    currentBranch,
+    hasWorkingContext,
+    stagedFiles,
+    unstagedFiles,
+    untrackedFiles,
+    compareFiles,
+    compareRef,
+    gitStatus,
+    resetCompareMode,
+    refreshRepositoryState,
+    compareAgainstRef,
+    compareWorktreeChanges,
+    onVisitCommits: markCommitsVisited,
   });
-  const selectedCommit = useMemo(
-    () => commitLog.commits.find((commit) => commit.hash === selectedCommitHash),
-    [commitLog.commits, selectedCommitHash],
-  );
-
-  const displayedComparedFiles = compareFiles;
-  const displayedStagedFiles = stagedFiles;
-  const displayedUnstagedFiles = unstagedFiles;
-  const displayedUntrackedFiles = untrackedFiles;
-  const selectedCommitLabel =
-    selectedCommit?.short_hash ?? selectedCommitHash?.slice(0, 7) ?? null;
-  const emptyCompareLabel = changesScope === "commit" ? null : compareRef;
-  const hasDisplayedChanges =
-    changesScope === "branch" || changesScope === "commit"
-      ? displayedComparedFiles.length > 0
-      : changesScope === "staged"
-        ? displayedStagedFiles.length > 0
-        : displayedUnstagedFiles.length > 0 || displayedUntrackedFiles.length > 0;
   const showAgentChatSidebar = activeCenterTab === "wiki";
   const transformWikiChatPrompt = useCallback(
     (prompt: string) =>
@@ -468,62 +277,6 @@ const RightSidebar: React.FC<RightSidebarProps> = () => {
       ),
     [activeWikiPage, currentProject?.mainFilePath, currentProjectPath],
   );
-
-  const handleSelectChangesScope = useCallback(
-    (scope: Exclude<ChangesDiffScope, "commit">) => {
-      setChangesScopeState({
-        key: changesScopeKey,
-        scope,
-        selectedCommitHash: null,
-        menuOpen: false,
-      });
-
-      if (scope === "branch") {
-        resetCompareMode();
-        void refreshRepositoryState({ fetchRemote: true });
-        return;
-      }
-
-      void compareWorktreeChanges();
-    },
-    [changesScopeKey, compareWorktreeChanges, refreshRepositoryState, resetCompareMode],
-  );
-
-  const handleSelectCommitScope = useCallback(
-    (commitHash: string) => {
-      setChangesScopeState({
-        key: changesScopeKey,
-        scope: "commit",
-        selectedCommitHash: commitHash,
-        menuOpen: false,
-      });
-      setHasVisitedCommits(true);
-      void compareAgainstRef(commitHash);
-    },
-    [changesScopeKey, compareAgainstRef],
-  );
-
-  const handleChangesRefresh = useCallback(async () => {
-    if (changesScope === "commit" && selectedCommitHash) {
-      await compareAgainstRef(selectedCommitHash);
-      return;
-    }
-
-    if (changesScope === "staged" || changesScope === "unstaged") {
-      await compareWorktreeChanges();
-      return;
-    }
-
-    resetCompareMode();
-    await refreshRepositoryState({ fetchRemote: true });
-  }, [
-    changesScope,
-    compareAgainstRef,
-    compareWorktreeChanges,
-    refreshRepositoryState,
-    resetCompareMode,
-    selectedCommitHash,
-  ]);
 
   const renderNoContextMessage = (
     <div className="flex h-full flex-col items-center justify-center text-muted-foreground/50">
@@ -738,7 +491,7 @@ const RightSidebar: React.FC<RightSidebarProps> = () => {
                               })
                             : t("rightSidebar.changes.noChangesDetected")}
                         </span>
-                        {changesScope === "branch" && !compareRef && gitStatus?.default_branch ? (
+                        {defaultBranchFallback ? (
                           <Button
                             size="sm"
                             variant="outline"
@@ -748,7 +501,7 @@ const RightSidebar: React.FC<RightSidebarProps> = () => {
                             }}
                           >
                             {t("rightSidebar.changes.compareWithDefaultBranch", {
-                              branch: gitStatus.default_branch,
+                              branch: defaultBranchFallback,
                             })}
                           </Button>
                         ) : null}

--- a/apps/web/src/app-shell/sidebar/ChangeSection.tsx
+++ b/apps/web/src/app-shell/sidebar/ChangeSection.tsx
@@ -34,6 +34,37 @@ function stopActionEvent(
   event.stopPropagation();
 }
 
+interface ChangeIconActionButtonProps {
+  title: string;
+  className?: string;
+  onRun: () => void;
+  children: React.ReactNode;
+}
+
+function ChangeIconActionButton({
+  title,
+  className,
+  onRun,
+  children,
+}: ChangeIconActionButtonProps) {
+  return (
+    <button
+      type="button"
+      onPointerDown={stopActionEvent}
+      onMouseDown={stopActionEvent}
+      onDoubleClick={stopActionEvent}
+      onClick={(event) => {
+        stopActionEvent(event);
+        onRun();
+      }}
+      title={title}
+      className={className}
+    >
+      {children}
+    </button>
+  );
+}
+
 export interface ChangeSectionProps {
   kind: DiffChangeGroupKind;
   title: string;
@@ -212,40 +243,30 @@ function ChangeFileRow({
             )}
           >
             {onStage && (
-              <button
-                type="button"
-                onPointerDown={stopActionEvent}
-                onMouseDown={stopActionEvent}
-                onDoubleClick={stopActionEvent}
-                onClick={(e) => {
-                  stopActionEvent(e);
+              <ChangeIconActionButton
+                title={stageLabel}
+                onRun={() => {
                   void runAction(`${kind}:${file.path}:stage`, () =>
                     onStage([file.path]),
                   );
                 }}
-                title={stageLabel}
                 className="p-1 rounded-md cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
               >
                 <Plus className="size-3.5" />
-              </button>
+              </ChangeIconActionButton>
             )}
             {kind === "staged" && onUnstage && (
-              <button
-                type="button"
-                onPointerDown={stopActionEvent}
-                onMouseDown={stopActionEvent}
-                onDoubleClick={stopActionEvent}
-                onClick={(e) => {
-                  stopActionEvent(e);
+              <ChangeIconActionButton
+                title={t("changeSection.unstageChanges")}
+                onRun={() => {
                   void runAction(`${kind}:${file.path}:unstage`, () =>
                     onUnstage([file.path]),
                   );
                 }}
-                title={t("changeSection.unstageChanges")}
                 className="p-1 rounded-md cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
               >
                 <Minus className="size-3.5" />
-              </button>
+              </ChangeIconActionButton>
             )}
             {isDestructiveSection
               ? renderConfirmableMinusAction({
@@ -475,40 +496,30 @@ export const ChangeSection = React.memo<ChangeSectionProps>(function ChangeSecti
                 return (
                   <>
                     {onStage && (
-                      <button
-                        type="button"
-                        onPointerDown={stopActionEvent}
-                        onMouseDown={stopActionEvent}
-                        onDoubleClick={stopActionEvent}
-                        onClick={(e) => {
-                          stopActionEvent(e);
+                      <ChangeIconActionButton
+                        title={stageLabel}
+                        onRun={() => {
                           void runAction(`${kind}:file:${file.path}:stage`, () =>
                             onStage([file.path]),
                           );
                         }}
-                        title={stageLabel}
                         className="p-1 rounded-md cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
                       >
                         <Plus className="size-3.5" />
-                      </button>
+                      </ChangeIconActionButton>
                     )}
                     {kind === "staged" && onUnstage && (
-                      <button
-                        type="button"
-                        onPointerDown={stopActionEvent}
-                        onMouseDown={stopActionEvent}
-                        onDoubleClick={stopActionEvent}
-                        onClick={(e) => {
-                          stopActionEvent(e);
+                      <ChangeIconActionButton
+                        title={t("changeSection.unstageChanges")}
+                        onRun={() => {
                           void runAction(`${kind}:file:${file.path}:unstage`, () =>
                             onUnstage([file.path]),
                           );
                         }}
-                        title={t("changeSection.unstageChanges")}
                         className="p-1 rounded-md cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
                       >
                         <Minus className="size-3.5" />
-                      </button>
+                      </ChangeIconActionButton>
                     )}
                     {isDestructiveSection
                       ? renderConfirmableMinusAction({
@@ -535,40 +546,30 @@ export const ChangeSection = React.memo<ChangeSectionProps>(function ChangeSecti
                 return (
                   <>
                     {onStage && (
-                      <button
-                        type="button"
-                        onPointerDown={stopActionEvent}
-                        onMouseDown={stopActionEvent}
-                        onDoubleClick={stopActionEvent}
-                        onClick={(e) => {
-                          stopActionEvent(e);
+                      <ChangeIconActionButton
+                        title={t("changeSection.stageInFolder", { stageLabel, label })}
+                        onRun={() => {
                           void runAction(`${kind}:dir:${key}:stage`, () =>
                             onStage(paths),
                           );
                         }}
-                        title={t("changeSection.stageInFolder", { stageLabel, label })}
                         className="p-1 rounded-md cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
                       >
                         <Plus className="size-3.5" />
-                      </button>
+                      </ChangeIconActionButton>
                     )}
                     {kind === "staged" && onUnstage && (
-                      <button
-                        type="button"
-                        onPointerDown={stopActionEvent}
-                        onMouseDown={stopActionEvent}
-                        onDoubleClick={stopActionEvent}
-                        onClick={(e) => {
-                          stopActionEvent(e);
+                      <ChangeIconActionButton
+                        title={t("changeSection.unstageInFolder", { label })}
+                        onRun={() => {
                           void runAction(`${kind}:dir:${key}:unstage`, () =>
                             onUnstage(paths),
                           );
                         }}
-                        title={t("changeSection.unstageInFolder", { label })}
                         className="p-1 rounded-md cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
                       >
                         <Minus className="size-3.5" />
-                      </button>
+                      </ChangeIconActionButton>
                     )}
                     {isDestructiveSection
                       ? renderConfirmableMinusAction({
@@ -640,36 +641,26 @@ export const ChangeSection = React.memo<ChangeSectionProps>(function ChangeSecti
         )}
       >
         {onStageAll && (
-          <button
-            type="button"
-            onPointerDown={stopActionEvent}
-            onMouseDown={stopActionEvent}
-            onDoubleClick={stopActionEvent}
-            onClick={(e) => {
-              stopActionEvent(e);
+          <ChangeIconActionButton
+            title={t("changeSection.stageAll")}
+            onRun={() => {
               void runAction(`${kind}-bulk-stage`, onStageAll);
             }}
-            title={t("changeSection.stageAll")}
             className="p-1 hover:bg-sidebar-accent rounded-sm cursor-pointer hover:text-foreground text-muted-foreground transition-colors"
           >
             <Plus className="size-3.5" />
-          </button>
+          </ChangeIconActionButton>
         )}
         {kind === "staged" && onUnstageAll && (
-          <button
-            type="button"
-            onPointerDown={stopActionEvent}
-            onMouseDown={stopActionEvent}
-            onDoubleClick={stopActionEvent}
-            onClick={(e) => {
-              stopActionEvent(e);
+          <ChangeIconActionButton
+            title={t("changeSection.unstageAll")}
+            onRun={() => {
               void runAction(`${kind}-bulk-unstage`, onUnstageAll);
             }}
-            title={t("changeSection.unstageAll")}
             className="p-1 hover:bg-sidebar-accent rounded-sm cursor-pointer hover:text-foreground text-muted-foreground transition-colors"
           >
             <Minus className="size-3.5" />
-          </button>
+          </ChangeIconActionButton>
         )}
         {isDestructiveSection
           ? renderConfirmableMinusAction({

--- a/apps/web/src/app-shell/sidebar/ChangesScopeMenu.tsx
+++ b/apps/web/src/app-shell/sidebar/ChangesScopeMenu.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import {
+  Check,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@workspace/ui";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/shared/lib/utils";
+import type { GitCommit } from "@/features/github/hooks/use-github";
+
+export type ChangesDiffScope = "branch" | "unstaged" | "staged" | "commit";
+
+interface ChangesScopeMenuProps {
+  scope: ChangesDiffScope;
+  selectedCommitHash: string | null;
+  commits: GitCommit[];
+  loadingCommits: boolean;
+  stagedCount: number;
+  unstagedCount: number;
+  open: boolean;
+  isVisible: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelectScope: (scope: Exclude<ChangesDiffScope, "commit">) => void;
+  onSelectCommit: (commitHash: string) => void;
+}
+
+function formatCommitScopeLabel(
+  commit: GitCommit | undefined,
+  fallbackHash: string | null,
+) {
+  if (commit) return commit.short_hash;
+  return fallbackHash ? fallbackHash.slice(0, 7) : null;
+}
+
+export function ChangesScopeMenu({
+  scope,
+  selectedCommitHash,
+  commits,
+  loadingCommits,
+  stagedCount,
+  unstagedCount,
+  open,
+  isVisible,
+  onOpenChange,
+  onSelectScope,
+  onSelectCommit,
+}: ChangesScopeMenuProps) {
+  const t = useTranslations("AppShell.chrome");
+  const selectedCommit = commits.find((commit) => commit.hash === selectedCommitHash);
+  const label =
+    scope === "commit"
+      ? formatCommitScopeLabel(selectedCommit, selectedCommitHash) ??
+        t("rightSidebar.changes.scope.commit")
+      : scope === "branch"
+        ? t("rightSidebar.changes.scope.branch")
+        : scope === "staged"
+          ? t("rightSidebar.changes.scope.staged")
+          : t("rightSidebar.changes.scope.unstaged");
+
+  const renderTrailingCheck = (checked: boolean) =>
+    checked ? <Check className="size-3.5 shrink-0" /> : null;
+  const renderCountBadge = (count: number) =>
+    count > 0 ? (
+      <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium tabular-nums text-muted-foreground">
+        {count}
+      </span>
+    ) : null;
+
+  return (
+    <DropdownMenu open={open} onOpenChange={onOpenChange}>
+      <DropdownMenuTrigger asChild>
+        <span
+          role="button"
+          title={t("rightSidebar.changes.selectScope")}
+          aria-label={t("rightSidebar.changes.selectScope")}
+          tabIndex={isVisible ? 0 : -1}
+          onPointerDown={(event) => {
+            event.stopPropagation();
+          }}
+          onMouseDown={(event) => {
+            event.stopPropagation();
+          }}
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+          onKeyDown={(event) => {
+            event.stopPropagation();
+          }}
+          className="flex h-full min-w-0 max-w-24 cursor-pointer items-center justify-center gap-1 border-l border-sidebar-border/60 px-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-foreground"
+        >
+          <span className="truncate">{label}</span>
+          <ChevronDown className="size-3 shrink-0" />
+        </span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-48">
+        <DropdownMenuItem
+          className="cursor-pointer"
+          onSelect={() => onSelectScope("unstaged")}
+        >
+          <span>{t("rightSidebar.changes.scope.unstaged")}</span>
+          {renderCountBadge(unstagedCount)}
+          <span className="flex-1" />
+          {renderTrailingCheck(scope === "unstaged")}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="cursor-pointer"
+          onSelect={() => onSelectScope("staged")}
+        >
+          <span>{t("rightSidebar.changes.scope.staged")}</span>
+          {renderCountBadge(stagedCount)}
+          <span className="flex-1" />
+          {renderTrailingCheck(scope === "staged")}
+        </DropdownMenuItem>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger
+            className={cn(
+              "group/commit-scope cursor-pointer",
+              scope === "commit" &&
+                "[&>svg:last-child]:hidden hover:[&>svg:last-child]:block data-[state=open]:[&>svg:last-child]:block",
+            )}
+          >
+            <span className="flex-1">{t("rightSidebar.changes.scope.commit")}</span>
+            {scope === "commit" ? (
+              <Check className="size-3.5 shrink-0 group-hover/commit-scope:hidden group-data-[state=open]/commit-scope:hidden" />
+            ) : null}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="max-h-72 w-80 overflow-y-auto">
+            {loadingCommits && commits.length === 0 ? (
+              <DropdownMenuItem disabled>
+                {t("rightSidebar.changes.loadingCommits")}
+              </DropdownMenuItem>
+            ) : commits.length === 0 ? (
+              <DropdownMenuItem disabled>
+                {t("rightSidebar.changes.noCommitsOnBranch")}
+              </DropdownMenuItem>
+            ) : (
+              commits.map((commit) => (
+                <DropdownMenuItem
+                  key={commit.hash}
+                  className="min-w-0 cursor-pointer"
+                  onSelect={() => onSelectCommit(commit.hash)}
+                >
+                  <span className="w-14 shrink-0 font-mono text-[11px] text-muted-foreground">
+                    {commit.short_hash}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate">{commit.subject}</span>
+                  {renderTrailingCheck(
+                    scope === "commit" && selectedCommitHash === commit.hash,
+                  )}
+                </DropdownMenuItem>
+              ))
+            )}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuItem
+          className="cursor-pointer"
+          onSelect={() => onSelectScope("branch")}
+        >
+          <span className="flex-1">{t("rightSidebar.changes.scope.branch")}</span>
+          {renderTrailingCheck(scope === "branch")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/src/app-shell/sidebar/useRightSidebarChangesScope.ts
+++ b/apps/web/src/app-shell/sidebar/useRightSidebarChangesScope.ts
@@ -1,0 +1,182 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useGitLog } from "@/features/github/hooks/use-github";
+import type { GitChangedFile, GitStatusResponse } from "@/api/ws-api";
+import type { ChangesDiffScope } from "@/app-shell/sidebar/ChangesScopeMenu";
+
+interface ChangesScopeState {
+  key: string;
+  scope: ChangesDiffScope;
+  selectedCommitHash: string | null;
+  menuOpen: boolean;
+}
+
+interface UseRightSidebarChangesScopeArgs {
+  currentProjectPath: string | null | undefined;
+  currentBranch: string | null | undefined;
+  hasWorkingContext: boolean;
+  stagedFiles: GitChangedFile[];
+  unstagedFiles: GitChangedFile[];
+  untrackedFiles: GitChangedFile[];
+  compareFiles: GitChangedFile[];
+  compareRef: string | null;
+  gitStatus: GitStatusResponse | null;
+  resetCompareMode: () => void;
+  refreshRepositoryState: (options?: { fetchRemote?: boolean }) => Promise<void>;
+  compareAgainstRef: (baseRef: string) => Promise<void>;
+  compareWorktreeChanges: () => Promise<void>;
+  onVisitCommits: () => void;
+}
+
+function defaultChangesScopeState(key: string): ChangesScopeState {
+  return {
+    key,
+    scope: "branch",
+    selectedCommitHash: null,
+    menuOpen: false,
+  };
+}
+
+export function useRightSidebarChangesScope({
+  currentProjectPath,
+  currentBranch,
+  hasWorkingContext,
+  stagedFiles,
+  unstagedFiles,
+  untrackedFiles,
+  compareFiles,
+  compareRef,
+  gitStatus,
+  resetCompareMode,
+  refreshRepositoryState,
+  compareAgainstRef,
+  compareWorktreeChanges,
+  onVisitCommits,
+}: UseRightSidebarChangesScopeArgs) {
+  const changesScopeKey = `${currentProjectPath ?? ""}:${currentBranch ?? ""}`;
+  const [changesScopeState, setChangesScopeState] = useState<ChangesScopeState>(
+    () => defaultChangesScopeState(changesScopeKey),
+  );
+  const activeChangesScopeState =
+    changesScopeState.key === changesScopeKey
+      ? changesScopeState
+      : defaultChangesScopeState(changesScopeKey);
+  const changesScope = activeChangesScopeState.scope;
+  const selectedCommitHash = activeChangesScopeState.selectedCommitHash;
+  const changesScopeMenuOpen = activeChangesScopeState.menuOpen;
+
+  useEffect(() => {
+    resetCompareMode();
+    if (hasWorkingContext) {
+      void refreshRepositoryState({ fetchRemote: true });
+    }
+  }, [changesScopeKey, hasWorkingContext, refreshRepositoryState, resetCompareMode]);
+
+  const setChangesScopeMenuOpen = useCallback(
+    (open: boolean) => {
+      setChangesScopeState((current) => ({
+        ...(current.key === changesScopeKey
+          ? current
+          : defaultChangesScopeState(changesScopeKey)),
+        menuOpen: open,
+      }));
+    },
+    [changesScopeKey],
+  );
+
+  const commitLog = useGitLog({
+    repoPath: hasWorkingContext ? currentProjectPath ?? null : null,
+    branchKey: hasWorkingContext ? currentBranch ?? null : null,
+  });
+  const selectedCommit = useMemo(
+    () => commitLog.commits.find((commit) => commit.hash === selectedCommitHash),
+    [commitLog.commits, selectedCommitHash],
+  );
+
+  const selectedCommitLabel =
+    selectedCommit?.short_hash ?? selectedCommitHash?.slice(0, 7) ?? null;
+  const emptyCompareLabel = changesScope === "commit" ? null : compareRef;
+  const hasDisplayedChanges =
+    changesScope === "branch" || changesScope === "commit"
+      ? compareFiles.length > 0
+      : changesScope === "staged"
+        ? stagedFiles.length > 0
+        : unstagedFiles.length > 0 || untrackedFiles.length > 0;
+
+  const handleSelectChangesScope = useCallback(
+    (scope: Exclude<ChangesDiffScope, "commit">) => {
+      setChangesScopeState({
+        key: changesScopeKey,
+        scope,
+        selectedCommitHash: null,
+        menuOpen: false,
+      });
+
+      if (scope === "branch") {
+        resetCompareMode();
+        void refreshRepositoryState({ fetchRemote: true });
+        return;
+      }
+
+      void compareWorktreeChanges();
+    },
+    [changesScopeKey, compareWorktreeChanges, refreshRepositoryState, resetCompareMode],
+  );
+
+  const handleSelectCommitScope = useCallback(
+    (commitHash: string) => {
+      setChangesScopeState({
+        key: changesScopeKey,
+        scope: "commit",
+        selectedCommitHash: commitHash,
+        menuOpen: false,
+      });
+      onVisitCommits();
+      void compareAgainstRef(commitHash);
+    },
+    [changesScopeKey, compareAgainstRef, onVisitCommits],
+  );
+
+  const handleChangesRefresh = useCallback(async () => {
+    if (changesScope === "commit" && selectedCommitHash) {
+      await compareAgainstRef(selectedCommitHash);
+      return;
+    }
+
+    if (changesScope === "staged" || changesScope === "unstaged") {
+      await compareWorktreeChanges();
+      return;
+    }
+
+    resetCompareMode();
+    await refreshRepositoryState({ fetchRemote: true });
+  }, [
+    changesScope,
+    compareAgainstRef,
+    compareWorktreeChanges,
+    refreshRepositoryState,
+    resetCompareMode,
+    selectedCommitHash,
+  ]);
+
+  return {
+    changesScope,
+    selectedCommitHash,
+    selectedCommitLabel,
+    emptyCompareLabel,
+    changesScopeMenuOpen,
+    setChangesScopeMenuOpen,
+    commitLog,
+    displayedComparedFiles: compareFiles,
+    displayedStagedFiles: stagedFiles,
+    displayedUnstagedFiles: unstagedFiles,
+    displayedUntrackedFiles: untrackedFiles,
+    hasDisplayedChanges,
+    defaultBranchFallback:
+      changesScope === "branch" && !compareRef ? gitStatus?.default_branch ?? null : null,
+    handleSelectChangesScope,
+    handleSelectCommitScope,
+    handleChangesRefresh,
+  };
+}

--- a/automations/review/quality/result/2026-06/06-30_score-88_RESULT.md
+++ b/automations/review/quality/result/2026-06/06-30_score-88_RESULT.md
@@ -1,0 +1,63 @@
+# Atmos main 每日代码质量评分（2026-06-30）
+
+## 1. 审查范围
+
+- 时间窗口：2026-06-29 00:00:00 到 2026-06-29 23:59:59（UTC+8 / Asia/Shanghai）。
+- 同步状态：已同步 `origin/main`，本地 `main` 快进到 `5cceed269` 后筛选提交。
+- 排除提交：`8fa2cf3b docs: add code quality review result 2026-06-29 score 84`，只归档 automation 结果。
+- 被审查业务/代码提交：`f3a3c1769`、`9d735deb5`、`ae7567a70`、`22a96fc0b`、`5529b6f75`、`51639371c`、`9834d5cca`、`6544ca318`、`a3d4a234c`、`e666885e5`、`fcd65f880`、`5affd74ec`、`60171d5e5`、`8bd7c68eb`、`321ad3483`、`e2e208249`、`934529a21`、`102eb961e`、`4bc90f5ff`、`cff928d98`、`7cf44cab0`、`4d790a443`、`1e8b68e19`、`241850fbe`。同时查看了无独立业务 diff 的合并提交 `119c4580e`、`60c13655f`、`aab4b5fcf`、`ba444eac4`、`cbfd5b20e`、`5cceed269`。
+
+## 2. 一份好代码应该是什么样
+
+本次按“职责边界清楚、分层方向正确、抽象不过度也不欠缺、控制流可追踪、重复规则收敛、文件体量与职责匹配、工程痕迹干净”的标准评分。复杂功能可以有复杂度，但复杂度要被放在正确模块里，后续维护者能快速定位修改点。
+
+## 3. 评分方法
+
+100 分制：设计与分层 30，可读性与复杂度 25，体量与内聚 20，可维护性与复用 15，工程卫生 10。高严重度通常扣 8-15 分，中严重度扣 3-7 分，低严重度扣 1-2 分。体量阈值只作为信号，只有“变大且职责更混杂”才扣分。
+
+## 4. 总分
+
+总分：88/100。总体判断：良好。后端 git/diff 分层和 E2E 脚本治理有明显改善，但 scoped changes UI 把新状态编排继续堆进已有大 shell 组件，低于 90，已触发自动修复。
+
+## 5. 分项评分
+
+- 设计与分层：26/30。`321ad3483` 将 changes scope 菜单、commit scope 状态、commit log 拉取和 diff 刷新分支放进 `apps/web/src/app-shell/RightSidebar.tsx`，全局 shell 组件承担 feature orchestration。
+- 可读性与复杂度：22/25。`RightSidebar.tsx` 新增的 scope 状态机和 `ChangeSection.tsx` 多处 action 按钮事件处理重复，阅读路径偏长。
+- 体量与内聚：17/20。`RightSidebar.tsx` 达到 1032 行，`ChangeSection.tsx` 达到 725 行，本次改动继续放大两个已偏大的 UI 文件。
+- 可维护性与复用：14/15。Git rename/commit diff 规则有测试支撑；扣分点主要是 list/tree/bulk action 按钮壳重复。
+- 工程卫生：9/10。无明显调试残留；E2E CI 多次修正后最终脚本化收口，但当天提交序列暴露出 CI 启动参数调试痕迹较多。
+
+## 6. 主要问题清单
+
+中严重度：`321ad3483`，`apps/web/src/app-shell/RightSidebar.tsx` 原约 103-260、410-526 行。问题是 scoped changes 的菜单渲染、状态 key、commit log、scope 切换和刷新分发都进入全局右侧栏组件。它让 shell 组件同时负责全局 tab chrome、PR/actions/wiki/file tree，以及 diff scope 业务编排。优化建议：将 scope 菜单抽成 `ChangesScopeMenu`，将 scope 状态和刷新分发抽成 `useRightSidebarChangesScope`，`RightSidebar` 只消费视图模型和渲染 tab。
+
+中严重度：`321ad3483` / `934529a21`，`apps/web/src/app-shell/sidebar/ChangeSection.tsx` 原约 472-589、625-690 行。问题是 file row、tree file、tree directory、bulk section 四处重复按钮事件壳与 stop propagation 细节，后续改 stage/unstage/discard 交互时容易漏改某一路径。优化建议：先收敛成共享的本地 `ChangeIconActionButton`；如果后续还继续增长，再把 action model 抽成 `buildChangeActions(kind, target)` 一类纯函数。
+
+## 7. 正向观察
+
+- `f3a3c1769` 把 E2E workflow 中的大段 inline Node 脚本迁到 `e2e/scripts/`，比前一天的 workflow 内嵌脚本质量明显更好。
+- `7cf44cab0`、`4d790a443`、`1e8b68e19`、`241850fbe` 将 rename diff、commit patch、shallow fetch、remote branch 校验放在 `core-engine`，API 只做 WS DTO 分发，分层方向正确。
+- `crates/core-engine/src/git/tests.rs` 覆盖 rename numstat、literal arrow path、merge commit first-parent patch、shallow fetch 和 branch validation，测试目标和技术风险对应较好。
+- 前一天指出的 `AgentChatPanel` 与 `TerminalAgentInputOverlay` 体量问题在 `f3a3c1769`、`60171d5e5`、`8bd7c68eb` 中有实际拆分改善。
+
+## 8. Review 建议
+
+人工 review 最值得盯三点：`useRightSidebarChangesScope` 是否保持 branch/staged/unstaged/commit 四种 scope 的刷新语义；`ChangesScopeMenu` 键盘/菜单事件是否仍阻止外层 tab 误触发；`ChangeSection` 的共享按钮是否保持原有 stage/unstage/discard 行为。
+
+## 9. 自动修复与 PR
+
+- 触发原因：总分 88，低于 90。
+- 修复分支：`codex/quality-fix/2026-06-29`。
+- 修复提交：`7da007c67 refactor: improve daily quality findings`。
+- PR：https://github.com/AruNi-01/atmos/pull/144。
+- 标签：已添加 `codex`；仓库未发现 `codex-automation` 标签，已按规则跳过。
+- 修复摘要：抽出 `apps/web/src/app-shell/sidebar/ChangesScopeMenu.tsx`；新增 `apps/web/src/app-shell/sidebar/useRightSidebarChangesScope.ts`；`RightSidebar.tsx` 从 1032 行降到 782 行；`ChangeSection.tsx` 用 `ChangeIconActionButton` 收敛重复按钮事件壳。
+- 验证通过：`bun --filter web typecheck`；`bun --filter web lint -- src/app-shell/RightSidebar.tsx src/app-shell/sidebar/ChangeSection.tsx src/app-shell/sidebar/ChangesScopeMenu.tsx src/app-shell/sidebar/useRightSidebarChangesScope.ts`；`git diff --check`。
+
+## 10. 结果文件
+
+`automations/review/quality/result/2026-06/06-30_score-88_RESULT.md`
+
+## 11. 结果提交与推送
+
+结果文件将随 PR 分支推送到 `origin/codex/quality-fix/2026-06-29`。结果文件提交 hash 将在提交后由最终回复补充；PR 已创建，用户主要通过 https://github.com/AruNi-01/atmos/pull/144 审查修复与报告。

--- a/automations/review/quality/result/2026-06/06-30_score-88_RESULT.md
+++ b/automations/review/quality/result/2026-06/06-30_score-88_RESULT.md
@@ -60,4 +60,4 @@
 
 ## 11. 结果提交与推送
 
-结果文件将随 PR 分支推送到 `origin/codex/quality-fix/2026-06-29`。结果文件提交 hash 将在提交后由最终回复补充；PR 已创建，用户主要通过 https://github.com/AruNi-01/atmos/pull/144 审查修复与报告。
+结果文件初始提交：`d9a241d38 docs: add code quality review result 2026-06-30 score 88`。结果文件随 PR 分支推送到 `origin/codex/quality-fix/2026-06-29`；PR 已创建，用户主要通过 https://github.com/AruNi-01/atmos/pull/144 审查修复与报告。


### PR DESCRIPTION
## Summary

- Extracted the changes diff scope menu from `RightSidebar.tsx` into a focused sidebar component.
- Moved changes scope state, commit log loading, scope selection, and refresh dispatch into `useRightSidebarChangesScope`.
- Consolidated repeated `ChangeSection` icon-button event plumbing into a shared local action button.

## Related Issue

Daily quality automation for the 2026-06-29 UTC+8 main-branch review. Original score: 88/100.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] Additional checks (describe below)

Additional checks:

- `bun --filter web typecheck`
- `bun --filter web lint -- src/app-shell/RightSidebar.tsx src/app-shell/sidebar/ChangeSection.tsx src/app-shell/sidebar/ChangesScopeMenu.tsx src/app-shell/sidebar/useRightSidebarChangesScope.ts`
- `git diff --check`

## Checklist

- [x] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

## Quality Findings Addressed

- `apps/web/src/app-shell/RightSidebar.tsx` had absorbed scoped changes menu rendering, commit scope state, commit-log loading, and refresh branching while already serving as the global app-shell sidebar.
- `apps/web/src/app-shell/sidebar/ChangeSection.tsx` repeated the same action button event plumbing across row, tree file, tree directory, and bulk actions.

## Remaining Risk

- This is a structure-preserving refactor. The main review focus should be whether the extracted hook preserves the same branch/staged/unstaged/commit scope refresh behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the Right Sidebar by extracting changes-scope logic into a hook and menu component, and deduplicating action button wiring. Behavior is unchanged; UI should look and work the same. Also archives the 2026-06-30 code quality review result.

- **Refactors**
  - Moved scope state, commit log loading, scope selection, and refresh logic into `useRightSidebarChangesScope`.
  - Extracted the scope selector UI into `ChangesScopeMenu`.
  - Consolidated repeated icon-button handlers in `ChangeSection` via `ChangeIconActionButton`.
  - Computed the default-branch compare CTA via `defaultBranchFallback` from the hook.
  - Trimmed `RightSidebar.tsx` to consume hook outputs and the new menu component.

<sup>Written for commit 79b7c05b988a04c470be95fcea4fe2cac63deb93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a more flexible changes view with separate options for unstaged, staged, branch, and commit-based comparisons.
  * Improved the sidebar changes menu with clearer labels, counts, and commit selection.
  * Added quicker access to compare and refresh actions from the sidebar.

* **Bug Fixes**
  * Improved empty-state handling for comparing changes against the default branch.
  * Reduced accidental sidebar interactions when using file and section action buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->