### PR TITLE
fix(terminal): restore interactive agent launches with TUI follow-up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "atmos-desktop"
-version = "2026.7.3"
+version = "2026.7.6-beta.1"
 dependencies = [
  "chrono",
  "core-foundation 0.10.1",

--- a/apps/web/src/app-shell/CenterStage.tsx
+++ b/apps/web/src/app-shell/CenterStage.tsx
@@ -51,7 +51,7 @@ import { CodeReviewDialog } from "@/features/code-review";
 import { useReviewSnapshotStore } from "@/features/code-review/store/review-snapshot-store";
 import { usePrewarmCodeLanguages } from "@/shared/hooks/use-prewarm-code-languages";
 import { useAppRouter } from "@/shared/hooks/use-app-router";
-import { buildInteractiveAgentCommand } from "@/features/agent/lib/terminal-agent-run-config";
+import { buildInteractiveAgentRunPlan } from "@/features/agent/lib/terminal-agent-run-config";
 import { useWorkspaceCreationStore } from "@/features/workspace/store/workspace-creation-store";
 import { useExperimentSettingsStore } from "@/features/settings/store/experiment-settings-store";
 import {
@@ -77,6 +77,7 @@ import {
   usePendingNamedTerminalCommand,
   useReloadOpenFilesWhenReady,
   useTerminalTabMountLifecycle,
+  type PendingNamedTerminalRun,
 } from "@/app-shell/center-stage-support";
 import { useCenterStageTabGroups } from "@/app-shell/use-center-stage-tab-groups";
 import { useCenterStageTerminalAgents } from "@/app-shell/use-center-stage-terminal-agents";
@@ -105,7 +106,8 @@ const CenterStage: React.FC = () => {
   const [mountedTerminalTabsByContext, setMountedTerminalTabsByContext] = React.useState<Record<string, string[]>>({});
   const scrollableTabsRef = React.useRef<HTMLDivElement>(null);
   const projectWikiTerminalGridRef = React.useRef<TerminalGridHandle>(null);
-  const [projectWikiPendingCommand, setProjectWikiPendingCommand] = React.useState<string | null>(null);
+  const [projectWikiPendingCommand, setProjectWikiPendingCommand] =
+    React.useState<PendingNamedTerminalRun | null>(null);
   const [projectWikiCloseConfirmOpen, setProjectWikiCloseConfirmOpen] = React.useState(false);
   const [wikiRefreshTrigger, setWikiRefreshTrigger] = React.useState(0);
   const [wikiRefreshing, setWikiRefreshing] = React.useState(false);
@@ -120,7 +122,8 @@ const CenterStage: React.FC = () => {
 
   // Code Review tab state
   const codeReviewTerminalGridRef = React.useRef<TerminalGridHandle>(null);
-  const [codeReviewPendingCommand, setCodeReviewPendingCommand] = React.useState<string | null>(null);
+  const [codeReviewPendingCommand, setCodeReviewPendingCommand] =
+    React.useState<PendingNamedTerminalRun | null>(null);
   const [codeReviewCloseConfirmOpen, setCodeReviewCloseConfirmOpen] = React.useState(false);
   // codeReviewDialogOpen is managed via useDialogStore for cross-component access
   const pendingWorkspaceAgentRun = useWorkspaceCreationStore((s) => s.pendingAgentRun);
@@ -555,14 +558,18 @@ const CenterStage: React.FC = () => {
     if (!selectedAgent) return;
 
     const prompt = pending.prompt.trim();
-    const command =
-      pending.command?.trim() ||
-      buildInteractiveAgentCommand({
-        agentId: selectedAgent.agent.id,
-        launchCommand: selectedAgent.command.trim(),
-        prompt,
-        runConfig: pending.agentRunConfig,
-      });
+    const plan =
+      pending.command?.trim()
+        ? {
+            launchCommand: pending.command.trim(),
+            tuiFollowUpPrompt: undefined,
+          }
+        : buildInteractiveAgentRunPlan({
+            agentId: selectedAgent.agent.id,
+            launchCommand: selectedAgent.command.trim(),
+            prompt,
+            runConfig: pending.agentRunConfig,
+          });
 
     const targetTerminalTabId = ensureRunnableTerminalTab();
     if (!targetTerminalTabId) return;
@@ -572,7 +579,8 @@ const CenterStage: React.FC = () => {
     runWhenTerminalGridReady(targetTerminalTabId, (grid) => {
       void grid.createAndRunTerminal({
         label: selectedAgent.agent.label,
-        command,
+        command: plan.launchCommand,
+        tuiFollowUpPrompt: plan.tuiFollowUpPrompt,
         agent: selectedAgent.agent,
       });
     }, 40);
@@ -637,7 +645,7 @@ const CenterStage: React.FC = () => {
       setActiveTerminalTab(effectiveContextId, nextTab.id);
       setUrlParams({ tab: nextTab.id, wikiPage: null });
 
-      const command = buildInteractiveAgentCommand({
+      const plan = buildInteractiveAgentRunPlan({
         agentId: request.agent.id,
         launchCommand: request.agent.launchCommand.trim(),
         prompt: request.prompt,
@@ -649,7 +657,8 @@ const CenterStage: React.FC = () => {
         (grid) => {
           void grid.createAndRunTerminal({
             label: request.terminalPaneLabel,
-            command,
+            command: plan.launchCommand,
+            tuiFollowUpPrompt: plan.tuiFollowUpPrompt,
             agent: {
               id: request.agent.id,
               label: request.agent.label,
@@ -1196,7 +1205,7 @@ const CenterStage: React.FC = () => {
           onStartTerminalMode={(command) => {
             if (!effectiveContextId) return;
             codeReviewUserTriggeredRef.current = true;
-            setCodeReviewPendingCommand(command);
+            setCodeReviewPendingCommand({ command });
             setCodeReviewVisibleMap(prev => ({ ...prev, [effectiveContextId]: true }));
             setFixedTab("code-review");
           }}
@@ -1206,7 +1215,7 @@ const CenterStage: React.FC = () => {
               await systemApi.killCodeReviewWindow(effectiveContextId);
               codeReviewTerminalGridRef.current?.removeTerminalByTmuxWindowName(CODE_REVIEW_WINDOW_NAME);
               codeReviewUserTriggeredRef.current = true;
-              setCodeReviewPendingCommand(command);
+              setCodeReviewPendingCommand({ command });
               setCodeReviewVisibleMap(prev => ({ ...prev, [effectiveContextId]: true }));
               setFixedTab("code-review");
               toastManager.add({

--- a/apps/web/src/app-shell/CenterStagePanels.tsx
+++ b/apps/web/src/app-shell/CenterStagePanels.tsx
@@ -27,6 +27,7 @@ import type { FixedTab } from "@/shared/lib/nuqs/searchParams";
 import { isDiffGroupEditorPath } from "@/features/diff/lib/diff-editor-paths";
 import { cn } from "@/shared/lib/utils";
 import type { TerminalGridHandle } from "@/features/terminal/components/TerminalGrid";
+import type { PendingNamedTerminalRun } from "@/app-shell/center-stage-support";
 import type { TerminalPaneAgent } from "@/features/terminal/types/index";
 import type { TerminalPaneProps } from "@/features/terminal/types/index";
 import type { Project, Workspace } from "@/shared/types/domain";
@@ -122,7 +123,7 @@ interface CenterStagePanelsProps {
   projectWikiUserTriggeredRef: React.RefObject<boolean>;
   reviewTarget: ReviewTarget | null;
   setFixedTab: (tab: FixedTab) => void;
-  setProjectWikiPendingCommand: React.Dispatch<React.SetStateAction<string | null>>;
+  setProjectWikiPendingCommand: React.Dispatch<React.SetStateAction<PendingNamedTerminalRun | null>>;
   setProjectWikiVisibleMap: React.Dispatch<React.SetStateAction<Record<string, boolean>>>;
   setWikiPage: (page: string) => void;
   terminalGridRef: React.RefObject<TerminalGridHandle | null>;
@@ -271,23 +272,23 @@ export function CenterStagePanels({
             refreshTrigger={wikiRefreshTrigger}
             terminalGridRef={terminalGridRef}
             onSwitchToTerminal={() => setFixedTab("terminal")}
-            onSwitchToProjectWikiAndRun={(command) => {
+            onSwitchToProjectWikiAndRun={(run) => {
               projectWikiUserTriggeredRef.current = true;
-              setProjectWikiPendingCommand(command);
+              setProjectWikiPendingCommand(run);
               setProjectWikiVisibleMap((prev) => ({
                 ...prev,
                 [effectiveContextId]: true,
               }));
               setFixedTab("project-wiki");
             }}
-            onProjectWikiReplaceAndRun={async (command) => {
+            onProjectWikiReplaceAndRun={async (run) => {
               try {
                 await systemApi.killProjectWikiWindow(effectiveContextId);
                 projectWikiTerminalGridRef.current?.removeTerminalByTmuxWindowName(
                   PROJECT_WIKI_WINDOW_NAME,
                 );
                 projectWikiUserTriggeredRef.current = true;
-                setProjectWikiPendingCommand(command);
+                setProjectWikiPendingCommand(run);
                 setProjectWikiVisibleMap((prev) => ({
                   ...prev,
                   [effectiveContextId]: true,

--- a/apps/web/src/app-shell/center-stage-support.tsx
+++ b/apps/web/src/app-shell/center-stage-support.tsx
@@ -289,6 +289,12 @@ export function useCenterStageTabScrollEffects({
   }, [activeValue, effectiveContextId, openFilesCount, projectWikiTabVisible, codeReviewTabVisible, visibleTerminalTabsCount, scrollableTabsRef]);
 }
 
+export type PendingNamedTerminalRun = {
+  command: string;
+  tuiFollowUpPrompt?: string;
+  agentId?: string;
+};
+
 export function usePendingNamedTerminalCommand({
   activeTabValue,
   activeValue,
@@ -303,8 +309,8 @@ export function usePendingNamedTerminalCommand({
   activeTabValue: string;
   activeValue: string;
   effectiveContextId: string | null | undefined;
-  pendingCommand: string | null;
-  setPendingCommand: React.Dispatch<React.SetStateAction<string | null>>;
+  pendingCommand: PendingNamedTerminalRun | null;
+  setPendingCommand: React.Dispatch<React.SetStateAction<PendingNamedTerminalRun | null>>;
   tabVisible: boolean;
   terminalGridRef: TerminalGridRef;
   terminalLabel: string;
@@ -313,11 +319,13 @@ export function usePendingNamedTerminalCommand({
   React.useEffect(() => {
     if (!pendingCommand || !effectiveContextId || !tabVisible || activeValue !== activeTabValue) return;
 
-    const cmd = pendingCommand;
+    const run = pendingCommand;
     setPendingCommand(null);
     terminalGridRef.current?.createOrFocusAndRunTerminal({
       label: terminalLabel,
-      command: cmd,
+      command: run.command,
+      agentId: run.agentId,
+      tuiFollowUpPrompt: run.tuiFollowUpPrompt,
     });
 
     const timer = setTimeout(() => {

--- a/apps/web/src/features/agent/lib/__tests__/terminal-agent-tui-follow-up.test.ts
+++ b/apps/web/src/features/agent/lib/__tests__/terminal-agent-tui-follow-up.test.ts
@@ -1,0 +1,31 @@
+// @ts-expect-error bun:test is available at runtime but not in tsconfig types
+import { describe, expect, it } from "bun:test";
+
+import {
+  agentNeedsTuiFollowUp,
+  getTerminalAgentTuiFollowUpConfig,
+  isAgentTuiReady,
+  listTerminalAgentTuiFollowUpAgentIds,
+} from "@/features/agent/lib/terminal-agent-tui-follow-up";
+
+describe("terminal-agent-tui-follow-up config", () => {
+  it("loads Hermes from the shared manifest", () => {
+    expect(listTerminalAgentTuiFollowUpAgentIds()).toContain("hermes");
+    expect(getTerminalAgentTuiFollowUpConfig("hermes")).toEqual({
+      agentId: "hermes",
+      readyPattern: "❯",
+    });
+  });
+
+  it("requires a configured agent and non-empty prompt", () => {
+    expect(agentNeedsTuiFollowUp("hermes", "fix this")).toBe(true);
+    expect(agentNeedsTuiFollowUp("hermes", "   ")).toBe(false);
+    expect(agentNeedsTuiFollowUp("claude", "fix this")).toBe(false);
+  });
+
+  it("detects ready state from the configured pattern", () => {
+    expect(isAgentTuiReady("hermes", "booting...\n❯ ")).toBe(true);
+    expect(isAgentTuiReady("hermes", "still loading")).toBe(false);
+    expect(isAgentTuiReady("claude", "❯ ")).toBe(false);
+  });
+});

--- a/apps/web/src/features/agent/lib/terminal-agent-run-config.ts
+++ b/apps/web/src/features/agent/lib/terminal-agent-run-config.ts
@@ -242,7 +242,7 @@ export function buildPipedAgentTerminalInput(
   }
   const interactiveParams = definition.interactiveParams ?? "";
   const baseCommand = [command.trim(), interactiveParams].filter(Boolean).join(" ");
-  return `printf '%s\\n' ${shellQuote(trimmed)} | ${baseCommand}`;
+  return `echo ${shellQuote(trimmed)} | ${baseCommand}`;
 }
 
 export interface TerminalAgentRunPlan {
@@ -284,7 +284,7 @@ export function buildInteractiveAgentRunPlan(args: {
   const quotedPrompt = shellQuote(prompt);
   if (strategy === "stdin") {
     return {
-      launchCommand: `printf '%s\\n' ${quotedPrompt} | ${baseCommand}`,
+      launchCommand: `echo ${quotedPrompt} | ${baseCommand}`,
     };
   }
   if (args.agentId === "opencode") {

--- a/apps/web/src/features/agent/lib/terminal-agent-run-config.ts
+++ b/apps/web/src/features/agent/lib/terminal-agent-run-config.ts
@@ -2,9 +2,11 @@ import { shellQuote } from "@/shared/lib/shell-quote";
 import {
   TERMINAL_AGENT_DEFINITIONS,
   type TerminalAgentDefinition,
+  type TerminalAgentPromptStrategy,
   type TerminalAgentReasoningMode as TerminalAgentReasoningCapabilityMode,
   type TerminalAgentReasoningSupport,
 } from "@/features/agent/lib/terminal-agent-definitions";
+import { agentNeedsTuiFollowUp } from "@/features/agent/lib/terminal-agent-tui-follow-up";
 
 export type TerminalAgentReasoningMode = Exclude<
   TerminalAgentReasoningCapabilityMode,
@@ -201,42 +203,149 @@ export function buildRunConfigSummary(
   return parts.join(" · ");
 }
 
-export function buildInteractiveAgentCommand(args: {
+function resolveInteractivePromptStrategy(
+  definition: TerminalAgentDefinition | undefined,
+): TerminalAgentPromptStrategy {
+  if (definition?.useEcho) {
+    return "stdin";
+  }
+  return definition?.promptStrategy ?? "arg";
+}
+
+function interactivePromptFlagSuffix(
+  definition: TerminalAgentDefinition,
+): string | null {
+  const automationParams = definition.params.trim();
+  const interactiveParams = definition.interactiveParams ?? "";
+  if (!automationParams || automationParams === interactiveParams.trim()) {
+    return null;
+  }
+  if (interactiveParams && automationParams.startsWith(interactiveParams)) {
+    const suffix = automationParams.slice(interactiveParams.length).trim();
+    return suffix || null;
+  }
+  return automationParams;
+}
+
+export function buildPipedAgentTerminalInput(
+  agentId: string,
+  command: string,
+  text: string,
+): string | null {
+  const definition = terminalAgentDefinitionById(agentId);
+  if (!definition?.useEcho) {
+    return null;
+  }
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const interactiveParams = definition.interactiveParams ?? "";
+  const baseCommand = [command.trim(), interactiveParams].filter(Boolean).join(" ");
+  return `echo ${shellQuote(trimmed)} | ${baseCommand}`;
+}
+
+export interface TerminalAgentRunPlan {
+  launchCommand: string;
+  tuiFollowUpPrompt?: string;
+}
+
+export type TerminalAgentRunMode = "interactive" | "headless";
+
+export function buildInteractiveAgentRunPlan(args: {
   agentId: string;
   launchCommand: string;
   prompt: string;
   runConfig?: TerminalAgentRunConfigInput | null;
-}): string {
+  mode?: TerminalAgentRunMode;
+}): TerminalAgentRunPlan {
+  const mode = args.mode ?? "interactive";
   const definition = TERMINAL_AGENT_DEFINITIONS.find((item) => item.id === args.agentId);
-  const strategy = definition?.promptStrategy ?? "arg";
+  const strategy =
+    mode === "headless"
+      ? (definition?.promptStrategy ?? "arg")
+      : resolveInteractivePromptStrategy(definition);
   const structuredArgs = buildStructuredRunConfigArgs(args.agentId, args.runConfig);
   const baseCommand = [args.launchCommand.trim(), ...structuredArgs.map((item) => shellQuote(item))]
     .filter(Boolean)
     .join(" ");
   const prompt = args.prompt.trim();
   if (!prompt) {
-    return baseCommand;
+    return { launchCommand: baseCommand };
   }
+
+  if (mode === "interactive" && agentNeedsTuiFollowUp(args.agentId, prompt)) {
+    return {
+      launchCommand: baseCommand,
+      tuiFollowUpPrompt: prompt,
+    };
+  }
+
   const quotedPrompt = shellQuote(prompt);
   if (strategy === "stdin") {
-    return `echo ${quotedPrompt} | ${baseCommand}`;
+    return {
+      launchCommand: `echo ${quotedPrompt} | ${baseCommand}`,
+    };
   }
   if (args.agentId === "opencode") {
-    return `${baseCommand} --prompt ${quotedPrompt}`;
+    return {
+      launchCommand: `${baseCommand} --prompt ${quotedPrompt}`,
+    };
   }
   if (args.agentId === "antigravity") {
-    return `${baseCommand} --prompt-interactive ${quotedPrompt}`;
+    return {
+      launchCommand: `${baseCommand} --prompt-interactive ${quotedPrompt}`,
+    };
   }
   if (strategy === "prompt_flag" && definition) {
+    if (mode === "interactive" && args.agentId === "pi") {
+      return {
+        launchCommand: `${baseCommand} ${quotedPrompt}`,
+      };
+    }
     const promptFlag = promptFlagForInteractiveCommand(definition);
     if (promptFlag) {
       const flagPrefix = commandContainsToken(args.launchCommand, promptFlag)
         ? ""
         : ` ${shellQuote(promptFlag)}`;
-      return `${baseCommand}${flagPrefix} ${quotedPrompt}`;
+      return {
+        launchCommand: `${baseCommand}${flagPrefix} ${quotedPrompt}`,
+      };
+    }
+    const promptFlagSuffix =
+      mode === "interactive" ? interactivePromptFlagSuffix(definition) : definition.params;
+    if (mode === "interactive" && promptFlagSuffix) {
+      const promptedBaseCommand = [baseCommand, promptFlagSuffix].filter(Boolean).join(" ");
+      return {
+        launchCommand: `${promptedBaseCommand} ${quotedPrompt}`,
+      };
+    }
+    if (definition.params?.trim()) {
+      const promptedBaseCommand = [
+        definition.cmd,
+        definition.params,
+        ...structuredArgs.map((item) => shellQuote(item)),
+      ]
+        .filter(Boolean)
+        .join(" ");
+      return {
+        launchCommand: `${promptedBaseCommand} ${quotedPrompt}`,
+      };
     }
   }
-  return `${baseCommand} ${quotedPrompt}`;
+  return {
+    launchCommand: `${baseCommand} ${quotedPrompt}`,
+  };
+}
+
+export function buildInteractiveAgentCommand(args: {
+  agentId: string;
+  launchCommand: string;
+  prompt: string;
+  runConfig?: TerminalAgentRunConfigInput | null;
+  mode?: TerminalAgentRunMode;
+}): string {
+  return buildInteractiveAgentRunPlan(args).launchCommand;
 }
 
 function promptFlagForInteractiveCommand(definition: TerminalAgentDefinition): string | null {

--- a/apps/web/src/features/agent/lib/terminal-agent-run-config.ts
+++ b/apps/web/src/features/agent/lib/terminal-agent-run-config.ts
@@ -242,7 +242,7 @@ export function buildPipedAgentTerminalInput(
   }
   const interactiveParams = definition.interactiveParams ?? "";
   const baseCommand = [command.trim(), interactiveParams].filter(Boolean).join(" ");
-  return `echo ${shellQuote(trimmed)} | ${baseCommand}`;
+  return `printf '%s\\n' ${shellQuote(trimmed)} | ${baseCommand}`;
 }
 
 export interface TerminalAgentRunPlan {
@@ -284,7 +284,7 @@ export function buildInteractiveAgentRunPlan(args: {
   const quotedPrompt = shellQuote(prompt);
   if (strategy === "stdin") {
     return {
-      launchCommand: `echo ${quotedPrompt} | ${baseCommand}`,
+      launchCommand: `printf '%s\\n' ${quotedPrompt} | ${baseCommand}`,
     };
   }
   if (args.agentId === "opencode") {

--- a/apps/web/src/features/agent/lib/terminal-agent-tui-follow-up.ts
+++ b/apps/web/src/features/agent/lib/terminal-agent-tui-follow-up.ts
@@ -1,0 +1,99 @@
+import tuiFollowUpManifest from "@atmos/resources/terminal-agents/tui_follow_up_agents.json";
+
+export interface TerminalAgentTuiFollowUpDefinition {
+  agentId: string;
+  /** Regex tested against the accumulated terminal output buffer. */
+  readyPattern: string;
+  readyPatternFlags?: string;
+}
+
+interface TerminalAgentTuiFollowUpManifest {
+  quietMs?: number;
+  timeoutMs?: number;
+  outputBufferLimit?: number;
+  agents: TerminalAgentTuiFollowUpDefinition[];
+}
+
+type CompiledTerminalAgentTuiFollowUp = TerminalAgentTuiFollowUpDefinition & {
+  readyRegex: RegExp;
+};
+
+function compileTuiFollowUpAgents(
+  agents: TerminalAgentTuiFollowUpDefinition[],
+): Map<string, CompiledTerminalAgentTuiFollowUp> {
+  const compiled = new Map<string, CompiledTerminalAgentTuiFollowUp>();
+  for (const agent of agents) {
+    const agentId = agent.agentId.trim();
+    if (!agentId) {
+      throw new Error("Terminal agent TUI follow-up config requires a non-empty agentId.");
+    }
+    if (compiled.has(agentId)) {
+      throw new Error(`Duplicate terminal agent TUI follow-up config for agentId: ${agentId}`);
+    }
+    const readyPattern = agent.readyPattern?.trim();
+    if (!readyPattern) {
+      throw new Error(`Terminal agent TUI follow-up config for ${agentId} requires readyPattern.`);
+    }
+    let readyRegex: RegExp;
+    try {
+      readyRegex = new RegExp(readyPattern, agent.readyPatternFlags ?? "");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Invalid readyPattern for terminal agent TUI follow-up config (${agentId}): ${message}`,
+      );
+    }
+    compiled.set(agentId, {
+      ...agent,
+      agentId,
+      readyPattern,
+      readyRegex,
+    });
+  }
+  return compiled;
+}
+
+const manifest = tuiFollowUpManifest as TerminalAgentTuiFollowUpManifest;
+const TUI_FOLLOW_UP_AGENTS = compileTuiFollowUpAgents(manifest.agents ?? []);
+
+export const TUI_FOLLOW_UP_QUIET_MS = manifest.quietMs ?? 250;
+export const TUI_FOLLOW_UP_TIMEOUT_MS = manifest.timeoutMs ?? 25_000;
+const TUI_OUTPUT_BUFFER_LIMIT = manifest.outputBufferLimit ?? 4096;
+
+export function getTerminalAgentTuiFollowUpConfig(
+  agentId: string,
+): TerminalAgentTuiFollowUpDefinition | undefined {
+  const config = TUI_FOLLOW_UP_AGENTS.get(agentId);
+  if (!config) {
+    return undefined;
+  }
+  return {
+    agentId: config.agentId,
+    readyPattern: config.readyPattern,
+    readyPatternFlags: config.readyPatternFlags,
+  };
+}
+
+export function listTerminalAgentTuiFollowUpAgentIds(): string[] {
+  return [...TUI_FOLLOW_UP_AGENTS.keys()];
+}
+
+export function agentNeedsTuiFollowUp(agentId: string, prompt: string): boolean {
+  return TUI_FOLLOW_UP_AGENTS.has(agentId) && prompt.trim().length > 0;
+}
+
+export function isAgentTuiReady(agentId: string, output: string): boolean {
+  const config = TUI_FOLLOW_UP_AGENTS.get(agentId);
+  if (!config) {
+    return false;
+  }
+  return config.readyRegex.test(output);
+}
+
+export function appendTuiOutputBuffer(current: string, chunk: string): string {
+  const next = current + chunk;
+  if (next.length <= TUI_OUTPUT_BUFFER_LIMIT) {
+    return next;
+  }
+  return next.slice(-TUI_OUTPUT_BUFFER_LIMIT);
+}

--- a/apps/web/src/features/agent/lib/terminal-agent-tui-follow-up.ts
+++ b/apps/web/src/features/agent/lib/terminal-agent-tui-follow-up.ts
@@ -89,7 +89,6 @@ export function isAgentTuiReady(agentId: string, output: string): boolean {
   if (!config) {
     return false;
   }
-  config.readyRegex.lastIndex = 0;
   return config.readyRegex.test(output);
 }
 

--- a/apps/web/src/features/agent/lib/terminal-agent-tui-follow-up.ts
+++ b/apps/web/src/features/agent/lib/terminal-agent-tui-follow-up.ts
@@ -89,6 +89,7 @@ export function isAgentTuiReady(agentId: string, output: string): boolean {
   if (!config) {
     return false;
   }
+  config.readyRegex.lastIndex = 0;
   return config.readyRegex.test(output);
 }
 

--- a/apps/web/src/features/agent/lib/terminal-agent-tui-follow-up.ts
+++ b/apps/web/src/features/agent/lib/terminal-agent-tui-follow-up.ts
@@ -70,7 +70,9 @@ export function getTerminalAgentTuiFollowUpConfig(
   return {
     agentId: config.agentId,
     readyPattern: config.readyPattern,
-    readyPatternFlags: config.readyPatternFlags,
+    ...(config.readyPatternFlags !== undefined
+      ? { readyPatternFlags: config.readyPatternFlags }
+      : {}),
   };
 }
 

--- a/apps/web/src/features/canvas/components/CanvasTerminalCard.tsx
+++ b/apps/web/src/features/canvas/components/CanvasTerminalCard.tsx
@@ -101,7 +101,6 @@ function CanvasTerminalCardInner({ shape }: { shape: CanvasTerminalShape }) {
   const terminalOverlayRef = React.useRef<HTMLDivElement | null>(null);
   const terminalApiRef = React.useRef<TerminalRef | null>(null);
   const agentInputOverlayRef = React.useRef<TerminalAgentInputOverlayHandle | null>(null);
-  const tuiFollowUpCleanupRef = React.useRef<(() => void) | null>(null);
   const [isTerminalReady, setIsTerminalReady] = React.useState(false);
   const terminalRefs = useCanvasTerminalRefs();
   const activeShapeId = useCanvasRuntimeStore((state) => state.activeShapeId);
@@ -200,7 +199,7 @@ function CanvasTerminalCardInner({ shape }: { shape: CanvasTerminalShape }) {
     setIsTerminalReady(true);
     const pendingRun = consumePendingTerminalRun(shape.id);
     if (pendingRun && terminalApiRef.current) {
-      tuiFollowUpCleanupRef.current = deliverPendingTerminalRun(terminalApiRef.current, pendingRun);
+      deliverPendingTerminalRun(terminalApiRef.current, pendingRun);
     }
   }, [consumePendingTerminalRun, markAttached, shape.id]);
 
@@ -301,13 +300,6 @@ function CanvasTerminalCardInner({ shape }: { shape: CanvasTerminalShape }) {
       cancelAnimationFrame(frame);
     };
   }, [focusTerminal, isActive, isRendered]);
-
-  React.useEffect(() => {
-    return () => {
-      tuiFollowUpCleanupRef.current?.();
-      tuiFollowUpCleanupRef.current = null;
-    };
-  }, []);
 
   React.useEffect(() => {
     const resolveCanvasTerminalTarget = (event: KeyboardEvent) => {

--- a/apps/web/src/features/canvas/components/CanvasTerminalCard.tsx
+++ b/apps/web/src/features/canvas/components/CanvasTerminalCard.tsx
@@ -101,6 +101,7 @@ function CanvasTerminalCardInner({ shape }: { shape: CanvasTerminalShape }) {
   const terminalOverlayRef = React.useRef<HTMLDivElement | null>(null);
   const terminalApiRef = React.useRef<TerminalRef | null>(null);
   const agentInputOverlayRef = React.useRef<TerminalAgentInputOverlayHandle | null>(null);
+  const tuiFollowUpCleanupRef = React.useRef<(() => void) | null>(null);
   const [isTerminalReady, setIsTerminalReady] = React.useState(false);
   const terminalRefs = useCanvasTerminalRefs();
   const activeShapeId = useCanvasRuntimeStore((state) => state.activeShapeId);
@@ -199,7 +200,7 @@ function CanvasTerminalCardInner({ shape }: { shape: CanvasTerminalShape }) {
     setIsTerminalReady(true);
     const pendingRun = consumePendingTerminalRun(shape.id);
     if (pendingRun && terminalApiRef.current) {
-      deliverPendingTerminalRun(terminalApiRef.current, pendingRun);
+      tuiFollowUpCleanupRef.current = deliverPendingTerminalRun(terminalApiRef.current, pendingRun);
     }
   }, [consumePendingTerminalRun, markAttached, shape.id]);
 
@@ -300,6 +301,13 @@ function CanvasTerminalCardInner({ shape }: { shape: CanvasTerminalShape }) {
       cancelAnimationFrame(frame);
     };
   }, [focusTerminal, isActive, isRendered]);
+
+  React.useEffect(() => {
+    return () => {
+      tuiFollowUpCleanupRef.current?.();
+      tuiFollowUpCleanupRef.current = null;
+    };
+  }, []);
 
   React.useEffect(() => {
     const resolveCanvasTerminalTarget = (event: KeyboardEvent) => {

--- a/apps/web/src/features/canvas/components/CanvasTerminalCard.tsx
+++ b/apps/web/src/features/canvas/components/CanvasTerminalCard.tsx
@@ -21,6 +21,7 @@ import { TerminalTitleWithAgent } from "@/features/terminal/components/terminal-
 import type { TerminalPaneAgent } from "@/features/terminal/types/index";
 import { useTerminalToolbarTitle } from "@/features/terminal/hooks/use-terminal-toolbar-title";
 import { useTerminalSideChats } from "@/features/terminal/hooks/use-terminal-side-chats";
+import { deliverPendingTerminalRun } from "@/features/terminal/lib/terminal-agent-run-delivery";
 import {
   isTerminalAgentInputPinShortcut,
   isTerminalAgentInputShortcut,
@@ -104,7 +105,7 @@ function CanvasTerminalCardInner({ shape }: { shape: CanvasTerminalShape }) {
   const terminalRefs = useCanvasTerminalRefs();
   const activeShapeId = useCanvasRuntimeStore((state) => state.activeShapeId);
   const renderedShapeIds = useCanvasRuntimeStore((state) => state.renderedShapeIds);
-  const consumePendingTerminalCommand = useCanvasRuntimeStore((state) => state.consumePendingTerminalCommand);
+  const consumePendingTerminalRun = useCanvasRuntimeStore((state) => state.consumePendingTerminalRun);
   const setActiveShapeId = useCanvasRuntimeStore((state) => state.setActiveShapeId);
   const setRenderedShapeIds = useCanvasRuntimeStore((state) => state.setRenderedShapeIds);
   const removeRenderedShapeId = useCanvasRuntimeStore((state) => state.removeRenderedShapeId);
@@ -196,11 +197,11 @@ function CanvasTerminalCardInner({ shape }: { shape: CanvasTerminalShape }) {
   const handleSessionReady = React.useCallback(() => {
     markAttached();
     setIsTerminalReady(true);
-    const pendingCommand = consumePendingTerminalCommand(shape.id);
-    if (pendingCommand) {
-      terminalApiRef.current?.sendText(pendingCommand);
+    const pendingRun = consumePendingTerminalRun(shape.id);
+    if (pendingRun && terminalApiRef.current) {
+      deliverPendingTerminalRun(terminalApiRef.current, pendingRun);
     }
-  }, [consumePendingTerminalCommand, markAttached, shape.id]);
+  }, [consumePendingTerminalRun, markAttached, shape.id]);
 
   const focusTerminal = React.useCallback(() => {
     terminalApiRef.current?.focus();
@@ -553,6 +554,7 @@ function CanvasTerminalCardInner({ shape }: { shape: CanvasTerminalShape }) {
             <TerminalAgentInputOverlay
               ref={agentInputOverlayRef}
               activeProjectId={shape.props.contextScope === "project" ? shape.props.workspaceId : null}
+              agent={agentForSubmit ?? null}
               getTerminalCursorClientPoint={() => terminalApiRef.current?.getCursorClientPoint() ?? null}
               isTerminalReady={isTerminalReady}
               localPath={shape.props.localPath || null}

--- a/apps/web/src/features/canvas/components/CanvasView.tsx
+++ b/apps/web/src/features/canvas/components/CanvasView.tsx
@@ -102,7 +102,8 @@ import { useProjectStore } from "@/features/project/store/use-project-store";
 import { useAgentFixLauncherStore } from "@/features/agent-fix/store/agent-fix-launcher-store";
 import type { ResolvedAgentFixLaunchRequest } from "@/features/agent-fix/types";
 import { useReviewTerminalRunnerStore } from "@/features/code-review/store/review-terminal-runner-store";
-import { buildInteractiveAgentCommand } from "@/features/agent/lib/terminal-agent-run-config";
+import { buildInteractiveAgentRunPlan } from "@/features/agent/lib/terminal-agent-run-config";
+import { toPendingTerminalRun } from "@/features/terminal/lib/terminal-agent-run-delivery";
 import {
   createRelatedCanvasTerminalShape,
   resolveRelatedCanvasTerminalFrameName,
@@ -185,7 +186,7 @@ export const CanvasView: React.FC = () => {
   const [lastSavedAt, setLastSavedAt] = React.useState<Date | null>(null);
   const [isManualSaving, setIsManualSaving] = React.useState(false);
   const setActiveShapeId = useCanvasRuntimeStore((state) => state.setActiveShapeId);
-  const queuePendingTerminalCommand = useCanvasRuntimeStore((state) => state.queuePendingTerminalCommand);
+  const queuePendingTerminalRun = useCanvasRuntimeStore((state) => state.queuePendingTerminalRun);
   const activeShapeId = useCanvasRuntimeStore((state) => state.activeShapeId);
   const renderedShapeIds = useCanvasRuntimeStore((state) => state.renderedShapeIds);
   const setRenderedShapeIds = useCanvasRuntimeStore((state) => state.setRenderedShapeIds);
@@ -491,11 +492,13 @@ export const CanvasView: React.FC = () => {
       command,
       label,
       requestedContext,
+      tuiFollowUpPrompt,
     }: {
       agent?: TerminalPaneAgent;
       command: string;
       label: string;
       requestedContext?: { contextId: string; scope: "project" | "workspace" };
+      tuiFollowUpPrompt?: string;
     }) => {
       const editor = editorRef.current;
       if (!editor) {
@@ -531,8 +534,13 @@ export const CanvasView: React.FC = () => {
         throw new Error(t("errors.terminalPlacementFailed"));
       }
 
-      const commandToRun = command.endsWith("\r") ? command : `${command}\r`;
-      queuePendingTerminalCommand(result.newShapeId, commandToRun);
+      queuePendingTerminalRun(
+        result.newShapeId,
+        toPendingTerminalRun(command, {
+          agentId: agent?.id,
+          tuiFollowUpPrompt,
+        }),
+      );
       dispatchCanvasTerminalPinStateChange(result.pinKey, true);
       setActiveShapeId(result.newShapeId);
       editor.select(result.newShapeId);
@@ -569,7 +577,7 @@ export const CanvasView: React.FC = () => {
       createTerminalTabWithInitialPane,
       maxRenderedTerminals,
       projects,
-      queuePendingTerminalCommand,
+      queuePendingTerminalRun,
       resolveCanvasTerminalSource,
       router,
       setActiveShapeId,
@@ -580,7 +588,7 @@ export const CanvasView: React.FC = () => {
 
   const handleRunAgentFixInCanvasTerminal = React.useCallback(
     async (request: ResolvedAgentFixLaunchRequest) => {
-      const command = buildInteractiveAgentCommand({
+      const plan = buildInteractiveAgentRunPlan({
         agentId: request.agent.id,
         launchCommand: request.agent.launchCommand.trim(),
         prompt: request.prompt,
@@ -594,7 +602,8 @@ export const CanvasView: React.FC = () => {
           command: request.agent.command,
           iconType: request.agent.iconType,
         },
-        command,
+        command: plan.launchCommand,
+        tuiFollowUpPrompt: plan.tuiFollowUpPrompt,
         label: request.terminalTabTitle,
         requestedContext: request.context,
       });

--- a/apps/web/src/features/canvas/store/canvas-runtime-store.ts
+++ b/apps/web/src/features/canvas/store/canvas-runtime-store.ts
@@ -3,6 +3,8 @@
 import type { TLShapeId } from "tldraw";
 import { create } from "zustand";
 
+import type { PendingTerminalRun } from "@/features/terminal/lib/terminal-agent-run-delivery";
+
 export interface CanvasUnsupportedInteractionNotice {
   widgetLabel: string | null;
   targetPath: string | null;
@@ -12,10 +14,10 @@ interface CanvasRuntimeState {
   activeShapeId: TLShapeId | null;
   renderedShapeIds: TLShapeId[];
   focusPulseShapeIds: TLShapeId[];
-  pendingTerminalCommands: Record<string, string>;
+  pendingTerminalRuns: Record<string, PendingTerminalRun>;
   unsupportedInteractionNotice: CanvasUnsupportedInteractionNotice | null;
-  consumePendingTerminalCommand: (shapeId: TLShapeId) => string | null;
-  queuePendingTerminalCommand: (shapeId: TLShapeId, command: string) => void;
+  consumePendingTerminalRun: (shapeId: TLShapeId) => PendingTerminalRun | null;
+  queuePendingTerminalRun: (shapeId: TLShapeId, run: PendingTerminalRun) => void;
   setActiveShapeId: (shapeId: TLShapeId | null) => void;
   setRenderedShapeIds: (shapeIds: TLShapeId[]) => void;
   setFocusPulseShapeIds: (shapeIds: TLShapeId[]) => void;
@@ -29,26 +31,26 @@ export const useCanvasRuntimeStore = create<CanvasRuntimeState>((set) => ({
   activeShapeId: null,
   renderedShapeIds: [],
   focusPulseShapeIds: [],
-  pendingTerminalCommands: {},
+  pendingTerminalRuns: {},
   unsupportedInteractionNotice: null,
-  consumePendingTerminalCommand: (shapeId) => {
-    let command: string | null = null;
+  consumePendingTerminalRun: (shapeId) => {
+    let run: PendingTerminalRun | null = null;
     set((state) => {
-      command = state.pendingTerminalCommands[shapeId] ?? null;
-      if (!command) {
+      run = state.pendingTerminalRuns[shapeId] ?? null;
+      if (!run) {
         return state;
       }
-      const next = { ...state.pendingTerminalCommands };
+      const next = { ...state.pendingTerminalRuns };
       delete next[shapeId];
-      return { pendingTerminalCommands: next };
+      return { pendingTerminalRuns: next };
     });
-    return command;
+    return run;
   },
-  queuePendingTerminalCommand: (shapeId, command) =>
+  queuePendingTerminalRun: (shapeId, run) =>
     set((state) => ({
-      pendingTerminalCommands: {
-        ...state.pendingTerminalCommands,
-        [shapeId]: command,
+      pendingTerminalRuns: {
+        ...state.pendingTerminalRuns,
+        [shapeId]: run,
       },
     })),
   setActiveShapeId: (shapeId) => set({ activeShapeId: shapeId }),
@@ -65,7 +67,7 @@ export const useCanvasRuntimeStore = create<CanvasRuntimeState>((set) => ({
       activeShapeId: null,
       renderedShapeIds: [],
       focusPulseShapeIds: [],
-      pendingTerminalCommands: {},
+      pendingTerminalRuns: {},
       unsupportedInteractionNotice: null,
     }),
 }));

--- a/apps/web/src/features/terminal/components/Terminal.tsx
+++ b/apps/web/src/features/terminal/components/Terminal.tsx
@@ -65,6 +65,8 @@ export interface TerminalRef {
   sendEnter: () => void;
   getCursorClientPoint: () => { x: number; y: number } | null;
   scrollToBottom: () => void;
+  /** Subscribe to decoded PTY output for agent readiness heuristics. */
+  subscribeOutput: (listener: (data: string) => void) => () => void;
   /** Paste clipboard content into the terminal */
   paste: () => Promise<void>;
   /** Destroy the terminal session (kills tmux window) */
@@ -153,6 +155,7 @@ const Terminal = ({
   const scaledTerminalFontSize = Math.max(2, terminalFont.size * appliedTerminalScale);
   const normalizedTerminalScaleRef = useRef(normalizedTerminalScale);
   const appliedTerminalScaleRef = useRef(appliedTerminalScale);
+  const outputListenersRef = useRef(new Set<(data: string) => void>());
   const {
     resetInputReady,
     scheduleInputReady,
@@ -233,6 +236,9 @@ const Terminal = ({
         : outputTextDecoderRef.current.decode(data, { stream: true });
     if (text) {
       onData?.(text); // Forward decoded text for parent features (e.g. URL detection)
+      for (const listener of outputListenersRef.current) {
+        listener(text);
+      }
     }
   }, [onData, scheduleInputReady, status]);
 
@@ -444,6 +450,12 @@ const Terminal = ({
           lines.push(buf.getLine(i)?.translateToString(true) ?? "");
         }
         return lines.join("\n");
+      },
+      subscribeOutput: (listener: (data: string) => void) => {
+        outputListenersRef.current.add(listener);
+        return () => {
+          outputListenersRef.current.delete(listener);
+        };
       },
     }),
     [sendDestroy, disconnect, sendInput, sendEnter, getCursorClientPoint]

--- a/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
+++ b/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
@@ -604,7 +604,7 @@ export const TerminalAgentInputOverlay = React.forwardRef<
       launchFlyingMessage(flyingText);
       const pipedInput =
         agent && trimmedExpandedText
-          ? buildPipedAgentTerminalInput(agent.id, agent.pipeCommand ?? agent.command, trimmedExpandedText)
+          ? buildPipedAgentTerminalInput(agent.id, agent.command, trimmedExpandedText)
           : null;
       if (pipedInput) {
         onSendText(`${pipedInput}\r`);

--- a/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
+++ b/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
@@ -604,7 +604,7 @@ export const TerminalAgentInputOverlay = React.forwardRef<
       launchFlyingMessage(flyingText);
       const pipedInput =
         agent && trimmedExpandedText
-          ? buildPipedAgentTerminalInput(agent.id, agent.command, trimmedExpandedText)
+          ? buildPipedAgentTerminalInput(agent.id, agent.pipeCommand ?? agent.command, trimmedExpandedText)
           : null;
       if (pipedInput) {
         onSendText(`${pipedInput}\r`);

--- a/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
+++ b/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
@@ -7,6 +7,7 @@ import { Bot } from "lucide-react";
 
 import { AgentIcon } from "@/features/agent/components/AgentIcon";
 import {
+  buildPipedAgentTerminalInput,
   sanitizeRunConfig,
   type TerminalAgentRunConfigInput,
 } from "@/features/agent/lib/terminal-agent-run-config";
@@ -66,6 +67,7 @@ import "./TerminalAgentInputOverlay.css";
 
 interface TerminalAgentInputOverlayProps {
   activeProjectId?: string | null;
+  agent?: TerminalPaneAgent | null;
   getSideChatFlyTargetClientPoint?: () => { x: number; y: number } | null;
   getTerminalCursorClientPoint?: () => { x: number; y: number } | null;
   isTerminalReady?: boolean;
@@ -98,6 +100,7 @@ export const TerminalAgentInputOverlay = React.forwardRef<
   TerminalAgentInputOverlayProps
 >(function TerminalAgentInputOverlay({
   activeProjectId,
+  agent,
   getSideChatFlyTargetClientPoint,
   getTerminalCursorClientPoint,
   isTerminalReady = true,
@@ -599,6 +602,21 @@ export const TerminalAgentInputOverlay = React.forwardRef<
       if (!trimmedExpandedText) return;
       const flyingText = stripResolvedTerminalAiProtocolTokens(rawText, promptContexts) || rawText;
       launchFlyingMessage(flyingText);
+      const pipedInput =
+        agent && trimmedExpandedText
+          ? buildPipedAgentTerminalInput(agent.id, agent.command, trimmedExpandedText)
+          : null;
+      if (pipedInput) {
+        onSendText(`${pipedInput}\r`);
+        setIsOpen(true);
+        setIsSendAnimating(true);
+        composerRef.current?.clear();
+        clearAttachments();
+        setPromptContexts([]);
+        setMentionPopover(null);
+        setSlashPopover(null);
+        return;
+      }
       const isMultiLine = trimmedExpandedText.includes("\n");
       if (submitMode === "bracketed-paste-enter") {
         onSendText(wrapBracketedPaste(trimmedExpandedText));
@@ -629,6 +647,7 @@ export const TerminalAgentInputOverlay = React.forwardRef<
       setIsSending(false);
     }
   }, [
+    agent,
     attachments,
     clearAttachments,
     isSendAnimating,

--- a/apps/web/src/features/terminal/components/TerminalGrid.tsx
+++ b/apps/web/src/features/terminal/components/TerminalGrid.tsx
@@ -40,6 +40,11 @@ import { TerminalGridCloseConfirmDialog } from "./terminal-grid-close-confirm-di
 import { TerminalGridEmptyState, TerminalGridLoadingState } from "./terminal-grid-states";
 import { useTerminalGridCanvasPins } from "../hooks/use-terminal-grid-canvas-pins";
 import { useTerminalGridHotkeys } from "../hooks/use-terminal-grid-hotkeys";
+import {
+  toPendingTerminalRun,
+  useTerminalAgentTuiFollowUp,
+  type PendingTerminalRun,
+} from "../hooks/use-terminal-agent-tui-follow-up";
 
 import "react-mosaic-component/react-mosaic-component.css";
 import "./terminal-grid.css";
@@ -55,8 +60,8 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
   // Track terminal refs for each pane to call destroy on close
   const terminalRefsMap = React.useRef<Map<string, TerminalRef>>(new Map());
   const agentInputOverlayRefsMap = React.useRef<Map<string, TerminalAgentInputOverlayHandle>>(new Map());
-  // Pending commands to send when terminal session becomes ready (createAndRunTerminal flow)
-  const pendingCommandsRef = React.useRef<Map<string, string>>(new Map());
+  // Pending runs to deliver when terminal session becomes ready (createAndRunTerminal flow)
+  const pendingRunsRef = React.useRef<Map<string, PendingTerminalRun>>(new Map());
   // Track panes whose session has already become ready, so we know whether
   // to call sendText directly or queue a pending command for onSessionReady.
   const readyPanesRef = React.useRef<Set<string>>(new Set());
@@ -70,6 +75,40 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
   const contextSplitSubmenuTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const terminalHotkeyScopeRef = React.useRef<HTMLDivElement | null>(null);
   const lastFocusedElementRef = React.useRef<HTMLElement | null>(null);
+  const { deliverPendingRun } = useTerminalAgentTuiFollowUp(terminalRefsMap);
+
+  const queuePendingRun = useCallback(
+    (
+      paneId: string,
+      command: string,
+      options?: { agentId?: string; tuiFollowUpPrompt?: string; execute?: boolean },
+    ) => {
+      pendingRunsRef.current.set(
+        paneId,
+        toPendingTerminalRun(command, {
+          agentId: options?.agentId,
+          tuiFollowUpPrompt: options?.tuiFollowUpPrompt,
+        }),
+      );
+      if (options?.execute === false) {
+        const run = pendingRunsRef.current.get(paneId);
+        if (run) {
+          pendingRunsRef.current.set(paneId, { ...run, execute: false });
+        }
+      }
+    },
+    [],
+  );
+
+  const deliverPendingRunForPane = useCallback(
+    (paneId: string) => {
+      const run = pendingRunsRef.current.get(paneId);
+      if (!run) return;
+      pendingRunsRef.current.delete(paneId);
+      deliverPendingRun(paneId, run);
+    },
+    [deliverPendingRun],
+  );
 
   const isProjectWiki = scope === "project-wiki";
   const isCodeReview = scope === "code-review";
@@ -333,13 +372,14 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
 
   React.useImperativeHandle(ref, () => ({
     addTerminal: (label?: string, agent?: TerminalPaneAgent) => addTerminal(label, agent),
-    createAndRunTerminal: async ({ label, command, agent }) => {
+    createAndRunTerminal: async ({ label, command, agent, agentId, tuiFollowUpPrompt }) => {
+      const runOptions = { agentId: agent?.id ?? agentId, tuiFollowUpPrompt };
       // If there's exactly one fresh default pane (no agent, no pending command),
       // reuse it directly instead of creating a second terminal window.
       const currentPanes = Object.entries(panes);
       if (currentPanes.length === 1) {
         const [existingId, existingPane] = currentPanes[0];
-        if (!existingPane.agent && !pendingCommandsRef.current.has(existingId)) {
+        if (!existingPane.agent && !pendingRunsRef.current.has(existingId)) {
           if (agent) {
             setPaneAgentForCurrentGrid(existingId, agent);
           }
@@ -348,33 +388,34 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
           // input-ready. Otherwise the websocket is still attaching and the
           // input would be silently dropped — queue it for onSessionReady.
           if (termRef && readyPanesRef.current.has(existingId)) {
-            termRef.sendText(command + "\r");
+            deliverPendingRun(existingId, toPendingTerminalRun(command, runOptions));
           } else {
-            pendingCommandsRef.current.set(existingId, command + "\r");
+            queuePendingRun(existingId, command, runOptions);
           }
           return;
         }
       }
       const paneId = addTerminal(label, agent);
-      pendingCommandsRef.current.set(paneId, command + "\r");
+      queuePendingRun(paneId, command, runOptions);
     },
-    createOrFocusAndRunTerminal: async ({ label, command, agent }) => {
+    createOrFocusAndRunTerminal: async ({ label, command, agent, agentId, tuiFollowUpPrompt }) => {
+      const runOptions = { agentId: agent?.id ?? agentId, tuiFollowUpPrompt };
       const existingPaneId = getPaneIdByLabelOrWindowName(label);
-      const cmd = command.trim() + "\r";
       if (existingPaneId) {
         if (agent && !panes[existingPaneId]?.agent) {
           setPaneAgentForCurrentGrid(existingPaneId, agent);
         }
         const termRef = terminalRefsMap.current.get(existingPaneId);
-        if (termRef) {
-          termRef.sendText(cmd);
+        const run = toPendingTerminalRun(command, runOptions);
+        if (termRef && readyPanesRef.current.has(existingPaneId)) {
+          deliverPendingRun(existingPaneId, run);
         } else {
-          pendingCommandsRef.current.set(existingPaneId, cmd);
+          pendingRunsRef.current.set(existingPaneId, run);
         }
         return;
       }
       const paneId = addTerminal(label, agent);
-      pendingCommandsRef.current.set(paneId, cmd);
+      queuePendingRun(paneId, command, runOptions);
     },
     removeTerminalByTmuxWindowName: (tmuxWindowName: string) => {
       const paneId = getPaneId(workspaceId, tmuxWindowName);
@@ -401,7 +442,7 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
     prefillTerminal: ({ label, command, agent }) => {
       const paneId = addTerminal(label, agent);
       // Pre-fill without \r so the command is typed but not executed
-      pendingCommandsRef.current.set(paneId, command);
+      queuePendingRun(paneId, command, { execute: false });
     },
     destroyAllTerminals: () => {
       for (const terminalRef of terminalRefsMap.current.values()) {
@@ -567,7 +608,7 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
       rememberLastSplitAgent(agent.id);
       const newPaneId = splitTerminal(id, direction, agent);
       if (!newPaneId) return;
-      pendingCommandsRef.current.set(newPaneId, command.trim() + "\r");
+      pendingRunsRef.current.set(newPaneId, toPendingTerminalRun(command.trim()));
       setSplitMenuKey(null);
     },
     [rememberLastSplitAgent, splitTerminal],
@@ -761,7 +802,8 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
           terminalRefsMap={terminalRefsMap}
           agentInputOverlayRefsMap={agentInputOverlayRefsMap}
           readyPanesRef={readyPanesRef}
-          pendingCommandsRef={pendingCommandsRef}
+          pendingRunsRef={pendingRunsRef}
+          deliverPendingRunForPane={deliverPendingRunForPane}
           markPaneAttached={markPaneAttached}
         />
       );
@@ -797,7 +839,8 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
         terminalRefsMap={terminalRefsMap}
         agentInputOverlayRefsMap={agentInputOverlayRefsMap}
         readyPanesRef={readyPanesRef}
-        pendingCommandsRef={pendingCommandsRef}
+        pendingRunsRef={pendingRunsRef}
+        deliverPendingRunForPane={deliverPendingRunForPane}
         setDynamicTitle={setDynamicTitleForScope}
         setPaneAgent={setPaneAgentForScope}
         markPaneAttached={isCodeReview ? markCodeReviewPaneAttached : markProjectWikiPaneAttached}
@@ -832,6 +875,8 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
     isProjectContext,
     pinnedPaneKeys,
     pinPaneToCanvas,
+    deliverPendingRunForPane,
+    pendingRunsRef,
   ]);
 
   // Wait for workspace to be ready before rendering any Terminal components

--- a/apps/web/src/features/terminal/components/TerminalGrid.tsx
+++ b/apps/web/src/features/terminal/components/TerminalGrid.tsx
@@ -75,6 +75,7 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
   const contextSplitSubmenuTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const terminalHotkeyScopeRef = React.useRef<HTMLDivElement | null>(null);
   const lastFocusedElementRef = React.useRef<HTMLElement | null>(null);
+  const { deliverPendingRun } = useTerminalAgentTuiFollowUp(terminalRefsMap);
 
   const queuePendingRun = useCallback(
     (
@@ -93,8 +94,6 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
     },
     [],
   );
-
-  const { deliverPendingRun } = useTerminalAgentTuiFollowUp(terminalRefsMap);
 
   const deliverPendingRunForPane = useCallback(
     (paneId: string) => {
@@ -462,7 +461,7 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
       focusPane(paneId);
       return true;
     },
-  }), [workspaceId, addTerminal, deliverPendingRun, effectiveActivePaneId, focusPane, getPaneId, getPaneIdByLabelOrWindowName, isCodeReview, isProjectWiki, onTerminalPaneClosed, queuePendingRun, removeTerminalFromScope, panes, restoreLastFocusedElement, setPaneAgentForCurrentGrid, terminalTabId]);
+  }), [workspaceId, addTerminal, effectiveActivePaneId, focusPane, getPaneId, getPaneIdByLabelOrWindowName, isCodeReview, isProjectWiki, onTerminalPaneClosed, removeTerminalFromScope, panes, restoreLastFocusedElement, setPaneAgentForCurrentGrid, terminalTabId]);
 
   const setLayoutForScope = isCodeReview
     ? setCodeReviewLayout

--- a/apps/web/src/features/terminal/components/TerminalGrid.tsx
+++ b/apps/web/src/features/terminal/components/TerminalGrid.tsx
@@ -75,7 +75,6 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
   const contextSplitSubmenuTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const terminalHotkeyScopeRef = React.useRef<HTMLDivElement | null>(null);
   const lastFocusedElementRef = React.useRef<HTMLElement | null>(null);
-  const { deliverPendingRun } = useTerminalAgentTuiFollowUp(terminalRefsMap);
 
   const queuePendingRun = useCallback(
     (
@@ -94,6 +93,8 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
     },
     [],
   );
+
+  const { deliverPendingRun } = useTerminalAgentTuiFollowUp(terminalRefsMap);
 
   const deliverPendingRunForPane = useCallback(
     (paneId: string) => {
@@ -461,7 +462,7 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
       focusPane(paneId);
       return true;
     },
-  }), [workspaceId, addTerminal, effectiveActivePaneId, focusPane, getPaneId, getPaneIdByLabelOrWindowName, isCodeReview, isProjectWiki, onTerminalPaneClosed, removeTerminalFromScope, panes, restoreLastFocusedElement, setPaneAgentForCurrentGrid, terminalTabId]);
+  }), [workspaceId, addTerminal, deliverPendingRun, effectiveActivePaneId, focusPane, getPaneId, getPaneIdByLabelOrWindowName, isCodeReview, isProjectWiki, onTerminalPaneClosed, queuePendingRun, removeTerminalFromScope, panes, restoreLastFocusedElement, setPaneAgentForCurrentGrid, terminalTabId]);
 
   const setLayoutForScope = isCodeReview
     ? setCodeReviewLayout

--- a/apps/web/src/features/terminal/components/TerminalGrid.tsx
+++ b/apps/web/src/features/terminal/components/TerminalGrid.tsx
@@ -83,19 +83,14 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
       command: string,
       options?: { agentId?: string; tuiFollowUpPrompt?: string; execute?: boolean },
     ) => {
+      const run = toPendingTerminalRun(command, {
+        agentId: options?.agentId,
+        tuiFollowUpPrompt: options?.tuiFollowUpPrompt,
+      });
       pendingRunsRef.current.set(
         paneId,
-        toPendingTerminalRun(command, {
-          agentId: options?.agentId,
-          tuiFollowUpPrompt: options?.tuiFollowUpPrompt,
-        }),
+        options?.execute === false ? { ...run, execute: false } : run,
       );
-      if (options?.execute === false) {
-        const run = pendingRunsRef.current.get(paneId);
-        if (run) {
-          pendingRunsRef.current.set(paneId, { ...run, execute: false });
-        }
-      }
     },
     [],
   );

--- a/apps/web/src/features/terminal/components/TerminalSideChatModal.tsx
+++ b/apps/web/src/features/terminal/components/TerminalSideChatModal.tsx
@@ -347,6 +347,7 @@ export function TerminalSideChatModal({
                   getTerminalCursorClientPoint={() =>
                     terminalRefs.current.get(record.side_chat_id)?.getCursorClientPoint() ?? null
                   }
+                  agent={record.agent}
                   isTerminalReady={readySideChatIds.has(record.side_chat_id)}
                   localPath={localPath}
                   onInteraction={onInteraction}

--- a/apps/web/src/features/terminal/components/terminal-mosaic-scoped-pane-window.tsx
+++ b/apps/web/src/features/terminal/components/terminal-mosaic-scoped-pane-window.tsx
@@ -27,6 +27,7 @@ import {
 } from "./terminal-title";
 import type { TerminalPaneAgent, TerminalPaneProps } from "../types/index";
 import { useTerminalSideChats } from "../hooks/use-terminal-side-chats";
+import type { PendingTerminalRun } from "../lib/terminal-agent-run-delivery";
 import { resolveTerminalAgentSubmitMode } from "../lib/terminal-runtime-utils";
 import { TerminalPaneAgentStatus } from "./terminal-mosaic-workspace-pane-window";
 import {
@@ -74,7 +75,8 @@ type ScopedPaneWindowProps = {
   terminalRefsMap: React.MutableRefObject<Map<string, TerminalRef>>;
   agentInputOverlayRefsMap: React.MutableRefObject<Map<string, TerminalAgentInputOverlayHandle>>;
   readyPanesRef: React.MutableRefObject<Set<string>>;
-  pendingCommandsRef: React.MutableRefObject<Map<string, string>>;
+  pendingRunsRef: React.MutableRefObject<Map<string, PendingTerminalRun>>;
+  deliverPendingRunForPane: (paneId: string) => void;
   setDynamicTitle: (workspaceId: string, paneId: string, title: string) => void;
   setPaneAgent: (workspaceId: string, paneId: string, agent: TerminalPaneAgent) => void;
   markPaneAttached: (workspaceId: string, paneId: string) => void;
@@ -109,7 +111,8 @@ export function TerminalMosaicScopedPaneWindow({
   terminalRefsMap,
   agentInputOverlayRefsMap,
   readyPanesRef,
-  pendingCommandsRef,
+  pendingRunsRef,
+  deliverPendingRunForPane,
   setDynamicTitle,
   setPaneAgent,
   markPaneAttached,
@@ -386,10 +389,8 @@ export function TerminalMosaicScopedPaneWindow({
             readyPanesRef.current.add(id);
             setIsTerminalReady(true);
             markPaneAttached(workspaceId, id);
-            const cmd = pendingCommandsRef.current.get(id);
-            if (cmd) {
-              pendingCommandsRef.current.delete(id);
-              terminalRefsMap.current.get(id)?.sendText(cmd);
+            if (pendingRunsRef.current.has(id)) {
+              deliverPendingRunForPane(id);
             }
           }}
           onSessionClose={() => {
@@ -410,6 +411,7 @@ export function TerminalMosaicScopedPaneWindow({
             }
           }}
           activeProjectId={activeProject?.id ?? null}
+          agent={agentForSubmit ?? null}
           getTerminalCursorClientPoint={() =>
             terminalRefsMap.current.get(id)?.getCursorClientPoint() ?? null
           }

--- a/apps/web/src/features/terminal/components/terminal-mosaic-workspace-pane-window.tsx
+++ b/apps/web/src/features/terminal/components/terminal-mosaic-workspace-pane-window.tsx
@@ -26,6 +26,7 @@ import { TerminalTitleWithAgent } from "./terminal-title";
 import type { TerminalPaneAgent, TerminalPaneProps } from "../types/index";
 import { useTerminalToolbarTitle } from "../hooks/use-terminal-toolbar-title";
 import { useTerminalSideChats } from "../hooks/use-terminal-side-chats";
+import type { PendingTerminalRun } from "../lib/terminal-agent-run-delivery";
 import { resolveTerminalAgentSubmitMode } from "../lib/terminal-runtime-utils";
 import {
   getAgentContextDragText,
@@ -90,7 +91,8 @@ type TerminalMosaicWorkspacePaneWindowProps = {
   terminalRefsMap: React.MutableRefObject<Map<string, TerminalRef>>;
   agentInputOverlayRefsMap: React.MutableRefObject<Map<string, TerminalAgentInputOverlayHandle>>;
   readyPanesRef: React.MutableRefObject<Set<string>>;
-  pendingCommandsRef: React.MutableRefObject<Map<string, string>>;
+  pendingRunsRef: React.MutableRefObject<Map<string, PendingTerminalRun>>;
+  deliverPendingRunForPane: (paneId: string) => void;
   markPaneAttached: (workspaceId: string, paneId: string, terminalTabId?: string) => void;
 };
 
@@ -127,7 +129,8 @@ export function TerminalMosaicWorkspacePaneWindow(props: TerminalMosaicWorkspace
     terminalRefsMap,
     agentInputOverlayRefsMap,
     readyPanesRef,
-    pendingCommandsRef,
+    pendingRunsRef,
+    deliverPendingRunForPane,
     markPaneAttached,
   } = props;
 
@@ -445,10 +448,8 @@ export function TerminalMosaicWorkspacePaneWindow(props: TerminalMosaicWorkspace
             readyPanesRef.current.add(id);
             setIsTerminalReady(true);
             markPaneAttached(workspaceId, id, terminalTabId);
-            const cmd = pendingCommandsRef.current.get(id);
-            if (cmd) {
-              pendingCommandsRef.current.delete(id);
-              terminalRefsMap.current.get(id)?.sendText(cmd);
+            if (pendingRunsRef.current.has(id)) {
+              deliverPendingRunForPane(id);
             }
           }}
           onSessionClose={() => {
@@ -469,6 +470,7 @@ export function TerminalMosaicWorkspacePaneWindow(props: TerminalMosaicWorkspace
             }
           }}
           activeProjectId={activeProject?.id ?? null}
+          agent={agentForSubmit ?? null}
           getTerminalCursorClientPoint={() =>
             terminalRefsMap.current.get(id)?.getCursorClientPoint() ?? null
           }

--- a/apps/web/src/features/terminal/hooks/use-terminal-agent-tui-follow-up.ts
+++ b/apps/web/src/features/terminal/hooks/use-terminal-agent-tui-follow-up.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef } from "react";
+
+import type { TerminalRef } from "@/features/terminal/components/Terminal";
+import {
+  deliverPendingTerminalRun,
+  type PendingTerminalRun,
+} from "@/features/terminal/lib/terminal-agent-run-delivery";
+
+export type { PendingTerminalRun } from "@/features/terminal/lib/terminal-agent-run-delivery";
+export { toPendingTerminalRun } from "@/features/terminal/lib/terminal-agent-run-delivery";
+
+export function useTerminalAgentTuiFollowUp(
+  terminalRefsMap: React.MutableRefObject<Map<string, TerminalRef>>,
+) {
+  const cleanupByPaneRef = useRef<Map<string, () => void>>(new Map());
+
+  const clearFollowUp = useCallback((paneId: string) => {
+    const cleanup = cleanupByPaneRef.current.get(paneId);
+    if (!cleanup) return;
+    cleanup();
+    cleanupByPaneRef.current.delete(paneId);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      for (const paneId of [...cleanupByPaneRef.current.keys()]) {
+        clearFollowUp(paneId);
+      }
+    };
+  }, [clearFollowUp]);
+
+  const deliverPendingRun = useCallback(
+    (paneId: string, run: PendingTerminalRun) => {
+      clearFollowUp(paneId);
+      const terminalRef = terminalRefsMap.current.get(paneId);
+      if (!terminalRef) return;
+      const cleanup = deliverPendingTerminalRun(terminalRef, run);
+      if (run.tuiFollowUp) {
+        cleanupByPaneRef.current.set(paneId, cleanup);
+      }
+    },
+    [clearFollowUp, terminalRefsMap],
+  );
+
+  return {
+    clearFollowUp,
+    deliverPendingRun,
+  };
+}

--- a/apps/web/src/features/terminal/hooks/use-terminal-side-chats.tsx
+++ b/apps/web/src/features/terminal/hooks/use-terminal-side-chats.tsx
@@ -61,6 +61,7 @@ export function useTerminalSideChats({
   const t = useTranslations("terminal.sideChat");
   const terminalRefs = React.useRef<Map<string, TerminalRef>>(new Map());
   const sideChatFlyTargetRef = React.useRef<HTMLDivElement | null>(null);
+  const tuiFollowUpCleanupBySideChatRef = React.useRef<Map<string, () => void>>(new Map());
   const [isStarting, setIsStarting] = React.useState(false);
   const {
     sideContextPromptBudgetBytes,
@@ -70,6 +71,15 @@ export function useTerminalSideChats({
   React.useEffect(() => {
     void loadTerminalSideChatSettings();
   }, [loadTerminalSideChatSettings]);
+
+  React.useEffect(() => {
+    return () => {
+      for (const cleanup of tuiFollowUpCleanupBySideChatRef.current.values()) {
+        cleanup();
+      }
+      tuiFollowUpCleanupBySideChatRef.current.clear();
+    };
+  }, []);
 
   const sourceSurfaceRefJson = React.useMemo(() => {
     if (sourceSurfaceRef == null) return null;
@@ -97,6 +107,19 @@ export function useTerminalSideChats({
     terminalRefs,
     workspaceId,
   });
+
+  const clearSideChatFollowUp = React.useCallback((sideChatId: string) => {
+    const cleanup = tuiFollowUpCleanupBySideChatRef.current.get(sideChatId);
+    if (cleanup) {
+      cleanup();
+      tuiFollowUpCleanupBySideChatRef.current.delete(sideChatId);
+    }
+  }, []);
+
+  const handleCloseSideChat = React.useCallback((sideChatId: string) => {
+    clearSideChatFollowUp(sideChatId);
+    closeSideChat(sideChatId);
+  }, [clearSideChatFollowUp, closeSideChat]);
 
   const startSideChat = React.useCallback(
     async (
@@ -225,9 +248,9 @@ export function useTerminalSideChats({
       terminalScale={terminalScale}
       workspaceId={workspaceId}
       workspaceName={workspaceName}
-      onClose={closeSideChat}
+      onClose={handleCloseSideChat}
       onCloseAll={(sideChatIds) => {
-        void Promise.all(sideChatIds.map((sideChatId) => closeSideChat(sideChatId)));
+        void Promise.all(sideChatIds.map(handleCloseSideChat));
       }}
       onHide={hideSideChat}
       onInteraction={onInteraction}
@@ -242,9 +265,11 @@ export function useTerminalSideChats({
       }}
       onReady={(record) => {
         if (record.pendingInitialRun && !record.hasSentInitialCommand) {
+          clearSideChatFollowUp(record.side_chat_id);
           const terminalRef = terminalRefs.current.get(record.side_chat_id);
           if (terminalRef) {
-            deliverPendingTerminalRun(terminalRef, record.pendingInitialRun);
+            const cleanup = deliverPendingTerminalRun(terminalRef, record.pendingInitialRun);
+            tuiFollowUpCleanupBySideChatRef.current.set(record.side_chat_id, cleanup);
           }
           updateLocalRecord(record.side_chat_id, {
             hasSentInitialCommand: true,

--- a/apps/web/src/features/terminal/hooks/use-terminal-side-chats.tsx
+++ b/apps/web/src/features/terminal/hooks/use-terminal-side-chats.tsx
@@ -6,9 +6,10 @@ import { toastManager } from "@workspace/ui";
 
 import { fsApi, terminalSideChatApi, type TerminalSideContextCaptureResponse } from "@/api/ws-api";
 import {
-  buildInteractiveAgentCommand,
+  buildInteractiveAgentRunPlan,
   type TerminalAgentRunConfigInput,
 } from "@/features/agent/lib/terminal-agent-run-config";
+import { toPendingTerminalRun, deliverPendingTerminalRun } from "@/features/terminal/lib/terminal-agent-run-delivery";
 import { useTerminalSideChatSettingsStore } from "@/features/settings/store/terminal-side-chat-settings-store";
 import { TerminalSideChatDots } from "@/features/terminal/components/TerminalSideChatDots";
 import { TerminalSideChatLayer } from "@/features/terminal/components/TerminalSideChatLayer";
@@ -145,12 +146,16 @@ export function useTerminalSideChats({
           userPrompt,
           workspaceId,
         });
-        const initialCommand = `${buildInteractiveAgentCommand({
+        const plan = buildInteractiveAgentRunPlan({
           agentId: agent.id,
           launchCommand: agent.command,
           prompt: sidePrompt,
           runConfig,
-        })}\r`;
+        });
+        const pendingInitialRun = toPendingTerminalRun(plan.launchCommand, {
+          agentId: agent.id,
+          tuiFollowUpPrompt: plan.tuiFollowUpPrompt,
+        });
         const record: LocalSideChatRecord = {
           side_chat_id: sideChatId,
           workspace_id: workspaceId,
@@ -172,7 +177,7 @@ export function useTerminalSideChats({
           status: "open",
           agent,
           hasSentInitialCommand: false,
-          initialCommand,
+          pendingInitialRun,
           isNew: true,
           sessionId: crypto.randomUUID(),
         };
@@ -236,11 +241,14 @@ export function useTerminalSideChats({
         void showSideChat(sideChatId);
       }}
       onReady={(record) => {
-        if (record.initialCommand && !record.hasSentInitialCommand) {
-          terminalRefs.current.get(record.side_chat_id)?.sendText(record.initialCommand);
+        if (record.pendingInitialRun && !record.hasSentInitialCommand) {
+          const terminalRef = terminalRefs.current.get(record.side_chat_id);
+          if (terminalRef) {
+            deliverPendingTerminalRun(terminalRef, record.pendingInitialRun);
+          }
           updateLocalRecord(record.side_chat_id, {
             hasSentInitialCommand: true,
-            initialCommand: undefined,
+            pendingInitialRun: undefined,
             isNew: false,
           });
         } else if (record.isNew) {
@@ -249,7 +257,7 @@ export function useTerminalSideChats({
         void persistRecord({
           ...record,
           hasSentInitialCommand: true,
-          initialCommand: undefined,
+          pendingInitialRun: undefined,
           isNew: false,
           status: "open",
         });

--- a/apps/web/src/features/terminal/hooks/use-terminal-side-chats.tsx
+++ b/apps/web/src/features/terminal/hooks/use-terminal-side-chats.tsx
@@ -61,7 +61,6 @@ export function useTerminalSideChats({
   const t = useTranslations("terminal.sideChat");
   const terminalRefs = React.useRef<Map<string, TerminalRef>>(new Map());
   const sideChatFlyTargetRef = React.useRef<HTMLDivElement | null>(null);
-  const tuiFollowUpCleanupBySideChatRef = React.useRef<Map<string, () => void>>(new Map());
   const [isStarting, setIsStarting] = React.useState(false);
   const {
     sideContextPromptBudgetBytes,
@@ -71,15 +70,6 @@ export function useTerminalSideChats({
   React.useEffect(() => {
     void loadTerminalSideChatSettings();
   }, [loadTerminalSideChatSettings]);
-
-  React.useEffect(() => {
-    return () => {
-      for (const cleanup of tuiFollowUpCleanupBySideChatRef.current.values()) {
-        cleanup();
-      }
-      tuiFollowUpCleanupBySideChatRef.current.clear();
-    };
-  }, []);
 
   const sourceSurfaceRefJson = React.useMemo(() => {
     if (sourceSurfaceRef == null) return null;
@@ -107,19 +97,6 @@ export function useTerminalSideChats({
     terminalRefs,
     workspaceId,
   });
-
-  const clearSideChatFollowUp = React.useCallback((sideChatId: string) => {
-    const cleanup = tuiFollowUpCleanupBySideChatRef.current.get(sideChatId);
-    if (cleanup) {
-      cleanup();
-      tuiFollowUpCleanupBySideChatRef.current.delete(sideChatId);
-    }
-  }, []);
-
-  const handleCloseSideChat = React.useCallback((sideChatId: string) => {
-    clearSideChatFollowUp(sideChatId);
-    closeSideChat(sideChatId);
-  }, [clearSideChatFollowUp, closeSideChat]);
 
   const startSideChat = React.useCallback(
     async (
@@ -248,9 +225,9 @@ export function useTerminalSideChats({
       terminalScale={terminalScale}
       workspaceId={workspaceId}
       workspaceName={workspaceName}
-      onClose={handleCloseSideChat}
+      onClose={closeSideChat}
       onCloseAll={(sideChatIds) => {
-        void Promise.all(sideChatIds.map(handleCloseSideChat));
+        void Promise.all(sideChatIds.map((sideChatId) => closeSideChat(sideChatId)));
       }}
       onHide={hideSideChat}
       onInteraction={onInteraction}
@@ -265,11 +242,9 @@ export function useTerminalSideChats({
       }}
       onReady={(record) => {
         if (record.pendingInitialRun && !record.hasSentInitialCommand) {
-          clearSideChatFollowUp(record.side_chat_id);
           const terminalRef = terminalRefs.current.get(record.side_chat_id);
           if (terminalRef) {
-            const cleanup = deliverPendingTerminalRun(terminalRef, record.pendingInitialRun);
-            tuiFollowUpCleanupBySideChatRef.current.set(record.side_chat_id, cleanup);
+            deliverPendingTerminalRun(terminalRef, record.pendingInitialRun);
           }
           updateLocalRecord(record.side_chat_id, {
             hasSentInitialCommand: true,

--- a/apps/web/src/features/terminal/lib/__tests__/terminal-agent-run-delivery.test.ts
+++ b/apps/web/src/features/terminal/lib/__tests__/terminal-agent-run-delivery.test.ts
@@ -1,0 +1,48 @@
+// @ts-expect-error bun:test is available at runtime but not in tsconfig types
+import { describe, expect, it } from "bun:test";
+
+import type { TerminalRef } from "@/features/terminal/components/Terminal";
+import { sendTuiFollowUpPrompt } from "@/features/terminal/lib/terminal-agent-run-delivery";
+
+function createTerminalRefMock() {
+  const calls: Array<{ method: "sendText" | "sendEnter"; value?: string }> = [];
+  const terminalRef = {
+    sendText: (value: string) => {
+      calls.push({ method: "sendText", value });
+    },
+    sendEnter: () => {
+      calls.push({ method: "sendEnter" });
+    },
+  } as unknown as TerminalRef;
+  return { terminalRef, calls };
+}
+
+describe("sendTuiFollowUpPrompt", () => {
+  it("submits single-line Hermes prompts with a trailing carriage return", () => {
+    const { terminalRef, calls } = createTerminalRefMock();
+
+    sendTuiFollowUpPrompt(terminalRef, "fix this", { agentId: "hermes" });
+
+    expect(calls).toEqual([{ method: "sendText", value: "fix this\r" }]);
+  });
+
+  it("uses bracketed paste and Enter for multiline prompts", () => {
+    const { terminalRef, calls } = createTerminalRefMock();
+
+    sendTuiFollowUpPrompt(terminalRef, "line one\nline two", { agentId: "hermes" });
+
+    expect(calls[0]?.method).toBe("sendText");
+    expect(calls[0]?.value).toContain("\x1b[200~line one\rline two\x1b[201~");
+    expect(calls.length).toBe(1);
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(calls).toEqual([
+          { method: "sendText", value: calls[0]?.value },
+          { method: "sendEnter" },
+        ]);
+        resolve();
+      }, 100);
+    });
+  });
+});

--- a/apps/web/src/features/terminal/lib/__tests__/terminal-side-chat.test.ts
+++ b/apps/web/src/features/terminal/lib/__tests__/terminal-side-chat.test.ts
@@ -42,7 +42,7 @@ describe("mergeSideChatRecords", () => {
       side_chat_id: "side-collision",
       workspace_id: "workspace-old",
       hasSentInitialCommand: true,
-      initialCommand: "old prompt\r",
+      pendingInitialRun: { launch: "old prompt" },
       isNew: true,
       sessionId: "session-old",
     });
@@ -50,7 +50,7 @@ describe("mergeSideChatRecords", () => {
       side_chat_id: "side-collision",
       workspace_id: "workspace-new",
       hasSentInitialCommand: false,
-      initialCommand: undefined,
+      pendingInitialRun: undefined,
       isNew: false,
       sessionId: "session-new",
     });
@@ -63,7 +63,7 @@ describe("mergeSideChatRecords", () => {
       side_chat_id: "side-stable",
       workspace_id: "workspace-1",
       hasSentInitialCommand: true,
-      initialCommand: "local prompt\r",
+      pendingInitialRun: { launch: "local prompt" },
       isNew: true,
       sessionId: "session-local",
     });
@@ -71,7 +71,7 @@ describe("mergeSideChatRecords", () => {
       side_chat_id: "side-stable",
       workspace_id: "workspace-1",
       hasSentInitialCommand: false,
-      initialCommand: undefined,
+      pendingInitialRun: undefined,
       isNew: false,
       sessionId: "session-server",
     });
@@ -80,7 +80,7 @@ describe("mergeSideChatRecords", () => {
       {
         ...incoming,
         hasSentInitialCommand: true,
-        initialCommand: "local prompt\r",
+        pendingInitialRun: { launch: "local prompt" },
         isNew: true,
         sessionId: "session-local",
       },

--- a/apps/web/src/features/terminal/lib/terminal-agent-run-delivery.ts
+++ b/apps/web/src/features/terminal/lib/terminal-agent-run-delivery.ts
@@ -19,8 +19,6 @@ export type PendingTerminalRun = {
   };
 };
 
-type TimerHandle = number | null;
-
 export function toPendingTerminalRun(
   launchCommand: string,
   options?: {
@@ -46,7 +44,7 @@ export function sendTuiFollowUpPrompt(
   terminalRef: TerminalRef,
   prompt: string,
   options?: { agentId?: string },
-): (() => void) | undefined {
+) {
   const trimmed = prompt.trim();
   if (!trimmed) return;
 
@@ -72,29 +70,18 @@ export function sendTuiFollowUpPrompt(
 
   if (submitMode === "bracketed-paste-enter" || hasMultiline) {
     terminalRef.sendText(wrapBracketedPaste(normalized));
-    const timer: TimerHandle = window.setTimeout(submitPrompt, TUI_FOLLOW_UP_SUBMIT_DELAY_MS);
-    return () => {
-      if (timer !== null) {
-        window.clearTimeout(timer);
-      }
-    };
+    setTimeout(submitPrompt, TUI_FOLLOW_UP_SUBMIT_DELAY_MS);
+    return;
   }
 
   if (submitMode === "text-ctrl-enter") {
     terminalRef.sendText(normalized);
-    const timer: TimerHandle = window.setTimeout(submitPrompt, TUI_FOLLOW_UP_SUBMIT_DELAY_MS);
-    return () => {
-      if (timer !== null) {
-        window.clearTimeout(timer);
-      }
-    };
+    setTimeout(submitPrompt, TUI_FOLLOW_UP_SUBMIT_DELAY_MS);
+    return;
   }
 
   // Default interactive agents (e.g. Hermes): fill and submit in one write.
   terminalRef.sendText(`${normalized}\r`);
-  return;
-}
-
 }
 
 export function deliverTerminalAgentLaunch(
@@ -109,11 +96,9 @@ export function deliverPendingTerminalRun(
   terminalRef: TerminalRef,
   run: PendingTerminalRun,
 ): () => void {
+  deliverTerminalAgentLaunch(terminalRef, run.launch, run.execute !== false);
   if (!run.tuiFollowUp) {
-    deliverTerminalAgentLaunch(terminalRef, run.launch, run.execute !== false);
     return () => {};
   }
-  const cleanup = startAgentTuiFollowUp(terminalRef, run.tuiFollowUp.agentId, run.tuiFollowUp.prompt);
-  deliverTerminalAgentLaunch(terminalRef, run.launch, run.execute !== false);
-  return cleanup;
+  return startAgentTuiFollowUp(terminalRef, run.tuiFollowUp.agentId, run.tuiFollowUp.prompt);
 }

--- a/apps/web/src/features/terminal/lib/terminal-agent-run-delivery.ts
+++ b/apps/web/src/features/terminal/lib/terminal-agent-run-delivery.ts
@@ -19,6 +19,8 @@ export type PendingTerminalRun = {
   };
 };
 
+type TimerHandle = number | null;
+
 export function toPendingTerminalRun(
   launchCommand: string,
   options?: {
@@ -44,7 +46,7 @@ export function sendTuiFollowUpPrompt(
   terminalRef: TerminalRef,
   prompt: string,
   options?: { agentId?: string },
-) {
+): (() => void) | undefined {
   const trimmed = prompt.trim();
   if (!trimmed) return;
 
@@ -70,18 +72,29 @@ export function sendTuiFollowUpPrompt(
 
   if (submitMode === "bracketed-paste-enter" || hasMultiline) {
     terminalRef.sendText(wrapBracketedPaste(normalized));
-    setTimeout(submitPrompt, TUI_FOLLOW_UP_SUBMIT_DELAY_MS);
-    return;
+    const timer: TimerHandle = window.setTimeout(submitPrompt, TUI_FOLLOW_UP_SUBMIT_DELAY_MS);
+    return () => {
+      if (timer !== null) {
+        window.clearTimeout(timer);
+      }
+    };
   }
 
   if (submitMode === "text-ctrl-enter") {
     terminalRef.sendText(normalized);
-    setTimeout(submitPrompt, TUI_FOLLOW_UP_SUBMIT_DELAY_MS);
-    return;
+    const timer: TimerHandle = window.setTimeout(submitPrompt, TUI_FOLLOW_UP_SUBMIT_DELAY_MS);
+    return () => {
+      if (timer !== null) {
+        window.clearTimeout(timer);
+      }
+    };
   }
 
   // Default interactive agents (e.g. Hermes): fill and submit in one write.
   terminalRef.sendText(`${normalized}\r`);
+  return;
+}
+
 }
 
 export function deliverTerminalAgentLaunch(
@@ -96,9 +109,11 @@ export function deliverPendingTerminalRun(
   terminalRef: TerminalRef,
   run: PendingTerminalRun,
 ): () => void {
-  deliverTerminalAgentLaunch(terminalRef, run.launch, run.execute !== false);
   if (!run.tuiFollowUp) {
+    deliverTerminalAgentLaunch(terminalRef, run.launch, run.execute !== false);
     return () => {};
   }
-  return startAgentTuiFollowUp(terminalRef, run.tuiFollowUp.agentId, run.tuiFollowUp.prompt);
+  const cleanup = startAgentTuiFollowUp(terminalRef, run.tuiFollowUp.agentId, run.tuiFollowUp.prompt);
+  deliverTerminalAgentLaunch(terminalRef, run.launch, run.execute !== false);
+  return cleanup;
 }

--- a/apps/web/src/features/terminal/lib/terminal-agent-run-delivery.ts
+++ b/apps/web/src/features/terminal/lib/terminal-agent-run-delivery.ts
@@ -1,0 +1,104 @@
+import type { TerminalRef } from "@/features/terminal/components/Terminal";
+import { startAgentTuiFollowUp } from "@/features/terminal/lib/terminal-agent-tui-follow-up-runner";
+import {
+  ctrlEnterInput,
+  resolveTerminalAgentSubmitMode,
+  wrapBracketedPaste,
+} from "@/features/terminal/lib/terminal-runtime-utils";
+import type { TerminalPaneAgent } from "@/features/terminal/types";
+
+const TUI_FOLLOW_UP_SUBMIT_DELAY_MS = 80;
+
+export type PendingTerminalRun = {
+  launch: string;
+  /** When false, type launch text without executing it. Defaults to true. */
+  execute?: boolean;
+  tuiFollowUp?: {
+    agentId: string;
+    prompt: string;
+  };
+};
+
+export function toPendingTerminalRun(
+  launchCommand: string,
+  options?: {
+    agentId?: string;
+    tuiFollowUpPrompt?: string;
+  },
+): PendingTerminalRun {
+  const launch = launchCommand.trim();
+  const prompt = options?.tuiFollowUpPrompt?.trim();
+  if (!prompt || !options?.agentId) {
+    return { launch };
+  }
+  return {
+    launch,
+    tuiFollowUp: {
+      agentId: options.agentId,
+      prompt,
+    },
+  };
+}
+
+export function sendTuiFollowUpPrompt(
+  terminalRef: TerminalRef,
+  prompt: string,
+  options?: { agentId?: string },
+) {
+  const trimmed = prompt.trim();
+  if (!trimmed) return;
+
+  const agent: TerminalPaneAgent | undefined = options?.agentId
+    ? {
+        id: options.agentId,
+        label: options.agentId,
+        command: options.agentId,
+        iconType: "built-in",
+      }
+    : undefined;
+  const submitMode = resolveTerminalAgentSubmitMode(agent);
+  const normalized = trimmed.replace(/\r?\n/g, "\r");
+  const hasMultiline = normalized.includes("\r");
+
+  const submitPrompt = () => {
+    if (submitMode === "text-ctrl-enter") {
+      terminalRef.sendText(ctrlEnterInput());
+      return;
+    }
+    terminalRef.sendEnter();
+  };
+
+  if (submitMode === "bracketed-paste-enter" || hasMultiline) {
+    terminalRef.sendText(wrapBracketedPaste(normalized));
+    setTimeout(submitPrompt, TUI_FOLLOW_UP_SUBMIT_DELAY_MS);
+    return;
+  }
+
+  if (submitMode === "text-ctrl-enter") {
+    terminalRef.sendText(normalized);
+    setTimeout(submitPrompt, TUI_FOLLOW_UP_SUBMIT_DELAY_MS);
+    return;
+  }
+
+  // Default interactive agents (e.g. Hermes): fill and submit in one write.
+  terminalRef.sendText(`${normalized}\r`);
+}
+
+export function deliverTerminalAgentLaunch(
+  terminalRef: TerminalRef,
+  launch: string,
+  execute = true,
+) {
+  terminalRef.sendText(execute ? `${launch}\r` : launch);
+}
+
+export function deliverPendingTerminalRun(
+  terminalRef: TerminalRef,
+  run: PendingTerminalRun,
+): () => void {
+  deliverTerminalAgentLaunch(terminalRef, run.launch, run.execute !== false);
+  if (!run.tuiFollowUp) {
+    return () => {};
+  }
+  return startAgentTuiFollowUp(terminalRef, run.tuiFollowUp.agentId, run.tuiFollowUp.prompt);
+}

--- a/apps/web/src/features/terminal/lib/terminal-agent-tui-follow-up-runner.ts
+++ b/apps/web/src/features/terminal/lib/terminal-agent-tui-follow-up-runner.ts
@@ -14,6 +14,8 @@ type ActiveTuiFollowUp = {
   quietTimer: ReturnType<typeof setTimeout> | null;
   timeoutTimer: ReturnType<typeof setTimeout>;
   unsubscribe: (() => void) | null;
+  submitCleanup: (() => void) | null;
+  completed: boolean;
 };
 
 export function startAgentTuiFollowUp(
@@ -30,6 +32,8 @@ export function startAgentTuiFollowUp(
       complete();
     }, TUI_FOLLOW_UP_TIMEOUT_MS),
     unsubscribe: null,
+    submitCleanup: null,
+    completed: false,
   };
 
   const clear = () => {
@@ -39,15 +43,25 @@ export function startAgentTuiFollowUp(
     }
     clearTimeout(active.timeoutTimer);
     active.unsubscribe?.();
+    active.submitCleanup?.();
     active = null;
   };
 
   const complete = () => {
-    if (!active) return;
+    if (!active || active.completed) return;
+    active.completed = true;
     const pendingPrompt = active.prompt;
     const pendingAgentId = active.agentId;
-    clear();
-    sendTuiFollowUpPrompt(terminalRef, pendingPrompt, { agentId: pendingAgentId });
+    const submitCleanup = sendTuiFollowUpPrompt(terminalRef, pendingPrompt, { agentId: pendingAgentId });
+    active.submitCleanup = submitCleanup ?? null;
+    // Clear timers and unsubscribe, but keep active state with submitCleanup for the final cleanup
+    if (active.quietTimer) {
+      clearTimeout(active.quietTimer);
+    }
+    clearTimeout(active.timeoutTimer);
+    active.unsubscribe?.();
+    active.quietTimer = null;
+    active.unsubscribe = null;
   };
 
   const scheduleQuietReady = () => {

--- a/apps/web/src/features/terminal/lib/terminal-agent-tui-follow-up-runner.ts
+++ b/apps/web/src/features/terminal/lib/terminal-agent-tui-follow-up-runner.ts
@@ -1,0 +1,80 @@
+import {
+  appendTuiOutputBuffer,
+  isAgentTuiReady,
+  TUI_FOLLOW_UP_QUIET_MS,
+  TUI_FOLLOW_UP_TIMEOUT_MS,
+} from "@/features/agent/lib/terminal-agent-tui-follow-up";
+import type { TerminalRef } from "@/features/terminal/components/Terminal";
+import { sendTuiFollowUpPrompt } from "@/features/terminal/lib/terminal-agent-run-delivery";
+
+type ActiveTuiFollowUp = {
+  agentId: string;
+  prompt: string;
+  buffer: string;
+  quietTimer: ReturnType<typeof setTimeout> | null;
+  timeoutTimer: ReturnType<typeof setTimeout>;
+  unsubscribe: (() => void) | null;
+};
+
+export function startAgentTuiFollowUp(
+  terminalRef: TerminalRef,
+  agentId: string,
+  prompt: string,
+): () => void {
+  let active: ActiveTuiFollowUp | null = {
+    agentId,
+    prompt,
+    buffer: "",
+    quietTimer: null,
+    timeoutTimer: setTimeout(() => {
+      complete();
+    }, TUI_FOLLOW_UP_TIMEOUT_MS),
+    unsubscribe: null,
+  };
+
+  const clear = () => {
+    if (!active) return;
+    if (active.quietTimer) {
+      clearTimeout(active.quietTimer);
+    }
+    clearTimeout(active.timeoutTimer);
+    active.unsubscribe?.();
+    active = null;
+  };
+
+  const complete = () => {
+    if (!active) return;
+    const pendingPrompt = active.prompt;
+    const pendingAgentId = active.agentId;
+    clear();
+    sendTuiFollowUpPrompt(terminalRef, pendingPrompt, { agentId: pendingAgentId });
+  };
+
+  const scheduleQuietReady = () => {
+    if (!active) return;
+    if (active.quietTimer) {
+      clearTimeout(active.quietTimer);
+    }
+    active.quietTimer = setTimeout(() => {
+      if (!active) return;
+      active.quietTimer = null;
+      complete();
+    }, TUI_FOLLOW_UP_QUIET_MS);
+  };
+
+  if (!terminalRef.subscribeOutput) {
+    complete();
+    return () => {};
+  }
+
+  active.unsubscribe = terminalRef.subscribeOutput((chunk) => {
+    if (!active) return;
+    active.buffer = appendTuiOutputBuffer(active.buffer, chunk);
+    if (!isAgentTuiReady(active.agentId, active.buffer)) {
+      return;
+    }
+    scheduleQuietReady();
+  });
+
+  return clear;
+}

--- a/apps/web/src/features/terminal/lib/terminal-agent-tui-follow-up-runner.ts
+++ b/apps/web/src/features/terminal/lib/terminal-agent-tui-follow-up-runner.ts
@@ -14,8 +14,6 @@ type ActiveTuiFollowUp = {
   quietTimer: ReturnType<typeof setTimeout> | null;
   timeoutTimer: ReturnType<typeof setTimeout>;
   unsubscribe: (() => void) | null;
-  submitCleanup: (() => void) | null;
-  completed: boolean;
 };
 
 export function startAgentTuiFollowUp(
@@ -32,8 +30,6 @@ export function startAgentTuiFollowUp(
       complete();
     }, TUI_FOLLOW_UP_TIMEOUT_MS),
     unsubscribe: null,
-    submitCleanup: null,
-    completed: false,
   };
 
   const clear = () => {
@@ -43,25 +39,15 @@ export function startAgentTuiFollowUp(
     }
     clearTimeout(active.timeoutTimer);
     active.unsubscribe?.();
-    active.submitCleanup?.();
     active = null;
   };
 
   const complete = () => {
-    if (!active || active.completed) return;
-    active.completed = true;
+    if (!active) return;
     const pendingPrompt = active.prompt;
     const pendingAgentId = active.agentId;
-    const submitCleanup = sendTuiFollowUpPrompt(terminalRef, pendingPrompt, { agentId: pendingAgentId });
-    active.submitCleanup = submitCleanup ?? null;
-    // Clear timers and unsubscribe, but keep active state with submitCleanup for the final cleanup
-    if (active.quietTimer) {
-      clearTimeout(active.quietTimer);
-    }
-    clearTimeout(active.timeoutTimer);
-    active.unsubscribe?.();
-    active.quietTimer = null;
-    active.unsubscribe = null;
+    clear();
+    sendTuiFollowUpPrompt(terminalRef, pendingPrompt, { agentId: pendingAgentId });
   };
 
   const scheduleQuietReady = () => {

--- a/apps/web/src/features/terminal/lib/terminal-grid-utils.ts
+++ b/apps/web/src/features/terminal/lib/terminal-grid-utils.ts
@@ -43,9 +43,21 @@ export interface TerminalGridProps {
 export interface TerminalGridHandle {
   addTerminal: (label?: string, agent?: TerminalPaneAgent) => void;
   /** Create a new terminal tab and run command after session is ready */
-  createAndRunTerminal: (options: { label: string; command: string; agent?: TerminalPaneAgent }) => Promise<void>;
+  createAndRunTerminal: (options: {
+    label: string;
+    command: string;
+    agent?: TerminalPaneAgent;
+    agentId?: string;
+    tuiFollowUpPrompt?: string;
+  }) => Promise<void>;
   /** Create or focus terminal by label/window name (e.g. "Generate Project Wiki") and run command. Reuses existing pane if found. */
-  createOrFocusAndRunTerminal: (options: { label: string; command: string; agent?: TerminalPaneAgent }) => Promise<void>;
+  createOrFocusAndRunTerminal: (options: {
+    label: string;
+    command: string;
+    agent?: TerminalPaneAgent;
+    agentId?: string;
+    tuiFollowUpPrompt?: string;
+  }) => Promise<void>;
   /** Remove terminal pane by tmux window name. Used when killing backend tmux window before replace. */
   removeTerminalByTmuxWindowName: (tmuxWindowName: string) => boolean;
   /** Create a new terminal and pre-fill command text without executing it */

--- a/apps/web/src/features/terminal/lib/terminal-side-chat.ts
+++ b/apps/web/src/features/terminal/lib/terminal-side-chat.ts
@@ -5,13 +5,14 @@ import type {
 } from "@/api/ws-api";
 import type { TerminalPaneAgent } from "@/features/terminal/types";
 import type { TerminalPromptContext } from "./terminal-ai-context-protocol";
+import type { PendingTerminalRun } from "@/features/terminal/lib/terminal-agent-run-delivery";
 
 export type SourceSurfaceKind = "terminal_pane" | "canvas_terminal";
 
 export type LocalSideChatRecord = TerminalSideChatRecord & {
   agent?: TerminalPaneAgent;
   hasSentInitialCommand?: boolean;
-  initialCommand?: string;
+  pendingInitialRun?: PendingTerminalRun;
   isNew: boolean;
   sessionId: string;
 };
@@ -70,7 +71,7 @@ export function mergeSideChatRecords(
       ...record,
       agent: currentRecord.agent ?? record.agent,
       hasSentInitialCommand: currentRecord.hasSentInitialCommand,
-      initialCommand: currentRecord.initialCommand,
+      pendingInitialRun: currentRecord.pendingInitialRun,
       isNew: currentRecord.isNew,
       sessionId: currentRecord.sessionId,
     };

--- a/apps/web/src/features/wiki/components/AgentSelect.tsx
+++ b/apps/web/src/features/wiki/components/AgentSelect.tsx
@@ -57,12 +57,11 @@ export function buildCommandPlan(
   const agent = AGENT_OPTIONS.find((a) => a.id === agentId);
   if (!agent) return { launchCommand: "" };
 
-  const structuredArgs = buildStructuredRunConfigArgs(agentId, runConfig).map((item) =>
-    shellQuote(item),
-  );
-
   if (prompt.trim() === "") {
     const interactiveParams = getInteractiveAgentParams(agent);
+    const structuredArgs = buildStructuredRunConfigArgs(agentId, runConfig).map((item) =>
+      shellQuote(item),
+    );
     return {
       launchCommand: [agent.cmd, interactiveParams, ...structuredArgs].filter(Boolean).join(" "),
     };
@@ -70,9 +69,7 @@ export function buildCommandPlan(
 
   if (mode === "interactive") {
     const interactiveParams = getInteractiveAgentParams(agent);
-    const launchCommand = [agent.cmd, interactiveParams, ...structuredArgs]
-      .filter(Boolean)
-      .join(" ");
+    const launchCommand = [agent.cmd, interactiveParams].filter(Boolean).join(" ");
     return buildInteractiveAgentRunPlan({
       agentId,
       launchCommand,
@@ -86,7 +83,6 @@ export function buildCommandPlan(
   if (agent.params) {
     launchParts.push(agent.params);
   }
-  launchParts.push(...structuredArgs);
   return buildInteractiveAgentRunPlan({
     agentId,
     launchCommand: launchParts.join(" "),

--- a/apps/web/src/features/wiki/components/AgentSelect.tsx
+++ b/apps/web/src/features/wiki/components/AgentSelect.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import React from "react";
+import { shellQuote } from "@/shared/lib/shell-quote";
 import { TERMINAL_AGENT_DEFINITIONS } from "@/features/agent/lib/terminal-agent-definitions";
 import { TerminalAgentSelectorWithRunConfig } from "@/features/agent/components/TerminalAgentSelectorWithRunConfig";
 import {
-  buildInteractiveAgentCommand,
+  buildInteractiveAgentRunPlan,
+  buildStructuredRunConfigArgs,
+  type TerminalAgentRunMode,
+  type TerminalAgentRunPlan,
   type TerminalAgentRunConfigInput,
 } from "@/features/agent/lib/terminal-agent-run-config";
 
@@ -44,22 +48,91 @@ function isNonInteractivePromptFlagsWithoutPrompt(agentId: string, flags: string
   return false;
 }
 
+export function buildCommandPlan(
+  agentId: AgentId,
+  prompt: string,
+  runConfig?: TerminalAgentRunConfigInput | null,
+  mode: TerminalAgentRunMode = "interactive",
+): TerminalAgentRunPlan {
+  const agent = AGENT_OPTIONS.find((a) => a.id === agentId);
+  if (!agent) return { launchCommand: "" };
+
+  const structuredArgs = buildStructuredRunConfigArgs(agentId, runConfig).map((item) =>
+    shellQuote(item),
+  );
+
+  if (prompt.trim() === "") {
+    const interactiveParams = getInteractiveAgentParams(agent);
+    return {
+      launchCommand: [agent.cmd, interactiveParams, ...structuredArgs].filter(Boolean).join(" "),
+    };
+  }
+
+  if (mode === "interactive") {
+    const interactiveParams = getInteractiveAgentParams(agent);
+    const launchCommand = [agent.cmd, interactiveParams, ...structuredArgs]
+      .filter(Boolean)
+      .join(" ");
+    return buildInteractiveAgentRunPlan({
+      agentId,
+      launchCommand,
+      prompt,
+      runConfig,
+      mode,
+    });
+  }
+
+  const launchParts: string[] = [agent.cmd];
+  if (agent.params) {
+    launchParts.push(agent.params);
+  }
+  launchParts.push(...structuredArgs);
+  return buildInteractiveAgentRunPlan({
+    agentId,
+    launchCommand: launchParts.join(" "),
+    prompt,
+    runConfig,
+    mode: "headless",
+  });
+}
+
 export function buildCommand(
   agentId: AgentId,
   prompt: string,
   runConfig?: TerminalAgentRunConfigInput | null,
+  mode: TerminalAgentRunMode = "interactive",
 ): string {
-  const agent = AGENT_OPTIONS.find((a) => a.id === agentId);
-  if (!agent) return "";
+  return buildCommandPlan(agentId, prompt, runConfig, mode).launchCommand;
+}
 
-  const interactiveParams = getInteractiveAgentParams(agent);
-  const launchCommand = [agent.cmd, interactiveParams].filter(Boolean).join(" ");
-  return buildInteractiveAgentCommand({
+export function toTerminalPaneAgent(agentId: AgentId) {
+  const agent = AGENT_OPTIONS.find((item) => item.id === agentId);
+  if (!agent) return undefined;
+  return {
+    id: agent.id,
+    label: agent.label,
+    command: agent.cmd,
+    iconType: "built-in" as const,
+  };
+}
+
+export type WikiTerminalRun = {
+  command: string;
+  tuiFollowUpPrompt?: string;
+  agentId: AgentId;
+};
+
+export function buildWikiTerminalRun(
+  agentId: AgentId,
+  prompt: string,
+  runConfig?: TerminalAgentRunConfigInput | null,
+): WikiTerminalRun {
+  const plan = buildCommandPlan(agentId, prompt, runConfig, "interactive");
+  return {
+    command: plan.launchCommand,
+    tuiFollowUpPrompt: plan.tuiFollowUpPrompt,
     agentId,
-    launchCommand,
-    prompt,
-    runConfig,
-  });
+  };
 }
 
 interface AgentSelectProps {

--- a/apps/web/src/features/wiki/components/WikiSetup.tsx
+++ b/apps/web/src/features/wiki/components/WikiSetup.tsx
@@ -20,7 +20,7 @@ import {
   DialogFooter,
 } from "@workspace/ui";
 import { BookOpen, Copy, Loader2, Download, AlertTriangle } from "lucide-react";
-import { AgentSelect, buildCommand, type AgentId } from "./AgentSelect";
+import { AgentSelect, buildCommand, buildWikiTerminalRun, toTerminalPaneAgent, type AgentId, type WikiTerminalRun } from "./AgentSelect";
 import { getWikiLanguageOptions } from "../lib/wiki-languages";
 import { systemApi } from "@/api/rest-api";
 import type { TerminalGridHandle } from "@/features/terminal/components/TerminalGrid";
@@ -51,9 +51,9 @@ interface WikiSetupProps {
   terminalGridRef: React.RefObject<TerminalGridHandle | null>;
   onSwitchToTerminal: () => void;
   /** Switch to Project Wiki tab and run command (preferred over Terminal tab) */
-  onSwitchToProjectWikiAndRun?: (command: string) => void;
+  onSwitchToProjectWikiAndRun?: (run: WikiTerminalRun) => void;
   /** Kill existing Project Wiki window, remount terminal, then run (for conflict replace) */
-  onProjectWikiReplaceAndRun?: (command: string) => Promise<void>;
+  onProjectWikiReplaceAndRun?: (run: WikiTerminalRun) => Promise<void>;
   onRetryCheck: () => void;
 }
 
@@ -76,7 +76,7 @@ export const WikiSetup: React.FC<WikiSetupProps> = ({
   const [customLanguage, setCustomLanguage] = useState("");
   const [isInstalling, setIsInstalling] = useState(false);
   const [conflictDialogOpen, setConflictDialogOpen] = useState(false);
-  const [pendingCommand, setPendingCommand] = useState<string | null>(null);
+  const [pendingCommand, setPendingCommand] = useState<WikiTerminalRun | null>(null);
   const currentAgentRunConfig = agentRunConfigs[agentId] ?? null;
 
   const checkSystemSkill = useCallback(async () => {
@@ -124,7 +124,7 @@ export const WikiSetup: React.FC<WikiSetupProps> = ({
 
   const handleCopyPrompt = useCallback(() => {
     const prompt = buildPrompt(language, customLanguage);
-    const command = buildCommand(agentId, prompt, currentAgentRunConfig);
+    const command = buildCommand(agentId, prompt, currentAgentRunConfig, "headless");
     navigator.clipboard.writeText(command);
     toastManager.add({
       title: t("toasts.copiedTitle"),
@@ -134,9 +134,9 @@ export const WikiSetup: React.FC<WikiSetupProps> = ({
   }, [agentId, currentAgentRunConfig, customLanguage, language, t]);
 
   const doRunGenerate = useCallback(
-    (command: string) => {
+    (run: WikiTerminalRun) => {
       if (onSwitchToProjectWikiAndRun) {
-        onSwitchToProjectWikiAndRun(command);
+        onSwitchToProjectWikiAndRun(run);
         toastManager.add({
           title: t("toasts.generationStartedTitle"),
           description: t("toasts.generationStartedDescription"),
@@ -145,7 +145,9 @@ export const WikiSetup: React.FC<WikiSetupProps> = ({
       } else if (terminalGridRef.current?.createAndRunTerminal) {
         terminalGridRef.current.createAndRunTerminal({
           label: t("terminalLabel"),
-          command,
+          command: run.command,
+          tuiFollowUpPrompt: run.tuiFollowUpPrompt,
+          agent: toTerminalPaneAgent(run.agentId),
         });
         onSwitchToTerminal();
         toastManager.add({
@@ -175,22 +177,22 @@ export const WikiSetup: React.FC<WikiSetupProps> = ({
     }
 
     const prompt = buildPrompt(language, customLanguage);
-    const command = buildCommand(agentId, prompt, currentAgentRunConfig);
+    const run = buildWikiTerminalRun(agentId, prompt, currentAgentRunConfig);
 
     setIsGenerating(true);
     try {
       if (workspaceId) {
         const { exists } = await systemApi.checkProjectWikiWindow(workspaceId);
         if (exists) {
-          setPendingCommand(command);
+          setPendingCommand(run);
           setConflictDialogOpen(true);
           setIsGenerating(false);
           return;
         }
       }
-      doRunGenerate(command);
+      doRunGenerate(run);
     } catch (_err) {
-      setPendingCommand(command);
+      setPendingCommand(run);
       setConflictDialogOpen(true);
     } finally {
       setIsGenerating(false);

--- a/apps/web/src/features/wiki/components/WikiSpecifyDialog.tsx
+++ b/apps/web/src/features/wiki/components/WikiSpecifyDialog.tsx
@@ -20,7 +20,7 @@ import {
   SelectValue,
 } from "@workspace/ui";
 import { Download, Loader2, FilePlus } from "lucide-react";
-import { AgentSelect, buildCommand, type AgentId } from "./AgentSelect";
+import { AgentSelect, buildWikiTerminalRun, toTerminalPaneAgent, type AgentId, type WikiTerminalRun } from "./AgentSelect";
 import { getWikiLanguageOptions } from "../lib/wiki-languages";
 import { systemApi } from "@/api/rest-api";
 import { skillsApi } from "@/api/ws-api";
@@ -52,8 +52,8 @@ interface WikiSpecifyDialogProps {
   workspaceId: string;
   terminalGridRef?: React.RefObject<TerminalGridHandle | null>;
   onSwitchToTerminal?: () => void;
-  onSwitchToProjectWikiAndRun?: (command: string) => void;
-  onProjectWikiReplaceAndRun?: (command: string) => Promise<void>;
+  onSwitchToProjectWikiAndRun?: (run: WikiTerminalRun) => void;
+  onProjectWikiReplaceAndRun?: (run: WikiTerminalRun) => Promise<void>;
   onComplete?: () => void;
 }
 
@@ -75,7 +75,7 @@ export const WikiSpecifyDialog: React.FC<WikiSpecifyDialogProps> = ({
   const [customLanguage, setCustomLanguage] = useState("");
   const [isRunning, setIsRunning] = useState(false);
   const [conflictDialogOpen, setConflictDialogOpen] = useState(false);
-  const [pendingCommand, setPendingCommand] = useState<string | null>(null);
+  const [pendingCommand, setPendingCommand] = useState<WikiTerminalRun | null>(null);
   const [systemHasSkill, setSystemHasSkill] = useState<boolean | null>(null);
   const [skillLoading, setSkillLoading] = useState(true);
   const [isInstalling, setIsInstalling] = useState(false);
@@ -125,9 +125,9 @@ export const WikiSpecifyDialog: React.FC<WikiSpecifyDialogProps> = ({
   }, [checkSystemSkill]);
 
   const doRunSpecify = useCallback(
-    (command: string) => {
+    (run: WikiTerminalRun) => {
       if (onSwitchToProjectWikiAndRun) {
-        onSwitchToProjectWikiAndRun(command);
+        onSwitchToProjectWikiAndRun(run);
         toastManager.add({
           title: t("toasts.started.title"),
           description: t("toasts.started.description"),
@@ -136,7 +136,9 @@ export const WikiSpecifyDialog: React.FC<WikiSpecifyDialogProps> = ({
       } else if (terminalGridRef?.current?.createAndRunTerminal) {
         terminalGridRef.current.createAndRunTerminal({
           label: t("terminalLabel"),
-          command,
+          command: run.command,
+          tuiFollowUpPrompt: run.tuiFollowUpPrompt,
+          agent: toTerminalPaneAgent(run.agentId),
         });
         onSwitchToTerminal?.();
         toastManager.add({
@@ -176,22 +178,22 @@ export const WikiSpecifyDialog: React.FC<WikiSpecifyDialogProps> = ({
     }
 
     const prompt = buildSpecifyPrompt(trimmed, language, customLanguage);
-    const command = buildCommand(agentId, prompt, currentAgentRunConfig);
+    const run = buildWikiTerminalRun(agentId, prompt, currentAgentRunConfig);
 
     setIsRunning(true);
     try {
       if (workspaceId) {
         const { exists } = await systemApi.checkProjectWikiWindow(workspaceId);
         if (exists) {
-          setPendingCommand(command);
+          setPendingCommand(run);
           setConflictDialogOpen(true);
           setIsRunning(false);
           return;
         }
       }
-      doRunSpecify(command);
+      doRunSpecify(run);
     } catch {
-      setPendingCommand(command);
+      setPendingCommand(run);
       setConflictDialogOpen(true);
     } finally {
       setIsRunning(false);

--- a/apps/web/src/features/wiki/components/WikiTab.tsx
+++ b/apps/web/src/features/wiki/components/WikiTab.tsx
@@ -6,6 +6,7 @@ import { useWikiContext } from "@/features/wiki/store/use-wiki-store";
 import { WikiSetup } from "./WikiSetup";
 import { WikiViewer } from "./WikiViewer";
 import type { TerminalGridHandle } from "@/features/terminal/components/TerminalGrid";
+import type { WikiTerminalRun } from "./AgentSelect";
 
 interface WikiTabProps {
   contextId: string;
@@ -16,9 +17,9 @@ interface WikiTabProps {
   terminalGridRef: React.RefObject<TerminalGridHandle | null>;
   onSwitchToTerminal: () => void;
   /** Switch to Project Wiki tab and run the given command in its terminal */
-  onSwitchToProjectWikiAndRun?: (command: string) => void;
+  onSwitchToProjectWikiAndRun?: (run: WikiTerminalRun) => void;
   /** Kill existing Project Wiki window, remount terminal, then run command (for replace flow) */
-  onProjectWikiReplaceAndRun?: (command: string) => Promise<void>;
+  onProjectWikiReplaceAndRun?: (run: WikiTerminalRun) => Promise<void>;
   /** Current wiki page from URL (e.g. "overview/index") */
   wikiPage?: string;
   /** Called when wiki page changes — syncs to URL */

--- a/apps/web/src/features/wiki/components/WikiUpdateDialog.tsx
+++ b/apps/web/src/features/wiki/components/WikiUpdateDialog.tsx
@@ -16,7 +16,7 @@ import { Download, Loader2, LoaderCircle, RotateCw } from "lucide-react";
 import { systemApi } from "@/api/rest-api";
 import { skillsApi } from "@/api/ws-api";
 import type { TerminalGridHandle } from "@/features/terminal/components/TerminalGrid";
-import { AgentSelect, buildCommand, type AgentId } from "./AgentSelect";
+import { AgentSelect, buildWikiTerminalRun, toTerminalPaneAgent, type AgentId, type WikiTerminalRun } from "./AgentSelect";
 import type { TerminalAgentRunConfigInput } from "@/features/agent/lib/terminal-agent-run-config";
 
 const PROJECT_WIKI_UPDATE_SKILL_PATH = "~/.atmos/skills/.system/project-wiki-update";
@@ -37,8 +37,8 @@ interface WikiUpdateDialogProps {
   workspaceId: string;
   terminalGridRef?: React.RefObject<TerminalGridHandle | null>;
   onSwitchToTerminal?: () => void;
-  onSwitchToProjectWikiAndRun?: (command: string) => void;
-  onProjectWikiReplaceAndRun?: (command: string) => Promise<void>;
+  onSwitchToProjectWikiAndRun?: (run: WikiTerminalRun) => void;
+  onProjectWikiReplaceAndRun?: (run: WikiTerminalRun) => Promise<void>;
   onComplete?: () => void;
 }
 
@@ -61,7 +61,7 @@ export const WikiUpdateDialog: React.FC<WikiUpdateDialogProps> = ({
   const [agentRunConfigs, setAgentRunConfigs] = useState<Record<string, TerminalAgentRunConfigInput | null>>({});
   const [isRunning, setIsRunning] = useState(false);
   const [conflictDialogOpen, setConflictDialogOpen] = useState(false);
-  const [pendingCommand, setPendingCommand] = useState<string | null>(null);
+  const [pendingCommand, setPendingCommand] = useState<WikiTerminalRun | null>(null);
   const [systemHasSkill, setSystemHasSkill] = useState<boolean | null>(null);
   const [skillLoading, setSkillLoading] = useState(true);
   const [isInstalling, setIsInstalling] = useState(false);
@@ -110,9 +110,9 @@ export const WikiUpdateDialog: React.FC<WikiUpdateDialogProps> = ({
   }, [checkSystemSkill]);
 
   const doRunUpdate = useCallback(
-    (command: string) => {
+    (run: WikiTerminalRun) => {
       if (onSwitchToProjectWikiAndRun) {
-        onSwitchToProjectWikiAndRun(command);
+        onSwitchToProjectWikiAndRun(run);
         toastManager.add({
           title: t("toasts.started.title"),
           description: t("toasts.started.description"),
@@ -121,7 +121,9 @@ export const WikiUpdateDialog: React.FC<WikiUpdateDialogProps> = ({
       } else if (terminalGridRef?.current?.createAndRunTerminal) {
         terminalGridRef.current.createAndRunTerminal({
           label: t("terminalLabel"),
-          command,
+          command: run.command,
+          tuiFollowUpPrompt: run.tuiFollowUpPrompt,
+          agent: toTerminalPaneAgent(run.agentId),
         });
         onSwitchToTerminal?.();
         toastManager.add({
@@ -151,22 +153,22 @@ export const WikiUpdateDialog: React.FC<WikiUpdateDialogProps> = ({
 
   const handleRunUpdate = useCallback(async () => {
     const prompt = buildUpdatePrompt(catalogCommit, currentCommit);
-    const command = buildCommand(agentId, prompt, currentAgentRunConfig);
+    const run = buildWikiTerminalRun(agentId, prompt, currentAgentRunConfig);
 
     setIsRunning(true);
     try {
       if (workspaceId) {
         const { exists } = await systemApi.checkProjectWikiWindow(workspaceId);
         if (exists) {
-          setPendingCommand(command);
+          setPendingCommand(run);
           setConflictDialogOpen(true);
           setIsRunning(false);
           return;
         }
       }
-      doRunUpdate(command);
+      doRunUpdate(run);
     } catch {
-      setPendingCommand(command);
+      setPendingCommand(run);
       setConflictDialogOpen(true);
     } finally {
       setIsRunning(false);

--- a/apps/web/src/features/wiki/components/WikiViewer.tsx
+++ b/apps/web/src/features/wiki/components/WikiViewer.tsx
@@ -26,6 +26,7 @@ import { WikiUpdateDialog } from "./WikiUpdateDialog";
 import { WikiSpecifyDialog } from "./WikiSpecifyDialog";
 
 import type { TerminalGridHandle } from "@/features/terminal/components/TerminalGrid";
+import type { WikiTerminalRun } from "./AgentSelect";
 
 interface WikiViewerProps {
   contextId: string;
@@ -39,8 +40,8 @@ interface WikiViewerProps {
   isWikiTabActive?: boolean;
   terminalGridRef?: React.RefObject<TerminalGridHandle | null>;
   onSwitchToTerminal?: () => void;
-  onSwitchToProjectWikiAndRun?: (command: string) => void;
-  onProjectWikiReplaceAndRun?: (command: string) => Promise<void>;
+  onSwitchToProjectWikiAndRun?: (run: WikiTerminalRun) => void;
+  onProjectWikiReplaceAndRun?: (run: WikiTerminalRun) => Promise<void>;
 }
 
 export const WikiViewer: React.FC<WikiViewerProps> = ({

--- a/apps/web/src/features/wiki/components/__tests__/agent-select.test.ts
+++ b/apps/web/src/features/wiki/components/__tests__/agent-select.test.ts
@@ -1,7 +1,11 @@
 // @ts-expect-error bun:test is available at runtime but not in tsconfig types
 import { describe, expect, it } from "bun:test";
-import { buildInteractiveAgentCommand } from "@/features/agent/lib/terminal-agent-run-config";
-import { AGENT_OPTIONS, buildCommand, getInteractiveAgentParams } from "../AgentSelect";
+import {
+  buildInteractiveAgentCommand,
+  buildInteractiveAgentRunPlan,
+  buildPipedAgentTerminalInput,
+} from "@/features/agent/lib/terminal-agent-run-config";
+import { AGENT_OPTIONS, buildCommand, buildCommandPlan, getInteractiveAgentParams } from "../AgentSelect";
 
 function agent(id: string) {
   const found = AGENT_OPTIONS.find((item) => item.id === id);
@@ -51,18 +55,49 @@ describe("getInteractiveAgentParams", () => {
     );
   });
 
-  it("builds Hermes one-shot prompts with the documented query flag", () => {
-    expect(buildCommand("hermes", "fix this")).toBe("hermes chat --yolo -q 'fix this'");
+  it("builds Hermes headless prompts with the documented query flag", () => {
+    expect(buildCommand("hermes", "fix this", null, "headless")).toBe(
+      "hermes chat --yolo -q 'fix this'",
+    );
   });
 
-  it("starts Hermes workspace prompts with the documented query flag", () => {
+  it("starts Hermes interactive sessions with launch plus TUI follow-up prompt", () => {
     expect(
-      buildInteractiveAgentCommand({
+      buildInteractiveAgentRunPlan({
         agentId: "hermes",
         launchCommand: "hermes chat --yolo",
         prompt: "fix this",
       }),
-    ).toBe("hermes chat --yolo -q 'fix this'");
+    ).toEqual({
+      launchCommand: "hermes chat --yolo",
+      tuiFollowUpPrompt: "fix this",
+    });
+    expect(buildCommand("hermes", "fix this")).toBe("hermes chat --yolo");
+    expect(buildCommandPlan("hermes", "fix this").tuiFollowUpPrompt).toBe("fix this");
+  });
+
+  it("starts Pi interactive sessions with a positional prompt", () => {
+    expect(
+      buildInteractiveAgentCommand({
+        agentId: "pi",
+        launchCommand: "pi",
+        prompt: "fix this",
+      }),
+    ).toBe("pi 'fix this'");
+  });
+
+  it("pipes Amp prompts into the interactive CLI", () => {
+    expect(buildCommand("amp", "fix this")).toBe("echo 'fix this' | amp --dangerously-allow-all");
+    expect(
+      buildInteractiveAgentCommand({
+        agentId: "amp",
+        launchCommand: "amp --dangerously-allow-all",
+        prompt: "fix this",
+      }),
+    ).toBe("echo 'fix this' | amp --dangerously-allow-all");
+    expect(buildPipedAgentTerminalInput("amp", "amp", "fix this")).toBe(
+      "echo 'fix this' | amp --dangerously-allow-all",
+    );
   });
 
   it("starts OpenClaw workspace prompts without the automation json flag", () => {

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "2026.7.6-beta.1",
+      "version": "2026.7.3",
       "devDependencies": {
         "@tauri-apps/cli": "^2.0.0",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "2026.7.3",
+      "version": "2026.7.6-beta.1",
       "devDependencies": {
         "@tauri-apps/cli": "^2.0.0",
       },

--- a/crates/core-service/src/service/automation/agents.rs
+++ b/crates/core-service/src/service/automation/agents.rs
@@ -1425,9 +1425,9 @@ mod tests {
             ),
             (
                 "amp",
-                PromptStrategy::Arg,
+                PromptStrategy::Stdin,
                 vec!["--dangerously-allow-all", "--execute"],
-                PromptDelivery::Arg,
+                PromptDelivery::Stdin,
                 StdoutParser::Plain,
             ),
             (

--- a/resources/terminal-agents/AGENTS.md
+++ b/resources/terminal-agents/AGENTS.md
@@ -5,6 +5,7 @@ This directory owns repo-level terminal-agent manifests that are consumed by bot
 ## Files
 
 - `builtin_agents.json`: Atmos built-in terminal agent defaults: stable ids, display labels, executable names, default launch flags, and prompt delivery strategy hints.
+- `tui_follow_up_agents.json`: Web terminal agents that must launch interactively first, then wait for a TUI-ready pattern before auto-sending the initial prompt. Each entry maps `agentId` to `readyPattern` (regex against accumulated terminal output).
 
 ## Rules
 
@@ -13,6 +14,7 @@ This directory owns repo-level terminal-agent manifests that are consumed by bot
 - When changing `builtin_agents.json`, verify both consumers:
   - Web Agent Select adapter: `apps/web/src/features/agent/lib/terminal-agent-definitions.ts`
   - Automation resolver: `crates/core-service/src/service/automation/agents.rs`
+- When changing `tui_follow_up_agents.json`, verify the web loader in `apps/web/src/features/agent/lib/terminal-agent-tui-follow-up.ts`.
 - Preserve existing agent `id` values unless a migration plan is documented; user settings and persisted automation definitions refer to these ids.
 - Use `promptStrategy` for automation prompt delivery. Supported values are `arg`, `stdin`, `prompt_flag`, and `file_flag`; keep `useEcho` only for existing interactive UI compatibility.
 - Keep the JSON plain and cross-runtime friendly. Avoid comments, trailing commas, or TypeScript/Rust-specific fields.

--- a/resources/terminal-agents/builtin_agents.json
+++ b/resources/terminal-agents/builtin_agents.json
@@ -85,7 +85,7 @@
     "cmd": "amp",
     "params": "--dangerously-allow-all --execute",
     "interactiveParams": "--dangerously-allow-all",
-    "promptStrategy": "arg",
+    "promptStrategy": "stdin",
     "useEcho": true,
     "modelSupport": "none",
     "reasoningSupport": {

--- a/resources/terminal-agents/tui_follow_up_agents.json
+++ b/resources/terminal-agents/tui_follow_up_agents.json
@@ -1,0 +1,11 @@
+{
+  "quietMs": 250,
+  "timeoutMs": 25000,
+  "outputBufferLimit": 4096,
+  "agents": [
+    {
+      "agentId": "hermes",
+      "readyPattern": "❯"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fix interactive terminal agent launches so users stay in a real CLI session instead of accidentally using headless one-shot flags.

- Add `buildInteractiveAgentRunPlan()` and `PendingTerminalRun` delivery across Terminal Grid, Canvas, Wiki, Quick Open, Agent Fix, and Side Chat
- Add config-driven TUI follow-up via `resources/terminal-agents/tui_follow_up_agents.json` (Hermes waits for `❯`, then fills and submits the prompt)
- Fix Pi interactive prompts to use positional args instead of `-p`
- Fix Amp interactive prompts to pipe via stdin (`echo 'prompt' | amp --dangerously-allow-all`) and align manifest/automation tests with `promptStrategy: "stdin"`
- Keep headless automation paths (`-q`, `--execute`, etc.) separate from interactive terminal flows

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [x] `just test`
- [ ] `just fmt`
- [x] Additional checks (describe below)

Ran targeted web tests:

- `bun test src/features/wiki/components/__tests__/agent-select.test.ts`
- `bun test src/features/agent/lib/__tests__/terminal-agent-tui-follow-up.test.ts`
- `bun test src/features/terminal/lib/__tests__/terminal-agent-run-delivery.test.ts`
- `bun test src/features/terminal/lib/__tests__/terminal-side-chat.test.ts`

Also ran `bun run typecheck` in `apps/web`.

## Checklist

- [x] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores interactive terminal agent launches with a TUI-ready follow-up: we start the CLI, wait for the agent’s UI (e.g., Hermes `❯`), then auto-submit the prompt. Headless/automation paths remain unchanged.

- New Features
  - Added TUI follow-up config via `resources/terminal-agents/tui_follow_up_agents.json` (Hermes waits for `❯`, with `quietMs`/`timeoutMs` and output buffer limits).
  - Introduced run plans and `PendingTerminalRun` with centralized delivery across Terminal Grid, Canvas, Wiki, and Side Chat.
  - Terminals expose `subscribeOutput`; a follow-up runner listens for readiness and submits prompts (bracketed paste for multi-line and correct submit modes).
  - Input overlay can pipe via stdin for agents with `promptStrategy: "stdin"` using `buildPipedAgentTerminalInput`.
  - Wiki “Run” uses interactive launch + TUI follow-up; “Copy” produces headless one-shot commands.

- Bug Fixes
  - Pi interactive prompts use a positional arg instead of `-p`.
  - Amp interactive prompts pipe via stdin; manifests set `promptStrategy: "stdin"` and Rust automation updated.
  - Kept headless flags (`-q`, `--execute`, etc.) out of interactive flows; queued runs execute after sessions are ready and panes are reused when possible.
  - Cleanup: simplified pending-run queuing, avoided duplicate structured args, and omitted undefined `readyPatternFlags` in TUI config.

<sup>Written for commit 53af5047d1918ae7f00234e2ded0997855edaa33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured “pending terminal run” support, including readiness-based TUI follow-up prompts for interactive agent sessions.
  * Enhanced wiki and workspace/agent flows to pass richer run details (command, agentId, follow-up prompt) end-to-end.
  * Added terminal output subscription to enable follow-up readiness detection.
* **Bug Fixes**
  * Fixed agent prompt/input handling to respect per-agent prompt strategies across interactive/headless modes.
  * Updated queued run delivery so panes execute the correct pending run when they become ready.
* **Tests**
  * Added Bun tests covering TUI follow-up prompt behavior and terminal delivery.
* **Documentation**
  * Updated terminal-agent documentation and resources for the new follow-up configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->