### PR TITLE
feat(web): terminal tab & pane custom naming (APP-033)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -171,7 +171,9 @@
       "closeProjectWikiTab": "Close Project Wiki tab",
       "codeReview": "Code Review",
       "codeReviewTerminal": "Code Review Terminal",
-      "closeCodeReviewTab": "Close Code Review tab"
+      "closeCodeReviewTab": "Close Code Review tab",
+      "renameTab": "Rename Tab",
+      "renameTabPlaceholder": "Enter a tab name…"
     },
     "footer": {
       "openOnCanvasLabel": "Open on canvas",
@@ -5276,7 +5278,11 @@
         "nextPanel": "Next Panel",
         "maximizeTerminal": "Maximize Terminal",
         "restoreTerminal": "Restore Terminal",
-        "closeTerminal": "Close Terminal"
+        "closeTerminal": "Close Terminal",
+        "renameTitle": "Rename Title",
+        "renamePlaceholder": "Enter a name…",
+        "keepAgentName": "Keep Agent Name",
+        "keepCwd": "Keep CWD"
       },
       "canvasPins": {
         "invalidTerminal": "This terminal cannot be pinned until the session is fully attached.",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -171,7 +171,9 @@
       "closeProjectWikiTab": "关闭项目 Wiki 标签页",
       "codeReview": "代码评审",
       "codeReviewTerminal": "代码评审终端",
-      "closeCodeReviewTab": "关闭代码评审标签页"
+      "closeCodeReviewTab": "关闭代码评审标签页",
+      "renameTab": "重命名标签页",
+      "renameTabPlaceholder": "输入标签页名称…"
     },
     "footer": {
       "openOnCanvasLabel": "在画布中打开",
@@ -5276,7 +5278,11 @@
         "nextPanel": "下一个面板",
         "maximizeTerminal": "最大化终端",
         "restoreTerminal": "还原终端",
-        "closeTerminal": "关闭终端"
+        "closeTerminal": "关闭终端",
+        "renameTitle": "重命名标题",
+        "renamePlaceholder": "输入名称…",
+        "keepAgentName": "保留 Agent 名称",
+        "keepCwd": "保留当前目录"
       },
       "canvasPins": {
         "invalidTerminal": "该终端在会话完全附加之前无法固定到 Canvas。",

--- a/apps/web/src/app-shell/CenterStage.tsx
+++ b/apps/web/src/app-shell/CenterStage.tsx
@@ -136,6 +136,7 @@ const CenterStage: React.FC = () => {
     closeTerminalTab,
     removeTerminal,
     setActiveTerminalTab,
+    setTabCustomTitle,
     primeWorkspace,
     evictWorkspaceRuntime,
   } = useTerminalStore(
@@ -147,6 +148,7 @@ const CenterStage: React.FC = () => {
       closeTerminalTab: state.closeTerminalTab,
       removeTerminal: state.removeTerminal,
       setActiveTerminalTab: state.setActiveTerminalTab,
+      setTabCustomTitle: state.setTabCustomTitle,
       primeWorkspace: state.primeWorkspace,
       evictWorkspaceRuntime: state.evictWorkspaceRuntime,
     }))
@@ -689,6 +691,11 @@ const CenterStage: React.FC = () => {
     runWhenTerminalGridReady(nextTab.id, (grid) => grid.focusActivePane());
   }, [effectiveContextId, createTerminalTab, runWhenTerminalGridReady, setActiveFile, setActiveTerminalTab, setUrlParams]);
 
+  const handleRenameTerminalCenterTab = React.useCallback((tabId: string, title: string) => {
+    if (!effectiveContextId) return;
+    setTabCustomTitle(effectiveContextId, tabId, title);
+  }, [effectiveContextId, setTabCustomTitle]);
+
   const cleanupCanvasTerminalsForClosedTerminal = React.useCallback(async ({
     contextScope,
     pinKeys,
@@ -1113,6 +1120,7 @@ const CenterStage: React.FC = () => {
           handleCloseFile={handleCloseFile}
           handleCloseTerminalCenterTab={handleCloseTerminalCenterTab}
           handleCreateTerminalCenterTab={handleCreateTerminalCenterTab}
+          handleRenameTerminalCenterTab={handleRenameTerminalCenterTab}
           handleTabGroupDragEnd={handleTabGroupDragEnd}
           pinFile={pinFile}
           setActiveFile={setActiveFile}

--- a/apps/web/src/app-shell/CenterStageTabBar.tsx
+++ b/apps/web/src/app-shell/CenterStageTabBar.tsx
@@ -342,8 +342,10 @@ function TerminalExtraTab({
       skipBlurCommitRef.current = false;
       return;
     }
+    // Persist the draft on blur but keep the menu open. Radix menu items steal
+    // focus on pointer-move (item.focus()), so any mouse movement blurs this
+    // input; closing here would collapse the whole menu on the first move.
     onRenameTab(tab.id, renameDraft);
-    setMenuPos(null);
   };
 
   // Focus the rename input only AFTER the submenu has mounted its focus scope

--- a/apps/web/src/app-shell/CenterStageTabBar.tsx
+++ b/apps/web/src/app-shell/CenterStageTabBar.tsx
@@ -314,14 +314,34 @@ function TerminalExtraTab({
   const displayTitle = tab.customTitle || tab.title;
   const [menuPos, setMenuPos] = React.useState<{ x: number; y: number } | null>(null);
   const [renameDraft, setRenameDraft] = React.useState(tab.customTitle ?? "");
+  const skipBlurCommitRef = React.useRef(false);
 
   React.useEffect(() => {
     if (menuPos) {
       setRenameDraft(tab.customTitle ?? "");
+      skipBlurCommitRef.current = false;
     }
   }, [menuPos, tab.customTitle]);
 
   const commitRename = () => {
+    // Prevent the unmount-blur (fired when the menu closes) from committing twice.
+    skipBlurCommitRef.current = true;
+    onRenameTab(tab.id, renameDraft);
+    setMenuPos(null);
+  };
+
+  const cancelRename = () => {
+    // Escape / dismiss: discard the draft and close without committing.
+    skipBlurCommitRef.current = true;
+    setRenameDraft(tab.customTitle ?? "");
+    setMenuPos(null);
+  };
+
+  const handleRenameBlur = () => {
+    if (skipBlurCommitRef.current) {
+      skipBlurCommitRef.current = false;
+      return;
+    }
     onRenameTab(tab.id, renameDraft);
     setMenuPos(null);
   };
@@ -426,9 +446,12 @@ function TerminalExtraTab({
                 if (event.key === "Enter") {
                   event.preventDefault();
                   commitRename();
+                } else if (event.key === "Escape") {
+                  event.preventDefault();
+                  cancelRename();
                 }
               }}
-              onBlur={commitRename}
+              onBlur={handleRenameBlur}
               className="h-8 text-sm"
             />
           </DropdownMenuSubContent>

--- a/apps/web/src/app-shell/CenterStageTabBar.tsx
+++ b/apps/web/src/app-shell/CenterStageTabBar.tsx
@@ -425,6 +425,7 @@ function TerminalExtraTab({
         <button
           type="button"
           aria-hidden
+          tabIndex={-1}
           className="fixed size-0 pointer-events-none"
           style={{ left: menuPos?.x ?? -9999, top: menuPos?.y ?? -9999 }}
         />

--- a/apps/web/src/app-shell/CenterStageTabBar.tsx
+++ b/apps/web/src/app-shell/CenterStageTabBar.tsx
@@ -346,6 +346,15 @@ function TerminalExtraTab({
     setMenuPos(null);
   };
 
+  // Focus the rename input only AFTER the submenu has mounted its focus scope
+  // (which pauses the parent menu's focus trap) and registered as a dismissable
+  // branch. Focusing synchronously via `autoFocus` during mount makes the root
+  // menu treat the focus as an outside interaction and collapse the whole menu.
+  const focusRenameInput = React.useCallback((el: HTMLInputElement | null) => {
+    if (!el) return;
+    requestAnimationFrame(() => el.focus());
+  }, []);
+
   return (
     <>
       <Tooltip>
@@ -417,7 +426,6 @@ function TerminalExtraTab({
 
     <DropdownMenu
       open={!!menuPos}
-      modal={false}
       onOpenChange={(open) => {
         if (!open) setMenuPos(null);
       }}
@@ -439,7 +447,7 @@ function TerminalExtraTab({
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent className="w-64 p-2">
             <Input
-              autoFocus
+              ref={focusRenameInput}
               value={renameDraft}
               placeholder={t("centerStageTabBar.renameTabPlaceholder")}
               onChange={(event) => setRenameDraft(event.target.value)}

--- a/apps/web/src/app-shell/CenterStageTabBar.tsx
+++ b/apps/web/src/app-shell/CenterStageTabBar.tsx
@@ -2,6 +2,13 @@
 
 import React from "react";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+  Input,
   TabsTab,
   Tooltip,
   TooltipContent,
@@ -12,6 +19,7 @@ import {
 import {
   BookOpen,
   LoaderCircle,
+  Pencil,
   Plus,
   RotateCw,
   SquareTerminal as TerminalIcon,
@@ -53,7 +61,7 @@ interface CenterStageTabBarProps {
   tabGroupDndSensors: React.ComponentProps<typeof CenterStageTabGroupPopover>["sensors"];
   tabGroupPopoverOpen: boolean;
   termTabPlusHoveredTabId: string | null;
-  visibleTerminalTabs: Array<{ id: string; title: string; closable: boolean }>;
+  visibleTerminalTabs: Array<{ id: string; title: string; closable: boolean; customTitle?: string }>;
   wikiCenterEligible: boolean;
   wikiRefreshing: boolean;
   handleCenterStageTabChange: (value: string) => void;
@@ -61,6 +69,7 @@ interface CenterStageTabBarProps {
   handleCloseFile: (file: OpenFile) => void;
   handleCloseTerminalCenterTab: (tabId: string) => void;
   handleCreateTerminalCenterTab: () => void;
+  handleRenameTerminalCenterTab: (tabId: string, title: string) => void;
   handleTabGroupDragEnd: (event: DragEndEvent) => void;
   pinFile: (path: string, workspaceId?: string) => void;
   setActiveFile: (path: string | null, workspaceId?: string) => void;
@@ -93,6 +102,7 @@ export function CenterStageTabBar({
   handleCloseFile,
   handleCloseTerminalCenterTab,
   handleCreateTerminalCenterTab,
+  handleRenameTerminalCenterTab,
   handleTabGroupDragEnd,
   pinFile,
   setActiveFile,
@@ -185,10 +195,11 @@ export function CenterStageTabBar({
               hoveredTabId={termTabPlusHoveredTabId}
               shortcutDigit={index + 1}
               newTerminalTabLabel={newTerminalTabLabel}
-              closeAriaLabel={t("centerStageTabBar.closeTab", { tab: tab.title })}
+              closeAriaLabel={t("centerStageTabBar.closeTab", { tab: tab.customTitle || tab.title })}
               tab={tab}
               onClose={handleCloseTerminalCenterTab}
               onCreateTab={handleCreateTerminalCenterTab}
+              onRenameTab={handleRenameTerminalCenterTab}
               setHoveredTabId={setTermTabPlusHoveredTabId}
             />
           ))}
@@ -283,6 +294,7 @@ function TerminalExtraTab({
   tab,
   onClose,
   onCreateTab,
+  onRenameTab,
   setHoveredTabId,
 }: {
   activeValue: string;
@@ -292,16 +304,38 @@ function TerminalExtraTab({
   shortcutDigit: number;
   newTerminalTabLabel: string;
   closeAriaLabel: string;
-  tab: { id: string; title: string };
+  tab: { id: string; title: string; customTitle?: string };
   onClose: (tabId: string) => void;
   onCreateTab: () => void;
+  onRenameTab: (tabId: string, title: string) => void;
   setHoveredTabId: React.Dispatch<React.SetStateAction<string | null>>;
 }) {
+  const t = useTranslations("appShell");
+  const displayTitle = tab.customTitle || tab.title;
+  const [menuPos, setMenuPos] = React.useState<{ x: number; y: number } | null>(null);
+  const [renameDraft, setRenameDraft] = React.useState(tab.customTitle ?? "");
+
+  React.useEffect(() => {
+    if (menuPos) {
+      setRenameDraft(tab.customTitle ?? "");
+    }
+  }, [menuPos, tab.customTitle]);
+
+  const commitRename = () => {
+    onRenameTab(tab.id, renameDraft);
+    setMenuPos(null);
+  };
+
   return (
+    <>
       <Tooltip>
         <TooltipTrigger asChild>
           <TabsTab
           value={tab.id}
+          onContextMenu={(event) => {
+            event.preventDefault();
+            setMenuPos({ x: event.clientX, y: event.clientY });
+          }}
           className="group/term-tab relative !h-full pl-4 pr-4 data-active:bg-muted/40 data-active:text-foreground text-muted-foreground hover:bg-muted/50 transition-colors gap-2 grow-0 shrink-0 justify-start rounded-none !border-0"
         >
           <span className="relative flex size-4 shrink-0 items-center justify-center">
@@ -322,7 +356,7 @@ function TerminalExtraTab({
             />
           ) : null}
           </span>
-          <span className="text-[13px] font-medium whitespace-nowrap">{tab.title}</span>
+          <span className="text-[13px] font-medium whitespace-nowrap">{displayTitle}</span>
           <TerminalTabAgentIndicatorWithPanes contextId={effectiveContextId} tabId={tab.id} />
           <div
             className={cn(
@@ -353,13 +387,55 @@ function TerminalExtraTab({
             </>
           ) : (
             <>
-              <span>{tab.title}</span>
+              <span>{displayTitle}</span>
               {hasShortcut ? <ShortcutHint digit={shortcutDigit} /> : null}
             </>
           )}
         </div>
       </TooltipContent>
     </Tooltip>
+
+    <DropdownMenu
+      open={!!menuPos}
+      onOpenChange={(open) => {
+        if (!open) setMenuPos(null);
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-hidden
+          className="fixed size-0 pointer-events-none"
+          style={{ left: menuPos?.x ?? -9999, top: menuPos?.y ?? -9999 }}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" sideOffset={4} className="w-56">
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger className="cursor-pointer">
+            <Pencil className="size-4 mr-2 text-muted-foreground" />
+            <span>{t("centerStageTabBar.renameTab")}</span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-64 p-2">
+            <Input
+              autoFocus
+              value={renameDraft}
+              placeholder={t("centerStageTabBar.renameTabPlaceholder")}
+              onChange={(event) => setRenameDraft(event.target.value)}
+              onKeyDown={(event) => {
+                event.stopPropagation();
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  commitRename();
+                }
+              }}
+              onBlur={commitRename}
+              className="h-8 text-sm"
+            />
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      </DropdownMenuContent>
+    </DropdownMenu>
+    </>
   );
 }
 

--- a/apps/web/src/app-shell/CenterStageTabBar.tsx
+++ b/apps/web/src/app-shell/CenterStageTabBar.tsx
@@ -417,6 +417,7 @@ function TerminalExtraTab({
 
     <DropdownMenu
       open={!!menuPos}
+      modal={false}
       onOpenChange={(open) => {
         if (!open) setMenuPos(null);
       }}

--- a/apps/web/src/app-shell/sidebar/WorkspaceContent.tsx
+++ b/apps/web/src/app-shell/sidebar/WorkspaceContent.tsx
@@ -384,6 +384,7 @@ export const WorkspaceContent = React.memo<WorkspaceContentProps>(function Works
 
   const shortName = getWorkspaceShortName(workspace.name);
   const rawDisplayName = workspace.displayName?.trim() || "";
+  const primaryLabel = rawDisplayName || shortName;
   const timeAgo = formatRelativeTime(workspace.lastVisitedAt ?? workspace.createdAt, locale);
 
   React.useEffect(() => {
@@ -481,7 +482,7 @@ export const WorkspaceContent = React.memo<WorkspaceContentProps>(function Works
               </div>
               <div className="flex items-center min-w-0 gap-1.5 pl-5">
                 <span className="text-[13px] font-medium truncate">
-                  {shortName}
+                  {primaryLabel}
                   {showProjectName && projectName && (
                     <span className="ml-1 font-normal text-muted-foreground/50">/ {projectName}</span>
                   )}

--- a/apps/web/src/app-shell/sidebar/WorkspaceContent.tsx
+++ b/apps/web/src/app-shell/sidebar/WorkspaceContent.tsx
@@ -210,14 +210,14 @@ export const WorkspaceContent = React.memo<WorkspaceContentProps>(function Works
   const scheduleInfoPopoverClose = React.useCallback(() => {
     cancelInfoPopoverClose();
     infoPopoverTimerRef.current = setTimeout(() => {
-      if (isStatusMenuOpen || isPriorityMenuOpen || isLabelPopoverOpen) {
+      if (isStatusMenuOpen || isPriorityMenuOpen || isLabelPopoverOpen || isEditingName) {
         infoPopoverTimerRef.current = null;
         return;
       }
       setIsInfoPopoverOpen(false);
       infoPopoverTimerRef.current = null;
     }, 150);
-  }, [cancelInfoPopoverClose, isLabelPopoverOpen, isPriorityMenuOpen, isStatusMenuOpen]);
+  }, [cancelInfoPopoverClose, isEditingName, isLabelPopoverOpen, isPriorityMenuOpen, isStatusMenuOpen]);
 
   React.useEffect(() => {
     return () => {
@@ -616,7 +616,14 @@ export const WorkspaceContent = React.memo<WorkspaceContentProps>(function Works
                           <Pencil className="size-2.5" />
                         </button>
                       </PopoverTrigger>
-                      <PopoverContent data-workspace-popover-surface="true" side="right" align="start" className="w-56 p-2">
+                      <PopoverContent
+                        data-workspace-popover-surface="true"
+                        side="right"
+                        align="start"
+                        className="w-56 p-2"
+                        onMouseEnter={cancelInfoPopoverClose}
+                        onMouseLeave={scheduleInfoPopoverClose}
+                      >
                         <div className="flex items-center gap-2">
                           <Input
                             value={editableName}

--- a/apps/web/src/app-shell/sidebar/WorkspaceContent.tsx
+++ b/apps/web/src/app-shell/sidebar/WorkspaceContent.tsx
@@ -399,7 +399,9 @@ export const WorkspaceContent = React.memo<WorkspaceContentProps>(function Works
 
   const handleSaveName = React.useCallback(async () => {
     const nextName = editableName.trim();
-    if (!nextName || nextName === rawDisplayName || !onUpdateName) {
+    // An empty value is allowed: it clears the display name (i.e. "not set").
+    // Only skip when nothing changed or there is no handler.
+    if (nextName === rawDisplayName || !onUpdateName) {
       setEditableName(rawDisplayName);
       setIsEditingName(false);
       return;
@@ -642,7 +644,7 @@ export const WorkspaceContent = React.memo<WorkspaceContentProps>(function Works
                           <Button
                             size="sm"
                             className="h-7 px-2 text-xs"
-                            disabled={isSavingName || !editableName.trim()}
+                            disabled={isSavingName || editableName.trim() === rawDisplayName}
                             onClick={() => void handleSaveName()}
                           >
                             {t("common.save")}

--- a/apps/web/src/features/terminal/components/TerminalGrid.tsx
+++ b/apps/web/src/features/terminal/components/TerminalGrid.tsx
@@ -106,6 +106,8 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
     setDynamicTitle,
     setPaneAgent,
     markPaneAttached,
+    setPaneCustomLabel,
+    setPaneTitleFlags,
     getProjectWikiPanes,
     getProjectWikiLayout,
     setProjectWikiLayout,
@@ -725,6 +727,49 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
     : null;
   const isFocusedPanePinned = focusedPanePinKey ? pinnedPaneKeys.has(focusedPanePinKey) : false;
 
+  // Custom naming (Rename Title / Keep Agent Name / Keep CWD) applies only to the
+  // main workspace terminal grid — not the Project Wiki / Code Review scopes.
+  const isDefaultScope = !isCodeReview && !isProjectWiki;
+  const canRenameFocusedPane = isDefaultScope && !!focusedPane;
+
+  const handleRenamePaneTitle = useCallback(
+    (value: string) => {
+      setContextMenu(null);
+      const focusedPaneId = getFocusedPaneId();
+      if (!focusedPaneId || !isDefaultScope) return;
+      setPaneCustomLabel(workspaceId, focusedPaneId, value, terminalTabId ?? FIXED_TERMINAL_TAB_VALUE);
+    },
+    [getFocusedPaneId, isDefaultScope, setPaneCustomLabel, workspaceId, terminalTabId],
+  );
+
+  const handleToggleKeepAgentName = useCallback(
+    (next: boolean) => {
+      const focusedPaneId = getFocusedPaneId();
+      if (!focusedPaneId || !isDefaultScope) return;
+      setPaneTitleFlags(
+        workspaceId,
+        focusedPaneId,
+        { keepAgentName: next },
+        terminalTabId ?? FIXED_TERMINAL_TAB_VALUE,
+      );
+    },
+    [getFocusedPaneId, isDefaultScope, setPaneTitleFlags, workspaceId, terminalTabId],
+  );
+
+  const handleToggleKeepCwd = useCallback(
+    (next: boolean) => {
+      const focusedPaneId = getFocusedPaneId();
+      if (!focusedPaneId || !isDefaultScope) return;
+      setPaneTitleFlags(
+        workspaceId,
+        focusedPaneId,
+        { keepCwd: next },
+        terminalTabId ?? FIXED_TERMINAL_TAB_VALUE,
+      );
+    },
+    [getFocusedPaneId, isDefaultScope, setPaneTitleFlags, workspaceId, terminalTabId],
+  );
+
   const renderTile = useCallback((id: string, path: MosaicPath) => {
     const pane = panes[id];
     if (!pane) return <div className="p-4 text-xs text-muted-foreground">Pane not found: {id}</div>;
@@ -885,6 +930,13 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
       quickOpenAgents={quickOpenAgents}
       isFocusedPanePinned={isFocusedPanePinned}
       isAnyPaneMaximized={!!maximizedId}
+      canRenamePane={canRenameFocusedPane}
+      paneCustomLabel={focusedPane?.customLabel ?? ""}
+      paneKeepAgentName={focusedPane?.keepAgentName ?? true}
+      paneKeepCwd={focusedPane?.keepCwd ?? true}
+      onRenamePaneTitle={handleRenamePaneTitle}
+      onToggleKeepAgentName={handleToggleKeepAgentName}
+      onToggleKeepCwd={handleToggleKeepCwd}
       onOpenChange={(open) => {
         if (!open) {
           setContextMenu(null);

--- a/apps/web/src/features/terminal/components/TerminalGrid.tsx
+++ b/apps/web/src/features/terminal/components/TerminalGrid.tsx
@@ -734,7 +734,6 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
 
   const handleRenamePaneTitle = useCallback(
     (value: string) => {
-      setContextMenu(null);
       const focusedPaneId = getFocusedPaneId();
       if (!focusedPaneId || !isDefaultScope) return;
       setPaneCustomLabel(workspaceId, focusedPaneId, value, terminalTabId ?? FIXED_TERMINAL_TAB_VALUE);

--- a/apps/web/src/features/terminal/components/TerminalGridContextMenu.tsx
+++ b/apps/web/src/features/terminal/components/TerminalGridContextMenu.tsx
@@ -98,13 +98,33 @@ export function TerminalGridContextMenu({
   const [renameDraft, setRenameDraft] = React.useState(paneCustomLabel);
   const hasCustomName = paneCustomLabel.trim().length > 0;
 
+  const skipBlurCommitRef = React.useRef(false);
+
   React.useEffect(() => {
     if (contextMenu) {
       setRenameDraft(paneCustomLabel);
+      skipBlurCommitRef.current = false;
     }
   }, [contextMenu, paneCustomLabel]);
 
   const commitRename = () => {
+    // Prevent the unmount-blur (fired when the menu closes) from committing twice.
+    skipBlurCommitRef.current = true;
+    onRenamePaneTitle(renameDraft);
+  };
+
+  const cancelRename = () => {
+    // Escape / dismiss: discard the draft and close without committing.
+    skipBlurCommitRef.current = true;
+    setRenameDraft(paneCustomLabel);
+    onOpenChange(false);
+  };
+
+  const handleRenameBlur = () => {
+    if (skipBlurCommitRef.current) {
+      skipBlurCommitRef.current = false;
+      return;
+    }
     onRenamePaneTitle(renameDraft);
   };
 
@@ -220,9 +240,12 @@ export function TerminalGridContextMenu({
                     if (event.key === "Enter") {
                       event.preventDefault();
                       commitRename();
+                    } else if (event.key === "Escape") {
+                      event.preventDefault();
+                      cancelRename();
                     }
                   }}
-                  onBlur={commitRename}
+                  onBlur={handleRenameBlur}
                   className="h-8 text-sm"
                 />
               </DropdownMenuSubContent>

--- a/apps/web/src/features/terminal/components/TerminalGridContextMenu.tsx
+++ b/apps/web/src/features/terminal/components/TerminalGridContextMenu.tsx
@@ -3,8 +3,8 @@
 import React from "react";
 import { useTranslations } from "next-intl";
 import {
+  Checkbox,
   DropdownMenu,
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
@@ -96,7 +96,10 @@ export function TerminalGridContextMenu({
 
   // Local draft for the rename input; reset whenever the menu (re)opens.
   const [renameDraft, setRenameDraft] = React.useState(paneCustomLabel);
-  const hasCustomName = paneCustomLabel.trim().length > 0;
+  // The Keep toggles are meaningful as soon as there is a name to keep — either a
+  // committed label or a non-empty draft — so they light up while typing.
+  const hasCustomName =
+    renameDraft.trim().length > 0 || paneCustomLabel.trim().length > 0;
 
   const skipBlurCommitRef = React.useRef(false);
 
@@ -111,6 +114,8 @@ export function TerminalGridContextMenu({
     // Prevent the unmount-blur (fired when the menu closes) from committing twice.
     skipBlurCommitRef.current = true;
     onRenamePaneTitle(renameDraft);
+    // Enter confirms and closes the whole menu.
+    onOpenChange(false);
   };
 
   const cancelRename = () => {
@@ -125,6 +130,8 @@ export function TerminalGridContextMenu({
       skipBlurCommitRef.current = false;
       return;
     }
+    // Blur (e.g. clicking a Keep toggle) persists the draft but keeps the menu
+    // open so the user can keep adjusting toggles in the same panel.
     onRenamePaneTitle(renameDraft);
   };
 
@@ -196,6 +203,7 @@ export function TerminalGridContextMenu({
     <DropdownMenu
       open={!!contextMenu}
       onOpenChange={onOpenChange}
+      modal={false}
     >
       <DropdownMenuTrigger asChild>
         <button
@@ -228,7 +236,7 @@ export function TerminalGridContextMenu({
                 <Pencil className="size-4 mr-2 text-muted-foreground" />
                 <span>{t("contextMenu.renameTitle")}</span>
               </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent className="w-64 p-2">
+              <DropdownMenuSubContent className="w-64 space-y-1 p-2">
                 <Input
                   autoFocus
                   value={renameDraft}
@@ -248,28 +256,60 @@ export function TerminalGridContextMenu({
                   onBlur={handleRenameBlur}
                   className="h-8 text-sm"
                 />
+                <div
+                  role="button"
+                  tabIndex={-1}
+                  aria-disabled={!hasCustomName}
+                  onClick={() => {
+                    if (!hasCustomName) return;
+                    onToggleKeepAgentName(!paneKeepAgentName);
+                  }}
+                  className={cn(
+                    "flex items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors",
+                    hasCustomName
+                      ? "cursor-pointer hover:bg-accent"
+                      : "cursor-not-allowed opacity-50",
+                  )}
+                >
+                  <span className="flex items-center gap-2">
+                    <Bot className="size-4 text-muted-foreground" />
+                    <span>{t("contextMenu.keepAgentName")}</span>
+                  </span>
+                  <Checkbox
+                    checked={paneKeepAgentName}
+                    disabled={!hasCustomName}
+                    tabIndex={-1}
+                    className="pointer-events-none"
+                  />
+                </div>
+                <div
+                  role="button"
+                  tabIndex={-1}
+                  aria-disabled={!hasCustomName}
+                  onClick={() => {
+                    if (!hasCustomName) return;
+                    onToggleKeepCwd(!paneKeepCwd);
+                  }}
+                  className={cn(
+                    "flex items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors",
+                    hasCustomName
+                      ? "cursor-pointer hover:bg-accent"
+                      : "cursor-not-allowed opacity-50",
+                  )}
+                >
+                  <span className="flex items-center gap-2">
+                    <FolderTree className="size-4 text-muted-foreground" />
+                    <span>{t("contextMenu.keepCwd")}</span>
+                  </span>
+                  <Checkbox
+                    checked={paneKeepCwd}
+                    disabled={!hasCustomName}
+                    tabIndex={-1}
+                    className="pointer-events-none"
+                  />
+                </div>
               </DropdownMenuSubContent>
             </DropdownMenuSub>
-            <DropdownMenuCheckboxItem
-              checked={paneKeepAgentName}
-              disabled={!hasCustomName}
-              onSelect={(event) => event.preventDefault()}
-              onCheckedChange={(checked) => onToggleKeepAgentName(checked === true)}
-              className="cursor-pointer"
-            >
-              <Bot className="size-4 mr-2 text-muted-foreground" />
-              <span>{t("contextMenu.keepAgentName")}</span>
-            </DropdownMenuCheckboxItem>
-            <DropdownMenuCheckboxItem
-              checked={paneKeepCwd}
-              disabled={!hasCustomName}
-              onSelect={(event) => event.preventDefault()}
-              onCheckedChange={(checked) => onToggleKeepCwd(checked === true)}
-              className="cursor-pointer"
-            >
-              <FolderTree className="size-4 mr-2 text-muted-foreground" />
-              <span>{t("contextMenu.keepCwd")}</span>
-            </DropdownMenuCheckboxItem>
           </>
         )}
         <DropdownMenuItem

--- a/apps/web/src/features/terminal/components/TerminalGridContextMenu.tsx
+++ b/apps/web/src/features/terminal/components/TerminalGridContextMenu.tsx
@@ -135,6 +135,15 @@ export function TerminalGridContextMenu({
     onRenamePaneTitle(renameDraft);
   };
 
+  // Focus the rename input only AFTER the submenu has mounted its focus scope
+  // (which pauses the parent menu's focus trap) and registered as a dismissable
+  // branch. Focusing synchronously via `autoFocus` during mount makes the root
+  // menu treat the focus as an outside interaction and collapse the whole menu.
+  const focusRenameInput = React.useCallback((el: HTMLInputElement | null) => {
+    if (!el) return;
+    requestAnimationFrame(() => el.focus());
+  }, []);
+
   const renderSplitMenuItem = (
     direction: "row" | "column",
     label: string,
@@ -203,7 +212,6 @@ export function TerminalGridContextMenu({
     <DropdownMenu
       open={!!contextMenu}
       onOpenChange={onOpenChange}
-      modal={false}
     >
       <DropdownMenuTrigger asChild>
         <button
@@ -238,7 +246,7 @@ export function TerminalGridContextMenu({
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent className="w-64 space-y-1 p-2">
                 <Input
-                  autoFocus
+                  ref={focusRenameInput}
                   value={renameDraft}
                   placeholder={t("contextMenu.renamePlaceholder")}
                   onChange={(event) => setRenameDraft(event.target.value)}

--- a/apps/web/src/features/terminal/components/TerminalGridContextMenu.tsx
+++ b/apps/web/src/features/terminal/components/TerminalGridContextMenu.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { useTranslations } from "next-intl";
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
@@ -12,6 +13,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
+  Input,
   cn,
 } from "@workspace/ui";
 import {
@@ -20,8 +22,10 @@ import {
   Bot,
   ClipboardPaste,
   Columns,
+  FolderTree,
   Maximize,
   Minimize,
+  Pencil,
   Pin,
   Rows,
   SquareTerminal,
@@ -50,6 +54,14 @@ type TerminalGridContextMenuProps = {
   }>;
   isFocusedPanePinned: boolean;
   isAnyPaneMaximized: boolean;
+  /** Whether the focused pane supports custom naming (main workspace grid only). */
+  canRenamePane: boolean;
+  paneCustomLabel: string;
+  paneKeepAgentName: boolean;
+  paneKeepCwd: boolean;
+  onRenamePaneTitle: (value: string) => void;
+  onToggleKeepAgentName: (next: boolean) => void;
+  onToggleKeepCwd: (next: boolean) => void;
   onOpenChange: (open: boolean) => void;
   onAction: (action: TerminalGridContextMenuAction) => void;
   onContextSplitSubmenuEnter: (key: "row" | "column") => void;
@@ -67,6 +79,13 @@ export function TerminalGridContextMenu({
   quickOpenAgents,
   isFocusedPanePinned,
   isAnyPaneMaximized,
+  canRenamePane,
+  paneCustomLabel,
+  paneKeepAgentName,
+  paneKeepCwd,
+  onRenamePaneTitle,
+  onToggleKeepAgentName,
+  onToggleKeepCwd,
   onOpenChange,
   onAction,
   onContextSplitSubmenuEnter,
@@ -74,6 +93,20 @@ export function TerminalGridContextMenu({
   onContextSplitWithAgent,
 }: TerminalGridContextMenuProps) {
   const t = useTranslations("Terminal.chrome");
+
+  // Local draft for the rename input; reset whenever the menu (re)opens.
+  const [renameDraft, setRenameDraft] = React.useState(paneCustomLabel);
+  const hasCustomName = paneCustomLabel.trim().length > 0;
+
+  React.useEffect(() => {
+    if (contextMenu) {
+      setRenameDraft(paneCustomLabel);
+    }
+  }, [contextMenu, paneCustomLabel]);
+
+  const commitRename = () => {
+    onRenamePaneTitle(renameDraft);
+  };
 
   const renderSplitMenuItem = (
     direction: "row" | "column",
@@ -167,6 +200,55 @@ export function TerminalGridContextMenu({
           <span>{t("contextMenu.paste")}</span>
           <DropdownMenuShortcut>⌘V</DropdownMenuShortcut>
         </DropdownMenuItem>
+        {canRenamePane && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger className="cursor-pointer">
+                <Pencil className="size-4 mr-2 text-muted-foreground" />
+                <span>{t("contextMenu.renameTitle")}</span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="w-64 p-2">
+                <Input
+                  autoFocus
+                  value={renameDraft}
+                  placeholder={t("contextMenu.renamePlaceholder")}
+                  onChange={(event) => setRenameDraft(event.target.value)}
+                  onKeyDown={(event) => {
+                    // Keep keystrokes inside the input (avoid menu typeahead / navigation).
+                    event.stopPropagation();
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      commitRename();
+                    }
+                  }}
+                  onBlur={commitRename}
+                  className="h-8 text-sm"
+                />
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+            <DropdownMenuCheckboxItem
+              checked={paneKeepAgentName}
+              disabled={!hasCustomName}
+              onSelect={(event) => event.preventDefault()}
+              onCheckedChange={(checked) => onToggleKeepAgentName(checked === true)}
+              className="cursor-pointer"
+            >
+              <Bot className="size-4 mr-2 text-muted-foreground" />
+              <span>{t("contextMenu.keepAgentName")}</span>
+            </DropdownMenuCheckboxItem>
+            <DropdownMenuCheckboxItem
+              checked={paneKeepCwd}
+              disabled={!hasCustomName}
+              onSelect={(event) => event.preventDefault()}
+              onCheckedChange={(checked) => onToggleKeepCwd(checked === true)}
+              className="cursor-pointer"
+            >
+              <FolderTree className="size-4 mr-2 text-muted-foreground" />
+              <span>{t("contextMenu.keepCwd")}</span>
+            </DropdownMenuCheckboxItem>
+          </>
+        )}
         <DropdownMenuItem
           onClick={() => onAction("pin-to-canvas")}
           className={cn("cursor-pointer", isFocusedPanePinned && "bg-accent text-primary")}

--- a/apps/web/src/features/terminal/components/terminal-mosaic-workspace-pane-window.tsx
+++ b/apps/web/src/features/terminal/components/terminal-mosaic-workspace-pane-window.tsx
@@ -146,6 +146,9 @@ export function TerminalMosaicWorkspacePaneWindow(props: TerminalMosaicWorkspace
     baseTitle: pane.label,
     configuredAgents,
     storeWrite,
+    customLabel: pane.customLabel,
+    keepAgentName: pane.keepAgentName,
+    keepCwd: pane.keepCwd,
   });
   const [isTerminalReady, setIsTerminalReady] = React.useState(false);
 

--- a/apps/web/src/features/terminal/hooks/use-terminal-toolbar-title.ts
+++ b/apps/web/src/features/terminal/hooks/use-terminal-toolbar-title.ts
@@ -10,6 +10,7 @@ import {
   FIXED_TERMINAL_TAB_VALUE,
 } from "@/features/terminal/store/use-terminal-store";
 import { getTerminalDisplayMeta, resolveAgentForTitle } from "@/features/terminal/components/terminal-title";
+import { isPathLikeTitle, shortenPath } from "@atmos/shared/terminal";
 import type { TerminalPaneAgent } from "@/features/terminal/types/index";
 
 /** Where OSC title updates should be persisted (center mosaic pane vs canvas pin). */
@@ -28,9 +29,12 @@ export function useTerminalToolbarTitle(options: {
   configuredAgents: TerminalPaneAgent[];
   pinnedAgent?: TerminalPaneAgent;
   storeWrite: TerminalToolbarStoreWrite;
+  customLabel?: string;
+  keepAgentName?: boolean;
+  keepCwd?: boolean;
 }) {
   const [localOscTitle, setLocalOscTitle] = useState<string | undefined>();
-  const { storeWrite, configuredAgents, baseTitle, pinnedAgent } = options;
+  const { storeWrite, configuredAgents, baseTitle, pinnedAgent, customLabel, keepAgentName, keepCwd } = options;
 
   const storeLive = useTerminalStore(
     useShallow((s) => {
@@ -101,13 +105,47 @@ export function useTerminalToolbarTitle(options: {
         (agent) => agent.label.trim().toLowerCase() === baseTitle.trim().toLowerCase(),
       );
     const mergedAgent = storeLive.agent ?? shapeAgent;
-    return getTerminalDisplayMeta({
+    const auto = getTerminalDisplayMeta({
       baseTitle,
       dynamicTitle: mergedDynamic,
       configuredAgents,
       agent: mergedAgent,
     });
-  }, [baseTitle, configuredAgents, pinnedAgent, storeLive.agent, storeLive.dynamicTitle, localOscTitle]);
+
+    const custom = customLabel?.trim();
+    if (!custom) {
+      return auto;
+    }
+
+    // Flags default to on: `undefined` is treated as `true`.
+    const wantAgent = keepAgentName !== false;
+    const wantCwd = keepCwd !== false;
+
+    const showAgent = wantAgent && !!auto.toolbarAgent;
+    // Agent wins over CWD: only show CWD when no agent suffix is shown (mutually exclusive).
+    const cwdSuffix =
+      !showAgent && wantCwd && isPathLikeTitle(mergedDynamic) ? shortenPath(mergedDynamic!) : undefined;
+
+    const displayTitle = [
+      custom,
+      showAgent ? auto.toolbarAgent!.label : undefined,
+      cwdSuffix,
+    ]
+      .filter(Boolean)
+      .join("  ");
+
+    return { displayTitle, toolbarAgent: showAgent ? auto.toolbarAgent : undefined };
+  }, [
+    baseTitle,
+    configuredAgents,
+    pinnedAgent,
+    storeLive.agent,
+    storeLive.dynamicTitle,
+    localOscTitle,
+    customLabel,
+    keepAgentName,
+    keepCwd,
+  ]);
 
   return { displayTitle, toolbarAgent, onTitleChange };
 }

--- a/apps/web/src/features/terminal/hooks/use-terminal-toolbar-title.ts
+++ b/apps/web/src/features/terminal/hooks/use-terminal-toolbar-title.ts
@@ -137,7 +137,7 @@ export function useTerminalToolbarTitle(options: {
       cwdSuffix,
     ]
       .filter(Boolean)
-      .join("  ");
+      .join(" · ");
 
     return { displayTitle, toolbarAgent: showAgent ? auto.toolbarAgent : undefined };
   }, [

--- a/apps/web/src/features/terminal/hooks/use-terminal-toolbar-title.ts
+++ b/apps/web/src/features/terminal/hooks/use-terminal-toolbar-title.ts
@@ -121,14 +121,13 @@ export function useTerminalToolbarTitle(options: {
     const wantAgent = keepAgentName !== false;
     const wantCwd = keepCwd !== false;
 
-    // Prefer the agent detected from the current title, but fall back to the
-    // persisted pane agent (`mergedAgent` — the same source as agentForSubmit).
-    // Once a pane is running an agent we keep showing the agent name even after
-    // the agent changes its OSC title to a path/status, matching the pre-custom
-    // behavior where entering an agent hides the CWD and shows only the agent.
-    const activeAgent = auto.toolbarAgent ?? mergedAgent;
-    const showAgent = wantAgent && !!activeAgent;
-    // Agent wins over CWD: only show a suffix when no agent suffix is shown (mutually exclusive).
+    // The suffix after the custom label mirrors the default (non-custom)
+    // display exactly; the flags only decide whether it is kept. Agent
+    // detection uses `auto.toolbarAgent` (derived from the *current* OSC
+    // title), so entering an agent shows the agent name and leaving it falls
+    // back to the CWD — identical to the pre-custom behavior.
+    const showAgent = wantAgent && !!auto.toolbarAgent;
+    // Agent wins over CWD: only show a CWD suffix when no agent is shown.
     // "Keep CWD" preserves the dynamic CWD/command title — shorten paths, keep commands as-is.
     const cwdSuffix =
       !showAgent && wantCwd && mergedDynamic
@@ -139,13 +138,13 @@ export function useTerminalToolbarTitle(options: {
 
     const displayTitle = [
       custom,
-      showAgent ? activeAgent!.label : undefined,
+      showAgent ? auto.toolbarAgent!.label : undefined,
       cwdSuffix,
     ]
       .filter(Boolean)
       .join(" · ");
 
-    return { displayTitle, toolbarAgent: showAgent ? activeAgent : undefined };
+    return { displayTitle, toolbarAgent: showAgent ? auto.toolbarAgent : undefined };
   }, [
     baseTitle,
     configuredAgents,

--- a/apps/web/src/features/terminal/hooks/use-terminal-toolbar-title.ts
+++ b/apps/web/src/features/terminal/hooks/use-terminal-toolbar-title.ts
@@ -121,7 +121,13 @@ export function useTerminalToolbarTitle(options: {
     const wantAgent = keepAgentName !== false;
     const wantCwd = keepCwd !== false;
 
-    const showAgent = wantAgent && !!auto.toolbarAgent;
+    // Prefer the agent detected from the current title, but fall back to the
+    // persisted pane agent (`mergedAgent` — the same source as agentForSubmit).
+    // Once a pane is running an agent we keep showing the agent name even after
+    // the agent changes its OSC title to a path/status, matching the pre-custom
+    // behavior where entering an agent hides the CWD and shows only the agent.
+    const activeAgent = auto.toolbarAgent ?? mergedAgent;
+    const showAgent = wantAgent && !!activeAgent;
     // Agent wins over CWD: only show a suffix when no agent suffix is shown (mutually exclusive).
     // "Keep CWD" preserves the dynamic CWD/command title — shorten paths, keep commands as-is.
     const cwdSuffix =
@@ -133,13 +139,13 @@ export function useTerminalToolbarTitle(options: {
 
     const displayTitle = [
       custom,
-      showAgent ? auto.toolbarAgent!.label : undefined,
+      showAgent ? activeAgent!.label : undefined,
       cwdSuffix,
     ]
       .filter(Boolean)
       .join(" · ");
 
-    return { displayTitle, toolbarAgent: showAgent ? auto.toolbarAgent : undefined };
+    return { displayTitle, toolbarAgent: showAgent ? activeAgent : undefined };
   }, [
     baseTitle,
     configuredAgents,

--- a/apps/web/src/features/terminal/hooks/use-terminal-toolbar-title.ts
+++ b/apps/web/src/features/terminal/hooks/use-terminal-toolbar-title.ts
@@ -122,9 +122,14 @@ export function useTerminalToolbarTitle(options: {
     const wantCwd = keepCwd !== false;
 
     const showAgent = wantAgent && !!auto.toolbarAgent;
-    // Agent wins over CWD: only show CWD when no agent suffix is shown (mutually exclusive).
+    // Agent wins over CWD: only show a suffix when no agent suffix is shown (mutually exclusive).
+    // "Keep CWD" preserves the dynamic CWD/command title — shorten paths, keep commands as-is.
     const cwdSuffix =
-      !showAgent && wantCwd && isPathLikeTitle(mergedDynamic) ? shortenPath(mergedDynamic!) : undefined;
+      !showAgent && wantCwd && mergedDynamic
+        ? isPathLikeTitle(mergedDynamic)
+          ? shortenPath(mergedDynamic)
+          : mergedDynamic
+        : undefined;
 
     const displayTitle = [
       custom,

--- a/apps/web/src/features/terminal/lib/terminal-layout-document.ts
+++ b/apps/web/src/features/terminal/lib/terminal-layout-document.ts
@@ -15,6 +15,8 @@ export interface PersistedTerminalTabDocument {
   layout: MosaicNode<string> | null;
   maximizedTerminalId?: string | null;
   panes: Record<string, PersistedTerminalPane>;
+  /** User custom tab name (display-only override). Persisted. */
+  customTitle?: string;
 }
 
 export interface PersistedTerminalWorkspaceLayoutDocument {
@@ -44,7 +46,7 @@ type LegacyPersistedTerminalWorkspaceLayout = {
 
 type NormalizableTerminalTab =
   & LegacyTerminalTabLike
-  & Partial<Pick<PersistedTerminalTabDocument, "layout" | "maximizedTerminalId" | "panes">>;
+  & Partial<Pick<PersistedTerminalTabDocument, "layout" | "maximizedTerminalId" | "panes" | "customTitle">>;
 
 function isPersistedTerminalWorkspaceLayout(
   value: unknown,

--- a/apps/web/src/features/terminal/store/terminal-store-helpers.ts
+++ b/apps/web/src/features/terminal/store/terminal-store-helpers.ts
@@ -43,6 +43,12 @@ export interface TerminalCenterTab {
   id: string;
   title: string;
   closable: boolean;
+  /**
+   * User custom tab name. Display-only override with top priority.
+   * Empty/undefined means no override (fall back to `title`). Persisted.
+   * `title` remains the auto name used for uniqueness/dedup.
+   */
+  customTitle?: string;
 }
 
 type TerminalLookupState = {
@@ -312,6 +318,17 @@ export function getAllDefaultPanesForWorkspace(
 
     return acc;
   }, {});
+}
+
+export const CUSTOM_NAME_MAX_LENGTH = 40;
+
+/**
+ * Normalize a user custom name: trim, collapse internal whitespace, cap length.
+ * Returns undefined when the result is empty (i.e. the override is cleared).
+ */
+export function normalizeCustomName(value: string): string | undefined {
+  const cleaned = value.trim().replace(/\s+/g, " ").slice(0, CUSTOM_NAME_MAX_LENGTH).trim();
+  return cleaned.length > 0 ? cleaned : undefined;
 }
 
 export function getNextTerminalTabTitle(existingTabs: TerminalCenterTab[]): string {
@@ -585,6 +602,7 @@ export function buildPersistedTerminalWorkspaceLayout(
             ...cachedTab,
             title: tab.id === FIXED_TERMINAL_TAB_VALUE ? terminalT("tab.fixedTitle") : tab.title,
             closable: true,
+            customTitle: tab.customTitle,
           });
         }
       continue;
@@ -601,6 +619,9 @@ export function buildPersistedTerminalWorkspaceLayout(
         projectName: pane.projectName,
         workspaceName: pane.workspaceName,
         isNewPane: pane.isNewPane,
+        customLabel: pane.customLabel,
+        keepAgentName: pane.keepAgentName,
+        keepCwd: pane.keepCwd,
       };
     }
 
@@ -611,6 +632,7 @@ export function buildPersistedTerminalWorkspaceLayout(
       layout,
       panes: cleanPanes,
       maximizedTerminalId: state.workspaceMaximizedIds[scopeKey] || null,
+      customTitle: tab.customTitle,
     });
   }
 

--- a/apps/web/src/features/terminal/store/terminal-store-types.ts
+++ b/apps/web/src/features/terminal/store/terminal-store-types.ts
@@ -74,6 +74,18 @@ export interface TerminalStore {
   setDynamicTitle: (workspaceId: string, paneId: string, dynamicTitle: string, terminalTabId?: string) => void;
   setPaneAgent: (workspaceId: string, paneId: string, agent: TerminalPaneAgent, terminalTabId?: string) => void;
 
+  /** Set/clear a tab's custom display title. Empty (after normalize) clears the override. */
+  setTabCustomTitle: (workspaceId: string, terminalTabId: string, title: string) => void;
+  /** Set/clear a pane's custom display label. Empty (after normalize) clears the override. */
+  setPaneCustomLabel: (workspaceId: string, paneId: string, label: string, terminalTabId?: string) => void;
+  /** Toggle a pane's keep-agent-name / keep-cwd display flags. */
+  setPaneTitleFlags: (
+    workspaceId: string,
+    paneId: string,
+    flags: { keepAgentName?: boolean; keepCwd?: boolean },
+    terminalTabId?: string,
+  ) => void;
+
   getProjectWikiPanes: (workspaceId: string) => Record<string, TerminalPaneProps>;
   getProjectWikiLayout: (workspaceId: string) => MosaicNode<string> | null;
   isProjectWikiReady: (workspaceId: string) => boolean;

--- a/apps/web/src/features/terminal/store/use-terminal-store.ts
+++ b/apps/web/src/features/terminal/store/use-terminal-store.ts
@@ -28,6 +28,7 @@ import {
   getWorkspaceTerminalTabs,
   hydratePersistedTab,
   isTerminalWorkspaceScopeKeyForWorkspace,
+  normalizeCustomName,
   removePaneFromLayout,
   samePaneAgent,
   splitPaneInLayout,
@@ -624,6 +625,7 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => {
               id: tab.id,
               title: tab.id === FIXED_TERMINAL_TAB_VALUE ? "Term" : tab.title,
               closable: true,
+              customTitle: tab.customTitle,
             }));
             const activeTabId =
               migrated.layout.activeTabId && availableTabs.some((tab) => tab.id === migrated.layout.activeTabId)
@@ -963,6 +965,73 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => {
           [paneId]: {
             ...panes[paneId],
             agent,
+          },
+        },
+      },
+    }));
+    get().saveToBackend(workspaceId);
+  },
+
+  setTabCustomTitle: (workspaceId, terminalTabId, title) => {
+    const nextCustomTitle = normalizeCustomName(title);
+    const tabs = getWorkspaceTerminalTabs(get(), workspaceId);
+    const target = tabs.find((tab) => tab.id === terminalTabId);
+    if (!target) return;
+    if (target.customTitle === nextCustomTitle) return;
+
+    set((state) => ({
+      workspaceTerminalTabs: {
+        ...state.workspaceTerminalTabs,
+        [workspaceId]: getWorkspaceTerminalTabs(state, workspaceId).map((tab) =>
+          tab.id === terminalTabId ? { ...tab, customTitle: nextCustomTitle } : tab,
+        ),
+      },
+    }));
+    get().saveToBackend(workspaceId);
+  },
+
+  setPaneCustomLabel: (workspaceId, paneId, label, terminalTabId = FIXED_TERMINAL_TAB_VALUE) => {
+    const scopeKey = getScopeKey(workspaceId, terminalTabId);
+    const panes = get().workspacePanes[scopeKey];
+    if (!panes || !panes[paneId]) return;
+
+    const nextCustomLabel = normalizeCustomName(label);
+    if (panes[paneId].customLabel === nextCustomLabel) return;
+
+    set((state) => ({
+      workspacePanes: {
+        ...state.workspacePanes,
+        [scopeKey]: {
+          ...panes,
+          [paneId]: {
+            ...panes[paneId],
+            customLabel: nextCustomLabel,
+          },
+        },
+      },
+    }));
+    get().saveToBackend(workspaceId);
+  },
+
+  setPaneTitleFlags: (workspaceId, paneId, flags, terminalTabId = FIXED_TERMINAL_TAB_VALUE) => {
+    const scopeKey = getScopeKey(workspaceId, terminalTabId);
+    const panes = get().workspacePanes[scopeKey];
+    if (!panes || !panes[paneId]) return;
+
+    const current = panes[paneId];
+    const nextKeepAgentName = flags.keepAgentName ?? current.keepAgentName;
+    const nextKeepCwd = flags.keepCwd ?? current.keepCwd;
+    if (current.keepAgentName === nextKeepAgentName && current.keepCwd === nextKeepCwd) return;
+
+    set((state) => ({
+      workspacePanes: {
+        ...state.workspacePanes,
+        [scopeKey]: {
+          ...panes,
+          [paneId]: {
+            ...current,
+            keepAgentName: nextKeepAgentName,
+            keepCwd: nextKeepCwd,
           },
         },
       },

--- a/apps/web/src/features/terminal/store/use-terminal-store.ts
+++ b/apps/web/src/features/terminal/store/use-terminal-store.ts
@@ -998,18 +998,21 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => {
     const nextCustomLabel = normalizeCustomName(label);
     if (panes[paneId].customLabel === nextCustomLabel) return;
 
-    set((state) => ({
-      workspacePanes: {
-        ...state.workspacePanes,
-        [scopeKey]: {
-          ...panes,
-          [paneId]: {
-            ...panes[paneId],
-            customLabel: nextCustomLabel,
+    set((state) => {
+      const currentPanes = state.workspacePanes[scopeKey] ?? panes;
+      return {
+        workspacePanes: {
+          ...state.workspacePanes,
+          [scopeKey]: {
+            ...currentPanes,
+            [paneId]: {
+              ...currentPanes[paneId],
+              customLabel: nextCustomLabel,
+            },
           },
         },
-      },
-    }));
+      };
+    });
     get().saveToBackend(workspaceId);
   },
 
@@ -1023,19 +1026,22 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => {
     const nextKeepCwd = flags.keepCwd ?? current.keepCwd;
     if (current.keepAgentName === nextKeepAgentName && current.keepCwd === nextKeepCwd) return;
 
-    set((state) => ({
-      workspacePanes: {
-        ...state.workspacePanes,
-        [scopeKey]: {
-          ...panes,
-          [paneId]: {
-            ...current,
-            keepAgentName: nextKeepAgentName,
-            keepCwd: nextKeepCwd,
+    set((state) => {
+      const currentPanes = state.workspacePanes[scopeKey] ?? panes;
+      return {
+        workspacePanes: {
+          ...state.workspacePanes,
+          [scopeKey]: {
+            ...currentPanes,
+            [paneId]: {
+              ...currentPanes[paneId],
+              keepAgentName: nextKeepAgentName,
+              keepCwd: nextKeepCwd,
+            },
           },
         },
-      },
-    }));
+      };
+    });
     get().saveToBackend(workspaceId);
   },
 

--- a/apps/web/src/features/terminal/types/index.ts
+++ b/apps/web/src/features/terminal/types/index.ts
@@ -123,6 +123,23 @@ export interface TerminalPaneProps {
    * This is transient and NOT persisted to backend — only used for tab display.
    */
   dynamicTitle?: string;
+  /**
+   * User custom display name. Highest-priority display source for the pane toolbar.
+   * Empty/undefined means no override (fall back to auto title logic). Persisted.
+   * NEVER used as the tmux window name / uniqueness key — display only.
+   */
+  customLabel?: string;
+  /**
+   * When a customLabel is set, also show the detected agent icon + label after it.
+   * `undefined` is treated as `true` (default on). Agent wins over CWD. Persisted.
+   */
+  keepAgentName?: boolean;
+  /**
+   * When a customLabel is set and no agent suffix is shown, also show the dynamic
+   * CWD/command title after it. `undefined` is treated as `true` (default on).
+   * Suppressed whenever the agent suffix is shown (mutually exclusive). Persisted.
+   */
+  keepCwd?: boolean;
 }
 
 export interface TerminalMosaicState {

--- a/specs/APP/APP-033_terminal-custom-naming/BRAINSTORM.md
+++ b/specs/APP/APP-033_terminal-custom-naming/BRAINSTORM.md
@@ -1,0 +1,44 @@
+# APP-033 · Terminal Custom Naming — BRAINSTORM
+
+> Scope: let users manually name terminal **tabs** and terminal **panes**, with the custom name taking top display priority and persisting across refresh.
+
+---
+
+## 1. Problem
+
+Terminal tabs and panes are named automatically today:
+
+- **Tab** title comes from `getNextTerminalTabTitle` / `getUniqueTerminalTabTitle` (`Term`, `Terminal 2`, ...) or the fixed tab label `Term`.
+- **Pane** title is derived by `getTerminalDisplayMeta` from three signals: the detected agent label, the dynamic OSC title (running command / CWD), or the base `label`.
+
+When a user runs several agents/panes in parallel, the auto names are ambiguous ("which pane is my review agent?"). There is no way to pin a human-friendly name, and any manual mental mapping is lost on refresh.
+
+## 2. Goal
+
+- Custom name is the highest-priority display source for both tabs and panes.
+- Empty custom name == "no override" == fall back to today's behavior (also the way to *delete* a custom name).
+- For panes, the user can optionally still surface the auto agent icon/name and/or the CWD **after** the custom name, via two toggles.
+- Everything persists to the existing terminal layout document so a browser refresh restores it.
+
+## 3. Key design choices
+
+| Decision | Choice | Why |
+|----------|--------|-----|
+| Store custom name separately from the auto name? | **Yes.** Add `customTitle` (tab) and `customLabel` (pane) alongside existing `title` / `label`. | `label`/`title` are load-bearing: `label` derives the tmux window name and pane-name uniqueness; `title` drives tab dedup. Custom naming must be display-only and never touch tmux identity. |
+| Where does the pane display decision live? | Extend `useTerminalToolbarTitle`, keep `getTerminalDisplayMeta` unchanged for the auto path. | The hook already has the pane's live fields; custom-name composition is a UI concern, not a shared-title-algorithm concern. |
+| Toggle semantics | `keepAgentName` and `keepCwd` only matter **when a custom name is set**. Without a custom name, the auto path already shows agent/CWD. | Avoids a confusing no-op state. |
+| Toggle defaults | Default **on**: when the user opens the rename input, both Keep Agent Name and Keep CWD are checked. | A named pane should still keep its familiar agent/CWD context by default; users opt out per pane if they want a pure custom name. |
+| Agent vs CWD | **Mutually exclusive** — agent wins over CWD, matching today's `getTerminalDisplayMeta`. Never show both. | Consistency with the existing auto title (agent label already suppresses the dynamic CWD/command title). |
+| Empty string | Saving `""` (after trim) clears the override. | Matches the workspace rename UX ("empty == unset") the user already expects. |
+
+## 4. Open questions
+
+- OQ-1: When `keepAgentName` is on, do we show the agent **icon + label** or just the icon next to the custom name? Leaning icon + label to match today's toolbar. (Resolved in PRD: icon + label.)
+- OQ-2: Should a custom **tab** name also get a "keep agent/CWD" style toggle? No — tabs have no single agent/CWD; keep tab naming to a pure override. (Resolved: tab = pure override.)
+- OQ-3: Length cap for custom names? Reuse the existing tab cap (40 chars, see `getUniqueTerminalTabTitle`). (Resolved: 40 chars, trimmed, collapse whitespace.)
+
+## 5. Non-goals
+
+- No server/tmux window rename — custom naming is display-only.
+- No sync of custom names into the shell prompt or OSC title.
+- No custom naming for Project Wiki / Code Review scoped panes in v1 (only the main workspace terminal grid + tabs).

--- a/specs/APP/APP-033_terminal-custom-naming/PRD.md
+++ b/specs/APP/APP-033_terminal-custom-naming/PRD.md
@@ -1,0 +1,100 @@
+# APP-033 · Terminal Custom Naming — PRD
+
+> **WHAT & WHY.** Users can manually name terminal tabs and terminal panes. The custom name wins over auto-generated names, persists across refresh, and can be cleared by saving an empty value.
+
+Related: [APP-002 Terminal Multiplexing](../APP-002_terminal-multiplexing/TECH.md), [APP-003 Web Terminal Dynamic Title](../APP-003_web-terminal-dynamic-title/TECH.md), [APP-022 Canvas Terminal New Tab](../APP-022_canvas-terminal-new-tab/TECH.md).
+
+---
+
+## 1. Users & motivation
+
+Developers who split the terminal into multiple panes/tabs and run several agents or long tasks in parallel. Auto titles (`Term`, `Terminal 2`, `claude`, `.../src/api`) collide and shift as commands change, so users lose track of "which pane does what". They want a stable, human-chosen label.
+
+## 2. User stories
+
+- As a user, I right-click a **terminal tab** and choose **Rename Tab** to type a custom tab name.
+- As a user, I right-click a **terminal pane** and choose **Rename Title** to type a custom pane name.
+- As a user, I toggle **Keep Agent Name** on a pane so, when an agent is detected, its icon + name still appears *after* my custom name.
+- As a user, I toggle **Keep CWD** on a pane so the current directory still appears *after* my custom name.
+- As a user, I clear a custom name by saving an empty value, returning the tab/pane to its automatic name.
+- As a user, my custom names and toggles survive a browser refresh.
+
+## 3. Functional requirements
+
+### Must have
+
+- **M1 — Tab rename entry point.** The terminal tab right-click menu includes **Rename Tab**, which opens an inline second-level input pre-filled with the current custom name (empty if none). Enter / blur saves; Escape cancels.
+- **M2 — Pane rename entry point.** The terminal pane right-click (grid) menu includes **Rename Title**, opening the same style of second-level input.
+- **M3 — Custom name priority.** A non-empty custom name is the top display source:
+  - Tab bar shows `customTitle` instead of the auto tab title (including for the fixed `Term` tab).
+  - Pane toolbar shows `customLabel` as the leading text.
+- **M4 — Empty clears.** Saving an empty/whitespace-only value removes the override; the tab/pane reverts to its existing automatic name and (for panes) the normal agent/CWD display.
+- **M5 — Pane toggles.** The pane menu (and the inline rename input) shows two checkboxes, **Keep Agent Name** and **Keep CWD**. **Both default to on** (checked) when the user opens the rename input.
+  - They are only meaningful when a custom pane name is set.
+  - The two are **mutually exclusive at display time**, matching today's `getTerminalDisplayMeta` behavior: **agent wins over CWD**. When an agent is detected, the CWD is hidden even if Keep CWD is on.
+  - Resolution (after the custom name, at most one suffix):
+    - **Keep Agent Name** on + an agent detected → append the agent icon + agent label. (CWD suppressed.)
+    - Else **Keep CWD** on + a CWD/command title available → append the CWD/command title.
+    - Else → only the custom name is shown.
+- **M6 — Persistence.** `customTitle`, `customLabel`, `keepAgentName`, and `keepCwd` are written into the persisted terminal layout document and restored on load, so a refresh keeps them.
+- **M7 — Display-only.** Custom naming never changes the tmux window name, pane `label`, tab `title` used for uniqueness, or any backend session identity.
+
+### Should have
+
+- **S1 — Normalization.** Custom names are trimmed, internal whitespace collapsed, and capped at 40 characters (reusing the existing tab-title cap).
+- **S2 — i18n.** All new menu labels, the input placeholder, and toggle labels use `next-intl` keys in both `en.json` and `zh.json` under the existing `Terminal.chrome` namespace.
+
+### Won't have (v1)
+
+- Custom naming for Project Wiki / Code Review scoped panes.
+- A "keep agent/CWD" style toggle for tabs.
+- Syncing custom names to the shell prompt or server-side tmux window titles.
+
+## 4. Display precedence
+
+### Tab
+
+```
+displayTabTitle = customTitle?.trim() || (isFixedTab ? "Term" : autoTitle)
+```
+
+### Pane
+
+At most one auto suffix is shown after the custom name — **agent wins over CWD** (same priority as the existing auto path):
+
+```
+if customLabel?.trim():
+    parts = [customLabel]
+    if keepAgentName and detectedAgent:      # agent wins, CWD suppressed
+        parts += agent icon + agent.label
+    elif keepCwd and dynamicCwdTitle:
+        parts += dynamicCwdTitle
+    displayPane = join(parts)                 # custom name always first
+else:
+    displayPane = getTerminalDisplayMeta(...)   # unchanged auto behavior
+
+# keepAgentName and keepCwd both default to true
+```
+
+## 5. UX flow
+
+```mermaid
+stateDiagram-v2
+    [*] --> Auto: no custom name
+    Auto --> Editing: right-click → Rename Tab/Title
+    Editing --> Custom: save non-empty
+    Editing --> Auto: save empty (clear) / cancel keeps prior
+    Custom --> Editing: right-click → Rename again
+    Custom --> Auto: save empty
+    Custom --> Custom: toggle Keep Agent Name / Keep CWD (pane only)
+```
+
+## 6. Success criteria
+
+- A renamed tab and pane keep their names and toggle states after a full browser refresh.
+- Clearing a name restores the exact previous auto behavior.
+- Toggling Keep Agent Name / Keep CWD changes only what is appended after the custom name, never the tmux window or session.
+
+## 7. Non-scope
+
+See §3 "Won't have" and [BRAINSTORM §5](./BRAINSTORM.md). No new REST endpoints — persistence rides the existing terminal layout document (WebSocket-first / existing layout save path).

--- a/specs/APP/APP-033_terminal-custom-naming/TECH.md
+++ b/specs/APP/APP-033_terminal-custom-naming/TECH.md
@@ -1,0 +1,251 @@
+# APP-033 · Terminal Custom Naming — TECH
+
+> **HOW.** Add display-only custom-name fields to the tab and pane models, thread them through the existing terminal layout persistence, extend the title composition in `useTerminalToolbarTitle`, and add rename/toggle UI to the tab and pane context menus. No backend/protocol changes — persistence reuses the existing terminal layout document.
+
+Implements [PRD.md](./PRD.md). All paths under `apps/web` unless noted.
+
+---
+
+## 1. Architecture overview
+
+```mermaid
+flowchart TD
+    subgraph UI
+        TAB[CenterStageTabBar → TerminalExtraTab\n+ new tab context menu] -->|setTabCustomTitle| STORE
+        PANEMENU[TerminalGridContextMenu\n+ Rename Title / Keep Agent Name / Keep CWD] -->|setPaneCustomLabel / setPaneTitleFlags| STORE
+    end
+    STORE[useTerminalStore] -->|saveToBackend debounce| PERSIST[terminal layout document\nworkspace/project terminal_layout]
+    STORE --> HOOK[useTerminalToolbarTitle]
+    HOOK -->|displayTitle + showAgentIcon| PANEVIEW[terminal-mosaic-workspace-pane-window]
+    STORE --> TABVIEW[tab bar renders customTitle || title]
+    PERSIST -->|loadFromBackend → hydratePersistedTab / getWorkspaceTerminalTabs| STORE
+```
+
+The custom fields are pure display metadata that live next to the existing identity fields. `label` / `tmuxWindowName` / `title` are untouched, so tmux attach, pane uniqueness (`getUniqueAgentName`, `getNextWindowName`), and tab dedup keep working exactly as today.
+
+## 2. Data model changes
+
+### 2.1 Pane — `apps/web/src/features/terminal/types/index.ts`
+
+Add three optional fields to `TerminalPaneProps`:
+
+```ts
+export interface TerminalPaneProps {
+  // ...existing...
+  /** User custom display name. Highest-priority display source. Persisted. Empty/undefined = no override. */
+  customLabel?: string;
+  /**
+   * When a customLabel is set, also show the detected agent icon + label after it.
+   * Defaults to true (see §5 for how undefined is treated). Agent wins over CWD. Persisted.
+   */
+  keepAgentName?: boolean;
+  /**
+   * When a customLabel is set and no agent suffix is shown, also show the dynamic CWD/command
+   * title after it. Defaults to true. Suppressed when the agent suffix is shown. Persisted.
+   */
+  keepCwd?: boolean;
+}
+```
+
+`dynamicTitle` stays transient (not persisted). The new fields ARE persisted.
+
+### 2.2 Tab — `apps/web/src/features/terminal/store/terminal-store-helpers.ts`
+
+Add to `TerminalCenterTab`:
+
+```ts
+export interface TerminalCenterTab {
+  id: string;
+  title: string;      // auto name, still used for dedup/uniqueness
+  closable: boolean;
+  customTitle?: string; // user override, display-only, persisted
+}
+```
+
+### 2.3 Persisted schema — `apps/web/src/features/terminal/lib/terminal-layout-document.ts`
+
+- `PersistedTerminalPane = Omit<TerminalPaneProps, "sessionId" | "dynamicTitle">` — automatically inherits `customLabel` / `keepAgentName` / `keepCwd`. No type change needed, but see §4 (whitelist).
+- `PersistedTerminalTabDocument`: add `customTitle?: string`.
+- `normalizePersistedTerminalTabs`: preserve `customTitle` (`customTitle: tab.customTitle`). The fixed-tab branch keeps forcing `title: "Term"`, but must NOT drop `customTitle`.
+- No schema version bump required (additive, optional fields; old documents simply have them undefined). Keep `TERMINAL_LAYOUT_SCHEMA = "terminal-layout.v1"`.
+
+## 3. Store actions — `terminal-store-types.ts` + `use-terminal-store.ts`
+
+New actions (all call the existing debounced `saveToBackend(workspaceId, isProjectContext)` after mutating, mirroring `setDynamicTitle`/`setTmuxWindowName`):
+
+```ts
+// normalize(): trim, collapse whitespace, cap 40; returns undefined when empty
+setTabCustomTitle: (workspaceId: string, terminalTabId: string, title: string) => void;
+setPaneCustomLabel: (workspaceId: string, paneId: string, label: string, terminalTabId?: string) => void;
+setPaneTitleFlags: (
+  workspaceId: string,
+  paneId: string,
+  flags: { keepAgentName?: boolean; keepCwd?: boolean },
+  terminalTabId?: string,
+) => void;
+```
+
+Behavior:
+
+- `setTabCustomTitle`: writes `customTitle` on the tab in `workspaceTerminalTabs[workspaceId]`; empty normalized value → set `customTitle = undefined`.
+- `setPaneCustomLabel`: writes `customLabel` on `workspacePanes[scopeKey][paneId]`; empty → `undefined`. Uses `getScopeKey(workspaceId, terminalTabId)`.
+- `setPaneTitleFlags`: shallow-merges the provided flags onto the pane.
+- Each action is a no-op (no save) if the target tab/pane is missing or the value is unchanged.
+
+## 4. Persistence wiring — `buildPersistedTerminalWorkspaceLayout`
+
+The serializer explicitly whitelists pane fields into `cleanPanes` — it must be extended:
+
+```ts
+cleanPanes[id] = {
+  id: pane.id,
+  label: pane.label,
+  workspaceId: pane.workspaceId,
+  tmuxWindowName: pane.tmuxWindowName,
+  agent: pane.agent,
+  projectName: pane.projectName,
+  workspaceName: pane.workspaceName,
+  isNewPane: pane.isNewPane,
+  customLabel: pane.customLabel,     // NEW
+  keepAgentName: pane.keepAgentName, // NEW
+  keepCwd: pane.keepCwd,             // NEW
+};
+```
+
+And each `persistedTabs.push({...})` (both the cached-tab branch and the live branch) must include `customTitle: tab.customTitle`.
+
+`hydratePersistedTab` copies persisted panes with `...pane`, so the new fields survive hydration automatically. Confirm the spread keeps `customLabel`/`keepAgentName`/`keepCwd` and does not overwrite them (it only overrides `label`, `tmuxWindowName`, `sessionId`, `isNewPane`, `workspaceId`).
+
+`getWorkspaceTerminalTabs` / `getAllDefaultPanesForWorkspace` need no change beyond carrying the extra fields through the object spreads already in place.
+
+## 5. Display composition — `hooks/use-terminal-toolbar-title.ts`
+
+Extend the hook input and return value:
+
+```ts
+useTerminalToolbarTitle(options: {
+  baseTitle: string;
+  configuredAgents: TerminalPaneAgent[];
+  pinnedAgent?: TerminalPaneAgent;
+  storeWrite: TerminalToolbarStoreWrite;
+  customLabel?: string;      // NEW
+  keepAgentName?: boolean;   // NEW
+  keepCwd?: boolean;         // NEW
+})
+```
+
+Logic (leaves `getTerminalDisplayMeta` unchanged). Note the flags **default to true** — treat `undefined` as `true` so pre-existing panes and freshly renamed panes keep agent/CWD context by default. Agent and CWD are **mutually exclusive** (agent wins):
+
+```ts
+const auto = getTerminalDisplayMeta({ baseTitle, dynamicTitle: mergedDynamic, configuredAgents, agent: mergedAgent });
+const custom = customLabel?.trim();
+
+if (!custom) {
+  return { displayTitle: auto.displayTitle, toolbarAgent: auto.toolbarAgent, onTitleChange };
+}
+
+// undefined => on (default true)
+const wantAgent = keepAgentName !== false;
+const wantCwd = keepCwd !== false;
+
+const showAgent = wantAgent && !!auto.toolbarAgent;
+// CWD only when the agent suffix is NOT shown (mutually exclusive, agent wins)
+const cwdSuffix =
+  !showAgent && wantCwd && isPathLikeTitle(mergedDynamic) ? shortenPath(mergedDynamic) : undefined;
+
+const displayTitle = [custom, showAgent ? auto.toolbarAgent!.label : undefined, cwdSuffix]
+  .filter(Boolean)
+  .join("  ");
+
+return { displayTitle, toolbarAgent: showAgent ? auto.toolbarAgent : undefined, onTitleChange };
+```
+
+- `toolbarAgent` controls whether the icon renders in `TerminalTitleWithAgent`; returning `undefined` when `keepAgentName` is off (or no agent detected) hides the icon.
+- At most one suffix (`agent label` **or** `cwd`) is ever appended, never both.
+- `isPathLikeTitle` / `shortenPath` already exist in `packages/shared/src/terminal/title.ts`.
+
+The pane window passes the new pane fields into the hook — `terminal-mosaic-workspace-pane-window.tsx` (and its scoped twin `terminal-mosaic-scoped-pane-window.tsx`):
+
+```ts
+const { displayTitle, toolbarAgent, onTitleChange } = useTerminalToolbarTitle({
+  baseTitle: pane.label,
+  configuredAgents,
+  storeWrite,
+  customLabel: pane.customLabel,
+  keepAgentName: pane.keepAgentName,
+  keepCwd: pane.keepCwd,
+});
+```
+
+## 6. UI — context menus
+
+### 6.1 Pane menu — `components/TerminalGridContextMenu.tsx`
+
+- Add a **Rename Title** entry as a `DropdownMenuSub`; the sub-content hosts a small controlled `<input>` (Enter/blur → save, Escape → close) **plus** the two checkboxes below it, so the user can rename and adjust the toggles in one place. This mirrors the inline rename pattern already used in `WorkspaceContent.tsx`.
+- Add two `DropdownMenuCheckboxItem`s: **Keep Agent Name** and **Keep CWD**. Their checked state is `keepAgentName !== false` / `keepCwd !== false` (undefined = checked, matching the default-on behavior in §5). Mute/disable them when no custom name is set (they are display-only no-ops then).
+- The two are display-exclusive (agent wins). Both may be checked simultaneously in the UI — the runtime composition (§5) simply hides CWD whenever an agent is present. No need to force radio-style mutual exclusion in the checkboxes.
+- Extend props with the current values + callbacks rather than only the `TerminalGridContextMenuAction` enum (the enum stays for value-less actions):
+
+```ts
+customLabel?: string;
+keepAgentName?: boolean;
+keepCwd?: boolean;
+onRenameTitle: (value: string) => void;      // "" clears
+onToggleKeepAgentName: (next: boolean) => void;
+onToggleKeepCwd: (next: boolean) => void;
+```
+
+The grid component that renders `TerminalGridContextMenu` resolves the focused pane id and wires these to `setPaneCustomLabel` / `setPaneTitleFlags`.
+
+### 6.2 Tab menu — `app-shell/CenterStageTabBar.tsx` (`TerminalExtraTab`)
+
+- There is **no** terminal-tab context menu today (only a file-tab menu). Add an `onContextMenu` handler on the terminal tab trigger that opens a small `DropdownMenu`/`ContextMenu` with a single **Rename Tab** `DropdownMenuSub` → input (same pattern as §6.1).
+- The tab bar renders `tab.customTitle || tab.title`. Keep `closeAriaLabel` using the effective display title.
+- Save calls `setTabCustomTitle(workspaceId, tab.id, value)`; empty clears.
+
+## 7. i18n keys (namespace `Terminal.chrome`)
+
+Add to `apps/web/messages/en.json` and `apps/web/messages/zh.json`:
+
+| Key | en | zh |
+|-----|----|----|
+| `contextMenu.renameTab` | Rename Tab | 重命名标签 |
+| `contextMenu.renameTitle` | Rename Title | 重命名标题 |
+| `contextMenu.keepAgentName` | Keep Agent Name | 保留 Agent 名称 |
+| `contextMenu.keepCwd` | Keep CWD | 保留当前目录 |
+| `contextMenu.renamePlaceholder` | Enter a name… | 输入名称… |
+
+(Final Chinese wording to be confirmed during implementation; must be natural, not English copy.)
+
+## 8. Sequence — rename a pane
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant M as TerminalGridContextMenu
+    participant G as Terminal grid container
+    participant S as useTerminalStore
+    participant B as layout persistence (terminal_layout)
+    U->>M: right-click pane → Rename Title → type "Review agent" → Enter
+    M->>G: onRenameTitle("Review agent")
+    G->>S: setPaneCustomLabel(wsId, paneId, "Review agent", tabId)
+    S->>S: normalize + set pane.customLabel
+    S-->>G: state update → useTerminalToolbarTitle recomputes displayTitle
+    S->>B: saveToBackend (debounced)
+    Note over U,B: refresh → loadFromBackend → hydratePersistedTab restores customLabel
+```
+
+## 9. Risks & mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Forgetting to add new fields to the `cleanPanes` whitelist → names silently not persisted | Explicit checklist item in TEST (persist-and-refresh scenario); the whitelist is the single serialization choke point. |
+| Fixed `Term` tab overwrites `customTitle` in `normalizePersistedTerminalTabs` / `buildPersistedTerminalWorkspaceLayout` | Force `title` for the fixed tab but keep `customTitle` untouched; display uses `customTitle || "Term"`. |
+| Toggles confusing when no custom name set | Disable/mute the checkboxes until a custom name exists (M5). |
+| Scoped pane twin (`terminal-mosaic-scoped-pane-window.tsx`) not updated | Update both pane window components; TEST covers a split/scoped pane. |
+| Custom name accidentally used as tmux window name | Never write `customLabel` into `label`/`tmuxWindowName`; getters for window name ignore `customLabel`. |
+
+## 10. Rollout
+
+- Pure additive frontend change; no migration. Old layout documents load with the new fields `undefined` (= no override).
+- No feature flag needed; ships with the web app.

--- a/specs/APP/APP-033_terminal-custom-naming/TEST.md
+++ b/specs/APP/APP-033_terminal-custom-naming/TEST.md
@@ -1,0 +1,115 @@
+# APP-033 · Terminal Custom Naming — TEST
+
+> Verification contract for [PRD.md](./PRD.md) / [TECH.md](./TECH.md). Persistence rides the existing terminal layout document, so most logic is deterministic and unit-testable; refresh restore + menu UX are covered by agent-browser / manual smoke until an E2E harness exists.
+
+---
+
+## 1. Test strategy
+
+| Level | Target | Why |
+|-------|--------|-----|
+| Bun unit | `use-terminal-toolbar-title` display composition, store normalization, layout serialize/hydrate round-trip | Deterministic precedence + persistence logic — the core risk. |
+| Bun unit | `terminal-layout-document` migrate/normalize keeps `customTitle` / pane custom fields | Guards the serialization choke point (TECH §4, §9). |
+| agent-browser (exploratory) | Rename menus, empty-clear, toggles, refresh restore in the running web app | UX + cross-refresh wiring not yet covered by scripted E2E. |
+| Manual | Split/scoped pane rename, fixed `Term` tab rename | Twin-component + fixed-tab edge cases. |
+
+## 2. Coverage map (PRD Must Haves → scenarios)
+
+| PRD | Scenario |
+|-----|----------|
+| M1 Tab rename entry | S-TAB-1 |
+| M2 Pane rename entry | S-PANE-1 |
+| M3 Custom name priority | S-TAB-2, S-PANE-2 |
+| M4 Empty clears | S-CLEAR-1 |
+| M5 Pane toggles | S-TOGGLE-1, S-TOGGLE-2, S-TOGGLE-3 |
+| M6 Persistence across refresh | S-PERSIST-1 |
+| M7 Display-only (tmux untouched) | S-IDENTITY-1 |
+| S1 Normalization | S-NORM-1 |
+
+## 3. Execution map
+
+| ID | Level | Tool | Target | Signals | Status |
+|----|-------|------|--------|---------|--------|
+| S-PANE-2 | Bun unit | `bun test` | `use-terminal-toolbar-title` composition | `displayTitle` starts with custom name; `toolbarAgent` undefined when `keepAgentName` off | planned |
+| S-TOGGLE-1 | Bun unit | `bun test` | hook with `keepAgentName` default (undefined) + detected agent | displayTitle = `custom + agent.label`; `toolbarAgent` defined (icon shows); CWD absent even if `keepCwd` on | planned |
+| S-TOGGLE-2 | Bun unit | `bun test` | hook with `keepCwd` default + path-like dynamicTitle + **no** agent | displayTitle appends `shortenPath(cwd)`; no agent suffix | planned |
+| S-TOGGLE-3 | Bun unit | `bun test` | hook with `keepAgentName=false` + detected agent + `keepCwd` on | agent hidden; CWD suffix shown instead (fallback) | planned |
+| S-CLEAR-1 | Bun unit | `bun test` | hook with `customLabel=""` | falls back to `getTerminalDisplayMeta` output | planned |
+| S-NORM-1 | Bun unit | `bun test` | `setPaneCustomLabel` / `setTabCustomTitle` normalize | trims, collapses whitespace, caps 40, `""`→undefined | planned |
+| S-PERSIST-1 | Bun unit | `bun test` | `buildPersistedTerminalWorkspaceLayout` → `parseTerminalLayoutDocument` → `hydratePersistedTab` | `customLabel`/`keepAgentName`/`keepCwd`/`customTitle` survive round-trip | planned |
+| S-IDENTITY-1 | Bun unit | `bun test` | serialize a pane with `customLabel` set | persisted `label` + `tmuxWindowName` unchanged by rename | planned |
+| S-TAB-1 / S-TAB-2 | agent-browser + manual | `just dev-web` + agent-browser | tab context menu | Rename Tab visible; tab shows custom name; fixed `Term` tab renamable | planned |
+| S-PANE-1 | agent-browser + manual | `just dev-web` + agent-browser | pane grid menu | Rename Title visible; pane toolbar shows custom name | planned |
+| S-REFRESH (UI) | agent-browser | reload page | custom names + toggles restored after refresh | planned |
+
+## 4. Scenarios
+
+### S-PANE-2 — custom name replaces auto label when toggles off
+- Given a pane with detected agent `claude` and dynamicTitle `.../src/api`, `keepAgentName=false`, `keepCwd=false`.
+- When `customLabel = "Backend"`.
+- Then `displayTitle === "Backend"` and `toolbarAgent === undefined`.
+- Signals: returned `displayTitle`, `toolbarAgent`.
+
+### S-TOGGLE-1 — default keeps agent, suppresses CWD
+- Given the S-PANE-2 pane with `keepAgentName` and `keepCwd` at their defaults (undefined = on) and a detected agent.
+- Then `displayTitle` begins with `"Backend"` and contains the agent label; `toolbarAgent` is defined (icon renders); the CWD is NOT appended (agent wins).
+
+### S-TOGGLE-2 — CWD shown when no agent
+- Given `customLabel="Backend"`, defaults on, dynamicTitle `/Users/x/proj/src/api`, **no** detected agent.
+- Then `displayTitle` begins with `"Backend"` and ends with `.../src/api`; no agent suffix.
+
+### S-TOGGLE-3 — opt out of agent falls back to CWD
+- Given `customLabel="Backend"`, `keepAgentName=false`, `keepCwd=true`, a detected agent, and dynamicTitle `/Users/x/proj/src/api`.
+- Then the agent suffix is hidden and `displayTitle` ends with `.../src/api`.
+
+### S-CLEAR-1 — empty clears override
+- Given a pane with `customLabel="Backend"`.
+- When saved with `""`.
+- Then `customLabel` becomes undefined and `displayTitle` equals the pure `getTerminalDisplayMeta` result.
+
+### S-PERSIST-1 — round-trip persistence
+- Given a workspace with a renamed tab (`customTitle`) and a renamed pane (`customLabel` + `keepAgentName=true`).
+- When the layout is serialized then parsed + hydrated.
+- Then all four custom fields are equal to their pre-serialize values.
+- Signals: hydrated tab/pane objects.
+
+### S-IDENTITY-1 — display only
+- Given a pane with `tmuxWindowName="2"`, `label="2"`.
+- When `customLabel="Deploy"` is set and serialized.
+- Then persisted `label==="2"` and `tmuxWindowName==="2"` (custom name only in `customLabel`).
+
+### S-NORM-1 — normalization
+- `"  My   Pane  "` → `"My Pane"`; a 60-char string → capped at 40; `"   "` → cleared.
+
+## 5. Exploratory agent-browser checks
+
+Run against `just dev-web`. Load the Agent Browser skill / `agent-browser skills get core --full` first.
+
+- Right-click a terminal tab → **Rename Tab** → type → Enter; confirm the tab label updates and the fixed `Term` tab is also renamable.
+- Right-click a pane → **Rename Title** → type → confirm toolbar shows the custom name first, and (defaults on) the agent icon+label appears after it, or the CWD when no agent is present.
+- Confirm **Keep Agent Name** and **Keep CWD** are checked by default in the rename input; toggle **Keep Agent Name** off → confirm agent hides and CWD (if any) appears; confirm agent and CWD are never shown together.
+- Clear a name (save empty) → confirm revert to auto name.
+- Reload the page → confirm tab name, pane name, and toggle states are restored.
+- Watch for console/network errors during rename + save.
+
+## 6. Regression checklist
+
+- Auto tab/pane titles unchanged when no custom name is set.
+- tmux attach/reconnect still works after rename (window name preserved).
+- Pane split/close and tab dedup (`getUniqueTerminalTabTitle`) unaffected.
+- Existing (pre-feature) persisted layouts load without error (fields undefined).
+
+## 7. Acceptance criteria
+
+- All planned Bun unit scenarios pass via `bun test`.
+- agent-browser refresh-restore check passes: names + toggles persist across reload.
+- No regression in the checklist above.
+
+## 8. Non-coverage
+
+- Project Wiki / Code Review scoped panes (out of scope, PRD §3 Won't have).
+- Playwright E2E: deferred until the terminal-grid E2E harness exists; tracked as a gap here.
+
+## 9. Coverage Status
+
+_To be appended after implementation and `atmos-specs-test-run` (exact test files, `bun test` command, agent-browser results, remaining gaps)._

--- a/specs/APP/APP-033_terminal-custom-naming/TEST.md
+++ b/specs/APP/APP-033_terminal-custom-naming/TEST.md
@@ -21,26 +21,27 @@
 | M2 Pane rename entry | S-PANE-1 |
 | M3 Custom name priority | S-TAB-2, S-PANE-2 |
 | M4 Empty clears | S-CLEAR-1 |
-| M5 Pane toggles | S-TOGGLE-1, S-TOGGLE-2, S-TOGGLE-3 |
+| M5 Pane toggles | S-TOGGLE-1, S-TOGGLE-2, S-TOGGLE-3, S-TOGGLE-4 |
 | M6 Persistence across refresh | S-PERSIST-1 |
 | M7 Display-only (tmux untouched) | S-IDENTITY-1 |
 | S1 Normalization | S-NORM-1 |
 
 ## 3. Execution map
 
-| ID | Level | Tool | Target | Signals | Status |
-|----|-------|------|--------|---------|--------|
-| S-PANE-2 | Bun unit | `bun test` | `use-terminal-toolbar-title` composition | `displayTitle` starts with custom name; `toolbarAgent` undefined when `keepAgentName` off | planned |
-| S-TOGGLE-1 | Bun unit | `bun test` | hook with `keepAgentName` default (undefined) + detected agent | displayTitle = `custom + agent.label`; `toolbarAgent` defined (icon shows); CWD absent even if `keepCwd` on | planned |
-| S-TOGGLE-2 | Bun unit | `bun test` | hook with `keepCwd` default + path-like dynamicTitle + **no** agent | displayTitle appends `shortenPath(cwd)`; no agent suffix | planned |
-| S-TOGGLE-3 | Bun unit | `bun test` | hook with `keepAgentName=false` + detected agent + `keepCwd` on | agent hidden; CWD suffix shown instead (fallback) | planned |
-| S-CLEAR-1 | Bun unit | `bun test` | hook with `customLabel=""` | falls back to `getTerminalDisplayMeta` output | planned |
-| S-NORM-1 | Bun unit | `bun test` | `setPaneCustomLabel` / `setTabCustomTitle` normalize | trims, collapses whitespace, caps 40, `""`→undefined | planned |
-| S-PERSIST-1 | Bun unit | `bun test` | `buildPersistedTerminalWorkspaceLayout` → `parseTerminalLayoutDocument` → `hydratePersistedTab` | `customLabel`/`keepAgentName`/`keepCwd`/`customTitle` survive round-trip | planned |
-| S-IDENTITY-1 | Bun unit | `bun test` | serialize a pane with `customLabel` set | persisted `label` + `tmuxWindowName` unchanged by rename | planned |
-| S-TAB-1 / S-TAB-2 | agent-browser + manual | `just dev-web` + agent-browser | tab context menu | Rename Tab visible; tab shows custom name; fixed `Term` tab renamable | planned |
-| S-PANE-1 | agent-browser + manual | `just dev-web` + agent-browser | pane grid menu | Rename Title visible; pane toolbar shows custom name | planned |
-| S-REFRESH (UI) | agent-browser | reload page | custom names + toggles restored after refresh | planned |
+| ID | Level | Tool | Target | Fixture / Data | Signals | Status |
+|----|-------|------|--------|----------------|---------|--------|
+| S-PANE-2 | Bun unit | `bun test` | `use-terminal-toolbar-title` composition | pane: `customLabel="Backend"`, `keepAgentName=false`, `keepCwd=false`, detected agent + dynamicTitle | `displayTitle` starts with custom name; `toolbarAgent` undefined when `keepAgentName` off | planned |
+| S-TOGGLE-1 | Bun unit | `bun test` | hook composition | `customLabel` set, `keepAgentName`/`keepCwd` default (undefined), detected agent | displayTitle = `custom + agent.label`; `toolbarAgent` defined (icon shows); CWD absent even if `keepCwd` on | planned |
+| S-TOGGLE-2 | Bun unit | `bun test` | hook composition | `customLabel` set, `keepCwd` default, path-like dynamicTitle, **no** agent | displayTitle appends `shortenPath(cwd)`; no agent suffix | planned |
+| S-TOGGLE-3 | Bun unit | `bun test` | hook composition | `customLabel` set, `keepAgentName=false`, `keepCwd` on, detected agent + path-like dynamicTitle | agent hidden; `shortenPath(cwd)` suffix shown instead (fallback) | planned |
+| S-TOGGLE-4 | Bun unit | `bun test` | hook composition | `customLabel` set, `keepCwd` on, non-path command dynamicTitle (e.g. `npm start`), no agent | command title kept verbatim as suffix (not dropped) | planned |
+| S-CLEAR-1 | Bun unit | `bun test` | hook composition | `customLabel=""` (empty) | falls back to `getTerminalDisplayMeta` output | planned |
+| S-NORM-1 | Bun unit | `bun test` | `setPaneCustomLabel` / `setTabCustomTitle` | inputs `"  My   Pane  "`, 60-char string, `"   "` | trims, collapses whitespace, caps 40, `""`→undefined | planned |
+| S-PERSIST-1 | Bun unit | `bun test` | `buildPersistedTerminalWorkspaceLayout` → `parseTerminalLayoutDocument` → `hydratePersistedTab` | workspace with renamed tab (`customTitle`) + renamed pane (`customLabel` + `keepAgentName=true`) | `customLabel`/`keepAgentName`/`keepCwd`/`customTitle` survive round-trip | planned |
+| S-IDENTITY-1 | Bun unit | `bun test` | `buildPersistedTerminalWorkspaceLayout` | pane `label="2"`, `tmuxWindowName="2"`, `customLabel="Deploy"` | persisted `label` + `tmuxWindowName` unchanged by rename | planned |
+| S-TAB-1 / S-TAB-2 | agent-browser + manual | `just dev-web` + agent-browser | tab context menu | running web app with ≥1 terminal tab (incl. fixed `Term`) | Rename Tab visible; tab shows custom name; fixed `Term` tab renamable | planned |
+| S-PANE-1 | agent-browser + manual | `just dev-web` + agent-browser | pane grid menu | running web app with a terminal pane | Rename Title visible; pane toolbar shows custom name | planned |
+| S-REFRESH (UI) | agent-browser | `just dev-web` + reload page | terminal grid after refresh | renamed tab + pane with non-default toggle states | custom names + toggle states restored after refresh | planned |
 
 ## 4. Scenarios
 
@@ -61,6 +62,10 @@
 ### S-TOGGLE-3 — opt out of agent falls back to CWD
 - Given `customLabel="Backend"`, `keepAgentName=false`, `keepCwd=true`, a detected agent, and dynamicTitle `/Users/x/proj/src/api`.
 - Then the agent suffix is hidden and `displayTitle` ends with `.../src/api`.
+
+### S-TOGGLE-4 — Keep CWD preserves non-path command titles
+- Given `customLabel="Server"`, `keepCwd=true` (default), no detected agent, and a non-path dynamicTitle such as `npm start`.
+- Then `displayTitle` begins with `"Server"` and keeps the command title verbatim (`Server  npm start`); the command is not dropped.
 
 ### S-CLEAR-1 — empty clears override
 - Given a pane with `customLabel="Backend"`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -111,6 +111,7 @@ These files are not requirements sources. Requirements live in `PRD.md`, archite
 | **APP-030** | Terminal Side Chat | `specs/APP/APP-030_terminal-side-chat/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
 | **APP-031** | Terminal Selection AI Context | `specs/APP/APP-031_terminal-selection-ai-context/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
 | **APP-032** | Antigravity CLI Support | `specs/APP/APP-032_antigravity-cli-support/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
+| **APP-033** | Terminal Custom Naming | `specs/APP/APP-033_terminal-custom-naming/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
 | **QUALITY-001** | Large File Code Debt Cleanup | `specs/APP/QUALITY-001_large-file-code-debt-cleanup/` (`TECH.md`, `TEST.md`) |
 | **QUALITY-002** | Spec Test Execution Loop | `specs/APP/QUALITY-002_spec-test-execution-loop/` (`TECH.md`, `TEST.md`) |
 | **QUALITY-003** | Playwright E2E Harness | `specs/APP/QUALITY-003_playwright-e2e-harness/` (`TECH.md`, `TEST.md`) |


### PR DESCRIPTION
## Summary

Adds display-only **custom naming** for terminal tabs and terminal panes in the web app (spec: `specs/APP/APP-033_terminal-custom-naming/`).

- **Rename Tab** — right-click a terminal tab → *Rename Tab* → inline input. A custom tab title overrides the auto name (including the fixed `Term` tab).
- **Rename Title (pane)** — right-click a terminal pane → *Rename Title* → inline input. The custom label leads the pane toolbar.
- **Keep Agent Name / Keep CWD** — pane checkboxes, **default on**, only meaningful when a custom name is set. They are **mutually exclusive** at display time (agent wins over CWD, matching the existing auto-title behavior), so at most one suffix is appended after the custom name.
- **Empty clears** — saving an empty/whitespace value removes the override and reverts to the automatic name.
- **Persistence** — `customTitle` (tab) and `customLabel` / `keepAgentName` / `keepCwd` (pane) are written into the existing terminal layout document and restored after a refresh. No new REST endpoints.
- **Display-only** — custom names never touch the tmux window name, pane `label`, or the tab `title` used for uniqueness/dedup.

Scope note: Project Wiki / Code Review scoped panes are intentionally excluded (per spec non-goals).

This branch also carries a small earlier fix: the sidebar workspace list now prefers `display_name` over the branch name (`apps/web/src/app-shell/sidebar/WorkspaceContent.tsx`).

### Key changes
- Data model: `TerminalPaneProps` (`customLabel`/`keepAgentName`/`keepCwd`), `TerminalCenterTab.customTitle`, `PersistedTerminalTabDocument.customTitle`.
- Store: `setTabCustomTitle` / `setPaneCustomLabel` / `setPaneTitleFlags` + `normalizeCustomName` (trim, collapse whitespace, cap 40, empty → clear); persistence whitelist + hydrate/restore.
- Display: `useTerminalToolbarTitle` composition (custom name first; agent-wins-over-CWD; flags default on).
- UI: pane `TerminalGridContextMenu` (Rename Title submenu + checkbox items), tab `TerminalExtraTab` (Rename Tab context menu, renders `customTitle || title`).
- i18n: new keys in `en.json` and `zh.json` (`Terminal.chrome.contextMenu.*`, `appShell.centerStageTabBar.renameTab*`).

## Related Issue

<!-- none -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] Additional checks (describe below)

Ran in `apps/web`:
- `bun run typecheck` (`tsc --noEmit`) — clean.
- `bun run lint` (`eslint`) — 0 errors; no new warnings in touched files.

Not yet run: automated unit tests from `TEST.md` (Bun) and agent-browser refresh-restore smoke check.

## Checklist

- [x] I updated documentation if behavior changed (APP-033 spec + `specs/README.md`)
- [ ] I added/updated tests where appropriate (unit tests per `TEST.md` still to be written)
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let users rename terminal tabs and panes; display-only, persisted across refresh, and never touches tmux identities. Implements APP-033.

- **New Features**
  - Tab: right-click → Rename Tab; `customTitle` overrides auto (including the fixed `Term`), empty clears, input is trimmed/collapsed and capped at 40.
  - Pane: right-click → Rename Title; `customLabel` leads the toolbar with Keep Agent Name / Keep CWD toggles (default on; agent wins over CWD). Suffix uses a middot (e.g., “Name · Cursor Agent”). Project Wiki / Code Review panes are excluded.
  - Persists `customTitle` (tab) and `customLabel`/`keepAgentName`/`keepCwd` (pane) in the existing terminal layout; restored on refresh; no new endpoints.

- **Bug Fixes**
  - Rename inputs are stable inside the submenu: focus is deferred; Enter commits; Escape cancels; blur saves without closing to avoid pointer-move collapse and double commits.
  - Keep CWD preserves non-path dynamic titles (e.g., “npm start”); the agent/CWD suffix mirrors the current OSC state—agent while active, CWD after exit.
  - Sidebar workspace list prefers `displayName`, keeps the edit popover open while typing, and allows clearing it; Save is disabled only when unchanged.

<sup>Written for commit 47c2aa84b8c8a73638edfd4018a6e0f870e858d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added terminal tab renaming (including center-stage support) and terminal pane title renaming with prompts.
  * Added “keep agent name” and “keep CWD” toggles for pane/tab display behavior, with clear precedence rules.
  * Persisted display-only custom names/labels and applied them to terminal titles.
* **Bug Fixes**
  * Kept the workspace info popover open while editing the workspace display name.
  * Allowed clearing a workspace display name and adjusted save-button disabling logic.
* **Localization**
  * Updated English and Chinese UI text for rename and “keep” options.
* **Documentation**
  * Added specs for terminal custom naming (product, technical, and QA).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->