### PR TITLE
feat: implement terminal caching strategy

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4698,6 +4698,16 @@
         "title": "Side chat context budget",
         "description": "Maximum terminal context bytes sent into a /side agent prompt. The server still clamps requests between {min} and {max} bytes.",
         "bytes": "bytes"
+      },
+      "cacheWorkspaces": {
+        "title": "Max cached workspaces",
+        "description": "Set the maximum number of Projects/Workspaces kept active in memory. Higher cache numbers use more memory but speed up switching.",
+        "contexts": "contexts"
+      },
+      "cachePanels": {
+        "title": "Max terminal panels per workspace",
+        "description": "Limit the number of terminal panels preserved in a single cached context. If this limit is exceeded, the context will be evicted from the cache.",
+        "panels": "panels"
       }
     },
     "headerLayoutSection": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -4698,6 +4698,16 @@
         "title": "Side chat 上下文预算",
         "description": "/side Agent prompt 中最多注入的终端上下文字节数。服务端仍会将请求限制在 {min} 到 {max} bytes 之间。",
         "bytes": "bytes"
+      },
+      "cacheWorkspaces": {
+        "title": "最大缓存上下文",
+        "description": "设置在内存中保持活跃状态的最大 Project/Workspace 数量。较多的缓存数量会占用更多内存，但可以加快切换速度。",
+        "contexts": "个"
+      },
+      "cachePanels": {
+        "title": "每个上下文最大缓存终端面板数",
+        "description": "限制单个缓存上下文中保留的终端面板数量。如果超过此限制，该上下文将被移出缓存。",
+        "panels": "个面板"
       }
     },
     "headerLayoutSection": {

--- a/apps/web/src/api/ws/settings-api.ts
+++ b/apps/web/src/api/ws/settings-api.ts
@@ -48,6 +48,8 @@ export interface FunctionSettings {
     file_link_open_mode?: "atmos" | "finder" | "app";
     file_link_open_app?: string;
     side_context_prompt_budget_bytes?: number;
+    max_cached_workspaces?: number;
+    max_cached_terminal_panels_per_workspace?: number;
   };
   git_commit?: {
     acp_new_session_switch?: boolean;

--- a/apps/web/src/app-shell/CenterStage.tsx
+++ b/apps/web/src/app-shell/CenterStage.tsx
@@ -1154,7 +1154,7 @@ const CenterStage: React.FC = () => {
           effectiveContextId={effectiveContextId}
           handleCreateTerminalCenterTab={handleCreateTerminalCenterTab}
           handleTerminalPaneClosed={handleTerminalPaneClosed}
-          mountedTerminalTabs={mountedTerminalTabs}
+          mountedTerminalTabsByContext={mountedTerminalTabsByContext}
           openFiles={openFiles}
           projectWikiTabVisible={projectWikiTabVisible}
           projectWikiTerminalGridRef={projectWikiTerminalGridRef}

--- a/apps/web/src/app-shell/CenterStage.tsx
+++ b/apps/web/src/app-shell/CenterStage.tsx
@@ -341,13 +341,8 @@ const CenterStage: React.FC = () => {
 
   useTerminalTabMountLifecycle({
     activeValue,
-    codeReviewTerminalGridRef,
     effectiveContextId,
-    evictWorkspaceRuntime,
-    projectWikiTerminalGridRef,
     setMountedTerminalTabsByContext,
-    terminalGridRef,
-    terminalGridRefsRef: terminalGridRefs,
     visibleTerminalTabs,
   });
 

--- a/apps/web/src/app-shell/CenterStagePanels.tsx
+++ b/apps/web/src/app-shell/CenterStagePanels.tsx
@@ -31,6 +31,8 @@ import type { PendingNamedTerminalRun } from "@/app-shell/center-stage-support";
 import type { TerminalPaneAgent } from "@/features/terminal/types/index";
 import type { TerminalPaneProps } from "@/features/terminal/types/index";
 import type { Project, Workspace } from "@/shared/types/domain";
+import { useTerminalCacheStore } from "@/features/terminal/store/use-terminal-cache-store";
+import { useTerminalStore } from "@/features/terminal/store/use-terminal-store";
 
 function TerminalGridLoadingFallback() {
   const t = useTranslations("appShell.centerStagePanels");
@@ -116,7 +118,7 @@ interface CenterStagePanelsProps {
     terminalTabId: string;
     isLastPane: boolean;
   }) => void;
-  mountedTerminalTabs: string[];
+
   openFiles: OpenFile[];
   projectWikiTabVisible: boolean;
   projectWikiTerminalGridRef: React.RefObject<TerminalGridHandle | null>;
@@ -133,6 +135,7 @@ interface CenterStagePanelsProps {
   wikiCenterEligible: boolean;
   wikiPageFromUrl?: string | null;
   wikiRefreshTrigger: number;
+  mountedTerminalTabsByContext: Record<string, string[]>;
 }
 
 export function CenterStagePanels({
@@ -147,7 +150,7 @@ export function CenterStagePanels({
   effectiveContextId,
   handleCreateTerminalCenterTab,
   handleTerminalPaneClosed,
-  mountedTerminalTabs,
+
   openFiles,
   projectWikiTabVisible,
   projectWikiTerminalGridRef,
@@ -164,39 +167,59 @@ export function CenterStagePanels({
   wikiCenterEligible,
   wikiPageFromUrl,
   wikiRefreshTrigger,
+  mountedTerminalTabsByContext,
 }: CenterStagePanelsProps) {
   const t = useTranslations("appShell.centerStagePanels");
+  const cachedContexts = useTerminalCacheStore(s => s.cachedContexts);
+  const allWorkspaceTerminalTabs = useTerminalStore(s => s.workspaceTerminalTabs);
+  const workspaceContexts = useTerminalStore(s => s.workspaceContexts);
+
+  const contextIdsToRender = Array.from(new Set([effectiveContextId, ...cachedContexts.map(c => c.contextId)])).filter(Boolean);
 
   return (
     <>
-      {visibleTerminalTabs
-        .filter((tab) => mountedTerminalTabs.includes(tab.id))
-        .map((tab) => (
-          <div
-            key={tab.id}
-            className={cn(
-              "flex-1 min-h-0 min-w-0",
-              activeValue !== tab.id && "hidden",
-            )}
-          >
-            <div className="h-full w-full">
-              <TerminalGrid
-                ref={tab.id === FIXED_TERMINAL_TAB_VALUE
-                  ? terminalGridRef
-                  : (instance) => {
-                      terminalGridRefs.current[tab.id] = instance;
-                    }}
-                workspaceId={effectiveContextId}
-                terminalTabId={tab.id === FIXED_TERMINAL_TAB_VALUE ? undefined : tab.id}
-                quickOpenAgents={terminalQuickOpenAgents}
-                className="h-full"
-                isProjectContext={currentView === "project"}
-                onNewTerminalTab={handleCreateTerminalCenterTab}
-                onTerminalPaneClosed={handleTerminalPaneClosed}
-              />
+      {contextIdsToRender.map((contextId) => {
+        const isActiveContext = contextId === effectiveContextId;
+        const tabs = isActiveContext 
+          ? visibleTerminalTabs 
+          : (allWorkspaceTerminalTabs[contextId] || [{ id: FIXED_TERMINAL_TAB_VALUE, title: "Term", closable: true }]);
+        const mountedTabs = mountedTerminalTabsByContext[contextId] || [];
+        const isProject = isActiveContext ? currentView === "project" : (workspaceContexts[contextId] ?? false);
+
+        return tabs
+          .filter((tab) => mountedTabs.includes(tab.id))
+          .map((tab) => (
+            <div
+              key={`${contextId}-${tab.id}`}
+              className={cn(
+                "flex-1 min-h-0 min-w-0",
+                (!isActiveContext || activeValue !== tab.id) && "hidden",
+              )}
+            >
+              <div className="h-full w-full">
+                <TerminalGrid
+                  ref={isActiveContext
+                    ? (tab.id === FIXED_TERMINAL_TAB_VALUE
+                        ? terminalGridRef
+                        : (instance) => {
+                            if (terminalGridRefs.current) {
+                              terminalGridRefs.current[tab.id] = instance;
+                            }
+                          })
+                    : undefined
+                  }
+                  workspaceId={contextId}
+                  terminalTabId={tab.id === FIXED_TERMINAL_TAB_VALUE ? undefined : tab.id}
+                  quickOpenAgents={terminalQuickOpenAgents}
+                  className="h-full"
+                  isProjectContext={isProject}
+                  onNewTerminalTab={isActiveContext ? handleCreateTerminalCenterTab : undefined}
+                  onTerminalPaneClosed={isActiveContext ? handleTerminalPaneClosed : undefined}
+                />
+              </div>
             </div>
-          </div>
-        ))}
+          ));
+      })}
 
       {projectWikiTabVisible && (
         <div

--- a/apps/web/src/app-shell/CenterStagePanels.tsx
+++ b/apps/web/src/app-shell/CenterStagePanels.tsx
@@ -182,43 +182,47 @@ export function CenterStagePanels({
         const isActiveContext = contextId === effectiveContextId;
         const tabs = isActiveContext 
           ? visibleTerminalTabs 
-          : (allWorkspaceTerminalTabs[contextId] || [{ id: FIXED_TERMINAL_TAB_VALUE, title: "Term", closable: true }]);
+          : (allWorkspaceTerminalTabs[contextId] || [{ id: FIXED_TERMINAL_TAB_VALUE, title: t("fallbackTerminalTitle"), closable: true }]);
         const mountedTabs = mountedTerminalTabsByContext[contextId] || [];
         const isProject = isActiveContext ? currentView === "project" : (workspaceContexts[contextId] ?? false);
 
-        return tabs
-          .filter((tab) => mountedTabs.includes(tab.id))
-          .map((tab) => (
-            <div
-              key={`${contextId}-${tab.id}`}
-              className={cn(
-                "flex-1 min-h-0 min-w-0",
-                (!isActiveContext || activeValue !== tab.id) && "hidden",
-              )}
-            >
-              <div className="h-full w-full">
-                <TerminalGrid
-                  ref={isActiveContext
-                    ? (tab.id === FIXED_TERMINAL_TAB_VALUE
-                        ? terminalGridRef
-                        : (instance) => {
-                            if (terminalGridRefs.current) {
-                              terminalGridRefs.current[tab.id] = instance;
-                            }
-                          })
-                    : undefined
-                  }
-                  workspaceId={contextId}
-                  terminalTabId={tab.id === FIXED_TERMINAL_TAB_VALUE ? undefined : tab.id}
-                  quickOpenAgents={terminalQuickOpenAgents}
-                  className="h-full"
-                  isProjectContext={isProject}
-                  onNewTerminalTab={isActiveContext ? handleCreateTerminalCenterTab : undefined}
-                  onTerminalPaneClosed={isActiveContext ? handleTerminalPaneClosed : undefined}
-                />
-              </div>
-            </div>
-          ));
+        return (
+          <React.Fragment key={contextId}>
+            {tabs
+              .filter((tab) => mountedTabs.includes(tab.id))
+              .map((tab) => (
+                <div
+                  key={`${contextId}-${tab.id}`}
+                  className={cn(
+                    "flex-1 min-h-0 min-w-0",
+                    (!isActiveContext || activeValue !== tab.id) && "hidden",
+                  )}
+                >
+                  <div className="h-full w-full">
+                    <TerminalGrid
+                      ref={isActiveContext
+                        ? (tab.id === FIXED_TERMINAL_TAB_VALUE
+                            ? terminalGridRef
+                            : (instance) => {
+                                if (terminalGridRefs.current) {
+                                  terminalGridRefs.current[tab.id] = instance;
+                                }
+                              })
+                        : undefined
+                      }
+                      workspaceId={contextId}
+                      terminalTabId={tab.id === FIXED_TERMINAL_TAB_VALUE ? undefined : tab.id}
+                      quickOpenAgents={terminalQuickOpenAgents}
+                      className="h-full"
+                      isProjectContext={isProject}
+                      onNewTerminalTab={isActiveContext ? handleCreateTerminalCenterTab : undefined}
+                      onTerminalPaneClosed={isActiveContext ? handleTerminalPaneClosed : undefined}
+                    />
+                  </div>
+                </div>
+              ))}
+          </React.Fragment>
+        );
       })}
 
       {projectWikiTabVisible && (

--- a/apps/web/src/app-shell/center-stage-support.tsx
+++ b/apps/web/src/app-shell/center-stage-support.tsx
@@ -13,6 +13,7 @@ import type { OpenFile } from "@/features/editor/store/use-editor-store";
 import type { TerminalCenterTab } from "@/features/terminal/store/use-terminal-store";
 import { FIXED_TABS, isTerminalCenterTabValue } from "@/app-shell/center-stage-tabs";
 import type { Project, Workspace } from "@/shared/types/domain";
+import { useTerminalCacheStore } from "@/features/terminal/store/use-terminal-cache-store";
 
 type TerminalGridRef = React.RefObject<TerminalGridHandle | null>;
 type TerminalGridRefs = React.RefObject<Record<string, TerminalGridHandle | null>>;
@@ -145,31 +146,15 @@ export function useTerminalTabMountLifecycle({
   visibleTerminalTabs: TerminalCenterTab[];
 }) {
   const previousTerminalContextRef = React.useRef<string | null>(null);
+  const touch = useTerminalCacheStore(s => s.touch);
 
   React.useEffect(() => {
     const previousContextId = previousTerminalContextRef.current;
 
     if (previousContextId && previousContextId !== effectiveContextId) {
-      terminalGridRef.current?.destroyAllTerminals();
-      for (const grid of Object.values(terminalGridRefsRef.current)) {
-        grid?.destroyAllTerminals();
-      }
-      projectWikiTerminalGridRef.current?.destroyAllTerminals();
-      codeReviewTerminalGridRef.current?.destroyAllTerminals();
-
-      terminalGridRefsRef.current = {};
-
-      setMountedTerminalTabsByContext((current) => {
-        if (!(previousContextId in current)) {
-          return current;
-        }
-
-        const next = { ...current };
-        delete next[previousContextId];
-        return next;
-      });
-
-      evictWorkspaceRuntime(previousContextId);
+      // Instead of destroying terminals immediately, we push it to the cache.
+      // The cache store's eviction logic will call destroyAllTerminals and evictWorkspaceRuntime.
+      touch(previousContextId);
     }
 
     previousTerminalContextRef.current = effectiveContextId ?? null;

--- a/apps/web/src/app-shell/center-stage-support.tsx
+++ b/apps/web/src/app-shell/center-stage-support.tsx
@@ -126,47 +126,43 @@ export function useReloadOpenFilesWhenReady({
 
 export function useTerminalTabMountLifecycle({
   activeValue,
-  codeReviewTerminalGridRef,
   effectiveContextId,
-  evictWorkspaceRuntime,
-  projectWikiTerminalGridRef,
   setMountedTerminalTabsByContext,
-  terminalGridRef,
-  terminalGridRefsRef,
   visibleTerminalTabs,
 }: {
   activeValue: string;
-  codeReviewTerminalGridRef: TerminalGridRef;
   effectiveContextId: string | null | undefined;
-  evictWorkspaceRuntime: (workspaceId: string) => void;
-  projectWikiTerminalGridRef: TerminalGridRef;
   setMountedTerminalTabsByContext: React.Dispatch<React.SetStateAction<Record<string, string[]>>>;
-  terminalGridRef: TerminalGridRef;
-  terminalGridRefsRef: TerminalGridRefs;
   visibleTerminalTabs: TerminalCenterTab[];
 }) {
   const previousTerminalContextRef = React.useRef<string | null>(null);
   const touch = useTerminalCacheStore(s => s.touch);
+  const activate = useTerminalCacheStore(s => s.activate);
+  const sweepExpired = useTerminalCacheStore(s => s.sweepExpired);
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      sweepExpired();
+    }, 60 * 1000); // Check every minute
+    return () => clearInterval(interval);
+  }, [sweepExpired]);
 
   React.useEffect(() => {
     const previousContextId = previousTerminalContextRef.current;
 
     if (previousContextId && previousContextId !== effectiveContextId) {
       // Instead of destroying terminals immediately, we push it to the cache.
-      // The cache store's eviction logic will call destroyAllTerminals and evictWorkspaceRuntime.
+      // The cache store's eviction logic will call evictWorkspaceRuntime.
+      // WebGL contexts are cleaned up automatically when the TerminalGrid unmounts.
       touch(previousContextId);
+    }
+    
+    if (effectiveContextId) {
+      activate(effectiveContextId);
     }
 
     previousTerminalContextRef.current = effectiveContextId ?? null;
-  }, [
-    codeReviewTerminalGridRef,
-    effectiveContextId,
-    evictWorkspaceRuntime,
-    projectWikiTerminalGridRef,
-    setMountedTerminalTabsByContext,
-    terminalGridRef,
-    terminalGridRefsRef,
-  ]);
+  }, [effectiveContextId, touch, activate]);
 
   React.useEffect(() => {
     if (!effectiveContextId || !isTerminalCenterTabValue(activeValue)) return;

--- a/apps/web/src/app-shell/center-stage-support.tsx
+++ b/apps/web/src/app-shell/center-stage-support.tsx
@@ -137,32 +137,51 @@ export function useTerminalTabMountLifecycle({
 }) {
   const previousTerminalContextRef = React.useRef<string | null>(null);
   const touch = useTerminalCacheStore(s => s.touch);
-  const activate = useTerminalCacheStore(s => s.activate);
+  const setActiveContextId = useTerminalCacheStore(s => s.setActiveContextId);
   const sweepExpired = useTerminalCacheStore(s => s.sweepExpired);
+  const cachedContexts = useTerminalCacheStore(s => s.cachedContexts);
 
   React.useEffect(() => {
-    const interval = setInterval(() => {
-      sweepExpired();
-    }, 60 * 1000); // Check every minute
-    return () => clearInterval(interval);
-  }, [sweepExpired]);
+    setMountedTerminalTabsByContext((current) => {
+      const activeIds = new Set([
+        effectiveContextId,
+        ...cachedContexts.map((c) => c.contextId),
+      ]);
+      let changed = false;
+      const next: Record<string, string[]> = {};
+      for (const [key, value] of Object.entries(current)) {
+        if (activeIds.has(key)) {
+          next[key] = value;
+        } else {
+          changed = true;
+        }
+      }
+      return changed ? next : current;
+    });
+  }, [effectiveContextId, cachedContexts, setMountedTerminalTabsByContext]);
+
+  React.useEffect(() => {
+    // Only register one sweeper interval globally to prevent HMR leaks
+    if (!(globalThis as any).__terminalCacheSweeperInterval) {
+      (globalThis as any).__terminalCacheSweeperInterval = setInterval(() => {
+        useTerminalCacheStore.getState().sweepExpired();
+      }, 60 * 1000);
+    }
+  }, []);
 
   React.useEffect(() => {
     const previousContextId = previousTerminalContextRef.current;
 
+    // First mark the new context as active so it is protected from eviction
+    setActiveContextId(effectiveContextId ?? null);
+
+    // Then touch the previous context to push it into the LRU cache
     if (previousContextId && previousContextId !== effectiveContextId) {
-      // Instead of destroying terminals immediately, we push it to the cache.
-      // The cache store's eviction logic will call evictWorkspaceRuntime.
-      // WebGL contexts are cleaned up automatically when the TerminalGrid unmounts.
       touch(previousContextId);
-    }
-    
-    if (effectiveContextId) {
-      activate(effectiveContextId);
     }
 
     previousTerminalContextRef.current = effectiveContextId ?? null;
-  }, [effectiveContextId, touch, activate]);
+  }, [effectiveContextId, touch, setActiveContextId]);
 
   React.useEffect(() => {
     if (!effectiveContextId || !isTerminalCenterTabValue(activeValue)) return;

--- a/apps/web/src/app-shell/center-stage-support.tsx
+++ b/apps/web/src/app-shell/center-stage-support.tsx
@@ -145,6 +145,7 @@ export function useTerminalTabMountLifecycle({
     setMountedTerminalTabsByContext((current) => {
       const activeIds = new Set([
         effectiveContextId,
+        previousTerminalContextRef.current,
         ...cachedContexts.map((c) => c.contextId),
       ]);
       let changed = false;

--- a/apps/web/src/features/settings/components/SettingsModal.tsx
+++ b/apps/web/src/features/settings/components/SettingsModal.tsx
@@ -14,6 +14,7 @@ import {
 import { AGENT_OPTIONS } from '@/features/wiki/components/AgentSelect';
 import { useTerminalLinkSettingsStore } from '@/features/settings/store/terminal-link-settings-store';
 import { useTerminalSideChatSettingsStore } from '@/features/settings/store/terminal-side-chat-settings-store';
+import { useTerminalCacheStore } from '@/features/terminal/store/use-terminal-cache-store';
 import { useTerminalSplitPrefsStore } from '@/features/settings/store/terminal-split-prefs-store';
 import {
   agentBehaviourSettingsApi,
@@ -279,6 +280,9 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
     loadSettings: loadTerminalSideChatSettings,
     setSideContextPromptBudgetBytes,
   } = useTerminalSideChatSettingsStore();
+  const { maxSize, maxTerminalPanelsPerWorkspace, loadSettings: loadTerminalCacheSettings } = useTerminalCacheStore();
+  const setTerminalCacheMaxSize = useTerminalCacheStore((state) => state.setMaxSize);
+  const setTerminalCacheMaxPanels = useTerminalCacheStore((state) => state.setMaxTerminalPanelsPerWorkspace);
 
   useEffect(() => {
     void loadTerminalLinkSettings();
@@ -896,6 +900,10 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                     setFileLinkOpenApp={setFileLinkOpenApp}
                     setUseLastSplitAgentOnSplit={setUseLastSplitAgentOnSplit}
                     setSideContextPromptBudgetBytes={setSideContextPromptBudgetBytes}
+                    terminalCacheMaxSize={maxSize}
+                    terminalCacheMaxPanels={maxTerminalPanelsPerWorkspace}
+                    setTerminalCacheMaxSize={setTerminalCacheMaxSize}
+                    setTerminalCacheMaxPanels={setTerminalCacheMaxPanels}
                     agentCustomSettings={agentCustomSettings}
                     agentSettingsLoading={agentSettingsLoading}
                     builtInAgentOpen={builtInAgentOpen}

--- a/apps/web/src/features/settings/components/SettingsModalSections.tsx
+++ b/apps/web/src/features/settings/components/SettingsModalSections.tsx
@@ -52,6 +52,10 @@ interface SettingsModalSectionsProps {
   setFileLinkOpenApp: (app: QuickOpenAppName) => Promise<void> | void;
   setUseLastSplitAgentOnSplit: (enabled: boolean) => void;
   setSideContextPromptBudgetBytes: (bytes: number) => Promise<void> | void;
+  terminalCacheMaxSize: number;
+  terminalCacheMaxPanels: number;
+  setTerminalCacheMaxSize: (size: number) => Promise<void> | void;
+  setTerminalCacheMaxPanels: (panels: number) => Promise<void> | void;
   agentCustomSettings: BuiltInAgentSettings;
   agentSettingsLoading: boolean;
   builtInAgentOpen: Record<string, boolean>;
@@ -156,6 +160,10 @@ export function SettingsModalSections(props: SettingsModalSectionsProps) {
           setFileLinkOpenApp={props.setFileLinkOpenApp}
           setUseLastSplitAgentOnSplit={props.setUseLastSplitAgentOnSplit}
           setSideContextPromptBudgetBytes={props.setSideContextPromptBudgetBytes}
+          terminalCacheMaxSize={props.terminalCacheMaxSize}
+          terminalCacheMaxPanels={props.terminalCacheMaxPanels}
+          setTerminalCacheMaxSize={props.setTerminalCacheMaxSize}
+          setTerminalCacheMaxPanels={props.setTerminalCacheMaxPanels}
         />
       );
     case 'code-agent':

--- a/apps/web/src/features/settings/components/TerminalSettingsSection.tsx
+++ b/apps/web/src/features/settings/components/TerminalSettingsSection.tsx
@@ -36,6 +36,10 @@ export function TerminalSettingsSection({
   setFileLinkOpenApp,
   setUseLastSplitAgentOnSplit,
   setSideContextPromptBudgetBytes,
+  terminalCacheMaxSize,
+  terminalCacheMaxPanels,
+  setTerminalCacheMaxSize,
+  setTerminalCacheMaxPanels,
 }: {
   fileLinkOpenMode: TerminalFileLinkOpenMode;
   fileLinkOpenApp: QuickOpenAppName;
@@ -46,9 +50,15 @@ export function TerminalSettingsSection({
   setFileLinkOpenApp: (app: QuickOpenAppName) => Promise<void> | void;
   setUseLastSplitAgentOnSplit: (enabled: boolean) => void;
   setSideContextPromptBudgetBytes: (bytes: number) => Promise<void> | void;
+  terminalCacheMaxSize: number;
+  terminalCacheMaxPanels: number;
+  setTerminalCacheMaxSize: (size: number) => Promise<void> | void;
+  setTerminalCacheMaxPanels: (panels: number) => Promise<void> | void;
 }) {
   const t = useTranslations('settings.terminalSection');
   const locale = useLocale();
+  const [localTerminalCacheMaxSize, setLocalTerminalCacheMaxSize] = React.useState(terminalCacheMaxSize.toString());
+  const [localTerminalCacheMaxPanels, setLocalTerminalCacheMaxPanels] = React.useState(terminalCacheMaxPanels.toString());
   const [localSideContextBudget, setLocalSideContextBudget] = React.useState(
     sideContextPromptBudgetBytes.toString(),
   );
@@ -81,6 +91,36 @@ export function TerminalSettingsSection({
   React.useEffect(() => {
     setLocalSideContextBudget(sideContextPromptBudgetBytes.toString());
   }, [sideContextPromptBudgetBytes]);
+
+  React.useEffect(() => {
+    setLocalTerminalCacheMaxSize(terminalCacheMaxSize.toString());
+  }, [terminalCacheMaxSize]);
+
+  React.useEffect(() => {
+    setLocalTerminalCacheMaxPanels(terminalCacheMaxPanels.toString());
+  }, [terminalCacheMaxPanels]);
+
+  const handleTerminalCacheMaxSizeCommit = async (value: string) => {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isNaN(parsed) || parsed < 1) {
+      setLocalTerminalCacheMaxSize(terminalCacheMaxSize.toString());
+      return;
+    }
+    const normalized = Math.min(50, Math.max(1, parsed));
+    setLocalTerminalCacheMaxSize(normalized.toString());
+    await setTerminalCacheMaxSize(normalized);
+  };
+
+  const handleTerminalCacheMaxPanelsCommit = async (value: string) => {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isNaN(parsed) || parsed < 1) {
+      setLocalTerminalCacheMaxPanels(terminalCacheMaxPanels.toString());
+      return;
+    }
+    const normalized = Math.min(100, Math.max(1, parsed));
+    setLocalTerminalCacheMaxPanels(normalized.toString());
+    await setTerminalCacheMaxPanels(normalized);
+  };
 
   const handleSideContextBudgetCommit = async (value: string) => {
     const parsed = Number.parseInt(value, 10);
@@ -213,6 +253,62 @@ export function TerminalSettingsSection({
               className="w-32"
             />
             <span className="text-sm text-muted-foreground">{t('sideContextBudget.bytes')}</span>
+          </div>
+        </div>
+      </div>
+      <div className="grid grid-cols-[minmax(0,1fr)_320px] gap-8 border-t border-border px-6 py-5">
+        <div>
+          <p className="text-base font-medium text-foreground">{t('cacheWorkspaces.title')}</p>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            {t('cacheWorkspaces.description')}
+          </p>
+        </div>
+        <div className="flex items-center justify-end">
+          <div className="flex items-center gap-2">
+            <Input
+              type="number"
+              min={1}
+              max={50}
+              step={1}
+              value={localTerminalCacheMaxSize}
+              onChange={(event) => setLocalTerminalCacheMaxSize(event.target.value)}
+              onBlur={(event) => void handleTerminalCacheMaxSizeCommit(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  void handleTerminalCacheMaxSizeCommit(localTerminalCacheMaxSize);
+                }
+              }}
+              className="w-24"
+            />
+            <span className="text-sm text-muted-foreground">{t('cacheWorkspaces.contexts')}</span>
+          </div>
+        </div>
+      </div>
+      <div className="grid grid-cols-[minmax(0,1fr)_320px] gap-8 border-t border-border px-6 py-5">
+        <div>
+          <p className="text-base font-medium text-foreground">{t('cachePanels.title')}</p>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            {t('cachePanels.description')}
+          </p>
+        </div>
+        <div className="flex items-center justify-end">
+          <div className="flex items-center gap-2">
+            <Input
+              type="number"
+              min={1}
+              max={100}
+              step={1}
+              value={localTerminalCacheMaxPanels}
+              onChange={(event) => setLocalTerminalCacheMaxPanels(event.target.value)}
+              onBlur={(event) => void handleTerminalCacheMaxPanelsCommit(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  void handleTerminalCacheMaxPanelsCommit(localTerminalCacheMaxPanels);
+                }
+              }}
+              className="w-24"
+            />
+            <span className="text-sm text-muted-foreground">{t('cachePanels.panels')}</span>
           </div>
         </div>
       </div>

--- a/apps/web/src/features/terminal/store/use-terminal-cache-store.ts
+++ b/apps/web/src/features/terminal/store/use-terminal-cache-store.ts
@@ -10,12 +10,13 @@ interface CachedContext {
 
 interface TerminalCacheStore {
   cachedContexts: CachedContext[];
+  activeContextId: string | null;
   maxSize: number;
   maxTerminalCount: number;
   ttlMs: number;
   
   touch: (contextId: string) => void;
-  activate: (contextId: string) => void;
+  setActiveContextId: (contextId: string | null) => void;
   remove: (contextId: string) => void;
   sweepExpired: () => void;
 }
@@ -23,12 +24,24 @@ interface TerminalCacheStore {
 export const useTerminalCacheStore = create<TerminalCacheStore>((set) => {
   return {
     cachedContexts: [],
+    activeContextId: null,
     maxSize: 5,
     maxTerminalCount: 15,
     ttlMs: 60 * 60 * 1000, // 1 hour
 
+    setActiveContextId: (contextId) => {
+      set((state) => {
+        if (state.activeContextId === contextId) return state;
+        const nextCached = state.cachedContexts.filter(c => c.contextId !== contextId);
+        return { activeContextId: contextId, cachedContexts: nextCached };
+      });
+    },
+
     touch: (contextId) => {
       set((state) => {
+        // Do not cache the currently active context
+        if (state.activeContextId === contextId) return state;
+
         const now = Date.now();
         const existingIndex = state.cachedContexts.findIndex(c => c.contextId === contextId);
         
@@ -47,7 +60,7 @@ export const useTerminalCacheStore = create<TerminalCacheStore>((set) => {
         while (nextCached.length > 0) {
           if (nextCached.length > state.maxSize) {
             const evicted = nextCached.shift(); // The oldest is at the beginning
-            if (evicted) {
+            if (evicted && evicted.contextId !== state.activeContextId) {
               setTimeout(() => {
                 useTerminalStore.getState().evictWorkspaceRuntime(evicted.contextId);
               }, 0);
@@ -65,7 +78,7 @@ export const useTerminalCacheStore = create<TerminalCacheStore>((set) => {
 
           if (currentTotalTerminals > state.maxTerminalCount) {
             const evicted = nextCached.shift();
-            if (evicted) {
+            if (evicted && evicted.contextId !== state.activeContextId) {
               setTimeout(() => {
                 useTerminalStore.getState().evictWorkspaceRuntime(evicted.contextId);
               }, 0);
@@ -76,13 +89,6 @@ export const useTerminalCacheStore = create<TerminalCacheStore>((set) => {
           break;
         }
 
-        return { cachedContexts: nextCached };
-      });
-    },
-
-    activate: (contextId) => {
-      set((state) => {
-        const nextCached = state.cachedContexts.filter(c => c.contextId !== contextId);
         return { cachedContexts: nextCached };
       });
     },
@@ -106,19 +112,21 @@ export const useTerminalCacheStore = create<TerminalCacheStore>((set) => {
         const evicted: string[] = [];
 
         for (const context of state.cachedContexts) {
-          if (now - context.lastAccessed > state.ttlMs) {
+          if (now - context.lastAccessed > state.ttlMs && context.contextId !== state.activeContextId) {
             evicted.push(context.contextId);
           } else {
             nextCached.push(context);
           }
         }
 
-        if (evicted.length > 0) {
-          setTimeout(() => {
-            const evictRuntime = useTerminalStore.getState().evictWorkspaceRuntime;
-            evicted.forEach(id => evictRuntime(id));
-          }, 0);
+        if (evicted.length === 0) {
+          return state;
         }
+
+        setTimeout(() => {
+          const evictRuntime = useTerminalStore.getState().evictWorkspaceRuntime;
+          evicted.forEach(id => evictRuntime(id));
+        }, 0);
 
         return { cachedContexts: nextCached };
       });

--- a/apps/web/src/features/terminal/store/use-terminal-cache-store.ts
+++ b/apps/web/src/features/terminal/store/use-terminal-cache-store.ts
@@ -1,0 +1,102 @@
+"use client";
+
+import { create } from "zustand";
+import { useTerminalStore } from "@/features/terminal/store/use-terminal-store";
+
+interface CachedContext {
+  contextId: string;
+  lastAccessed: number;
+}
+
+interface TerminalCacheStore {
+  cachedContexts: CachedContext[];
+  maxSize: number;
+  ttlMs: number;
+  
+  touch: (contextId: string) => void;
+  remove: (contextId: string) => void;
+  sweepExpired: () => void;
+}
+
+export const useTerminalCacheStore = create<TerminalCacheStore>((set) => {
+  return {
+    cachedContexts: [],
+    maxSize: 5,
+    ttlMs: 60 * 60 * 1000, // 1 hour
+
+    touch: (contextId) => {
+      set((state) => {
+        const now = Date.now();
+        const existingIndex = state.cachedContexts.findIndex(c => c.contextId === contextId);
+        
+        const nextCached = [...state.cachedContexts];
+        
+        if (existingIndex !== -1) {
+          // Update timestamp and move to end (most recently used)
+          const item = nextCached.splice(existingIndex, 1)[0];
+          nextCached.push({ ...item, lastAccessed: now });
+        } else {
+          // Add new item
+          nextCached.push({ contextId, lastAccessed: now });
+        }
+
+        // Evict if over maxSize
+        if (nextCached.length > state.maxSize) {
+          const evicted = nextCached.shift(); // The oldest is at the beginning
+          if (evicted) {
+            // Trigger destruction
+            setTimeout(() => {
+              useTerminalStore.getState().evictWorkspaceRuntime(evicted.contextId);
+            }, 0);
+          }
+        }
+
+        return { cachedContexts: nextCached };
+      });
+    },
+
+    remove: (contextId) => {
+      set((state) => {
+        const nextCached = state.cachedContexts.filter(c => c.contextId !== contextId);
+        if (nextCached.length !== state.cachedContexts.length) {
+          setTimeout(() => {
+            useTerminalStore.getState().evictWorkspaceRuntime(contextId);
+          }, 0);
+        }
+        return { cachedContexts: nextCached };
+      });
+    },
+
+    sweepExpired: () => {
+      set((state) => {
+        const now = Date.now();
+        const nextCached = [];
+        const evicted: string[] = [];
+
+        for (const context of state.cachedContexts) {
+          if (now - context.lastAccessed > state.ttlMs) {
+            evicted.push(context.contextId);
+          } else {
+            nextCached.push(context);
+          }
+        }
+
+        if (evicted.length > 0) {
+          setTimeout(() => {
+            const evictRuntime = useTerminalStore.getState().evictWorkspaceRuntime;
+            evicted.forEach(id => evictRuntime(id));
+          }, 0);
+        }
+
+        return { cachedContexts: nextCached };
+      });
+    },
+  };
+});
+
+// Setup TTL sweeper interval
+if (typeof window !== "undefined") {
+  setInterval(() => {
+    useTerminalCacheStore.getState().sweepExpired();
+  }, 60 * 1000); // Check every minute
+}

--- a/apps/web/src/features/terminal/store/use-terminal-cache-store.ts
+++ b/apps/web/src/features/terminal/store/use-terminal-cache-store.ts
@@ -15,6 +15,7 @@ interface TerminalCacheStore {
   ttlMs: number;
   
   touch: (contextId: string) => void;
+  activate: (contextId: string) => void;
   remove: (contextId: string) => void;
   sweepExpired: () => void;
 }
@@ -79,6 +80,13 @@ export const useTerminalCacheStore = create<TerminalCacheStore>((set) => {
       });
     },
 
+    activate: (contextId) => {
+      set((state) => {
+        const nextCached = state.cachedContexts.filter(c => c.contextId !== contextId);
+        return { cachedContexts: nextCached };
+      });
+    },
+
     remove: (contextId) => {
       set((state) => {
         const nextCached = state.cachedContexts.filter(c => c.contextId !== contextId);
@@ -117,10 +125,3 @@ export const useTerminalCacheStore = create<TerminalCacheStore>((set) => {
     },
   };
 });
-
-// Setup TTL sweeper interval
-if (typeof window !== "undefined") {
-  setInterval(() => {
-    useTerminalCacheStore.getState().sweepExpired();
-  }, 60 * 1000); // Check every minute
-}

--- a/apps/web/src/features/terminal/store/use-terminal-cache-store.ts
+++ b/apps/web/src/features/terminal/store/use-terminal-cache-store.ts
@@ -12,9 +12,12 @@ interface TerminalCacheStore {
   cachedContexts: CachedContext[];
   activeContextId: string | null;
   maxSize: number;
-  maxTerminalCount: number;
+  maxTerminalPanelsPerWorkspace: number;
   ttlMs: number;
   
+  loadSettings: () => Promise<void>;
+  setMaxSize: (maxSize: number) => Promise<void>;
+  setMaxTerminalPanelsPerWorkspace: (max: number) => Promise<void>;
   touch: (contextId: string) => void;
   setActiveContextId: (contextId: string | null) => void;
   remove: (contextId: string) => void;
@@ -25,9 +28,34 @@ export const useTerminalCacheStore = create<TerminalCacheStore>((set) => {
   return {
     cachedContexts: [],
     activeContextId: null,
-    maxSize: 5,
-    maxTerminalCount: 15,
+    maxSize: 10,
+    maxTerminalPanelsPerWorkspace: 15,
     ttlMs: 60 * 60 * 1000, // 1 hour
+
+    loadSettings: async () => {
+      try {
+        const { useFunctionSettingsStore } = await import("@/features/settings/store/function-settings-store");
+        const settings = await useFunctionSettingsStore.getState().load();
+        set((state) => ({
+          maxSize: settings.terminal?.max_cached_workspaces ?? state.maxSize,
+          maxTerminalPanelsPerWorkspace: settings.terminal?.max_cached_terminal_panels_per_workspace ?? state.maxTerminalPanelsPerWorkspace,
+        }));
+      } catch {
+        // ignore
+      }
+    },
+
+    setMaxSize: async (maxSize: number) => {
+      set({ maxSize });
+      const { functionSettingsApi } = await import("@/api/ws-api");
+      await functionSettingsApi.update("terminal", "max_cached_workspaces", maxSize);
+    },
+
+    setMaxTerminalPanelsPerWorkspace: async (max: number) => {
+      set({ maxTerminalPanelsPerWorkspace: max });
+      const { functionSettingsApi } = await import("@/api/ws-api");
+      await functionSettingsApi.update("terminal", "max_cached_terminal_panels_per_workspace", max);
+    },
 
     setActiveContextId: (contextId) => {
       set((state) => {
@@ -56,40 +84,52 @@ export const useTerminalCacheStore = create<TerminalCacheStore>((set) => {
           nextCached.push({ contextId, lastAccessed: now });
         }
 
-        // Evict if over maxSize or over maxTerminalCount
-        while (nextCached.length > 0) {
-          if (nextCached.length > state.maxSize) {
-            const evicted = nextCached.shift(); // The oldest is at the beginning
-            if (evicted && evicted.contextId !== state.activeContextId) {
-              setTimeout(() => {
-                useTerminalStore.getState().evictWorkspaceRuntime(evicted.contextId);
-              }, 0);
+        // Evict if over maxSize or if ANY context violates the maxTerminalPanelsPerWorkspace limit
+        const nextCachedFiltered: typeof nextCached = [];
+        const evictedList: string[] = [];
+
+        const terminalStoreState = useTerminalStore.getState();
+
+        // 1. Check maxTerminalPanelsPerWorkspace for each context
+        for (const cacheItem of nextCached) {
+          const tabs = terminalStoreState.workspaceTerminalTabs[cacheItem.contextId];
+          let totalPanelsInContext = 0;
+          if (tabs) {
+            for (const tab of tabs) {
+              const panes = terminalStoreState.getPanes(cacheItem.contextId, tab.id);
+              totalPanelsInContext += Object.keys(panes).length;
             }
-            continue;
+          } else {
+            totalPanelsInContext = 1;
           }
 
-          // Check terminal count
-          const terminalStoreState = useTerminalStore.getState();
-          let currentTotalTerminals = 0;
-          for (const cacheItem of nextCached) {
-            const tabs = terminalStoreState.workspaceTerminalTabs[cacheItem.contextId];
-            currentTotalTerminals += tabs ? tabs.length : 1;
+          if (totalPanelsInContext > state.maxTerminalPanelsPerWorkspace) {
+            evictedList.push(cacheItem.contextId);
+          } else {
+            nextCachedFiltered.push(cacheItem);
           }
-
-          if (currentTotalTerminals > state.maxTerminalCount) {
-            const evicted = nextCached.shift();
-            if (evicted && evicted.contextId !== state.activeContextId) {
-              setTimeout(() => {
-                useTerminalStore.getState().evictWorkspaceRuntime(evicted.contextId);
-              }, 0);
-            }
-            continue;
-          }
-
-          break;
         }
 
-        return { cachedContexts: nextCached };
+        // 2. Enforce maxSize (LRU - oldest at the beginning of the array)
+        while (nextCachedFiltered.length > state.maxSize) {
+          const evicted = nextCachedFiltered.shift();
+          if (evicted) {
+            evictedList.push(evicted.contextId);
+          }
+        }
+
+        if (evictedList.length > 0) {
+          setTimeout(() => {
+            const evictRuntime = useTerminalStore.getState().evictWorkspaceRuntime;
+            for (const id of evictedList) {
+              if (id !== state.activeContextId) {
+                evictRuntime(id);
+              }
+            }
+          }, 0);
+        }
+
+        return { cachedContexts: nextCachedFiltered };
       });
     },
 
@@ -133,3 +173,4 @@ export const useTerminalCacheStore = create<TerminalCacheStore>((set) => {
     },
   };
 });
+if (typeof window !== 'undefined') { useTerminalCacheStore.getState().loadSettings(); }

--- a/apps/web/src/features/terminal/store/use-terminal-cache-store.ts
+++ b/apps/web/src/features/terminal/store/use-terminal-cache-store.ts
@@ -11,6 +11,7 @@ interface CachedContext {
 interface TerminalCacheStore {
   cachedContexts: CachedContext[];
   maxSize: number;
+  maxTerminalCount: number;
   ttlMs: number;
   
   touch: (contextId: string) => void;
@@ -22,6 +23,7 @@ export const useTerminalCacheStore = create<TerminalCacheStore>((set) => {
   return {
     cachedContexts: [],
     maxSize: 5,
+    maxTerminalCount: 15,
     ttlMs: 60 * 60 * 1000, // 1 hour
 
     touch: (contextId) => {
@@ -40,15 +42,37 @@ export const useTerminalCacheStore = create<TerminalCacheStore>((set) => {
           nextCached.push({ contextId, lastAccessed: now });
         }
 
-        // Evict if over maxSize
-        if (nextCached.length > state.maxSize) {
-          const evicted = nextCached.shift(); // The oldest is at the beginning
-          if (evicted) {
-            // Trigger destruction
-            setTimeout(() => {
-              useTerminalStore.getState().evictWorkspaceRuntime(evicted.contextId);
-            }, 0);
+        // Evict if over maxSize or over maxTerminalCount
+        while (nextCached.length > 0) {
+          if (nextCached.length > state.maxSize) {
+            const evicted = nextCached.shift(); // The oldest is at the beginning
+            if (evicted) {
+              setTimeout(() => {
+                useTerminalStore.getState().evictWorkspaceRuntime(evicted.contextId);
+              }, 0);
+            }
+            continue;
           }
+
+          // Check terminal count
+          const terminalStoreState = useTerminalStore.getState();
+          let currentTotalTerminals = 0;
+          for (const cacheItem of nextCached) {
+            const tabs = terminalStoreState.workspaceTerminalTabs[cacheItem.contextId];
+            currentTotalTerminals += tabs ? tabs.length : 1;
+          }
+
+          if (currentTotalTerminals > state.maxTerminalCount) {
+            const evicted = nextCached.shift();
+            if (evicted) {
+              setTimeout(() => {
+                useTerminalStore.getState().evictWorkspaceRuntime(evicted.contextId);
+              }, 0);
+            }
+            continue;
+          }
+
+          break;
         }
 
         return { cachedContexts: nextCached };

--- a/specs/APP/APP-034_terminal_caching/PRD.md
+++ b/specs/APP/APP-034_terminal_caching/PRD.md
@@ -1,0 +1,27 @@
+# PRD: Terminal Workspace Caching
+
+## 1. Context & Problem Statement
+Currently, every time a user switches between workspaces or projects, all terminal tabs in the center stage are destroyed and reloaded from scratch. This causes unnecessary overhead, PTY process restarting, and loses immediate UI continuity for heavily used workspaces.
+
+## 2. Target Audience
+Users who frequently switch between multiple workspaces or projects within a single Atmos session.
+
+## 3. Goals & Success Metrics
+- **Goal:** Cache up to 5 recently used project/workspace terminal tabs in the background.
+- **Goal:** Unused caches expire after 1 hour (TTL) to free up memory and backend PTY resources.
+- **Success Metric:** Switching between recently accessed workspaces feels instantaneous and retains terminal scroll/state.
+
+## 4. Scope
+### Must Have
+- LRU (Least Recently Used) cache strategy for terminal contexts.
+- Maximum capacity of 5 cached contexts.
+- TTL (Time To Live) of 1 hour for each cached context.
+- Keep-alive React rendering (display: none) for cached terminals instead of unmounting.
+
+### Out of Scope
+- Persisting this cache across full browser reloads (localStorage/IndexedDB).
+- Backend PTY hibernation (this is purely frontend keep-alive for now).
+
+## 5. User Stories
+- As a user, when I switch from Workspace A to Workspace B, and back to Workspace A within an hour, my terminals in Workspace A should be exactly as I left them, without a loading delay.
+- As a user, if I switch through 6 different workspaces, the oldest one is evicted to conserve my browser's memory.

--- a/specs/APP/APP-034_terminal_caching/TECH.md
+++ b/specs/APP/APP-034_terminal_caching/TECH.md
@@ -1,0 +1,30 @@
+# TECH: Terminal Workspace Caching
+
+## 1. Architecture
+We use a Zustand store (`useTerminalCacheStore`) to manage the LRU cache and TTL.
+Instead of `TanStack Query` (which is for server state), we leverage React's capability to keep DOM elements mounted but visually hidden (`display: none`).
+
+### Store: `useTerminalCacheStore`
+- **State:**
+  - `cachedContexts`: Array/Map of context IDs and their last access timestamp.
+  - `maxSize`: 5
+  - `ttlMs`: 3,600,000 (1 hour)
+- **Actions:**
+  - `touch(contextId)`: Updates/inserts the context into the cache, moving it to the most recently used.
+  - `evict(contextId)`: Removes the context from the cache and calls `destroyAllTerminals` / `evictWorkspaceRuntime`.
+  - `evictExpired()`: Sweeps through the cache and evicts items older than 1 hour.
+
+### Integration in `CenterStage`
+Currently, `CenterStage` unmounts previous contexts when `effectiveContextId` changes.
+We will:
+1. Render a list of all contexts (active + cached).
+2. For inactive contexts, apply a CSS style `display: none` to `CenterStagePanels`.
+
+### Integration in `useTerminalTabMountLifecycle`
+Instead of immediately calling `evictWorkspaceRuntime(previousContextId)` and destroying terminals, we:
+1. `touch(previousContextId)` in the cache store.
+2. The destruction logic is moved to the cache store's eviction callback.
+
+## 2. Risk & Mitigations
+- **xterm.js Resize Issue:** When returning to a cached workspace (`display: none` -> `display: block`), the canvas may not properly size itself. Mitigation: We may need to trigger a window resize event or call xterm's `fit()` addon when a context becomes active again.
+- **Memory Pressure:** Keeping terminals alive means keeping WebGL instances alive. Max size of 5 and TTL of 1 hour mitigate infinite growth.

--- a/specs/APP/APP-034_terminal_caching/TECH.md
+++ b/specs/APP/APP-034_terminal_caching/TECH.md
@@ -6,8 +6,9 @@ Instead of `TanStack Query` (which is for server state), we leverage React's cap
 
 ### Store: `useTerminalCacheStore`
 - **State:**
-  - `cachedContexts`: Array/Map of context IDs and their last access timestamp.
+  - `cachedContexts`: Array of objects (`{ contextId: string, lastAccessed: number }`) maintaining LRU order.
   - `maxSize`: 5
+  - `maxTerminalCount`: 15
   - `ttlMs`: 3,600,000 (1 hour)
 - **Actions:**
   - `touch(contextId)`: Updates/inserts the context into the cache, moving it to the most recently used.
@@ -26,5 +27,5 @@ Instead of immediately calling `evictWorkspaceRuntime(previousContextId)` and de
 2. The destruction logic is moved to the cache store's eviction callback.
 
 ## 2. Risk & Mitigations
-- **xterm.js Resize Issue:** When returning to a cached workspace (`display: none` -> `display: block`), the canvas may not properly size itself. Mitigation: We may need to trigger a window resize event or call xterm's `fit()` addon when a context becomes active again.
+- **xterm.js Resize Issue:** When returning to a cached workspace (`display: none` -> `display: block`), the canvas may not properly size itself. Mitigation: We commit to relying on the existing `ResizeObserver` inside `TerminalGrid` which automatically triggers `fit()` when the element's dimensions change upon becoming visible. If edge cases appear where `fit()` misses the visibility transition, we will explicitly call `fit()` in an effect tied to the active context state.
 - **Memory Pressure:** Keeping terminals alive means keeping WebGL instances alive. Max size of 5 and TTL of 1 hour mitigate infinite growth.

--- a/specs/APP/APP-034_terminal_caching/TEST.md
+++ b/specs/APP/APP-034_terminal_caching/TEST.md
@@ -1,11 +1,19 @@
 # TEST: Terminal Workspace Caching
 
 ## 1. Unit/Integration Tests
+Tool: `just test-web`
 - [ ] Zustand store (`useTerminalCacheStore`): Verify that adding a 6th context evicts the oldest (LRU).
 - [ ] Zustand store: Verify that sweeping after 1 hour evicts expired contexts.
+- [ ] Zustand store: Verify that adding terminals beyond `maxTerminalCount=15` evicts contexts correctly.
 
 ## 2. E2E / Manual Scenarios
-- [ ] Given I have a terminal open in Workspace A, when I switch to Workspace B, Workspace A's terminal should not be destroyed.
-- [ ] When I switch back to Workspace A, the terminal should be instantly visible and retain its previous content/scroll position.
-- [ ] When I switch across 6 different workspaces consecutively, the very first workspace I opened should be evicted (terminals destroyed) to respect the max 5 cache limit.
-- [ ] After 1 hour of inactivity on Workspace A, the TTL should trigger and its terminals should be destroyed.
+Tool: `just test-e2e` / Manual Verification
+- [ ] Given I have a terminal open in Workspace A with command output visible, when I switch to Workspace B, Workspace A's terminal should not be destroyed (Signal: DOM nodes for Workspace A still exist with `hidden` class).
+- [ ] When I switch back to Workspace A, the terminal should be instantly visible and retain its previous content/scroll position (Signal: terminal output buffer contains the exact same lines and `xterm-viewport` scrollTop is preserved).
+- [ ] When I switch across 6 different workspaces consecutively, the very first workspace I opened should be evicted (Signal: DOM nodes for the first workspace are removed from the page).
+- [ ] After 1 hour of inactivity on Workspace A, the TTL should trigger and its terminals should be destroyed (Signal: `evictWorkspaceRuntime` is called and DOM nodes for Workspace A are removed).
+
+## 3. PRD Coverage Map
+- **LRU Eviction (max 5 workspaces, max 15 terminals):** Covered by Unit Test (Zustand store evictions) and E2E Scenario (6 consecutive workspace switches).
+- **TTL 1 Hour:** Covered by Unit Test (sweeping expired contexts) and E2E Scenario (1 hour inactivity).
+- **Keep-alive rendering (no re-renders on context switch):** Covered by E2E Scenarios (DOM nodes retained, scroll position/content preserved).

--- a/specs/APP/APP-034_terminal_caching/TEST.md
+++ b/specs/APP/APP-034_terminal_caching/TEST.md
@@ -1,19 +1,34 @@
 # TEST: Terminal Workspace Caching
 
-## 1. Unit/Integration Tests
-Tool: `just test-web`
-- [ ] Zustand store (`useTerminalCacheStore`): Verify that adding a 6th context evicts the oldest (LRU).
+## 1. Test Strategy
+The testing strategy involves unit tests for the zustand caching store logic (LRU, TTL, pinned active state) and manual/E2E verification of the UI rendering layer (terminal container preservation, resize handling on visibility restore).
+
+## 2. Execution Map
+- **Zustand store logic**: `just test-web` (under `apps/web/src/features/terminal/store/`)
+- **UI & DOM assertions**: `just test-e2e` / Manual Verification
+
+## 3. Coverage Map
+- **LRU Eviction (max 5 workspaces, max 15 terminals):** Covered by unit tests and manual acceptance criteria (6 consecutive switches).
+- **TTL 1 Hour:** Covered by unit tests and manual scenario (1 hour inactivity).
+- **Keep-alive rendering:** Covered by manual/E2E DOM checks (nodes not removed).
+- **Correct sizing on restore:** Covered by manual resize path scenario.
+
+## 4. Acceptance Criteria (Automated)
+- [ ] Zustand store: Verify that adding a 6th context evicts the oldest (LRU).
 - [ ] Zustand store: Verify that sweeping after 1 hour evicts expired contexts.
 - [ ] Zustand store: Verify that adding terminals beyond `maxTerminalCount=15` evicts contexts correctly.
+- [ ] Zustand store: Verify that the active pinned context is NOT evicted during sweep or LRU limits.
 
-## 2. E2E / Manual Scenarios
-Tool: `just test-e2e` / Manual Verification
-- [ ] Given I have a terminal open in Workspace A with command output visible, when I switch to Workspace B, Workspace A's terminal should not be destroyed (Signal: DOM nodes for Workspace A still exist with `hidden` class).
-- [ ] When I switch back to Workspace A, the terminal should be instantly visible and retain its previous content/scroll position (Signal: terminal output buffer contains the exact same lines and `xterm-viewport` scrollTop is preserved).
-- [ ] When I switch across 6 different workspaces consecutively, the very first workspace I opened should be evicted (Signal: DOM nodes for the first workspace are removed from the page).
-- [ ] After 1 hour of inactivity on Workspace A, the TTL should trigger and its terminals should be destroyed (Signal: `evictWorkspaceRuntime` is called and DOM nodes for Workspace A are removed).
+## 5. Manual Verification Steps
+- [ ] **DOM Preservation:** Given a terminal open in Workspace A, when I switch to Workspace B, Workspace A's terminal should not be destroyed (Signal: DOM nodes for Workspace A still exist with `hidden` class).
+- [ ] **Instant Reactivation:** When I switch back to Workspace A, the terminal should be instantly visible and retain its previous content/scroll position (Signal: terminal output buffer contains the exact same lines and `xterm-viewport` scrollTop is preserved).
+- [ ] **LRU Eviction:** When I switch across 6 different workspaces consecutively, the very first workspace I opened should be evicted (Signal: DOM nodes for the first workspace are removed from the page).
+- [ ] **TTL Eviction:** After 1 hour of inactivity on Workspace A, the TTL should trigger and its terminals should be destroyed (Signal: `evictWorkspaceRuntime` is called and DOM nodes for Workspace A are removed).
+- [ ] **Reactivation Resize Path:** Switch from Workspace A to another workspace so Workspace A's terminal is hidden with `display:none`. Then switch back to Workspace A and verify the restored terminal is immediately visible and correctly sized (Signal: A refit/resize happens on visibility restore, xterm fills the available container without a stale layout).
 
-## 3. PRD Coverage Map
-- **LRU Eviction (max 5 workspaces, max 15 terminals):** Covered by Unit Test (Zustand store evictions) and E2E Scenario (6 consecutive workspace switches).
-- **TTL 1 Hour:** Covered by Unit Test (sweeping expired contexts) and E2E Scenario (1 hour inactivity).
-- **Keep-alive rendering (no re-renders on context switch):** Covered by E2E Scenarios (DOM nodes retained, scroll position/content preserved).
+## 6. Non-Coverage
+- Testing terminal backend state on the Rust side (PTY lifetime is already tested in `core-engine`).
+- Simulating exactly 1 hour of manual waiting in E2E (TTL is unit tested via mock timers).
+
+## 7. Coverage Status
+- **Status:** Pending implementation and run.

--- a/specs/APP/APP-034_terminal_caching/TEST.md
+++ b/specs/APP/APP-034_terminal_caching/TEST.md
@@ -1,0 +1,11 @@
+# TEST: Terminal Workspace Caching
+
+## 1. Unit/Integration Tests
+- [ ] Zustand store (`useTerminalCacheStore`): Verify that adding a 6th context evicts the oldest (LRU).
+- [ ] Zustand store: Verify that sweeping after 1 hour evicts expired contexts.
+
+## 2. E2E / Manual Scenarios
+- [ ] Given I have a terminal open in Workspace A, when I switch to Workspace B, Workspace A's terminal should not be destroyed.
+- [ ] When I switch back to Workspace A, the terminal should be instantly visible and retain its previous content/scroll position.
+- [ ] When I switch across 6 different workspaces consecutively, the very first workspace I opened should be evicted (terminals destroyed) to respect the max 5 cache limit.
+- [ ] After 1 hour of inactivity on Workspace A, the TTL should trigger and its terminals should be destroyed.


### PR DESCRIPTION
- Introduce useTerminalCacheStore to manage LRU caching of terminal tabs.
- Refactor useTerminalTabMountLifecycle to keep tabs alive by updating cache instead of destroying instances immediately.
- Update CenterStage and CenterStagePanels to render cached context terminal grids with display:none.

## Summary

<!-- What does this PR change? -->

## Related Issue

<!-- e.g. Closes #123 -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [ ] Additional checks (describe below)

## Checklist

- [ ] I updated documentation if behavior changed
- [ ] I added/updated tests where appropriate
- [ ] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds LRU caching for terminal contexts so tabs stay alive across workspace switches. Meets APP-034 (keep 5 recent contexts with a 1‑hour TTL) and adds a per‑workspace panel cap with settings to tune both.

- **New Features**
  - Introduced `useTerminalCacheStore` (Zustand) with LRU (5 contexts), 1‑hour TTL, and per‑workspace panel cap; loads/persists settings and exposes `touch`, `setActiveContextId`, `remove`, `sweepExpired`, `setMaxSize`, and `setMaxTerminalPanelsPerWorkspace`.
  - `CenterStagePanels` renders active + cached `TerminalGrid`s per context with `display: none`; refs/handlers attach only for the active context.
  - Terminal settings: add “Max cached workspaces” and “Max terminal panels per workspace” (i18n, `settings-api` fields `max_cached_workspaces` and `max_cached_terminal_panels_per_workspace`), persisted via Function Settings.

- **Refactors & Fixes**
  - `useTerminalTabMountLifecycle` sets the active context first, then `touch`es the previous; preserves previous context tabs during cache transition and prunes stale `mountedTerminalTabsByContext`.
  - Register a single global sweeper to prevent HMR leaks; fix React reconciliation by scoping keys with context ID; remove unused params and stale deps.

<sup>Written for commit e181786e1e0ba66063b44e7566403807fb5b590f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal workspaces now stay available when switching between contexts, so open tabs can reappear without reloading.
  * Multiple workspace contexts can now be shown from cache, improving continuity when moving around the app.

* **Bug Fixes**
  * Reduced terminal recreation when changing contexts, helping preserve tab state and recently used sessions.
  * Older inactive terminal workspaces are now managed more predictably with automatic cleanup after inactivity or when too many are open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->