### PR TITLE
fix(web): agent-fix multiline paste and related UI polish

### DIFF
--- a/apps/web/src/app-shell/header-action-controls.tsx
+++ b/apps/web/src/app-shell/header-action-controls.tsx
@@ -406,7 +406,7 @@ function AtmosComputerPopoverContent({
           onClick={() => void refreshComputers()}
           className="h-7 cursor-pointer px-2 text-xs"
         >
-          <RotateCw className={cn("mr-1.5 size-3.5", isRefreshing && "animate-spin-reverse")} />
+          <RotateCw className={cn("mr-1.5 size-3.5", isRefreshing && "animate-spin")} />
           {t("remoteAccess.refresh")}
         </Button>
       </div>

--- a/apps/web/src/features/files/components/FileTree.tsx
+++ b/apps/web/src/features/files/components/FileTree.tsx
@@ -11,6 +11,7 @@ import { useEditorStore } from '@/features/editor/store/use-editor-store';
 import { useContextParams } from "@/shared/hooks/use-context-params";
 import { clientPointToLocalElementPoint } from '@/shared/lib/dom-position';
 import {
+  buildFallbackFileTreeItem,
   buildDuplicateName,
   buildItemsMap,
   getBaseName,
@@ -84,10 +85,20 @@ export const FileTree: React.FC<FileTreeProps> = ({
 
   const highlightTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const revealRequestIdRef = React.useRef(0);
+  const knownItemsRef = React.useRef<{
+    rootPath: string | null;
+    items: Map<string, FileTreeItem>;
+  }>({ rootPath: null, items: new Map() });
 
   const initialItemsMap = useMemo(() => buildItemsMap(data), [data]);
   const [lazyItemsMap, setLazyItemsMap] = useState<Map<string, FileTreeItem>>(new Map());
   const rootItemIds = useMemo(() => data.map((node) => node.path), [data]);
+
+  if (knownItemsRef.current.rootPath !== rootPath) {
+    knownItemsRef.current = { rootPath, items: new Map() };
+  }
+  initialItemsMap.forEach((value, key) => knownItemsRef.current.items.set(key, value));
+  lazyItemsMap.forEach((value, key) => knownItemsRef.current.items.set(key, value));
 
   useEffect(() => {
     // Reset lazily-loaded entries only when the project root itself
@@ -162,14 +173,7 @@ export const FileTree: React.FC<FileTreeProps> = ({
           };
         }
         const item = initialItemsMap.get(itemId) || lazyItemsMap.get(itemId);
-        return item || {
-          id: itemId,
-          name: itemId,
-          path: itemId,
-          isDir: false,
-          isSymlink: false,
-          isIgnored: false,
-        };
+        return item || buildFallbackFileTreeItem(itemId, knownItemsRef.current.items);
       },
       getChildren: async (itemId: string): Promise<string[]> => {
         if (itemId === 'root') return rootItemIds;
@@ -324,7 +328,7 @@ export const FileTree: React.FC<FileTreeProps> = ({
       setIsMutating(false);
       setMenuState(null);
     }
-  }, [handleRefresh, selectedItem]);
+  }, [handleRefresh, selectedItem, t]);
 
   const handleDelete = useCallback(async () => {
     if (!selectedItem) return;
@@ -350,7 +354,7 @@ export const FileTree: React.FC<FileTreeProps> = ({
     } finally {
       setIsMutating(false);
     }
-  }, [closeFilesByPrefix, closeOverlays, editorContextId, handleRefresh, selectedItem]);
+  }, [closeFilesByPrefix, closeOverlays, editorContextId, handleRefresh, selectedItem, t]);
 
   const submitPanel = useCallback(async () => {
     if (!panelState) return;
@@ -418,6 +422,7 @@ export const FileTree: React.FC<FileTreeProps> = ({
     panelName,
     panelState,
     replaceOpenFilePath,
+    t,
   ]);
 
   const applyRenameSelection = React.useCallback((input: HTMLInputElement | null) => {

--- a/apps/web/src/features/files/components/FileTree.tsx
+++ b/apps/web/src/features/files/components/FileTree.tsx
@@ -254,7 +254,9 @@ export const FileTree: React.FC<FileTreeProps> = ({
   }, [editorContextId, onOpenFile, pinFile]);
 
   const selectedItem = menuState
-    ? initialItemsMap.get(menuState.itemPath) || lazyItemsMap.get(menuState.itemPath) || null
+    ? initialItemsMap.get(menuState.itemPath) ||
+      lazyItemsMap.get(menuState.itemPath) ||
+      buildFallbackFileTreeItem(menuState.itemPath, knownItemsRef.current.items)
     : null;
 
   const relativePath = selectedItem && rootPath

--- a/apps/web/src/features/files/components/FileTreePanel.tsx
+++ b/apps/web/src/features/files/components/FileTreePanel.tsx
@@ -98,6 +98,7 @@ export const FileTreePanel: React.FC<FileTreePanelProps> = ({
       )}
       <div className="flex-1 overflow-y-auto no-scrollbar min-h-0 pt-1.5">
         <FileTree
+          key={effectiveRootPath}
           data={effectiveData}
           rootPath={effectiveRootPath}
           isLoading={effectiveIsLoading}

--- a/apps/web/src/features/files/lib/file-tree-utils.test.ts
+++ b/apps/web/src/features/files/lib/file-tree-utils.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  buildFallbackFileTreeItem,
+  type FileTreeItem,
+} from './file-tree-utils';
+
+describe('file-tree-utils', () => {
+  test('uses the basename for missing tree item fallback labels', () => {
+    const item = buildFallbackFileTreeItem(
+      '/Users/lurunrun/.atmos/workspaces/atmos/blastoise/specs/APP/QUALITY-005_typescript-7-upgrade',
+    );
+
+    expect(item.name).toBe('QUALITY-005_typescript-7-upgrade');
+    expect(item.path).toBe(
+      '/Users/lurunrun/.atmos/workspaces/atmos/blastoise/specs/APP/QUALITY-005_typescript-7-upgrade',
+    );
+    expect(item.isDir).toBe(false);
+  });
+
+  test('preserves known item metadata before constructing a fallback', () => {
+    const known = new Map<string, FileTreeItem>();
+    known.set('/repo/specs/APP', {
+      id: '/repo/specs/APP',
+      name: 'APP',
+      path: '/repo/specs/APP',
+      isDir: true,
+      isSymlink: false,
+      isIgnored: true,
+    });
+
+    expect(buildFallbackFileTreeItem('/repo/specs/APP', known)).toEqual(
+      known.get('/repo/specs/APP'),
+    );
+  });
+
+  test('infers a missing item is a directory when known descendants exist', () => {
+    const known = new Map<string, FileTreeItem>();
+    known.set('/repo/specs/APP/QUALITY-005_typescript-7-upgrade/TECH.md', {
+      id: '/repo/specs/APP/QUALITY-005_typescript-7-upgrade/TECH.md',
+      name: 'TECH.md',
+      path: '/repo/specs/APP/QUALITY-005_typescript-7-upgrade/TECH.md',
+      isDir: false,
+      isSymlink: false,
+      isIgnored: false,
+    });
+
+    const item = buildFallbackFileTreeItem(
+      '/repo/specs/APP/QUALITY-005_typescript-7-upgrade',
+      known,
+    );
+
+    expect(item.name).toBe('QUALITY-005_typescript-7-upgrade');
+    expect(item.isDir).toBe(true);
+  });
+});

--- a/apps/web/src/features/files/lib/file-tree-utils.ts
+++ b/apps/web/src/features/files/lib/file-tree-utils.ts
@@ -74,6 +74,28 @@ export function buildItemsMap(nodes: FileTreeNode[]): Map<string, FileTreeItem> 
   return map;
 }
 
+export function buildFallbackFileTreeItem(
+  itemPath: string,
+  knownItems: Map<string, FileTreeItem> = new Map(),
+): FileTreeItem {
+  const knownItem = knownItems.get(itemPath);
+  if (knownItem) return knownItem;
+
+  const descendantPrefix = itemPath.endsWith('/') ? itemPath : `${itemPath}/`;
+  const hasKnownDescendant = Array.from(knownItems.keys()).some((knownPath) =>
+    knownPath.startsWith(descendantPrefix),
+  );
+
+  return {
+    id: itemPath,
+    name: getBaseName(itemPath),
+    path: itemPath,
+    isDir: hasKnownDescendant,
+    isSymlink: false,
+    isIgnored: false,
+  };
+}
+
 export function getParentPath(path: string): string {
   const parts = path.split('/');
   parts.pop();

--- a/apps/web/src/features/files/lib/file-tree-utils.ts
+++ b/apps/web/src/features/files/lib/file-tree-utils.ts
@@ -82,9 +82,13 @@ export function buildFallbackFileTreeItem(
   if (knownItem) return knownItem;
 
   const descendantPrefix = itemPath.endsWith('/') ? itemPath : `${itemPath}/`;
-  const hasKnownDescendant = Array.from(knownItems.keys()).some((knownPath) =>
-    knownPath.startsWith(descendantPrefix),
-  );
+  let hasKnownDescendant = false;
+  for (const knownPath of knownItems.keys()) {
+    if (knownPath.startsWith(descendantPrefix)) {
+      hasKnownDescendant = true;
+      break;
+    }
+  }
 
   return {
     id: itemPath,

--- a/apps/web/src/features/terminal/components/Terminal.tsx
+++ b/apps/web/src/features/terminal/components/Terminal.tsx
@@ -82,6 +82,22 @@ const INITIAL_CONNECT_STABLE_FRAMES = 2;
 const INITIAL_CONNECT_MAX_WAIT_FRAMES = 20;
 const CANVAS_TERMINAL_SCALE_FIT_DEBOUNCE_MS = 300;
 
+function fitTerminalPreservingScroll(term: XTerm, fit: FitAddon) {
+  const before = term.buffer.active;
+  const wasAtBottom = before.viewportY >= before.baseY;
+  const distanceFromBottom = Math.max(0, before.baseY - before.viewportY);
+
+  fit.fit();
+
+  if (wasAtBottom) {
+    jumpXtermToBottom(term);
+    return;
+  }
+
+  const after = term.buffer.active;
+  term.scrollToLine(Math.max(0, after.baseY - distanceFromBottom));
+}
+
 const Terminal = ({
   sessionId,
   workspaceId,
@@ -174,6 +190,8 @@ const Terminal = ({
     setSearchStats,
     terminalSearchInputId,
   } = useTerminalSearch({ isDark, searchAddonRef, terminalRef });
+  // SearchAddon selects matches for highlighting; suppress the selection toolbar while find is open.
+  const isSearchVisibleRef = useRef(isSearchVisible);
   const {
     handleResolvedLinkRef,
     handleTerminalLinkRef,
@@ -249,8 +267,8 @@ const Terminal = ({
 
     // Re-fit before sending the post-connect size so full-screen TUIs see the
     // browser's current grid, not the constructor's default 80x24 grid.
-    fitAddonRef.current?.fit();
-    if (terminalRef.current) {
+    if (terminalRef.current && fitAddonRef.current) {
+      fitTerminalPreservingScroll(terminalRef.current, fitAddonRef.current);
       sendResizeRef.current({ cols: terminalRef.current.cols, rows: terminalRef.current.rows });
     }
     scheduleInputReadyFallback();
@@ -330,6 +348,14 @@ const Terminal = ({
     setSelectionSnapshot(snapshot);
     onSelectionSnapshotChangeRef.current?.(snapshot);
   }, []);
+
+  // SearchAddon selects matches for highlighting; suppress the selection toolbar while find is open.
+  useEffect(() => {
+    isSearchVisibleRef.current = isSearchVisible;
+    if (isSearchVisible) {
+      setCurrentSelectionSnapshot(null);
+    }
+  }, [isSearchVisible, setCurrentSelectionSnapshot]);
 
   const getCursorClientPoint = useCallback(() => {
     const terminal = terminalRef.current;
@@ -505,7 +531,7 @@ const Terminal = ({
       if (!isTerminalContainerVisible(containerRef.current)) {
         return;
       }
-      fit.fit();
+      fitTerminalPreservingScroll(terminal, fit);
       sendResizeRef.current({ cols: terminal.cols, rows: terminal.rows });
     });
 
@@ -599,6 +625,10 @@ const Terminal = ({
 
     const emitCurrentSelectionSnapshot = () => {
       if (cancelled) return;
+      if (isSearchVisibleRef.current) {
+        setCurrentSelectionSnapshot(null);
+        return;
+      }
       setCurrentSelectionSnapshot(readCurrentSelectionSnapshot());
     };
 
@@ -905,7 +935,7 @@ const Terminal = ({
       // Skip when terminal container is hidden (e.g. tab not visible)
       if (!isTerminalContainerVisible(containerRef.current)) return;
 
-      fit.fit();
+      fitTerminalPreservingScroll(term, fit);
       connectWhenVisible();
     };
     const scheduleResizeFit = () => {

--- a/apps/web/src/features/terminal/hooks/use-terminal-agent-tui-follow-up.ts
+++ b/apps/web/src/features/terminal/hooks/use-terminal-agent-tui-follow-up.ts
@@ -35,9 +35,7 @@ export function useTerminalAgentTuiFollowUp(
       const terminalRef = terminalRefsMap.current.get(paneId);
       if (!terminalRef) return;
       const cleanup = deliverPendingTerminalRun(terminalRef, run);
-      if (run.tuiFollowUp) {
-        cleanupByPaneRef.current.set(paneId, cleanup);
-      }
+      cleanupByPaneRef.current.set(paneId, cleanup);
     },
     [clearFollowUp, terminalRefsMap],
   );

--- a/apps/web/src/features/terminal/hooks/use-terminal-search.ts
+++ b/apps/web/src/features/terminal/hooks/use-terminal-search.ts
@@ -63,6 +63,7 @@ export function useTerminalSearch({
     setSearchHasMatch(null);
     setSearchStats({ current: 0, total: 0 });
     searchAddonRef.current?.clearDecorations();
+    terminalRef.current?.clearSelection();
     terminalRef.current?.focus();
   }, [searchAddonRef, terminalRef]);
 

--- a/apps/web/src/features/terminal/lib/__tests__/terminal-agent-run-delivery.test.ts
+++ b/apps/web/src/features/terminal/lib/__tests__/terminal-agent-run-delivery.test.ts
@@ -2,7 +2,10 @@
 import { describe, expect, it } from "bun:test";
 
 import type { TerminalRef } from "@/features/terminal/components/Terminal";
-import { sendTuiFollowUpPrompt } from "@/features/terminal/lib/terminal-agent-run-delivery";
+import {
+  deliverTerminalAgentLaunch,
+  sendTuiFollowUpPrompt,
+} from "@/features/terminal/lib/terminal-agent-run-delivery";
 
 function createTerminalRefMock() {
   const calls: Array<{ method: "sendText" | "sendEnter"; value?: string }> = [];
@@ -44,5 +47,53 @@ describe("sendTuiFollowUpPrompt", () => {
         resolve();
       }, 100);
     });
+  });
+});
+
+describe("deliverTerminalAgentLaunch", () => {
+  it("submits single-line launches with a trailing carriage return", () => {
+    const { terminalRef, calls } = createTerminalRefMock();
+
+    deliverTerminalAgentLaunch(terminalRef, "agent --yolo 'fix this'");
+
+    expect(calls).toEqual([
+      { method: "sendText", value: "agent --yolo 'fix this'\r" },
+    ]);
+  });
+
+  it("uses bracketed paste and Enter for multiline launches", () => {
+    const { terminalRef, calls } = createTerminalRefMock();
+    const launch = "agent --yolo 'line one\n```diff\n+ new\n```'";
+
+    deliverTerminalAgentLaunch(terminalRef, launch);
+
+    expect(calls[0]?.method).toBe("sendText");
+    expect(calls[0]?.value).toBe(
+      "\x1b[200~agent --yolo 'line one\r```diff\r+ new\r```'\x1b[201~",
+    );
+    expect(calls.length).toBe(1);
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(calls).toEqual([
+          { method: "sendText", value: calls[0]?.value },
+          { method: "sendEnter" },
+        ]);
+        resolve();
+      }, 100);
+    });
+  });
+
+  it("prefills multiline launches with bracketed paste and no Enter", () => {
+    const { terminalRef, calls } = createTerminalRefMock();
+
+    deliverTerminalAgentLaunch(terminalRef, "echo 'a\nb'", false);
+
+    expect(calls).toEqual([
+      {
+        method: "sendText",
+        value: "\x1b[200~echo 'a\rb'\x1b[201~",
+      },
+    ]);
   });
 });

--- a/apps/web/src/features/terminal/lib/__tests__/terminal-agent-run-delivery.test.ts
+++ b/apps/web/src/features/terminal/lib/__tests__/terminal-agent-run-delivery.test.ts
@@ -6,6 +6,7 @@ import {
   deliverTerminalAgentLaunch,
   sendTuiFollowUpPrompt,
 } from "@/features/terminal/lib/terminal-agent-run-delivery";
+import { wrapBracketedPaste } from "@/features/terminal/lib/terminal-runtime-utils";
 
 function createTerminalRefMock() {
   const calls: Array<{ method: "sendText" | "sendEnter"; value?: string }> = [];
@@ -95,5 +96,55 @@ describe("deliverTerminalAgentLaunch", () => {
         value: "\x1b[200~echo 'a\rb'\x1b[201~",
       },
     ]);
+  });
+
+  it("defers onSubmitted until after multiline launch Enter", () => {
+    const { terminalRef, calls } = createTerminalRefMock();
+    const submittedAt: number[] = [];
+
+    deliverTerminalAgentLaunch(terminalRef, "agent --yolo 'a\nb'", true, () => {
+      submittedAt.push(calls.length);
+    });
+
+    expect(submittedAt).toEqual([]);
+    expect(calls).toHaveLength(1);
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(calls.map((call) => call.method)).toEqual(["sendText", "sendEnter"]);
+        expect(submittedAt).toEqual([2]);
+        resolve();
+      }, 100);
+    });
+  });
+
+  it("aborts an unsubmitted multiline paste when cleanup runs", () => {
+    const { terminalRef, calls } = createTerminalRefMock();
+
+    const cleanup = deliverTerminalAgentLaunch(terminalRef, "agent --yolo 'a\nb'");
+    cleanup();
+
+    expect(calls).toEqual([
+      {
+        method: "sendText",
+        value: "\x1b[200~agent --yolo 'a\rb'\x1b[201~",
+      },
+      { method: "sendText", value: "\x03" },
+    ]);
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(calls.map((call) => call.method)).toEqual(["sendText", "sendText"]);
+        resolve();
+      }, 100);
+    });
+  });
+});
+
+describe("wrapBracketedPaste", () => {
+  it("strips ESC bytes so paste mode cannot end early", () => {
+    expect(wrapBracketedPaste("before\x1b[201~after")).toBe(
+      "\x1b[200~before[201~after\x1b[201~",
+    );
   });
 });

--- a/apps/web/src/features/terminal/lib/terminal-agent-run-delivery.ts
+++ b/apps/web/src/features/terminal/lib/terminal-agent-run-delivery.ts
@@ -88,17 +88,48 @@ export function deliverTerminalAgentLaunch(
   terminalRef: TerminalRef,
   launch: string,
   execute = true,
-) {
-  terminalRef.sendText(execute ? `${launch}\r` : launch);
+): () => void {
+  const trimmed = launch.trimEnd();
+  if (!trimmed) return () => {};
+
+  const hasMultiline = /[\r\n]/.test(trimmed);
+  if (!hasMultiline) {
+    terminalRef.sendText(execute ? `${trimmed}\r` : trimmed);
+    return () => {};
+  }
+
+  // Multiline shell launches (e.g. Agent Fix prompts with diff hunks) must use
+  // bracketed paste so embedded newlines are not treated as Enter by the shell.
+  terminalRef.sendText(wrapBracketedPaste(trimmed));
+  if (!execute) return () => {};
+
+  const timer = setTimeout(() => {
+    terminalRef.sendEnter();
+  }, TUI_FOLLOW_UP_SUBMIT_DELAY_MS);
+  return () => {
+    clearTimeout(timer);
+  };
 }
 
 export function deliverPendingTerminalRun(
   terminalRef: TerminalRef,
   run: PendingTerminalRun,
 ): () => void {
-  deliverTerminalAgentLaunch(terminalRef, run.launch, run.execute !== false);
+  const clearLaunch = deliverTerminalAgentLaunch(
+    terminalRef,
+    run.launch,
+    run.execute !== false,
+  );
   if (!run.tuiFollowUp) {
-    return () => {};
+    return clearLaunch;
   }
-  return startAgentTuiFollowUp(terminalRef, run.tuiFollowUp.agentId, run.tuiFollowUp.prompt);
+  const clearFollowUp = startAgentTuiFollowUp(
+    terminalRef,
+    run.tuiFollowUp.agentId,
+    run.tuiFollowUp.prompt,
+  );
+  return () => {
+    clearLaunch();
+    clearFollowUp();
+  };
 }

--- a/apps/web/src/features/terminal/lib/terminal-agent-run-delivery.ts
+++ b/apps/web/src/features/terminal/lib/terminal-agent-run-delivery.ts
@@ -88,6 +88,7 @@ export function deliverTerminalAgentLaunch(
   terminalRef: TerminalRef,
   launch: string,
   execute = true,
+  onSubmitted?: () => void,
 ): () => void {
   const trimmed = launch.trimEnd();
   if (!trimmed) return () => {};
@@ -95,6 +96,7 @@ export function deliverTerminalAgentLaunch(
   const hasMultiline = /[\r\n]/.test(trimmed);
   if (!hasMultiline) {
     terminalRef.sendText(execute ? `${trimmed}\r` : trimmed);
+    if (execute) onSubmitted?.();
     return () => {};
   }
 
@@ -103,11 +105,19 @@ export function deliverTerminalAgentLaunch(
   terminalRef.sendText(wrapBracketedPaste(trimmed));
   if (!execute) return () => {};
 
+  let submitted = false;
   const timer = setTimeout(() => {
+    submitted = true;
     terminalRef.sendEnter();
+    onSubmitted?.();
   }, TUI_FOLLOW_UP_SUBMIT_DELAY_MS);
   return () => {
     clearTimeout(timer);
+    // A newer delivery cancelled this run after paste but before Enter — discard
+    // the orphaned edit-buffer text so the next launch is not concatenated.
+    if (!submitted) {
+      terminalRef.sendText("\x03");
+    }
   };
 }
 
@@ -115,18 +125,20 @@ export function deliverPendingTerminalRun(
   terminalRef: TerminalRef,
   run: PendingTerminalRun,
 ): () => void {
+  let clearFollowUp = () => {};
   const clearLaunch = deliverTerminalAgentLaunch(
     terminalRef,
     run.launch,
     run.execute !== false,
-  );
-  if (!run.tuiFollowUp) {
-    return clearLaunch;
-  }
-  const clearFollowUp = startAgentTuiFollowUp(
-    terminalRef,
-    run.tuiFollowUp.agentId,
-    run.tuiFollowUp.prompt,
+    run.tuiFollowUp
+      ? () => {
+          clearFollowUp = startAgentTuiFollowUp(
+            terminalRef,
+            run.tuiFollowUp!.agentId,
+            run.tuiFollowUp!.prompt,
+          );
+        }
+      : undefined,
   );
   return () => {
     clearLaunch();

--- a/apps/web/src/features/terminal/lib/terminal-runtime-utils.ts
+++ b/apps/web/src/features/terminal/lib/terminal-runtime-utils.ts
@@ -66,7 +66,8 @@ export class SafeClipboardProvider implements IClipboardProvider {
 }
 
 export function wrapBracketedPaste(text: string): string {
-  const normalised = text.replace(/\r?\n/g, "\r");
+  // Strip ESC so an embedded `\x1b[201~` (or any CSI) cannot end paste mode early.
+  const normalised = text.replace(/\x1b/g, "").replace(/\r?\n/g, "\r");
   return `\x1b[200~${normalised}\x1b[201~`;
 }
 


### PR DESCRIPTION
## Summary

- Fix Agent Fix / multiline terminal launches hanging mid-command by delivering them with bracketed paste, then Enter
- Improve file-tree fallbacks for missing nodes (basename labels, known metadata, directory inference) and remount on root path change
- Preserve terminal scroll position across fit/resize, and suppress selection toolbar while find is open
- Spin the Atmos Computer refresh icon forward instead of reverse

## Related Issue

<!-- e.g. Closes #123 -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [x] `just test` (scoped: `bun test src/features/terminal/lib/__tests__/terminal-agent-run-delivery.test.ts`)
- [ ] `just fmt`
- [ ] Additional checks (describe below)

## Checklist

- [ ] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multiline agent launches by using bracketed paste with a delayed Enter and preserves terminal scroll on resize; also defers TUI follow-up until after submit. Improves file tree fallbacks and remount behavior on root changes, and fixes the refresh icon spin direction.

- **Bug Fixes**
  - Terminal: deliver multiline launches via bracketed paste (strip ESC), then Enter; cancel pending pastes on cleanup with Ctrl-C; single-line launches add a trailing carriage return. Defer TUI follow-up until after submit. Preserve scroll on fit/resize, hide the selection toolbar while search is open, and clear selections when closing search. Tests added for delivery and paste wrapper.
  - Files: fallback items use basename labels, reuse known metadata, infer directories from descendants, and the context menu respects these fallbacks; the tree remounts when the root path changes. Tests added for fallback logic.
  - UI: Atmos Computer refresh icon now spins forward.

<sup>Written for commit 825693e5be5810aac29efaf6f82d3f9287f400b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal launches now handle multi-line input more reliably, including safer paste behavior and better follow-up submission timing.
  * File browsing now shows fallback entries for missing items instead of leaving gaps.

* **Bug Fixes**
  * Improved refresh animation direction in the header.
  * Terminal search now clears selection when opened or closed, and resizing better preserves scroll position.
  * File tree and context menu behavior is more consistent when items are loaded lazily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->