### PR TITLE
feat(canvas): improve agent diagram quality, follow, and screenshot preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,6 +514,7 @@ dependencies = [
 name = "atmos"
 version = "2026.7.2"
 dependencies = [
+ "base64 0.22.1",
  "chrono",
  "clap",
  "dirs 5.0.1",

--- a/apps/api/src/api/system/handlers.rs
+++ b/apps/api/src/api/system/handlers.rs
@@ -490,6 +490,7 @@ pub async fn capture_tmux_window(
         "rows": snapshot.rows,
         "cols": snapshot.cols,
         "alternate": snapshot.alternate,
+        "restore_mouse_tracking": snapshot.restore_mouse_tracking,
         "skip_lines": page.skip_from_bottom,
         "lines_returned": page.lines_returned,
         "has_more_older": page.has_more_older,

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -4,6 +4,7 @@ version = "2026.7.2"
 edition = "2021"
 
 [dependencies]
+base64 = "0.22"
 clap = { workspace = true }
 chrono = { version = "0.4", features = ["serde", "clock"] }
 dirs = "5.0"

--- a/apps/cli/src/commands/canvas.rs
+++ b/apps/cli/src/commands/canvas.rs
@@ -103,7 +103,11 @@ pub async fn execute(
             let body = args.body();
             invoke(&api, &canvas, "place", body).await
         }
-        CanvasCommand::Lint => invoke(&api, &canvas, "lint", json!({})).await,
+        CanvasCommand::Lint(args) => {
+            let body = args.body();
+            invoke(&api, &canvas, "lint", body).await
+        }
+        CanvasCommand::Screenshot(args) => screenshot(&api, &canvas, args).await,
         CanvasCommand::Apply(args) => {
             let body = args.body()?;
             invoke(&api, &canvas, "apply", body).await
@@ -167,9 +171,11 @@ pub enum CanvasCommand {
     Distribute(DistributeArgs),
     /// Place one shape relative to another (page-bounds math).
     Place(PlaceArgs),
-    /// Report overlap / unbound-arrow lints on the current page.
-    Lint,
-    /// Run up to 32 mutating commands in one request (stops on first failure).
+    /// Report layout lints (bad overlaps, text overflow, unbound arrows).
+    Lint(LintArgs),
+    /// Export a JPEG of the agent-drawn region only (excludes Atmos chrome widgets/terminals).
+    Screenshot(ScreenshotArgs),
+    /// Run up to 64 mutating commands in one request (stops on first failure).
     Apply(ApplyArgs),
     /// Set the dashed agent-view frame (explicit page-space rect or shape union).
     SetAgentView(SetAgentViewArgs),
@@ -759,6 +765,161 @@ impl CanvasSessionStatus {
             Self::Idle => "idle",
         }
     }
+}
+
+#[derive(Debug, Args)]
+pub struct LintArgs {
+    /// Include CLI-ready `fix_suggestions` (move / update_shape) for each remediable lint.
+    #[arg(long, default_value_t = false)]
+    pub fix_suggestions: bool,
+}
+
+impl LintArgs {
+    fn body(&self) -> Value {
+        if self.fix_suggestions {
+            json!({ "fix_suggestions": true })
+        } else {
+            json!({})
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+pub enum ScreenshotSize {
+    Small,
+    Medium,
+    Large,
+}
+
+impl ScreenshotSize {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Small => "small",
+            Self::Medium => "medium",
+            Self::Large => "large",
+        }
+    }
+}
+
+#[derive(Debug, Args)]
+pub struct ScreenshotArgs {
+    /// Comma-separated shape ids — region is their page-bounds union (chrome still excluded).
+    #[arg(long)]
+    pub ids: Option<String>,
+    /// Explicit page-space crop box (use with --y --w --h).
+    #[arg(long)]
+    pub x: Option<f64>,
+    #[arg(long)]
+    pub y: Option<f64>,
+    #[arg(long)]
+    pub w: Option<f64>,
+    #[arg(long)]
+    pub h: Option<f64>,
+    /// Use the dashed agent-view frame from `set-agent-view` (recommended for turn-end verify).
+    #[arg(long, default_value_t = false)]
+    pub use_agent_view: bool,
+    /// Extra padding around the region when using --ids or --x/--y/--w/--h (default 48).
+    #[arg(long)]
+    pub padding: Option<f64>,
+    /// Export resolution preset.
+    #[arg(long, value_enum, default_value_t = ScreenshotSize::Medium)]
+    pub size: ScreenshotSize,
+    /// Include Atmos canvas-widget / canvas-terminal chrome (default off).
+    #[arg(long, default_value_t = false)]
+    pub include_widgets: bool,
+    /// Write the JPEG to this path (decoded from data_url). Prints the path on success.
+    #[arg(long)]
+    pub out: Option<PathBuf>,
+}
+
+impl ScreenshotArgs {
+    fn body(&self) -> Result<Value, String> {
+        let mut body = json!({
+            "size": self.size.as_str(),
+        });
+        if self.use_agent_view {
+            body["use_agent_view"] = json!(true);
+        }
+        if self.include_widgets {
+            body["include_widgets"] = json!(true);
+        }
+        if let Some(padding) = self.padding {
+            body["padding"] = json!(padding);
+        }
+        if let Some(ids) = &self.ids {
+            body["ids"] = json!(split_ids(ids));
+        }
+        let has_box = self.x.is_some() || self.y.is_some() || self.w.is_some() || self.h.is_some();
+        if has_box {
+            let x = self.x.ok_or("screenshot --x is required with y,w,h")?;
+            let y = self.y.ok_or("screenshot --y is required with x,w,h")?;
+            let w = self.w.ok_or("screenshot --w is required with x,y,h")?;
+            let h = self.h.ok_or("screenshot --h is required with x,y,w")?;
+            body["x"] = json!(x);
+            body["y"] = json!(y);
+            body["w"] = json!(w);
+            body["h"] = json!(h);
+        }
+        Ok(body)
+    }
+}
+
+async fn screenshot(
+    api: &ApiClientArgs,
+    canvas: &CanvasOpts,
+    args: ScreenshotArgs,
+) -> Result<Value, String> {
+    let body = args.body()?;
+    let result = invoke(api, canvas, "screenshot", body).await?;
+    if let Some(out) = &args.out {
+        let data = result
+            .get("data")
+            .cloned()
+            .unwrap_or(Value::Null);
+        let data_url = data
+            .get("data_url")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "screenshot response missing data_url".to_string())?;
+        write_data_url_to_file(data_url, out)?;
+        return Ok(json!({
+            "ok": true,
+            "request_id": result.get("request_id").cloned().unwrap_or(Value::Null),
+            "data": {
+                "file_path": out,
+                "width": data.get("width"),
+                "height": data.get("height"),
+                "region": data.get("region"),
+                "shape_count": data.get("shape_count"),
+                "shape_ids": data.get("shape_ids"),
+                "excluded_chrome": data.get("excluded_chrome"),
+                "size": data.get("size"),
+                // Omit the huge data_url when writing to disk.
+            },
+        }));
+    }
+    Ok(result)
+}
+
+fn write_data_url_to_file(data_url: &str, path: &PathBuf) -> Result<(), String> {
+    const PREFIX: &str = "base64,";
+    let idx = data_url
+        .find(PREFIX)
+        .ok_or_else(|| "data_url is not base64-encoded".to_string())?;
+    let b64 = &data_url[idx + PREFIX.len()..];
+    use base64::Engine as _;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(b64)
+        .map_err(|err| format!("failed to decode screenshot base64: {err}"))?;
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .map_err(|err| format!("failed to create {}: {err}", parent.display()))?;
+        }
+    }
+    std::fs::write(path, bytes)
+        .map_err(|err| format!("failed to write {}: {err}", path.display()))?;
+    Ok(())
 }
 
 #[derive(Debug, Args)]

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2337,6 +2337,10 @@
         "descriptionSuffix": "commands to interact with this canvas.",
         "aria": "Enable Canvas Agent Bridge"
       },
+      "follow": {
+        "title": "Follow Agent",
+        "aria": "Follow Agent"
+      },
       "snippet": {
         "label": "Command",
         "copied": "Copied",
@@ -2584,6 +2588,7 @@
     },
     "agentFeedLabels": {
       "readingCanvas": "Reading canvas",
+      "capturingScreenshot": "Capturing screenshot",
       "extractingShapeText": "Extracting shape text",
       "creatingStickyNote": "Creating sticky note",
       "creatingFrame": "Creating frame",
@@ -2686,7 +2691,11 @@
       "agentIsland": {
         "agentWorkingOnCanvas": "Agent working on canvas",
         "canvasAgentActivity": "Canvas agent activity",
-        "canvasAgentActivityHistory": "Canvas agent activity history"
+        "canvasAgentActivityHistory": "Canvas agent activity history",
+        "openScreenshotPreview": "Open agent screenshot preview",
+        "screenshotThumbLabel": "Preview",
+        "screenshotPreviewTitle": "Agent canvas screenshot",
+        "screenshotPreviewAlt": "Screenshot of the agent-drawn canvas region"
       },
       "settingsStore": {
         "settingsLoadFailed": "Settings Load Failed",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2693,8 +2693,6 @@
         "canvasAgentActivity": "Canvas agent activity",
         "canvasAgentActivityHistory": "Canvas agent activity history",
         "openScreenshotPreview": "Open agent screenshot preview",
-        "screenshotThumbLabel": "Preview",
-        "screenshotPreviewTitle": "Agent canvas screenshot",
         "screenshotPreviewAlt": "Screenshot of the agent-drawn canvas region"
       },
       "settingsStore": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2693,8 +2693,6 @@
         "canvasAgentActivity": "Canvas Agent 活动",
         "canvasAgentActivityHistory": "Canvas Agent 活动历史",
         "openScreenshotPreview": "打开 Agent 截图预览",
-        "screenshotThumbLabel": "预览",
-        "screenshotPreviewTitle": "Agent 画布截图",
         "screenshotPreviewAlt": "Agent 绘制区域的截图"
       },
       "settingsStore": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2337,6 +2337,10 @@
         "descriptionSuffix": "命令与当前画布交互。",
         "aria": "启用 Canvas Agent Bridge"
       },
+      "follow": {
+        "title": "Follow Agent",
+        "aria": "Follow Agent"
+      },
       "snippet": {
         "label": "命令",
         "copied": "已复制",
@@ -2584,6 +2588,7 @@
     },
     "agentFeedLabels": {
       "readingCanvas": "读取画布",
+      "capturingScreenshot": "正在截图",
       "extractingShapeText": "提取图形文本",
       "creatingStickyNote": "创建便签",
       "creatingFrame": "创建画框",
@@ -2686,7 +2691,11 @@
       "agentIsland": {
         "agentWorkingOnCanvas": "Agent 正在操作画布",
         "canvasAgentActivity": "Canvas Agent 活动",
-        "canvasAgentActivityHistory": "Canvas Agent 活动历史"
+        "canvasAgentActivityHistory": "Canvas Agent 活动历史",
+        "openScreenshotPreview": "打开 Agent 截图预览",
+        "screenshotThumbLabel": "预览",
+        "screenshotPreviewTitle": "Agent 画布截图",
+        "screenshotPreviewAlt": "Agent 绘制区域的截图"
       },
       "settingsStore": {
         "settingsLoadFailed": "设置加载失败",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2338,8 +2338,8 @@
         "aria": "启用 Canvas Agent Bridge"
       },
       "follow": {
-        "title": "Follow Agent",
-        "aria": "Follow Agent"
+        "title": "跟随 Agent",
+        "aria": "跟随 Agent"
       },
       "snippet": {
         "label": "命令",

--- a/apps/web/src/features/canvas/__tests__/canvas-agent-bus.test.ts
+++ b/apps/web/src/features/canvas/__tests__/canvas-agent-bus.test.ts
@@ -132,18 +132,34 @@ describe("CanvasAgentBus", () => {
   });
 
   it("set_status works without an accepting bridge and reports lint readiness", async () => {
-    const { bus } = busFromEditor({ acceptsCommands: false });
+    const { editor, bus } = busFromEditor({ acceptsCommands: false });
+    // Overlapping pair so ready_to_idle is false while status can still be idle.
+    editor.createShape({
+      id: "shape:a",
+      type: "geo",
+      x: 0,
+      y: 0,
+      props: { w: 100, h: 100 },
+    });
+    editor.createShape({
+      id: "shape:b",
+      type: "geo",
+      x: 40,
+      y: 40,
+      props: { w: 100, h: 100 },
+    });
     const res = await bus.handleDispatch(call("set_status", { status: "idle" }));
     expect(res.success).toBe(true);
     if (res.success) {
       const data = res.data as {
         status: string;
         ready_to_idle: boolean;
-        lints_summary: { clean: boolean };
+        lints_summary: { clean: boolean; error_count: number };
       };
       expect(data.status).toBe("idle");
-      expect(data.ready_to_idle).toBe(true);
-      expect(data.lints_summary.clean).toBe(true);
+      expect(data.ready_to_idle).toBe(false);
+      expect(data.lints_summary.clean).toBe(false);
+      expect(data.lints_summary.error_count).toBeGreaterThan(0);
     }
   });
 

--- a/apps/web/src/features/canvas/__tests__/canvas-agent-bus.test.ts
+++ b/apps/web/src/features/canvas/__tests__/canvas-agent-bus.test.ts
@@ -131,12 +131,43 @@ describe("CanvasAgentBus", () => {
     expect(res.success).toBe(true);
   });
 
-  it("set_status works without an accepting bridge", async () => {
+  it("set_status works without an accepting bridge and reports lint readiness", async () => {
     const { bus } = busFromEditor({ acceptsCommands: false });
     const res = await bus.handleDispatch(call("set_status", { status: "idle" }));
     expect(res.success).toBe(true);
     if (res.success) {
-      expect(res.data).toEqual({ status: "idle" });
+      const data = res.data as {
+        status: string;
+        ready_to_idle: boolean;
+        lints_summary: { clean: boolean };
+      };
+      expect(data.status).toBe("idle");
+      expect(data.ready_to_idle).toBe(true);
+      expect(data.lints_summary.clean).toBe(true);
+    }
+  });
+
+  it("create_geo returns bounds and can warn on text overflow", async () => {
+    const { bus } = busFromEditor();
+    const res = await bus.handleDispatch(
+      call("create_geo", {
+        kind: "rectangle",
+        x: 0,
+        y: 0,
+        w: 60,
+        h: 30,
+        text: "This label is intentionally much too long for the tiny box",
+      }),
+    );
+    expect(res.success).toBe(true);
+    if (res.success) {
+      const data = res.data as {
+        id: string;
+        bounds: { min_x: number; w: number } | null;
+        warnings?: string[];
+      };
+      expect(data.bounds?.w).toBe(60);
+      expect(data.warnings).toContain("text_may_overflow");
     }
   });
 

--- a/apps/web/src/features/canvas/__tests__/canvas-agent-feed-summarize.test.ts
+++ b/apps/web/src/features/canvas/__tests__/canvas-agent-feed-summarize.test.ts
@@ -29,4 +29,26 @@ describe("summarizeConsecutiveEntries", () => {
     expect(rows[0]?.label).toBe("Creating arrow");
     expect(rows[1]?.label).toBe("Creating shape");
   });
+
+  it("does not merge screenshot rows so each keeps its thumb", () => {
+    const rows = summarizeConsecutiveEntries([
+      entry({
+        requestId: "s1",
+        label: "Capturing screenshot",
+        command: "screenshot",
+        kind: "read",
+        screenshot: { dataUrl: "data:image/jpeg;base64,a", width: 10, height: 10 },
+      }),
+      entry({
+        requestId: "s2",
+        label: "Capturing screenshot",
+        command: "screenshot",
+        kind: "read",
+        screenshot: { dataUrl: "data:image/jpeg;base64,b", width: 10, height: 10 },
+      }),
+    ]);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.screenshot?.dataUrl).toContain("base64,a");
+    expect(rows[1]?.screenshot?.dataUrl).toContain("base64,b");
+  });
 });

--- a/apps/web/src/features/canvas/__tests__/canvas-agent-feed.test.ts
+++ b/apps/web/src/features/canvas/__tests__/canvas-agent-feed.test.ts
@@ -111,5 +111,41 @@ describe("CanvasAgentFeedStore", () => {
     expect(entry?.status).toBe("done");
     expect(entry?.screenshot?.dataUrl).toContain("data:image/jpeg");
     expect(entry?.screenshot?.width).toBe(100);
+    expect(entry?.screenshot?.height).toBe(80);
+  });
+
+  it("begin clears a previous screenshot when reusing request_id", () => {
+    const store = new CanvasAgentFeedStore();
+    store.begin("r-reuse", "screenshot");
+    store.finalizeRequest("r-reuse", true, {
+      screenshot: {
+        dataUrl: "data:image/jpeg;base64,old",
+        width: 100,
+        height: 80,
+      },
+    });
+    store.begin("r-reuse", "create-note");
+    const entry = store.getCurrentEntry();
+    expect(entry?.status).toBe("active");
+    expect(entry?.screenshot).toBeNull();
+  });
+
+  it("finalizeRequest emits when attaching screenshot to an already-completed entry", () => {
+    const store = new CanvasAgentFeedStore();
+    store.begin("r-late", "screenshot");
+    store.complete("r-late", true);
+    let emits = 0;
+    store.subscribe(() => {
+      emits += 1;
+    });
+    store.finalizeRequest("r-late", true, {
+      screenshot: {
+        dataUrl: "data:image/jpeg;base64,late",
+        width: 50,
+        height: 40,
+      },
+    });
+    expect(emits).toBeGreaterThan(0);
+    expect(store.getCurrentEntry()?.screenshot?.dataUrl).toContain("base64,late");
   });
 });

--- a/apps/web/src/features/canvas/__tests__/canvas-agent-feed.test.ts
+++ b/apps/web/src/features/canvas/__tests__/canvas-agent-feed.test.ts
@@ -96,4 +96,20 @@ describe("CanvasAgentFeedStore", () => {
     const { batches } = store.getSnapshot();
     expect(batches[0]?.entries).toHaveLength(1);
   });
+
+  it("finalizeRequest attaches screenshot onto the feed entry", () => {
+    const store = new CanvasAgentFeedStore();
+    store.begin("r-shot", "screenshot");
+    store.finalizeRequest("r-shot", true, {
+      screenshot: {
+        dataUrl: "data:image/jpeg;base64,abc",
+        width: 100,
+        height: 80,
+      },
+    });
+    const entry = store.getCurrentEntry();
+    expect(entry?.status).toBe("done");
+    expect(entry?.screenshot?.dataUrl).toContain("data:image/jpeg");
+    expect(entry?.screenshot?.width).toBe(100);
+  });
 });

--- a/apps/web/src/features/canvas/__tests__/canvas-agent-lint.test.ts
+++ b/apps/web/src/features/canvas/__tests__/canvas-agent-lint.test.ts
@@ -1,0 +1,318 @@
+// @ts-expect-error bun:test is available at runtime but not in tsconfig types
+import { describe, expect, it } from "bun:test";
+
+import {
+  buildLintFixSuggestions,
+  computeCanvasLints,
+  estimateGeoTextOverflow,
+  suggestOverlapSeparation,
+  summarizeLints,
+} from "../lib/canvas-agent-lint";
+
+const CANVAS_TERMINAL_SHAPE_TYPE = "canvas-terminal";
+const CANVAS_WIDGET_SHAPE_TYPE = "canvas-widget";
+
+type FakeShape = {
+  id: string;
+  type: string;
+  x: number;
+  y: number;
+  parentId: string;
+  props: Record<string, unknown>;
+};
+
+function makeEditor(shapes: FakeShape[]) {
+  const byId = new Map(shapes.map((s) => [s.id, s]));
+  return {
+    getCurrentPageShapes: () => shapes,
+    getShape: (id: string) => byId.get(id),
+    getShapePageBounds: (id: string | FakeShape) => {
+      const s = typeof id === "string" ? byId.get(id) : id;
+      if (!s) return null;
+      const w = Number(s.props.w ?? 100);
+      const h = Number(s.props.h ?? 100);
+      return {
+        minX: s.x,
+        minY: s.y,
+        maxX: s.x + w,
+        maxY: s.y + h,
+        width: w,
+        height: h,
+        midX: s.x + w / 2,
+        midY: s.y + h / 2,
+      };
+    },
+  };
+}
+
+function richText(text: string) {
+  return {
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  };
+}
+
+describe("canvas-agent-lint", () => {
+  it("flags content-on-content overlap as error", () => {
+    const editor = makeEditor([
+      {
+        id: "shape:a",
+        type: "geo",
+        x: 0,
+        y: 0,
+        parentId: "page:main",
+        props: { w: 200, h: 100 },
+      },
+      {
+        id: "shape:b",
+        type: "geo",
+        x: 50,
+        y: 20,
+        parentId: "page:main",
+        props: { w: 200, h: 100 },
+      },
+    ]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const lints = computeCanvasLints(editor as any);
+    const overlaps = lints.filter((l) => l.type === "overlap");
+    expect(overlaps.length).toBe(1);
+    expect(overlaps[0]!.severity).toBe("error");
+  });
+
+  it("does not flag non-overlapping neighbours", () => {
+    const editor = makeEditor([
+      {
+        id: "shape:a",
+        type: "geo",
+        x: 0,
+        y: 0,
+        parentId: "page:main",
+        props: { w: 100, h: 100 },
+      },
+      {
+        id: "shape:b",
+        type: "geo",
+        x: 140,
+        y: 0,
+        parentId: "page:main",
+        props: { w: 100, h: 100 },
+      },
+    ]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const lints = computeCanvasLints(editor as any);
+    expect(lints.filter((l) => l.type === "overlap")).toHaveLength(0);
+  });
+
+  it("ignores arrow vs content AABB collision", () => {
+    const editor = makeEditor([
+      {
+        id: "shape:a",
+        type: "geo",
+        x: 0,
+        y: 0,
+        parentId: "page:main",
+        props: { w: 100, h: 100 },
+      },
+      {
+        id: "shape:arr",
+        type: "arrow",
+        x: 20,
+        y: 20,
+        parentId: "page:main",
+        props: { w: 80, h: 80 },
+      },
+    ]);
+    // Arrow bindings stub — getArrowBindings needs real tldraw; unbound check
+    // may throw. We only assert no content/content overlap from the arrow.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let lints: ReturnType<typeof computeCanvasLints> = [];
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      lints = computeCanvasLints(editor as any);
+    } catch {
+      // getArrowBindings may fail on fake shapes; treat as no arrow lint.
+      lints = [];
+    }
+    expect(lints.filter((l) => l.type === "overlap")).toHaveLength(0);
+  });
+
+  it("ignores atmos chrome widgets in overlap checks", () => {
+    const editor = makeEditor([
+      {
+        id: "shape:a",
+        type: "geo",
+        x: 0,
+        y: 0,
+        parentId: "page:main",
+        props: { w: 200, h: 200 },
+      },
+      {
+        id: "shape:term",
+        type: CANVAS_TERMINAL_SHAPE_TYPE,
+        x: 50,
+        y: 50,
+        parentId: "page:main",
+        props: { w: 400, h: 300 },
+      },
+      {
+        id: "shape:widget",
+        type: CANVAS_WIDGET_SHAPE_TYPE,
+        x: 10,
+        y: 10,
+        parentId: "page:main",
+        props: { w: 300, h: 200 },
+      },
+    ]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const lints = computeCanvasLints(editor as any);
+    expect(lints.filter((l) => l.type === "overlap")).toHaveLength(0);
+  });
+
+  it("ignores frame containing a child content shape", () => {
+    const editor = makeEditor([
+      {
+        id: "shape:frame",
+        type: "frame",
+        x: 0,
+        y: 0,
+        parentId: "page:main",
+        props: { w: 400, h: 300 },
+      },
+      {
+        id: "shape:card",
+        type: "geo",
+        x: 40,
+        y: 60,
+        parentId: "shape:frame",
+        props: { w: 120, h: 80 },
+      },
+    ]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const lints = computeCanvasLints(editor as any);
+    // frame is not content; no pairwise content overlap
+    expect(lints.filter((l) => l.type === "overlap")).toHaveLength(0);
+  });
+
+  it("detects geo text overflow heuristically", () => {
+    const tight = {
+      id: "shape:t",
+      type: "geo",
+      x: 0,
+      y: 0,
+      parentId: "page:main",
+      props: {
+        w: 80,
+        h: 40,
+        richText: richText(
+          "This is a very long label that cannot possibly fit in a tiny box at all",
+        ),
+      },
+    } as FakeShape;
+    expect(estimateGeoTextOverflow(tight)).toBe(true);
+
+    const roomy = {
+      ...tight,
+      props: { w: 400, h: 200, richText: richText("Short") },
+    };
+    expect(estimateGeoTextOverflow(roomy)).toBe(false);
+  });
+
+  it("summarizeLints counts severities", () => {
+    const summary = summarizeLints([
+      {
+        type: "overlap",
+        severity: "error",
+        shape_ids: ["a", "b"],
+        message: "x",
+      },
+      {
+        type: "unbound_arrow",
+        severity: "warn",
+        shape_ids: ["c"],
+        message: "y",
+      },
+    ]);
+    expect(summary).toEqual({ error_count: 1, warn_count: 1, clean: false });
+  });
+
+  it("suggestOverlapSeparation pushes the cheaper axis with gap", () => {
+    const a = {
+      minX: 0,
+      minY: 0,
+      maxX: 100,
+      maxY: 100,
+      width: 100,
+      height: 100,
+      midX: 50,
+      midY: 50,
+    };
+    // B overlaps A on the right by 20px
+    const b = {
+      minX: 80,
+      minY: 10,
+      maxX: 180,
+      maxY: 110,
+      width: 100,
+      height: 100,
+      midX: 130,
+      midY: 60,
+    };
+    const { dx, dy } = suggestOverlapSeparation(a, b, 24);
+    expect(dy).toBe(0);
+    expect(dx).toBe(20 + 24);
+  });
+
+  it("buildLintFixSuggestions emits move for overlaps", () => {
+    const editor = makeEditor([
+      {
+        id: "shape:a",
+        type: "geo",
+        x: 0,
+        y: 0,
+        parentId: "page:main",
+        props: { w: 100, h: 100 },
+      },
+      {
+        id: "shape:b",
+        type: "geo",
+        x: 50,
+        y: 20,
+        parentId: "page:main",
+        props: { w: 100, h: 100 },
+      },
+    ]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { fix_suggestions, lints } = buildLintFixSuggestions(editor as any);
+    expect(lints.some((l) => l.type === "overlap")).toBe(true);
+    const move = fix_suggestions.find((s) => s.command === "move");
+    expect(move).toBeDefined();
+    expect(move!.args.ids).toEqual(["shape:b"]);
+    expect(typeof move!.args.dx).toBe("number");
+    expect(typeof move!.args.dy).toBe("number");
+  });
+
+  it("buildLintFixSuggestions emits update_shape for text overflow", () => {
+    const editor = makeEditor([
+      {
+        id: "shape:t",
+        type: "geo",
+        x: 0,
+        y: 0,
+        parentId: "page:main",
+        props: {
+          w: 60,
+          h: 30,
+          richText: richText(
+            "This label is intentionally much too long for the tiny box and will overflow",
+          ),
+        },
+      },
+    ]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { fix_suggestions } = buildLintFixSuggestions(editor as any);
+    const update = fix_suggestions.find((s) => s.command === "update_shape");
+    expect(update).toBeDefined();
+    expect(update!.args.id).toBe("shape:t");
+    const patch = update!.args.patch as { h: number };
+    expect(patch.h).toBeGreaterThan(30);
+  });
+});

--- a/apps/web/src/features/canvas/__tests__/canvas-agent-lint.test.ts
+++ b/apps/web/src/features/canvas/__tests__/canvas-agent-lint.test.ts
@@ -279,6 +279,34 @@ describe("canvas-agent-lint", () => {
     expect(dx).toBe(24);
   });
 
+  it("suggestOverlapSeparation remediates near-touching boxes (1–2px gap)", () => {
+    // Lint reports these as overlap via boxesOverlap padding=2; fix must
+    // still produce a move even though penX is negative (not pure overlap).
+    const a = {
+      minX: 0,
+      minY: 0,
+      maxX: 100,
+      maxY: 100,
+      width: 100,
+      height: 100,
+      midX: 50,
+      midY: 50,
+    };
+    const b = {
+      minX: 102, // 2px gap
+      minY: 0,
+      maxX: 202,
+      maxY: 100,
+      width: 100,
+      height: 100,
+      midX: 152,
+      midY: 50,
+    };
+    const { dx, dy } = suggestOverlapSeparation(a, b, 24);
+    expect(dy).toBe(0);
+    expect(dx).toBe(22); // gap shortfall: 24 - 2
+  });
+
   it("buildLintFixSuggestions emits move for overlaps", () => {
     const editor = makeEditor([
       {

--- a/apps/web/src/features/canvas/__tests__/canvas-agent-lint.test.ts
+++ b/apps/web/src/features/canvas/__tests__/canvas-agent-lint.test.ts
@@ -121,17 +121,8 @@ describe("canvas-agent-lint", () => {
         props: { w: 80, h: 80 },
       },
     ]);
-    // Arrow bindings stub — getArrowBindings needs real tldraw; unbound check
-    // may throw. We only assert no content/content overlap from the arrow.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let lints: ReturnType<typeof computeCanvasLints> = [];
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      lints = computeCanvasLints(editor as any);
-    } catch {
-      // getArrowBindings may fail on fake shapes; treat as no arrow lint.
-      lints = [];
-    }
+    const lints = computeCanvasLints(editor as any);
     expect(lints.filter((l) => l.type === "overlap")).toHaveLength(0);
   });
 
@@ -259,6 +250,33 @@ describe("canvas-agent-lint", () => {
     const { dx, dy } = suggestOverlapSeparation(a, b, 24);
     expect(dy).toBe(0);
     expect(dx).toBe(20 + 24);
+  });
+
+  it("suggestOverlapSeparation separates touching boxes with gap", () => {
+    const a = {
+      minX: 0,
+      minY: 0,
+      maxX: 100,
+      maxY: 100,
+      width: 100,
+      height: 100,
+      midX: 50,
+      midY: 50,
+    };
+    // B touches A on the right edge (penX = 0)
+    const b = {
+      minX: 100,
+      minY: 0,
+      maxX: 200,
+      maxY: 100,
+      width: 100,
+      height: 100,
+      midX: 150,
+      midY: 50,
+    };
+    const { dx, dy } = suggestOverlapSeparation(a, b, 24);
+    expect(dy).toBe(0);
+    expect(dx).toBe(24);
   });
 
   it("buildLintFixSuggestions emits move for overlaps", () => {

--- a/apps/web/src/features/canvas/__tests__/canvas-agent-spawn.test.ts
+++ b/apps/web/src/features/canvas/__tests__/canvas-agent-spawn.test.ts
@@ -1,7 +1,7 @@
 // @ts-expect-error bun:test is available at runtime but not in tsconfig types
 import { describe, expect, it } from "bun:test";
 
-import { findNonOverlappingSpawn } from "../lib/canvas-agent-spawn";
+import { findNonOverlappingSpawn, rectsOverlap } from "../lib/canvas-agent-spawn";
 
 function makeEditor(
   shapes: Array<{
@@ -41,19 +41,6 @@ function makeEditor(
   };
 }
 
-function overlaps(
-  a: { x: number; y: number; w: number; h: number },
-  b: { x: number; y: number; w: number; h: number },
-  gap: number,
-) {
-  return !(
-    a.x + a.w + gap <= b.x ||
-    b.x + b.w + gap <= a.x ||
-    a.y + a.h + gap <= b.y ||
-    b.y + b.h + gap <= a.y
-  );
-}
-
 describe("findNonOverlappingSpawn", () => {
   it("returns near viewport center when empty", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -78,7 +65,7 @@ describe("findNonOverlappingSpawn", () => {
     });
     const candidate = { x: pos.x, y: pos.y, w: 200, h: 200 };
     const occupied = { x: -100, y: -100, w: 200, h: 200 };
-    expect(overlaps(candidate, occupied, 28)).toBe(false);
+    expect(rectsOverlap(candidate, occupied, 28)).toBe(false);
   });
 
   it("does not use a 120×80 grid that guarantees 200×200 collisions", () => {
@@ -110,7 +97,7 @@ describe("findNonOverlappingSpawn", () => {
         const a = shapes[i]!;
         const b = shapes[j]!;
         expect(
-          overlaps(
+          rectsOverlap(
             { x: a.x, y: a.y, w: 200, h: 200 },
             { x: b.x, y: b.y, w: 200, h: 200 },
             28,

--- a/apps/web/src/features/canvas/__tests__/canvas-agent-spawn.test.ts
+++ b/apps/web/src/features/canvas/__tests__/canvas-agent-spawn.test.ts
@@ -1,0 +1,122 @@
+// @ts-expect-error bun:test is available at runtime but not in tsconfig types
+import { describe, expect, it } from "bun:test";
+
+import { findNonOverlappingSpawn } from "../lib/canvas-agent-spawn";
+
+function makeEditor(
+  shapes: Array<{
+    id: string;
+    type: string;
+    x: number;
+    y: number;
+    props: Record<string, unknown>;
+  }>,
+) {
+  const byId = new Map(shapes.map((s) => [s.id, s]));
+  return {
+    getCurrentPageShapes: () => shapes,
+    getViewportPageBounds: () => ({
+      minX: -500,
+      minY: -500,
+      width: 1000,
+      height: 1000,
+      center: { x: 0, y: 0 },
+    }),
+    getShapePageBounds: (id: string) => {
+      const s = byId.get(id);
+      if (!s) return null;
+      const w = Number(s.props.w ?? 100);
+      const h = Number(s.props.h ?? 100);
+      return {
+        minX: s.x,
+        minY: s.y,
+        maxX: s.x + w,
+        maxY: s.y + h,
+        width: w,
+        height: h,
+        midX: s.x + w / 2,
+        midY: s.y + h / 2,
+      };
+    },
+  };
+}
+
+function overlaps(
+  a: { x: number; y: number; w: number; h: number },
+  b: { x: number; y: number; w: number; h: number },
+  gap: number,
+) {
+  return !(
+    a.x + a.w + gap <= b.x ||
+    b.x + b.w + gap <= a.x ||
+    a.y + a.h + gap <= b.y ||
+    b.y + b.h + gap <= a.y
+  );
+}
+
+describe("findNonOverlappingSpawn", () => {
+  it("returns near viewport center when empty", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pos = findNonOverlappingSpawn(makeEditor([]) as any, { w: 200, h: 200 });
+    // center is 0,0 → top-left ≈ -100,-100
+    expect(pos.x).toBeCloseTo(-100, 0);
+    expect(pos.y).toBeCloseTo(-100, 0);
+  });
+
+  it("avoids stacking on an existing default-size geo", () => {
+    const existing = {
+      id: "shape:a",
+      type: "geo",
+      x: -100,
+      y: -100,
+      props: { w: 200, h: 200 },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pos = findNonOverlappingSpawn(makeEditor([existing]) as any, {
+      w: 200,
+      h: 200,
+    });
+    const candidate = { x: pos.x, y: pos.y, w: 200, h: 200 };
+    const occupied = { x: -100, y: -100, w: 200, h: 200 };
+    expect(overlaps(candidate, occupied, 28)).toBe(false);
+  });
+
+  it("does not use a 120×80 grid that guarantees 200×200 collisions", () => {
+    // Simulate three sequential spawns with default geo size.
+    const shapes: Array<{
+      id: string;
+      type: string;
+      x: number;
+      y: number;
+      props: Record<string, unknown>;
+    }> = [];
+    for (let i = 0; i < 3; i++) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pos = findNonOverlappingSpawn(makeEditor(shapes) as any, {
+        w: 200,
+        h: 200,
+      });
+      shapes.push({
+        id: `shape:${i}`,
+        type: "geo",
+        x: pos.x,
+        y: pos.y,
+        props: { w: 200, h: 200 },
+      });
+    }
+    // Pairwise non-overlap with gap.
+    for (let i = 0; i < shapes.length; i++) {
+      for (let j = i + 1; j < shapes.length; j++) {
+        const a = shapes[i]!;
+        const b = shapes[j]!;
+        expect(
+          overlaps(
+            { x: a.x, y: a.y, w: 200, h: 200 },
+            { x: b.x, y: b.y, w: 200, h: 200 },
+            28,
+          ),
+        ).toBe(false);
+      }
+    }
+  });
+});

--- a/apps/web/src/features/canvas/__tests__/canvas-agent-view-bounds.test.ts
+++ b/apps/web/src/features/canvas/__tests__/canvas-agent-view-bounds.test.ts
@@ -4,6 +4,25 @@ import { describe, expect, it } from "bun:test";
 import { shapeIdsFromAgentResult, unionBounds } from "../lib/canvas-agent-view-bounds";
 
 describe("canvas-agent-view-bounds", () => {
+  it("extracts ids from apply results", () => {
+    const ids = shapeIdsFromAgentResult({
+      results: [
+        { success: true, data: { id: "shape:a" } },
+        { success: true, data: { id: "shape:b" } },
+      ],
+      partial: false,
+    });
+    expect(ids).toEqual(["shape:a", "shape:b"]);
+  });
+
+  it("extracts shape_ids from screenshot results", () => {
+    const ids = shapeIdsFromAgentResult({
+      shape_ids: ["shape:a", "shape:b"],
+      shape_count: 2,
+    });
+    expect(ids).toEqual(["shape:a", "shape:b"]);
+  });
+
   it("unionBounds merges two boxes", () => {
     const a = { x: 0, y: 0, w: 100, h: 50 };
     const b = { x: 80, y: 40, w: 100, h: 50 };

--- a/apps/web/src/features/canvas/components/CanvasAgentIsland.tsx
+++ b/apps/web/src/features/canvas/components/CanvasAgentIsland.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { AnimatePresence, motion } from "motion/react";
 import {
+  Camera,
   Eye,
   LayoutGrid,
   Maximize2,
@@ -14,7 +15,7 @@ import {
   Trash2,
   Type,
 } from "lucide-react";
-import { cn, DotmSquare12 } from "@workspace/ui";
+import { cn, DotmSquare12, TextShimmer } from "@workspace/ui";
 
 import type { CanvasAgentFeedStore } from "../lib/canvas-agent-feed";
 import type {
@@ -32,6 +33,7 @@ import {
   resolveCanvasAgentIslandWorking,
 } from "../lib/canvas-agent-activity";
 import type { CanvasAgentBridgeState } from "../hooks/use-canvas-agent-bridge";
+import { ImagePreviewOverlay } from "@/shared/components/image-preview-overlay";
 
 const PANEL_TRANSITION = {
   duration: 0.24,
@@ -152,7 +154,16 @@ export function CanvasAgentIsland({ bridge }: { bridge: CanvasAgentBridgeState }
             transition={PANEL_TRANSITION}
             className="pointer-events-auto w-[min(100vw-2rem,20rem)]"
           >
-            <ExpandedPanel batches={snapshot.batches} />
+            <ExpandedPanel
+              batches={snapshot.batches}
+              // While the island is in "working" mode, shimmer the current
+              // doing row even if the entry just flipped to done (15s window).
+              shimmerEntryId={
+                isWorking
+                  ? (snapshot.activeEntryId ?? current.requestId)
+                  : snapshot.activeEntryId
+              }
+            />
           </motion.div>
         ) : null}
       </AnimatePresence>
@@ -182,14 +193,20 @@ export function CanvasAgentIsland({ bridge }: { bridge: CanvasAgentBridgeState }
         <IslandStatusLabel
           labelKey={`${current.requestId}:${isWorking ? "work" : "idle"}`}
           label={current.label}
-          isWorking={isWorking}
+          isWorking={isWorking && !reducedMotion}
         />
       </button>
     </div>
   );
 }
 
-function ExpandedPanel({ batches }: { batches: CanvasAgentFeedBatch[] }) {
+function ExpandedPanel({
+  batches,
+  shimmerEntryId,
+}: {
+  batches: CanvasAgentFeedBatch[];
+  shimmerEntryId: string | null;
+}) {
   const t = useTranslations("Canvas.chrome");
   const visibleBatches = buildVisibleHistoryBatches(batches);
 
@@ -207,7 +224,11 @@ function ExpandedPanel({ batches }: { batches: CanvasAgentFeedBatch[] }) {
             ) : null}
             <ul className="flex flex-col gap-1">
               {batch.rows.map(row => (
-                <HistoryRow key={row.id} row={row} />
+                <HistoryRow
+                  key={row.id}
+                  row={row}
+                  shimmer={row.id === shimmerEntryId || row.status === "active"}
+                />
               ))}
             </ul>
           </React.Fragment>
@@ -217,8 +238,18 @@ function ExpandedPanel({ batches }: { batches: CanvasAgentFeedBatch[] }) {
   );
 }
 
-function HistoryRow({ row }: { row: SummarizedFeedRow }) {
+function HistoryRow({
+  row,
+  shimmer,
+}: {
+  row: SummarizedFeedRow;
+  shimmer: boolean;
+}) {
   const locale = useLocale();
+  const t = useTranslations("Canvas.chrome");
+  const [previewOpen, setPreviewOpen] = React.useState(false);
+  const shot = row.screenshot?.dataUrl ? row.screenshot : null;
+  const label = formatRowLabel(row);
 
   return (
     <li className="flex items-center gap-2 rounded-lg px-1 py-1.5 text-xs">
@@ -228,27 +259,75 @@ function HistoryRow({ row }: { row: SummarizedFeedRow }) {
           "size-3.5 shrink-0",
           row.status === "error"
             ? "text-destructive"
-            : row.status === "active"
+            : shimmer
               ? "text-emerald-500"
               : "text-muted-foreground",
         )}
       />
       <span
         className={cn(
-          "min-w-0 flex-1 truncate",
-          row.status === "active" ? "text-foreground" : "text-foreground/85",
+          "min-w-0 flex-1",
+          shimmer ? "text-foreground" : "truncate text-foreground/85",
         )}
       >
-        {formatRowLabel(row)}
+        {shimmer ? (
+          <TextShimmer
+            as="span"
+            duration={1.5}
+            className="text-xs font-medium"
+          >
+            {label}
+          </TextShimmer>
+        ) : (
+          <span className="truncate">{label}</span>
+        )}
       </span>
+      {shot ? (
+        <button
+          type="button"
+          aria-label={t("agentIsland.openScreenshotPreview")}
+          title={t("agentIsland.openScreenshotPreview")}
+          onClick={e => {
+            e.stopPropagation();
+            setPreviewOpen(true);
+          }}
+          className={cn(
+            "size-7 shrink-0 overflow-hidden rounded-md border border-border/60 bg-muted/40",
+            "cursor-zoom-in transition-opacity hover:opacity-90",
+          )}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={shot.dataUrl}
+            alt=""
+            width={shot.width || 28}
+            height={shot.height || 28}
+            className="size-full object-cover object-top"
+            draggable={false}
+          />
+        </button>
+      ) : null}
       <time
         className="shrink-0 tabular-nums text-[10px] text-muted-foreground"
         dateTime={new Date(row.time).toISOString()}
       >
         {formatTime(row.time, locale)}
       </time>
+      {previewOpen && shot ? (
+        <ImagePreviewOverlay
+          src={shot.dataUrl}
+          alt={t("agentIsland.screenshotPreviewAlt")}
+          onClose={() => setPreviewOpen(false)}
+        />
+      ) : null}
     </li>
   );
+}
+
+function isScreenshotRow(row: SummarizedFeedRow): boolean {
+  if (row.screenshot?.dataUrl) return true;
+  const command = (row.command ?? "").trim().toLowerCase().replace(/_/g, "-");
+  return command === "screenshot";
 }
 
 function HistoryIcon({
@@ -258,6 +337,7 @@ function HistoryIcon({
   className?: string;
   row: SummarizedFeedRow;
 }) {
+  if (isScreenshotRow(row)) return <Camera className={className} aria-hidden />;
   if (row.label.includes("writing")) return <Type className={className} aria-hidden />;
 
   switch (row.kind) {
@@ -283,8 +363,8 @@ function HistoryIcon({
 }
 
 /**
- * Label slot — no motion wrapper around TextShimmer (see Footer ticker comment).
- * Keyed remount + tailwind `animate-in` handles enter transitions.
+ * Label slot — TextShimmer matches Footer / AgentActivityIndicator.
+ * Do not wrap TextShimmer in motion/AnimatePresence (see HostedAppShellGate).
  */
 function IslandStatusLabel({
   labelKey,
@@ -298,19 +378,16 @@ function IslandStatusLabel({
   return (
     <span
       key={labelKey}
-      className="block whitespace-nowrap text-sm font-medium animate-in fade-in slide-in-from-bottom-1 duration-200"
+      className="block max-w-[14rem] truncate whitespace-nowrap text-sm font-medium"
       aria-live="polite"
       aria-atomic
     >
       {isWorking ? (
-        <span
-          className="canvas-agent-island-shimmer whitespace-nowrap"
-          style={{ animationDuration: "1.8s" }}
-        >
+        <TextShimmer as="span" duration={1.5} className="text-sm font-medium">
           {label}
-        </span>
+        </TextShimmer>
       ) : (
-        <span className="whitespace-nowrap opacity-90">{label}</span>
+        <span className="opacity-90">{label}</span>
       )}
     </span>
   );
@@ -372,8 +449,18 @@ function useDismissOnOutsidePress(
     if (!enabled) return;
 
     const onPointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
       const root = rootRef.current;
-      if (!root || root.contains(event.target as Node)) return;
+      if (!root || root.contains(target)) return;
+      // Image preview is portaled to document.body — closing it must not
+      // collapse the Island history popover.
+      if (
+        target instanceof Element &&
+        target.closest("[data-image-preview-overlay]")
+      ) {
+        return;
+      }
       onDismiss();
     };
 

--- a/apps/web/src/features/canvas/components/CanvasAgentIsland.tsx
+++ b/apps/web/src/features/canvas/components/CanvasAgentIsland.tsx
@@ -163,6 +163,7 @@ export function CanvasAgentIsland({ bridge }: { bridge: CanvasAgentBridgeState }
                   ? (snapshot.activeEntryId ?? current.requestId)
                   : snapshot.activeEntryId
               }
+              reducedMotion={reducedMotion}
             />
           </motion.div>
         ) : null}
@@ -203,9 +204,11 @@ export function CanvasAgentIsland({ bridge }: { bridge: CanvasAgentBridgeState }
 function ExpandedPanel({
   batches,
   shimmerEntryId,
+  reducedMotion,
 }: {
   batches: CanvasAgentFeedBatch[];
   shimmerEntryId: string | null;
+  reducedMotion: boolean;
 }) {
   const t = useTranslations("Canvas.chrome");
   const visibleBatches = buildVisibleHistoryBatches(batches);
@@ -223,13 +226,17 @@ function ExpandedPanel({
               <div className="my-2 border-t border-dashed border-border/60" aria-hidden />
             ) : null}
             <ul className="flex flex-col gap-1">
-              {batch.rows.map(row => (
-                <HistoryRow
-                  key={row.id}
-                  row={row}
-                  shimmer={row.id === shimmerEntryId || row.status === "active"}
-                />
-              ))}
+              {batch.rows.map(row => {
+                const wantsShimmer =
+                  row.id === shimmerEntryId || row.status === "active";
+                return (
+                  <HistoryRow
+                    key={row.id}
+                    row={row}
+                    shimmer={wantsShimmer && !reducedMotion}
+                  />
+                );
+              })}
             </ul>
           </React.Fragment>
         ))}
@@ -266,15 +273,17 @@ function HistoryRow({
       />
       <span
         className={cn(
-          "min-w-0 flex-1",
-          shimmer ? "text-foreground" : "truncate text-foreground/85",
+          // Keep truncate in both states so long labels never cover the
+          // screenshot control / timestamp while shimmering.
+          "min-w-0 flex-1 truncate",
+          shimmer ? "text-foreground" : "text-foreground/85",
         )}
       >
         {shimmer ? (
           <TextShimmer
             as="span"
             duration={1.5}
-            className="text-xs font-medium"
+            className="block truncate text-xs font-medium"
           >
             {label}
           </TextShimmer>
@@ -299,7 +308,7 @@ function HistoryRow({
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={shot.dataUrl}
-            alt=""
+            alt={t("agentIsland.screenshotPreviewAlt")}
             width={shot.width || 28}
             height={shot.height || 28}
             className="size-full object-cover object-top"

--- a/apps/web/src/features/canvas/components/CanvasAgentOverlay.tsx
+++ b/apps/web/src/features/canvas/components/CanvasAgentOverlay.tsx
@@ -26,8 +26,11 @@ const SKILL_PATH = "~/.atmos/skills/.system/atmos-canvas-agent/SKILL.md";
 
 /** Window after activity within which the bridge is rendered as "Active". */
 const ACTIVE_WINDOW_MS = 30_000;
-/** How long the transient ring around just-touched shapes stays visible. */
-const RING_DURATION_MS = 1_500;
+/**
+ * How long the agent-touched shape ring stays visible.
+ * Keep in sync with `FOCUS_PULSE_MS` in canvas-shape-focus (CanvasFocusPulse).
+ */
+const RING_DURATION_MS = 2_400;
 
 /**
  * Renders a soft pulsing ring around the shapes the agent most recently
@@ -108,9 +111,10 @@ function ShapeRing({
         height: height + 8,
       }}
       className={cn(
-        "absolute rounded-lg border border-emerald-400/80",
-        "shadow-[0_0_0_2px_rgba(52,211,153,0.16),0_0_12px_2px_rgba(52,211,153,0.28)]",
-        "animate-[canvas-agent-ring_1500ms_ease-out_forwards]",
+        "absolute rounded-lg border border-emerald-400/90",
+        "shadow-[0_0_0_3px_rgba(52,211,153,0.18),0_0_14px_2px_rgba(52,211,153,0.30)]",
+        // Reuse the multi-peak flash from canvas-focus-pulse (terminal / pin focus).
+        "animate-[canvas-focus-pulse_2400ms_ease-in-out_forwards]",
       )}
     />
   );
@@ -275,8 +279,19 @@ function BridgePopoverBody({
         />
       </div>
 
+      <div className="mx-4 border-t border-border" />
+      <div className="flex items-center justify-between gap-3 px-4 py-3">
+        <div className="text-sm font-medium">{t("follow.title")}</div>
+        <Switch
+          checked={bridge.agentFollow}
+          onCheckedChange={(value) => bridge.setAgentFollow(Boolean(value))}
+          disabled={!bridge.acceptsCommands}
+          aria-label={t("follow.aria")}
+        />
+      </div>
+
+      <div className="mx-4 border-t border-border" />
       <div className="px-4 py-3">
-        <div className="mb-3 border-t border-border" />
         <div className="mb-2 flex items-center justify-between gap-2">
           <div className="text-xs font-medium text-muted-foreground">
             {t("snippet.label")}
@@ -296,8 +311,8 @@ function BridgePopoverBody({
         </pre>
       </div>
 
+      <div className="mx-4 border-t border-border" />
       <div className="px-4 py-3">
-        <div className="mb-3 border-t border-border" />
         <LastActivityRow activity={activity} onJump={onJump} />
       </div>
     </div>

--- a/apps/web/src/features/canvas/hooks/use-canvas-agent-bridge.ts
+++ b/apps/web/src/features/canvas/hooks/use-canvas-agent-bridge.ts
@@ -4,7 +4,10 @@ import * as React from "react";
 import type { Editor, TLShapeId } from "tldraw";
 
 import { canvasAgentBridgeWsApi } from "@/api/ws-api";
-import { resolveCanvasPrefsInstanceId } from "@/shared/stores/use-ui-pref-hooks";
+import {
+  DEFAULT_CANVAS_PREFS,
+  resolveCanvasPrefsInstanceId,
+} from "@/shared/stores/use-ui-pref-hooks";
 import { useUiPrefStore } from "@/shared/stores/use-ui-pref-store";
 import { useWebSocketStore } from "@/features/connection/hooks/use-websocket";
 import { CanvasAgentBus, type CanvasAgentDispatchInput } from "../lib/canvas-agent-bus";
@@ -16,17 +19,6 @@ import {
 } from "../lib/canvas-agent-view-bounds";
 import { focusCanvasShapes } from "../lib/canvas-shape-focus";
 import { useCanvasRuntimeStore } from "../store/canvas-runtime-store";
-
-const DEFAULT_CANVAS_PREFS = {
-  sessionByBoard: {} as Record<string, unknown>,
-  agentClientId: null as string | null,
-  acceptsCommands: false,
-  /**
-   * When true, successful agent dispatches that touch shapes pan/zoom the
-   * camera to those shapes. Users drawing alongside the agent can turn this off.
-   */
-  agentFollow: true,
-};
 
 const DISPATCH_EVENT = "canvas_agent_dispatch";
 

--- a/apps/web/src/features/canvas/hooks/use-canvas-agent-bridge.ts
+++ b/apps/web/src/features/canvas/hooks/use-canvas-agent-bridge.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import type { Editor } from "tldraw";
+import type { Editor, TLShapeId } from "tldraw";
 
 import { canvasAgentBridgeWsApi } from "@/api/ws-api";
 import { resolveCanvasPrefsInstanceId } from "@/shared/stores/use-ui-pref-hooks";
@@ -14,11 +14,18 @@ import {
   shapeIdsFromAgentResult,
   type CanvasAgentBounds,
 } from "../lib/canvas-agent-view-bounds";
+import { focusCanvasShapes } from "../lib/canvas-shape-focus";
+import { useCanvasRuntimeStore } from "../store/canvas-runtime-store";
 
 const DEFAULT_CANVAS_PREFS = {
   sessionByBoard: {} as Record<string, unknown>,
   agentClientId: null as string | null,
   acceptsCommands: false,
+  /**
+   * When true, successful agent dispatches that touch shapes pan/zoom the
+   * camera to those shapes. Users drawing alongside the agent can turn this off.
+   */
+  agentFollow: true,
 };
 
 const DISPATCH_EVENT = "canvas_agent_dispatch";
@@ -50,11 +57,24 @@ function loadAcceptsCommands(): boolean {
     .acceptsCommands;
 }
 
+function loadAgentFollow(): boolean {
+  if (typeof window === "undefined") return true;
+  const instanceId = resolveCanvasPrefsInstanceId();
+  const prefs = useUiPrefStore.getState().readSlice(instanceId, "canvas", DEFAULT_CANVAS_PREFS);
+  return prefs.agentFollow !== false;
+}
+
 export interface CanvasAgentBridgeState {
   clientId: string;
   acceptsCommands: boolean;
+  /**
+   * Camera follows agent-touched shapes after each successful mutating dispatch.
+   * Independent of bridge enable — only applies while the bridge is accepting work.
+   */
+  agentFollow: boolean;
   isConnected: boolean;
   setAcceptsCommands: (value: boolean) => void;
+  setAgentFollow: (value: boolean) => void;
   activity: CanvasAgentActivityStore;
   feed: CanvasAgentFeedStore;
   /** Fail the in-flight CLI dispatch (e.g. after canvas crash recovery). */
@@ -69,10 +89,21 @@ export function useCanvasAgentBridge(editor: Editor | null): CanvasAgentBridgeSt
   const [acceptsCommands, setAcceptsCommandsState] = React.useState(() =>
     loadAcceptsCommands(),
   );
+  const [agentFollow, setAgentFollowState] = React.useState(() => loadAgentFollow());
 
   const [activity] = React.useState(() => new CanvasAgentActivityStore());
   const [feed] = React.useState(() => new CanvasAgentFeedStore());
-  const [bus] = React.useState(() => new CanvasAgentBus({}));
+  // Stable ref so the bus can read the latest agent-view frame without re-creating.
+  const activityRef = React.useRef(activity);
+  activityRef.current = activity;
+  const agentFollowRef = React.useRef(agentFollow);
+  agentFollowRef.current = agentFollow;
+  const [bus] = React.useState(
+    () =>
+      new CanvasAgentBus({
+        getAgentViewBounds: () => activityRef.current.getViewState().viewBounds,
+      }),
+  );
   const inflightRequestIdRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
@@ -141,6 +172,10 @@ export function useCanvasAgentBridge(editor: Editor | null): CanvasAgentBridgeSt
           | Awaited<ReturnType<CanvasAgentBus["handleDispatch"]>>
           | undefined;
         let success = false;
+        /** Captured in try, attached via finalizeRequest in finally (HMR-safe). */
+        let screenshotForFeed:
+          | { dataUrl: string; width: number; height: number }
+          | undefined;
         try {
           try {
             result = await bus.handleDispatch(payload);
@@ -160,18 +195,60 @@ export function useCanvasAgentBridge(editor: Editor | null): CanvasAgentBridgeSt
             const view = (result.data as { view?: CanvasAgentBounds }).view;
             if (view) {
               activity.setAgentView(view, true);
+              // Follow agent-view frames when Follow is on (CLI --zoom is independent).
+              if (agentFollowRef.current && editor && view.w > 0 && view.h > 0) {
+                try {
+                  editor.zoomToBounds(
+                    { x: view.x, y: view.y, w: view.w, h: view.h },
+                    { animation: { duration: 320 } },
+                  );
+                } catch {
+                  // Editor may be mid-dispose.
+                }
+              }
             }
           } else if (success && normalized === "set-status") {
             const status = (result.data as { status?: string }).status;
             if (status === "idle" || status === "active") {
               activity.setStatus(status);
             }
+          } else if (success && normalized === "screenshot" && result.data) {
+            activity.record(payload.command, editor, touchedShapeIds);
+            const shot = result.data as {
+              data_url?: string;
+              width?: number;
+              height?: number;
+              region?: CanvasAgentBounds;
+            };
+            if (typeof shot.data_url === "string" && shot.data_url.startsWith("data:")) {
+              screenshotForFeed = {
+                dataUrl: shot.data_url,
+                width: typeof shot.width === "number" ? shot.width : 0,
+                height: typeof shot.height === "number" ? shot.height : 0,
+              };
+              if (typeof activity.setLastScreenshot === "function") {
+                activity.setLastScreenshot({
+                  ...screenshotForFeed,
+                  region: shot.region ?? null,
+                });
+              }
+            }
           } else if (success) {
             activity.record(payload.command, editor, touchedShapeIds);
+            // Pulse operated shapes (CanvasFocusPulse) and optionally follow camera.
+            if (editor && touchedShapeIds.length > 0) {
+              highlightAgentTouchedShapes(editor, touchedShapeIds, {
+                followCamera: agentFollowRef.current,
+              });
+            }
           }
         } finally {
           activity.endWork();
-          feed.finalizeRequest(payload.request_id, success);
+          feed.finalizeRequest(
+            payload.request_id,
+            success,
+            screenshotForFeed ? { screenshot: screenshotForFeed } : undefined,
+          );
         }
         if (!result) return;
 
@@ -240,13 +317,48 @@ export function useCanvasAgentBridge(editor: Editor | null): CanvasAgentBridgeSt
     );
   }, []);
 
+  const setAgentFollow = React.useCallback((value: boolean) => {
+    setAgentFollowState(value);
+    agentFollowRef.current = value;
+    const instanceId = resolveCanvasPrefsInstanceId();
+    useUiPrefStore.getState().patchSlice(
+      instanceId,
+      "canvas",
+      prev => ({ ...prev, agentFollow: value }),
+      DEFAULT_CANVAS_PREFS,
+    );
+  }, []);
+
   return {
     clientId,
     acceptsCommands,
+    agentFollow,
     isConnected,
     setAcceptsCommands,
+    setAgentFollow,
     activity,
     feed,
     failInflight,
   };
+}
+
+/**
+ * Reuses the shared canvas focus pulse (same animation as pin-to-canvas /
+ * terminal focus) so agent-touched shapes flash without stealing selection.
+ * Camera follow is opt-in via Agent Follow.
+ */
+function highlightAgentTouchedShapes(
+  editor: Editor,
+  shapeIds: string[],
+  options: { followCamera: boolean },
+) {
+  const ids = shapeIds.filter(Boolean) as TLShapeId[];
+  if (ids.length === 0) return;
+  focusCanvasShapes(editor, ids, {
+    select: false,
+    animateCamera: options.followCamera,
+    getFocusPulseShapeIds: () => useCanvasRuntimeStore.getState().focusPulseShapeIds,
+    setFocusPulseShapeIds: (next) =>
+      useCanvasRuntimeStore.getState().setFocusPulseShapeIds(next),
+  });
 }

--- a/apps/web/src/features/canvas/hooks/use-canvas-agent-bridge.ts
+++ b/apps/web/src/features/canvas/hooks/use-canvas-agent-bridge.ts
@@ -210,20 +210,14 @@ export function useCanvasAgentBridge(editor: Editor | null): CanvasAgentBridgeSt
               data_url?: string;
               width?: number;
               height?: number;
-              region?: CanvasAgentBounds;
             };
             if (typeof shot.data_url === "string" && shot.data_url.startsWith("data:")) {
+              // Island thumb comes from the feed entry (finalizeRequest extras).
               screenshotForFeed = {
                 dataUrl: shot.data_url,
                 width: typeof shot.width === "number" ? shot.width : 0,
                 height: typeof shot.height === "number" ? shot.height : 0,
               };
-              if (typeof activity.setLastScreenshot === "function") {
-                activity.setLastScreenshot({
-                  ...screenshotForFeed,
-                  region: shot.region ?? null,
-                });
-              }
             }
           } else if (success) {
             activity.record(payload.command, editor, touchedShapeIds);

--- a/apps/web/src/features/canvas/lib/canvas-agent-activity.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-activity.ts
@@ -79,9 +79,20 @@ export interface CanvasAgentActivity {
   at: number;
 }
 
+/** Last agent-region screenshot captured via `atmos canvas screenshot`. */
+export interface CanvasAgentScreenshotPreview {
+  dataUrl: string;
+  width: number;
+  height: number;
+  /** Page-space region that was cropped (when known). */
+  region: CanvasAgentBounds | null;
+  at: number;
+}
+
 export class CanvasAgentActivityStore {
   private last: CanvasAgentActivity | null = null;
   private viewBounds: CanvasAgentBounds | null = null;
+  private lastScreenshot: CanvasAgentScreenshotPreview | null = null;
   private inflightDepth = 0;
   private inflight = false;
   /** Set by `set-status`; cleared when a new dispatch begins. */
@@ -100,6 +111,31 @@ export class CanvasAgentActivityStore {
   getSnapshot = (): CanvasAgentActivity | null => this.last;
 
   getViewState = (): CanvasAgentViewState => this.cachedViewState;
+
+  getLastScreenshot = (): CanvasAgentScreenshotPreview | null => this.lastScreenshot;
+
+  setLastScreenshot(preview: {
+    dataUrl: string;
+    width: number;
+    height: number;
+    region?: CanvasAgentBounds | null;
+  }) {
+    if (!preview.dataUrl.startsWith("data:")) return;
+    this.lastScreenshot = {
+      dataUrl: preview.dataUrl,
+      width: preview.width,
+      height: preview.height,
+      region: preview.region ?? null,
+      at: Date.now(),
+    };
+    this.emit();
+  }
+
+  clearLastScreenshot() {
+    if (!this.lastScreenshot) return;
+    this.lastScreenshot = null;
+    this.emit();
+  }
 
   /**
    * Session signal from `atmos canvas set-status`. `idle` stops UI indicators
@@ -205,6 +241,10 @@ export class CanvasAgentActivityStore {
     }
     if (this.viewBounds !== null) {
       this.viewBounds = null;
+      changed = true;
+    }
+    if (this.lastScreenshot !== null) {
+      this.lastScreenshot = null;
       changed = true;
     }
     if (this.inflightDepth > 0 || this.inflight) {

--- a/apps/web/src/features/canvas/lib/canvas-agent-activity.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-activity.ts
@@ -79,20 +79,9 @@ export interface CanvasAgentActivity {
   at: number;
 }
 
-/** Last agent-region screenshot captured via `atmos canvas screenshot`. */
-export interface CanvasAgentScreenshotPreview {
-  dataUrl: string;
-  width: number;
-  height: number;
-  /** Page-space region that was cropped (when known). */
-  region: CanvasAgentBounds | null;
-  at: number;
-}
-
 export class CanvasAgentActivityStore {
   private last: CanvasAgentActivity | null = null;
   private viewBounds: CanvasAgentBounds | null = null;
-  private lastScreenshot: CanvasAgentScreenshotPreview | null = null;
   private inflightDepth = 0;
   private inflight = false;
   /** Set by `set-status`; cleared when a new dispatch begins. */
@@ -111,31 +100,6 @@ export class CanvasAgentActivityStore {
   getSnapshot = (): CanvasAgentActivity | null => this.last;
 
   getViewState = (): CanvasAgentViewState => this.cachedViewState;
-
-  getLastScreenshot = (): CanvasAgentScreenshotPreview | null => this.lastScreenshot;
-
-  setLastScreenshot(preview: {
-    dataUrl: string;
-    width: number;
-    height: number;
-    region?: CanvasAgentBounds | null;
-  }) {
-    if (!preview.dataUrl.startsWith("data:")) return;
-    this.lastScreenshot = {
-      dataUrl: preview.dataUrl,
-      width: preview.width,
-      height: preview.height,
-      region: preview.region ?? null,
-      at: Date.now(),
-    };
-    this.emit();
-  }
-
-  clearLastScreenshot() {
-    if (!this.lastScreenshot) return;
-    this.lastScreenshot = null;
-    this.emit();
-  }
 
   /**
    * Session signal from `atmos canvas set-status`. `idle` stops UI indicators
@@ -241,10 +205,6 @@ export class CanvasAgentActivityStore {
     }
     if (this.viewBounds !== null) {
       this.viewBounds = null;
-      changed = true;
-    }
-    if (this.lastScreenshot !== null) {
-      this.lastScreenshot = null;
       changed = true;
     }
     if (this.inflightDepth > 0 || this.inflight) {

--- a/apps/web/src/features/canvas/lib/canvas-agent-bus-helpers.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-bus-helpers.ts
@@ -1,14 +1,12 @@
 import type { Editor, TLShapeId } from "tldraw";
 
 import { CanvasAgentError } from "./canvas-agent-errors";
+import { findNonOverlappingSpawn } from "./canvas-agent-spawn";
 
 export const MAX_LAYOUT_GRID = 24;
 export const MAX_LAYOUT_IDS = 256;
-export const MAX_APPLY_STEPS = 32;
-
-const SPAWN_GRID_COLS = 4;
-const SPAWN_CELL_W = 120;
-const SPAWN_CELL_H = 80;
+/** Raised from 32 so a full intro diagram can ship in one apply. */
+export const MAX_APPLY_STEPS = 64;
 
 export function requireString(value: unknown, label: string): string {
   if (typeof value !== "string" || !value.length) {
@@ -163,17 +161,16 @@ export function shallowFilterProps(
   return out;
 }
 
+/**
+ * @deprecated Prefer `findNonOverlappingSpawn` from canvas-agent-spawn.
+ * Kept as a thin adapter for any remaining call sites / tests.
+ */
 export function resolveAutoSpawnPosition(
   editor: Editor,
-  slot: number,
+  _slot?: number,
+  size: { w: number; h: number } = { w: 200, h: 200 },
 ): { x: number; y: number } {
-  const center = editor.getViewportPageBounds().center;
-  const col = slot % SPAWN_GRID_COLS;
-  const row = Math.floor(slot / SPAWN_GRID_COLS);
-  return {
-    x: center.x - 100 + col * SPAWN_CELL_W,
-    y: center.y - 100 + row * SPAWN_CELL_H,
-  };
+  return findNonOverlappingSpawn(editor, size);
 }
 
 export function requireExistingShapes(editor: Editor, ids: readonly string[]) {

--- a/apps/web/src/features/canvas/lib/canvas-agent-bus-read.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-bus-read.ts
@@ -2,7 +2,11 @@ import type { Editor, TLShapeId } from "tldraw";
 
 import { getShapePageBoundsBox } from "./canvas-agent-bounds";
 import { CanvasAgentError } from "./canvas-agent-errors";
-import { computeCanvasLints } from "./canvas-agent-lint";
+import {
+  buildLintFixSuggestions,
+  computeCanvasLints,
+  summarizeLints,
+} from "./canvas-agent-lint";
 import {
   optionalString,
   parseOlderOffset,
@@ -66,6 +70,7 @@ export function runCanvasAgentGetState(
   const viewport = editor.getViewportPageBounds();
   const selection = editor.getSelectedShapeIds();
 
+  const lints = computeCanvasLints(editor);
   return {
     schema: "canvas_agent_state.v1",
     page_id: pageId,
@@ -102,15 +107,37 @@ export function runCanvasAgentGetState(
         parent_id: s.parentId,
       };
     }),
-    lints: computeCanvasLints(editor),
+    lints,
+    lints_summary: summarizeLints(lints),
   };
 }
 
-export function runCanvasAgentLint(editor: Editor) {
-  return { lints: computeCanvasLints(editor) };
+export function runCanvasAgentLint(
+  editor: Editor,
+  args: Record<string, unknown> = {},
+) {
+  const wantFixes =
+    args.fix_suggestions === true ||
+    args.fixSuggestions === true ||
+    args.include_fix_suggestions === true;
+
+  if (wantFixes) {
+    const { lints, fix_suggestions } = buildLintFixSuggestions(editor);
+    return {
+      lints,
+      summary: summarizeLints(lints),
+      fix_suggestions,
+    };
+  }
+
+  const lints = computeCanvasLints(editor);
+  return { lints, summary: summarizeLints(lints) };
 }
 
-export function runCanvasAgentSetStatus(args: Record<string, unknown>) {
+export function runCanvasAgentSetStatus(
+  editor: Editor,
+  args: Record<string, unknown>,
+) {
   const raw = optionalString(args.status);
   if (!raw) {
     throw new CanvasAgentError(
@@ -127,7 +154,17 @@ export function runCanvasAgentSetStatus(args: Record<string, unknown>) {
       false,
     );
   }
-  return { status };
+  const lints = computeCanvasLints(editor);
+  const summary = summarizeLints(lints);
+  return {
+    status,
+    lints_summary: summary,
+    /**
+     * When finishing a turn (`idle`), agents should treat non-zero
+     * `error_count` as "not done" and fix before stopping.
+     */
+    ready_to_idle: status !== "idle" || summary.clean,
+  };
 }
 
 /** Read text content for specific shapes on demand (includes tmux capture for terminals). */

--- a/apps/web/src/features/canvas/lib/canvas-agent-bus-result.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-bus-result.ts
@@ -27,14 +27,26 @@ export interface CanvasAgentBusOptions {
   /**
    * Initial value of "Allow terminal/CLI control". The bus owns this flag
    * after construction; the React hook keeps it in sync via
-   * `setBridgeAccepting`. When `false`, only `status` is allowed; everything
-   * else answers with `BRIDGE_DISABLED`.
+   * `setBridgeAccepting`. When `false`, only read-only diagnostics are allowed
+   * (`status`, `get_state`, `extract_text`, `lint`, `screenshot`, `set_status`);
+   * mutating verbs answer with `BRIDGE_DISABLED`.
    */
   isBridgeAccepting?: boolean;
   /**
    * Optional logger — defaults to console.debug. Tests can pass `noop`.
    */
   log?: (message: string, payload?: unknown) => void;
+  /**
+   * Returns the dashed agent-view frame set by `set-agent-view` (if any).
+   * Used by `screenshot --use-agent-view` so verification crops to the
+   * agent-drawn region and ignores other canvas chrome.
+   */
+  getAgentViewBounds?: () => {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+  } | null;
 }
 
 export function ok(data: unknown): CanvasAgentSuccess {

--- a/apps/web/src/features/canvas/lib/canvas-agent-bus-result.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-bus-result.ts
@@ -1,4 +1,5 @@
 import type { CanvasAgentErrorCode } from "./canvas-agent-errors";
+import type { CanvasAgentBounds } from "./canvas-agent-view-bounds";
 
 export interface CanvasAgentDispatchInput {
   request_id: string;
@@ -41,12 +42,7 @@ export interface CanvasAgentBusOptions {
    * Used by `screenshot --use-agent-view` so verification crops to the
    * agent-drawn region and ignores other canvas chrome.
    */
-  getAgentViewBounds?: () => {
-    x: number;
-    y: number;
-    w: number;
-    h: number;
-  } | null;
+  getAgentViewBounds?: () => CanvasAgentBounds | null;
 }
 
 export function ok(data: unknown): CanvasAgentSuccess {

--- a/apps/web/src/features/canvas/lib/canvas-agent-bus.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-bus.ts
@@ -82,7 +82,6 @@ import { runCanvasAgentScreenshot } from "./canvas-agent-screenshot";
 import {
   DEFAULT_FRAME_SIZE,
   DEFAULT_GEO_SIZE,
-  DEFAULT_NOTE_SIZE,
   findNonOverlappingSpawn,
 } from "./canvas-agent-spawn";
 import { currentAppLocale } from "@/shared/lib/current-app-locale";
@@ -291,10 +290,9 @@ export class CanvasAgentBus {
       );
     }
     const w = positiveNumberOr(args.w, NOTE_BASE_WIDTH);
-    const spawn = this.resolveSpawn(editor, args.x, args.y, {
-      w,
-      h: DEFAULT_NOTE_SIZE.h,
-    });
+    // Reserve content-driven height for collision spawn (notes grow with text).
+    const spawnSize = estimateNoteSpawnSize(text, w);
+    const spawn = this.resolveSpawn(editor, args.x, args.y, spawnSize);
     const x = spawn.x;
     const y = spawn.y;
     const color = optionalString(args.color);
@@ -673,4 +671,18 @@ export class CanvasAgentBus {
       console.debug(message, payload);
     }
   }
+}
+
+/** Rough page-space size for note collision spawn (notes auto-grow with text). */
+function estimateNoteSpawnSize(text: string, w: number): { w: number; h: number } {
+  const scale = w / NOTE_BASE_WIDTH;
+  const lineH = 22 * scale;
+  const pad = 40 * scale;
+  let lines = 0;
+  for (const line of text.split("\n")) {
+    const charsPerLine = Math.max(1, Math.floor(w / (8 * scale)));
+    lines += Math.max(1, Math.ceil(Math.max(1, line.length) / charsPerLine));
+  }
+  const h = Math.max(w, Math.ceil(lines * lineH + pad));
+  return { w, h };
 }

--- a/apps/web/src/features/canvas/lib/canvas-agent-bus.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-bus.ts
@@ -57,7 +57,6 @@ import {
   requireNumber,
   requirePositiveInt,
   requireString,
-  resolveAutoSpawnPosition,
 } from "./canvas-agent-bus-helpers";
 import {
   runCanvasAgentExtractText,
@@ -77,6 +76,15 @@ import {
   runCanvasAgentSetAgentView,
   runCanvasAgentViewport,
 } from "./canvas-agent-bus-viewport";
+import { getShapePageBoundsBox } from "./canvas-agent-bounds";
+import { estimateGeoTextOverflow } from "./canvas-agent-lint";
+import { runCanvasAgentScreenshot } from "./canvas-agent-screenshot";
+import {
+  DEFAULT_FRAME_SIZE,
+  DEFAULT_GEO_SIZE,
+  DEFAULT_NOTE_SIZE,
+  findNonOverlappingSpawn,
+} from "./canvas-agent-spawn";
 import { currentAppLocale } from "@/shared/lib/current-app-locale";
 import enMessages from "../../../../messages/en.json";
 import zhMessages from "../../../../messages/zh.json";
@@ -110,8 +118,6 @@ function canvasBusT(key: string, values?: Record<string, string | number>): stri
 export class CanvasAgentBus {
   private editor: Editor | null = null;
   private bridgeAccepting: boolean;
-  /** Stagger default spawn positions when x/y are omitted. */
-  private spawnSlot = 0;
 
   constructor(private readonly options: CanvasAgentBusOptions) {
     this.bridgeAccepting = options.isBridgeAccepting ?? false;
@@ -145,8 +151,7 @@ export class CanvasAgentBus {
     }
 
     try {
-      // `status`, `get_state`, and `extract_text` are always available — diagnostics
-      // and on-demand shape reads must work even while the bridge is disabled.
+      // Read-only / session diagnostics work even while the bridge is disabled.
       if (command === "status") {
         return ok(runCanvasAgentStatus(editor, this.bridgeAccepting));
       }
@@ -157,10 +162,17 @@ export class CanvasAgentBus {
         return ok(await runCanvasAgentExtractText(editor, input.args ?? {}));
       }
       if (command === "lint") {
-        return ok(runCanvasAgentLint(editor));
+        return ok(runCanvasAgentLint(editor, input.args ?? {}));
+      }
+      if (command === "screenshot") {
+        return ok(
+          await runCanvasAgentScreenshot(editor, input.args ?? {}, {
+            getAgentViewBounds: this.options.getAgentViewBounds,
+          }),
+        );
       }
       if (command === "set_status" || command === "set-status") {
-        return ok(runCanvasAgentSetStatus(input.args ?? {}));
+        return ok(runCanvasAgentSetStatus(editor, input.args ?? {}));
       }
 
       if (!this.bridgeAccepting) {
@@ -278,10 +290,13 @@ export class CanvasAgentBus {
         false,
       );
     }
-    const spawn = this.resolveSpawn(editor, args.x, args.y);
+    const w = positiveNumberOr(args.w, NOTE_BASE_WIDTH);
+    const spawn = this.resolveSpawn(editor, args.x, args.y, {
+      w,
+      h: DEFAULT_NOTE_SIZE.h,
+    });
     const x = spawn.x;
     const y = spawn.y;
-    const w = positiveNumberOr(args.w, NOTE_BASE_WIDTH);
     const color = optionalString(args.color);
     const id = createShapeId();
     // tldraw v5 notes use `richText`, not legacy `text`; they have no w/h props.
@@ -291,13 +306,13 @@ export class CanvasAgentBus {
       props.scale = w / NOTE_BASE_WIDTH;
     }
     mutateEditor(editor, () => editor.createShape({ id, type: "note", x, y, props }));
-    return { id, type: "note" };
+    return this.shapeCreateResult(editor, id, "note");
   }
 
   private runCreateFrame(editor: Editor, args: Record<string, unknown>) {
-    const w = positiveNumberOr(args.w, 640);
-    const h = positiveNumberOr(args.h, 440);
-    const spawn = this.resolveSpawn(editor, args.x, args.y);
+    const w = positiveNumberOr(args.w, DEFAULT_FRAME_SIZE.w);
+    const h = positiveNumberOr(args.h, DEFAULT_FRAME_SIZE.h);
+    const spawn = this.resolveSpawn(editor, args.x, args.y, { w, h });
     const x = spawn.x;
     const y = spawn.y;
     const name = optionalString(args.title) ?? optionalString(args.name);
@@ -305,16 +320,16 @@ export class CanvasAgentBus {
     const props: Record<string, unknown> = { w, h };
     if (name) props.name = name;
     mutateEditor(editor, () => editor.createShape({ id, type: "frame", x, y, props }));
-    return { id, type: "frame" };
+    return this.shapeCreateResult(editor, id, "frame");
   }
 
   private runCreateGeo(editor: Editor, args: Record<string, unknown>) {
     const kind = optionalString(args.kind) ?? "rectangle";
-    const spawn = this.resolveSpawn(editor, args.x, args.y);
+    const w = positiveNumberOr(args.w, DEFAULT_GEO_SIZE.w);
+    const h = positiveNumberOr(args.h, DEFAULT_GEO_SIZE.h);
+    const spawn = this.resolveSpawn(editor, args.x, args.y, { w, h });
     const x = spawn.x;
     const y = spawn.y;
-    const w = positiveNumberOr(args.w, 200);
-    const h = positiveNumberOr(args.h, 200);
     const id = createShapeId();
     const props: Record<string, unknown> = { geo: kind, w, h };
     const text = optionalString(args.text);
@@ -323,7 +338,12 @@ export class CanvasAgentBus {
     applyOptionalFill(props, optionalString(args.fill));
     applyOptionalSize(props, optionalString(args.size));
     mutateEditor(editor, () => editor.createShape({ id, type: "geo", x, y, props }));
-    return { id, type: "geo" };
+    const shape = editor.getShape(id);
+    const warnings: string[] = [];
+    if (shape && estimateGeoTextOverflow(shape)) {
+      warnings.push("text_may_overflow");
+    }
+    return this.shapeCreateResult(editor, id, "geo", warnings);
   }
 
   private runCreateArrow(editor: Editor, args: Record<string, unknown>) {
@@ -607,10 +627,28 @@ export class CanvasAgentBus {
 
   // ===== helpers =====
 
+  private shapeCreateResult(
+    editor: Editor,
+    id: TLShapeId,
+    type: string,
+    warnings: string[] = [],
+  ) {
+    const bb = getShapePageBoundsBox(editor, id);
+    return {
+      id,
+      type,
+      bounds: bb
+        ? { min_x: bb.minX, min_y: bb.minY, w: bb.width, h: bb.height }
+        : null,
+      ...(warnings.length ? { warnings } : {}),
+    };
+  }
+
   private resolveSpawn(
     editor: Editor,
     xArg: unknown,
     yArg: unknown,
+    size: { w: number; h: number },
   ): { x: number; y: number } {
     if (xArg !== undefined && xArg !== null && yArg !== undefined && yArg !== null) {
       return { x: requireNumber(xArg, "x"), y: requireNumber(yArg, "y") };
@@ -625,8 +663,7 @@ export class CanvasAgentBus {
         false,
       );
     }
-    const slot = this.spawnSlot++;
-    return resolveAutoSpawnPosition(editor, slot);
+    return findNonOverlappingSpawn(editor, size);
   }
 
   private log(message: string, payload?: unknown) {

--- a/apps/web/src/features/canvas/lib/canvas-agent-feed-labels.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-feed-labels.ts
@@ -90,6 +90,9 @@ export function describeCanvasAgentCommand(
   if (verb === "get-state" || verb === "status" || verb === "lint") {
     return { kind: "read", label: canvasAgentFeedT("readingCanvas") };
   }
+  if (verb === "screenshot") {
+    return { kind: "read", label: canvasAgentFeedT("capturingScreenshot") };
+  }
   if (verb === "extract-text") {
     return { kind: "read", label: canvasAgentFeedT("extractingShapeText") };
   }

--- a/apps/web/src/features/canvas/lib/canvas-agent-feed-labels.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-feed-labels.ts
@@ -39,7 +39,8 @@ function canvasAgentFeedT(key: string, values?: Record<string, unknown>): string
   return cachedCanvasAgentFeedTranslator(key as never, values);
 }
 
-function normalizeCommand(command: string): string {
+/** Normalize CLI/WS verb aliases (`create_note` → `create-note`). */
+export function normalizeCanvasAgentCommand(command: string): string {
   return command.trim().toLowerCase().replace(/_/g, "-");
 }
 
@@ -85,7 +86,7 @@ export function describeCanvasAgentCommand(
   command: string,
   args?: Record<string, unknown> | null,
 ): CanvasAgentCommandDescriptor {
-  const verb = normalizeCommand(command);
+  const verb = normalizeCanvasAgentCommand(command);
 
   if (verb === "get-state" || verb === "status" || verb === "lint") {
     return { kind: "read", label: canvasAgentFeedT("readingCanvas") };

--- a/apps/web/src/features/canvas/lib/canvas-agent-feed-summarize.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-feed-summarize.ts
@@ -1,4 +1,7 @@
-import type { CanvasAgentFeedEntry } from "./canvas-agent-feed";
+import type {
+  CanvasAgentFeedEntry,
+  CanvasAgentFeedScreenshot,
+} from "./canvas-agent-feed";
 import type { CanvasAgentFeedKind } from "./canvas-agent-feed-labels";
 
 export interface SummarizedFeedRow {
@@ -9,6 +12,9 @@ export interface SummarizedFeedRow {
   status: CanvasAgentFeedEntry["status"];
   /** Latest timestamp among merged entries. */
   time: number;
+  /** Screenshot thumb for a successful capture row (not merged). */
+  screenshot?: CanvasAgentFeedScreenshot | null;
+  command?: string;
 }
 
 /** Merge consecutive identical labels (agent often issues many `create-*` in a row). */
@@ -20,7 +26,17 @@ export function summarizeConsecutiveEntries(
   for (const entry of entries) {
     const time = entry.completedAt ?? entry.startedAt;
     const last = rows.at(-1);
-    if (last && last.label === entry.label && last.kind === entry.kind) {
+    // Never merge screenshot rows — each keeps its own thumbnail.
+    const isScreenshot =
+      normalizeVerb(entry.command) === "screenshot" || Boolean(entry.screenshot);
+    const canMerge =
+      last &&
+      !isScreenshot &&
+      !last.screenshot &&
+      last.label === entry.label &&
+      last.kind === entry.kind;
+
+    if (canMerge && last) {
       last.count += 1;
       if (entry.status === "active") last.status = "active";
       else if (entry.status === "error") last.status = "error";
@@ -34,8 +50,14 @@ export function summarizeConsecutiveEntries(
       count: 1,
       status: entry.status,
       time,
+      screenshot: entry.screenshot ?? null,
+      command: entry.command,
     });
   }
 
   return rows;
+}
+
+function normalizeVerb(command: string): string {
+  return command.trim().toLowerCase().replace(/_/g, "-");
 }

--- a/apps/web/src/features/canvas/lib/canvas-agent-feed-summarize.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-feed-summarize.ts
@@ -2,7 +2,10 @@ import type {
   CanvasAgentFeedEntry,
   CanvasAgentFeedScreenshot,
 } from "./canvas-agent-feed";
-import type { CanvasAgentFeedKind } from "./canvas-agent-feed-labels";
+import {
+  normalizeCanvasAgentCommand,
+  type CanvasAgentFeedKind,
+} from "./canvas-agent-feed-labels";
 
 export interface SummarizedFeedRow {
   id: string;
@@ -28,7 +31,8 @@ export function summarizeConsecutiveEntries(
     const last = rows.at(-1);
     // Never merge screenshot rows — each keeps its own thumbnail.
     const isScreenshot =
-      normalizeVerb(entry.command) === "screenshot" || Boolean(entry.screenshot);
+      normalizeCanvasAgentCommand(entry.command) === "screenshot" ||
+      Boolean(entry.screenshot);
     const canMerge =
       last &&
       !isScreenshot &&
@@ -56,8 +60,4 @@ export function summarizeConsecutiveEntries(
   }
 
   return rows;
-}
-
-function normalizeVerb(command: string): string {
-  return command.trim().toLowerCase().replace(/_/g, "-");
 }

--- a/apps/web/src/features/canvas/lib/canvas-agent-feed.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-feed.ts
@@ -85,6 +85,8 @@ export class CanvasAgentFeedStore {
       existing.status = "active";
       existing.startedAt = Date.now();
       existing.completedAt = null;
+      // Clear stale thumb when reusing a completed screenshot request id.
+      existing.screenshot = null;
       this.emit();
       return;
     }
@@ -144,36 +146,34 @@ export class CanvasAgentFeedStore {
    * Optional `screenshot` is attached to the same entry so the Island timeline
    * can show a thumb on the "Capturing screenshot" row (HMR-safe: no new
    * method call sites required beyond this existing finalize path).
+   *
+   * Always emits when screenshot metadata is attached, even if the entry was
+   * already finalized (race / double-complete paths still refresh the Island).
    */
   finalizeRequest(
     requestId: string,
     success: boolean,
     extras?: { screenshot?: CanvasAgentFeedScreenshot | null },
   ) {
+    let attachedScreenshot = false;
+    let wasActive = false;
     if (extras?.screenshot?.dataUrl?.startsWith("data:")) {
       const entry = this.findEntry(requestId);
       if (entry) {
+        wasActive = entry.status === "active";
         entry.screenshot = {
           dataUrl: extras.screenshot.dataUrl,
           width: extras.screenshot.width,
           height: extras.screenshot.height,
         };
+        attachedScreenshot = true;
       }
     }
     this.complete(requestId, success);
     this.expireStaleActive(CANVAS_AGENT_FEED_STALE_MS);
-  }
-
-  /**
-   * Attach a region screenshot JPEG to a feed entry.
-   * Prefer `finalizeRequest(..., { screenshot })` from the bridge so a single
-   * code path always runs (avoids HMR stale instances missing this method).
-   */
-  attachScreenshot(
-    requestId: string,
-    screenshot: CanvasAgentFeedScreenshot,
-  ) {
-    this.finalizeRequest(requestId, true, { screenshot });
+    // `complete` only emits when an active entry flips; late screenshot attach
+    // onto an already-done row needs its own notify so the Island thumb updates.
+    if (attachedScreenshot && !wasActive) this.emit();
   }
 
   /** Close orphaned `active` rows (missed complete, duplicate WS, tab race). */

--- a/apps/web/src/features/canvas/lib/canvas-agent-feed.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-feed.ts
@@ -24,6 +24,12 @@ export const CANVAS_AGENT_FEED_STALE_MS = 45_000;
 
 export type CanvasAgentFeedEntryStatus = "active" | "done" | "error";
 
+export interface CanvasAgentFeedScreenshot {
+  dataUrl: string;
+  width: number;
+  height: number;
+}
+
 export interface CanvasAgentFeedEntry {
   requestId: string;
   command: string;
@@ -32,6 +38,8 @@ export interface CanvasAgentFeedEntry {
   status: CanvasAgentFeedEntryStatus;
   startedAt: number;
   completedAt: number | null;
+  /** Present when this entry was a successful `screenshot` capture. */
+  screenshot?: CanvasAgentFeedScreenshot | null;
 }
 
 export interface CanvasAgentFeedBatch {
@@ -131,10 +139,41 @@ export class CanvasAgentFeedStore {
     }
   }
 
-  /** Idempotent complete — safe to call from `finally` after each dispatch. */
-  finalizeRequest(requestId: string, success: boolean) {
+  /**
+   * Idempotent complete — safe to call from `finally` after each dispatch.
+   * Optional `screenshot` is attached to the same entry so the Island timeline
+   * can show a thumb on the "Capturing screenshot" row (HMR-safe: no new
+   * method call sites required beyond this existing finalize path).
+   */
+  finalizeRequest(
+    requestId: string,
+    success: boolean,
+    extras?: { screenshot?: CanvasAgentFeedScreenshot | null },
+  ) {
+    if (extras?.screenshot?.dataUrl?.startsWith("data:")) {
+      const entry = this.findEntry(requestId);
+      if (entry) {
+        entry.screenshot = {
+          dataUrl: extras.screenshot.dataUrl,
+          width: extras.screenshot.width,
+          height: extras.screenshot.height,
+        };
+      }
+    }
     this.complete(requestId, success);
     this.expireStaleActive(CANVAS_AGENT_FEED_STALE_MS);
+  }
+
+  /**
+   * Attach a region screenshot JPEG to a feed entry.
+   * Prefer `finalizeRequest(..., { screenshot })` from the bridge so a single
+   * code path always runs (avoids HMR stale instances missing this method).
+   */
+  attachScreenshot(
+    requestId: string,
+    screenshot: CanvasAgentFeedScreenshot,
+  ) {
+    this.finalizeRequest(requestId, true, { screenshot });
   }
 
   /** Close orphaned `active` rows (missed complete, duplicate WS, tab race). */

--- a/apps/web/src/features/canvas/lib/canvas-agent-lint.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-lint.ts
@@ -87,16 +87,20 @@ function isContentShape(shape: TLShape): boolean {
   return !NON_CONTENT_TYPES.has(shape.type);
 }
 
+/**
+ * True when boxes collide or sit closer than `padding` (gutter).
+ * With padding=2, shapes 0–2px apart count as overlapping for lint.
+ */
 function boxesOverlap(
   a: ShapePageBounds,
   b: ShapePageBounds,
   padding = 2,
 ): boolean {
   return !(
-    a.maxX + padding < b.minX ||
-    b.maxX + padding < a.minX ||
-    a.maxY + padding < b.minY ||
-    b.maxY + padding < a.minY
+    a.maxX + padding <= b.minX ||
+    b.maxX + padding <= a.minX ||
+    a.maxY + padding <= b.minY ||
+    b.maxY + padding <= a.minY
   );
 }
 
@@ -194,23 +198,44 @@ export function estimateGeoTextOverflow(shape: TLShape): boolean {
 
 /**
  * Suggest moving `b` just far enough to clear `a` with a gutter.
- * Chooses the cheaper axis (smaller penetration).
+ * Chooses the cheaper axis. Handles pure gap shortfalls (touching /
+ * near-touching boxes with pen ≤ 0) so we never return {0,0} when the
+ * boxes still violate the requested gap.
  */
 export function suggestOverlapSeparation(
   a: ShapePageBounds,
   b: ShapePageBounds,
   gap = DEFAULT_SEPARATION_GAP,
 ): { dx: number; dy: number } {
+  // Positive = penetration; negative = clearance (gap between edges).
   const penX = Math.min(a.maxX, b.maxX) - Math.max(a.minX, b.minX);
   const penY = Math.min(a.maxY, b.maxY) - Math.max(a.minY, b.minY);
-  if (penX <= 0 || penY <= 0) return { dx: 0, dy: 0 };
 
-  if (penX <= penY) {
+  // Already separated by more than `gap` on either axis → no move needed.
+  if (penX < -gap || penY < -gap) {
+    return { dx: 0, dy: 0 };
+  }
+
+  // Displacement needed on each axis to achieve `gap` clearance.
+  // When pen is positive (overlap), move by pen + gap.
+  // When pen is zero (touching) or negative but > -gap (too close), move by gap - |clearance| = gap + pen.
+  const needX = penX + gap;
+  const needY = penY + gap;
+
+  if (needX <= 0 && needY <= 0) {
+    return { dx: 0, dy: 0 };
+  }
+
+  // Prefer the cheaper axis (smaller absolute move that still clears).
+  const preferX =
+    needY <= 0 ? true : needX <= 0 ? false : needX <= needY;
+
+  if (preferX) {
     const pushRight = b.midX >= a.midX;
-    return { dx: pushRight ? penX + gap : -(penX + gap), dy: 0 };
+    return { dx: pushRight ? needX : -needX, dy: 0 };
   }
   const pushDown = b.midY >= a.midY;
-  return { dx: 0, dy: pushDown ? penY + gap : -(penY + gap) };
+  return { dx: 0, dy: pushDown ? needY : -needY };
 }
 
 export function computeCanvasLints(editor: Editor): CanvasAgentLint[] {
@@ -267,12 +292,21 @@ function computeCanvasLintsWithContext(editor: Editor): {
     const metrics = geoTextMetrics(shape);
     if (!metrics?.overflows) continue;
 
+    // Effective box uses neededH so overflow that only collides once text
+    // grows past props.h is still detected.
+    const effectiveBb: ShapePageBounds = {
+      ...bb,
+      height: metrics.neededH,
+      maxY: bb.minY + metrics.neededH,
+      midY: bb.minY + metrics.neededH / 2,
+    };
+
     const collides = content.some(
       (other) =>
         other.shape.id !== shape.id &&
         !shapesAreRelated(shape, other.shape, byId) &&
-        !boxesContain(bb, other.bb) &&
-        boxesOverlap(bb, other.bb, 0),
+        !boxesContain(effectiveBb, other.bb) &&
+        boxesOverlap(effectiveBb, other.bb, 0),
     );
 
     const lint: CanvasAgentLint = {

--- a/apps/web/src/features/canvas/lib/canvas-agent-lint.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-lint.ts
@@ -1,17 +1,96 @@
-import { getArrowBindings, type Editor, type TLArrowShape, type TLShapeId } from "tldraw";
+import {
+  getArrowBindings,
+  type Editor,
+  type TLArrowShape,
+  type TLShape,
+  type TLShapeId,
+} from "tldraw";
 
-import { getShapePageBoundsBox } from "./canvas-agent-bounds";
+import { getShapePageBoundsBox, type ShapePageBounds } from "./canvas-agent-bounds";
+
+/** Keep string literals here to avoid pulling heavy shape util modules into lint/tests. */
+const CANVAS_TERMINAL_SHAPE_TYPE = "canvas-terminal";
+const CANVAS_WIDGET_SHAPE_TYPE = "canvas-widget";
+
+/** Local plain-text extract — do not import canvas-shape-text (heavy dep graph). */
+function plainTextFromProps(props: Record<string, unknown>): string | undefined {
+  const rich = props.richText;
+  if (rich && typeof rich === "object" && !Array.isArray(rich)) {
+    const content = (rich as { content?: unknown }).content;
+    if (Array.isArray(content)) {
+      const lines = content.map((block) => {
+        if (!block || typeof block !== "object") return "";
+        const nodes = (block as { content?: unknown }).content;
+        if (!Array.isArray(nodes)) return "";
+        return nodes
+          .map((node) =>
+            node && typeof node === "object" && "text" in node
+              ? String((node as { text: unknown }).text)
+              : "",
+          )
+          .join("");
+      });
+      const joined = lines.join("\n").trim();
+      if (joined) return joined;
+    }
+  }
+  const legacy = props.text;
+  if (typeof legacy === "string" && legacy.trim()) return legacy.trim();
+  return undefined;
+}
+
+/**
+ * Canvas-agent lint model (aligned with tldraw offline helpers.getLints intent):
+ *
+ * - **overlap** — two *content* shapes unexpectedly collide (not parent/child,
+ *   not containment, not arrows). Severity `error`.
+ * - **text_overflow** — geo label likely exceeds its box (or tldraw growY>0
+ *   collides with a neighbour). Severity `error` when colliding, else `warn`.
+ * - **unbound_arrow** — arrow missing start/end binding. Severity `warn`
+ *   (decorative arrows are allowed; diagram arrows should bind).
+ */
+
+export type CanvasAgentLintSeverity = "error" | "warn";
+
+export type CanvasAgentLintType = "overlap" | "text_overflow" | "unbound_arrow";
 
 export type CanvasAgentLint = {
-  type: "overlap" | "unbound_arrow";
+  type: CanvasAgentLintType;
+  severity: CanvasAgentLintSeverity;
   shape_ids: string[];
   message: string;
 };
 
+/** CLI-ready command suggestion to clear a lint (agent can `atmos canvas move` / `update-shape`). */
+export type CanvasAgentLintFixSuggestion = {
+  /** Index into the `lints` array this suggestion addresses. */
+  lint_index: number;
+  /** Canvas command verb (snake_case, matches bus). */
+  command: string;
+  args: Record<string, unknown>;
+  reason: string;
+};
+
+const DEFAULT_SEPARATION_GAP = 24;
+
+/** Shapes that are Atmos chrome / product widgets — never participate in layout lint. */
+const NON_CONTENT_TYPES = new Set<string>([
+  CANVAS_TERMINAL_SHAPE_TYPE,
+  CANVAS_WIDGET_SHAPE_TYPE,
+  "arrow",
+  "frame",
+  "group",
+  "highlight",
+]);
+
+function isContentShape(shape: TLShape): boolean {
+  return !NON_CONTENT_TYPES.has(shape.type);
+}
+
 function boxesOverlap(
-  a: { minX: number; minY: number; maxX: number; maxY: number },
-  b: { minX: number; minY: number; maxX: number; maxY: number },
-  padding = 4,
+  a: ShapePageBounds,
+  b: ShapePageBounds,
+  padding = 2,
 ): boolean {
   return !(
     a.maxX + padding < b.minX ||
@@ -21,48 +100,311 @@ function boxesOverlap(
   );
 }
 
-export function computeCanvasLints(editor: Editor): CanvasAgentLint[] {
-  const lints: CanvasAgentLint[] = [];
-  const shapes = editor.getCurrentPageShapes();
-  const boxes: Array<{ id: string; bb: NonNullable<ReturnType<typeof getShapePageBoundsBox>> }> =
-    [];
+/** True when one box approximately contains the other (frame wrapping cards). */
+function boxesContain(
+  a: ShapePageBounds,
+  b: ShapePageBounds,
+  tolerance = 2,
+): boolean {
+  const aContainsB =
+    a.minX <= b.minX + tolerance &&
+    a.minY <= b.minY + tolerance &&
+    a.maxX >= b.maxX - tolerance &&
+    a.maxY >= b.maxY - tolerance;
+  const bContainsA =
+    b.minX <= a.minX + tolerance &&
+    b.minY <= a.minY + tolerance &&
+    b.maxX >= a.maxX - tolerance &&
+    b.maxY >= a.maxY - tolerance;
+  return aContainsB || bContainsA;
+}
 
+function isAncestorOf(
+  ancestorId: string,
+  shape: TLShape,
+  byId: Map<string, TLShape>,
+): boolean {
+  let parent = byId.get(shape.parentId as string);
+  while (parent) {
+    if (parent.id === ancestorId) return true;
+    parent = byId.get(parent.parentId as string);
+  }
+  return false;
+}
+
+function shapesAreRelated(
+  a: TLShape,
+  b: TLShape,
+  byId: Map<string, TLShape>,
+): boolean {
+  return isAncestorOf(a.id, b, byId) || isAncestorOf(b.id, a, byId);
+}
+
+/**
+ * Heuristic: does the geo's label text likely overflow its fixed box?
+ * Mirrors the offline `growY-on-shape` intent without requiring DOM measure.
+ */
+function geoTextMetrics(shape: TLShape): {
+  text: string;
+  w: number;
+  h: number;
+  lineH: number;
+  neededH: number;
+  overflows: boolean;
+} | null {
+  if (shape.type !== "geo") return null;
+  const props = shape.props as unknown as Record<string, unknown>;
+  const w = typeof props.w === "number" && props.w > 0 ? props.w : 200;
+  const h = typeof props.h === "number" && props.h > 0 ? props.h : 200;
+  const sizeToken = typeof props.size === "string" ? props.size : "m";
+  const charW = sizeToken === "s" ? 6 : sizeToken === "l" ? 9 : sizeToken === "xl" ? 11 : 7.5;
+  const lineH = sizeToken === "s" ? 14 : sizeToken === "l" ? 22 : sizeToken === "xl" ? 28 : 18;
+  const pad = 16;
+
+  if (typeof props.growY === "number" && props.growY > 0) {
+    const text = plainTextFromProps(props) ?? "";
+    return {
+      text,
+      w,
+      h,
+      lineH,
+      neededH: Math.ceil(h + props.growY + pad),
+      overflows: true,
+    };
+  }
+
+  const text = plainTextFromProps(props);
+  if (!text?.trim()) {
+    return { text: "", w, h, lineH, neededH: h, overflows: false };
+  }
+
+  const usableW = Math.max(8, w - pad);
+  const charsPerLine = Math.max(1, Math.floor(usableW / charW));
+  let lines = 0;
+  for (const line of text.split("\n")) {
+    lines += Math.max(1, Math.ceil(Math.max(1, line.length) / charsPerLine));
+  }
+  const neededH = Math.ceil(lines * lineH + pad);
+  return { text, w, h, lineH, neededH, overflows: neededH > h };
+}
+
+export function estimateGeoTextOverflow(shape: TLShape): boolean {
+  return geoTextMetrics(shape)?.overflows ?? false;
+}
+
+/**
+ * Suggest moving `b` just far enough to clear `a` with a gutter.
+ * Chooses the cheaper axis (smaller penetration).
+ */
+export function suggestOverlapSeparation(
+  a: ShapePageBounds,
+  b: ShapePageBounds,
+  gap = DEFAULT_SEPARATION_GAP,
+): { dx: number; dy: number } {
+  const penX = Math.min(a.maxX, b.maxX) - Math.max(a.minX, b.minX);
+  const penY = Math.min(a.maxY, b.maxY) - Math.max(a.minY, b.minY);
+  if (penX <= 0 || penY <= 0) return { dx: 0, dy: 0 };
+
+  if (penX <= penY) {
+    const pushRight = b.midX >= a.midX;
+    return { dx: pushRight ? penX + gap : -(penX + gap), dy: 0 };
+  }
+  const pushDown = b.midY >= a.midY;
+  return { dx: 0, dy: pushDown ? penY + gap : -(penY + gap) };
+}
+
+export function computeCanvasLints(editor: Editor): CanvasAgentLint[] {
+  return computeCanvasLintsWithContext(editor).lints;
+}
+
+type LintWithContext = {
+  lint: CanvasAgentLint;
+  /** For overlap: bounds of both shapes in shape_ids order. */
+  boxes?: [ShapePageBounds, ShapePageBounds];
+  /** For text_overflow: suggested height. */
+  neededH?: number;
+};
+
+function computeCanvasLintsWithContext(editor: Editor): {
+  lints: CanvasAgentLint[];
+  contexts: LintWithContext[];
+} {
+  const lints: CanvasAgentLint[] = [];
+  const contexts: LintWithContext[] = [];
+  const shapes = editor.getCurrentPageShapes();
+  const byId = new Map(shapes.map((s) => [s.id as string, s]));
+
+  const content: Array<{ shape: TLShape; bb: ShapePageBounds }> = [];
   for (const shape of shapes) {
+    if (!isContentShape(shape)) continue;
     const bb = getShapePageBoundsBox(editor, shape.id);
     if (!bb || bb.width < 1 || bb.height < 1) continue;
-    boxes.push({ id: shape.id, bb });
+    content.push({ shape, bb });
   }
 
-  for (let i = 0; i < boxes.length; i++) {
-    for (let j = i + 1; j < boxes.length; j++) {
-      const a = boxes[i]!;
-      const b = boxes[j]!;
-      if (boxesOverlap(a.bb, b.bb)) {
-        lints.push({
-          type: "overlap",
-          shape_ids: [a.id, b.id],
-          message: `Shapes ${a.id} and ${b.id} overlap on the page.`,
-        });
-      }
+  // Pairwise unexpected overlap among content shapes.
+  for (let i = 0; i < content.length; i++) {
+    for (let j = i + 1; j < content.length; j++) {
+      const a = content[i]!;
+      const b = content[j]!;
+      if (shapesAreRelated(a.shape, b.shape, byId)) continue;
+      if (boxesContain(a.bb, b.bb)) continue;
+      if (!boxesOverlap(a.bb, b.bb)) continue;
+      const lint: CanvasAgentLint = {
+        type: "overlap",
+        severity: "error",
+        shape_ids: [a.shape.id, b.shape.id],
+        message: `Shapes ${a.shape.id} and ${b.shape.id} overlap. Reposition with place/layout/move or recreate with non-overlapping coordinates.`,
+      };
+      lints.push(lint);
+      contexts.push({ lint, boxes: [a.bb, b.bb] });
     }
   }
 
+  // Text overflow on geo shapes.
+  for (const { shape, bb } of content) {
+    if (shape.type !== "geo") continue;
+    const metrics = geoTextMetrics(shape);
+    if (!metrics?.overflows) continue;
+
+    const collides = content.some(
+      (other) =>
+        other.shape.id !== shape.id &&
+        !shapesAreRelated(shape, other.shape, byId) &&
+        !boxesContain(bb, other.bb) &&
+        boxesOverlap(bb, other.bb, 0),
+    );
+
+    const lint: CanvasAgentLint = {
+      type: "text_overflow",
+      severity: collides ? "error" : "warn",
+      shape_ids: [shape.id],
+      message: collides
+        ? `Shape ${shape.id} has overflowing text that collides with a neighbour. Increase --h/--w or shorten the label.`
+        : `Shape ${shape.id} may have overflowing text. Increase --h/--w or shorten the label.`,
+    };
+    lints.push(lint);
+    contexts.push({ lint, neededH: metrics.neededH });
+  }
+
+  // Unbound arrows (warn only — decorative arrows are intentional sometimes).
   for (const shape of shapes) {
     if (shape.type !== "arrow") continue;
-    const bindings = getArrowBindings(editor, shape as TLArrowShape);
-    const hasStart = Boolean(bindings.start);
-    const hasEnd = Boolean(bindings.end);
-    if (!hasStart || !hasEnd) {
-      const missing: string[] = [];
-      if (!hasStart) missing.push("start");
-      if (!hasEnd) missing.push("end");
-      lints.push({
-        type: "unbound_arrow",
-        shape_ids: [shape.id],
-        message: `Arrow ${shape.id} is missing ${missing.join(" and ")} binding(s). Use create-arrow --from-id / --to-id.`,
-      });
+    let hasStart = false;
+    let hasEnd = false;
+    try {
+      const bindings = getArrowBindings(editor, shape as TLArrowShape);
+      hasStart = Boolean(bindings.start);
+      hasEnd = Boolean(bindings.end);
+    } catch {
+      // Incomplete editor stubs (unit tests) may not support arrow bindings.
+      continue;
     }
+    if (hasStart && hasEnd) continue;
+    const missing: string[] = [];
+    if (!hasStart) missing.push("start");
+    if (!hasEnd) missing.push("end");
+    const lint: CanvasAgentLint = {
+      type: "unbound_arrow",
+      severity: "warn",
+      shape_ids: [shape.id as string],
+      message: `Arrow ${shape.id} is missing ${missing.join(" and ")} binding(s). For diagrams use create-arrow --from-id / --to-id.`,
+    };
+    lints.push(lint);
+    contexts.push({ lint });
   }
 
-  return lints;
+  return { lints, contexts };
+}
+
+/**
+ * Build CLI-ready fix suggestions for lints that can be auto-remediated.
+ * Overlaps → `move` the second shape; text overflow → `update_shape` taller h.
+ * Unbound arrows have no automatic fix (need re-create with bindings).
+ */
+export function buildLintFixSuggestions(
+  editor: Editor,
+  options?: { gap?: number },
+): {
+  lints: CanvasAgentLint[];
+  fix_suggestions: CanvasAgentLintFixSuggestion[];
+} {
+  const gap = options?.gap ?? DEFAULT_SEPARATION_GAP;
+  const { lints, contexts } = computeCanvasLintsWithContext(editor);
+  const fix_suggestions: CanvasAgentLintFixSuggestion[] = [];
+
+  contexts.forEach((ctx, lint_index) => {
+    if (ctx.lint.type === "overlap" && ctx.boxes) {
+      const [boxA, boxB] = ctx.boxes;
+      const moveId = ctx.lint.shape_ids[1]!;
+      const { dx, dy } = suggestOverlapSeparation(boxA, boxB, gap);
+      if (dx === 0 && dy === 0) return;
+      fix_suggestions.push({
+        lint_index,
+        command: "move",
+        args: { ids: [moveId], dx, dy },
+        reason: `Separate ${ctx.lint.shape_ids[0]} and ${moveId} by moving the latter (${dx !== 0 ? `dx=${dx}` : `dy=${dy}`}).`,
+      });
+      return;
+    }
+
+    if (ctx.lint.type === "text_overflow" && ctx.neededH != null) {
+      const id = ctx.lint.shape_ids[0]!;
+      const shape = editor.getShape(id as TLShapeId);
+      if (!shape || shape.type !== "geo") return;
+      const currentH =
+        typeof (shape.props as { h?: number }).h === "number"
+          ? (shape.props as { h: number }).h
+          : 0;
+      const nextH = Math.max(ctx.neededH, currentH + 24);
+      if (nextH <= currentH) return;
+      fix_suggestions.push({
+        lint_index,
+        command: "update_shape",
+        args: { id, patch: { h: nextH } },
+        reason: `Grow ${id} height to ~${nextH} so the label fits.`,
+      });
+    }
+  });
+
+  return { lints, fix_suggestions };
+}
+
+export function summarizeLints(lints: CanvasAgentLint[]): {
+  error_count: number;
+  warn_count: number;
+  clean: boolean;
+} {
+  let error_count = 0;
+  let warn_count = 0;
+  for (const lint of lints) {
+    if (lint.severity === "error") error_count += 1;
+    else warn_count += 1;
+  }
+  return { error_count, warn_count, clean: error_count === 0 };
+}
+
+/**
+ * Occupied page rects for collision-aware spawn.
+ * Includes diagram content, frames, and Atmos chrome so new shapes do not
+ * land under terminals/widgets.
+ */
+export function collectContentOccupiedRects(
+  editor: Editor,
+  excludeIds?: ReadonlySet<string>,
+): Array<{ x: number; y: number; w: number; h: number }> {
+  const out: Array<{ x: number; y: number; w: number; h: number }> = [];
+  for (const shape of editor.getCurrentPageShapes()) {
+    if (excludeIds?.has(shape.id as string)) continue;
+    const include =
+      isContentShape(shape) ||
+      shape.type === "frame" ||
+      shape.type === CANVAS_TERMINAL_SHAPE_TYPE ||
+      shape.type === CANVAS_WIDGET_SHAPE_TYPE;
+    if (!include) continue;
+    const bb = getShapePageBoundsBox(editor, shape.id as TLShapeId);
+    if (!bb || bb.width < 1 || bb.height < 1) continue;
+    out.push({ x: bb.minX, y: bb.minY, w: bb.width, h: bb.height });
+  }
+  return out;
 }

--- a/apps/web/src/features/canvas/lib/canvas-agent-screenshot.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-screenshot.ts
@@ -223,10 +223,14 @@ function selectShapesForRegion(
   explicitIds?: string[],
 ): TLShape[] {
   if (explicitIds && explicitIds.length) {
-    // Already validated as current-page shapes in resolveRegion / call site.
+    // Validate page + filter chrome, then apply the same region rule as the
+    // auto-selected path so ids outside an explicit crop do not pad the
+    // result with blank / clipped shapes while still reporting shape_count.
     return requireScreenshotableIds(editor, explicitIds).filter((s) => {
       if (!includeChrome && ATMOS_CHROME_TYPES.has(s.type)) return false;
-      return true;
+      const bb = getShapePageBoundsBox(editor, s.id);
+      if (!bb) return false;
+      return shapeQualifiesForRegion(bb, region);
     });
   }
 
@@ -311,21 +315,26 @@ export async function runCanvasAgentScreenshot(
     );
   }
 
+  // Optional size-reduction pass — keep the first valid image if it fails.
   const approxBytes = Math.ceil((result.url.length * 3) / 4);
   if (approxBytes > 900_000 && size !== "small") {
-    const retry = await editor.toImageDataUrl(
-      selected.map((s) => s.id as TLShapeId),
-      {
-        format: "jpeg",
-        quality: 0.72,
-        background: true,
-        padding: 8,
-        pixelRatio: Math.min(1.25, MAX_EDGE.small / longest),
-        bounds: new Box(region.x, region.y, region.w, region.h),
-      },
-    );
-    if (retry?.url?.startsWith("data:")) {
-      result = retry;
+    try {
+      const retry = await editor.toImageDataUrl(
+        selected.map((s) => s.id as TLShapeId),
+        {
+          format: "jpeg",
+          quality: 0.72,
+          background: true,
+          padding: 8,
+          pixelRatio: Math.min(1.25, MAX_EDGE.small / longest),
+          bounds: new Box(region.x, region.y, region.w, region.h),
+        },
+      );
+      if (retry?.url?.startsWith("data:")) {
+        result = retry;
+      }
+    } catch {
+      // Best-effort only; initial export already succeeded.
     }
   }
 

--- a/apps/web/src/features/canvas/lib/canvas-agent-screenshot.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-screenshot.ts
@@ -5,7 +5,6 @@ import { CanvasAgentError } from "./canvas-agent-errors";
 import {
   nonNegativeNumberOr,
   optionalNumber,
-  requireExistingShapes,
   requireIds,
   unionShapePageBounds,
 } from "./canvas-agent-bus-helpers";
@@ -14,19 +13,22 @@ import {
   expandBounds,
   type CanvasAgentBounds,
 } from "./canvas-agent-view-bounds";
+
 /** String literals avoid heavy shape-util imports on the agent path. */
 const CANVAS_TERMINAL_SHAPE_TYPE = "canvas-terminal";
 const CANVAS_WIDGET_SHAPE_TYPE = "canvas-widget";
 
 /**
- * Screenshot only the agent-drawn region so product widgets / terminals
- * elsewhere on the canvas do not pollute visual verification.
+ * Screenshot the agent-drawn region so product chrome does not pollute
+ * visual verification by default.
  *
  * Shape inclusion rules (when region is known):
- * 1. Never include Atmos chrome: `canvas-terminal`, `canvas-widget`.
+ * 1. Exclude Atmos chrome (`canvas-terminal`, `canvas-widget`) unless
+ *    `include_widgets` is set.
  * 2. Include a shape only if its center lies inside the region, OR ≥50% of
- *    its area intersects the region (so edge-grazing terminals stay out).
+ *    its area intersects the region.
  * 3. Crop export with `bounds` so off-region paint is clipped.
+ * 4. Explicit `--ids` must exist and live on the **current page**.
  */
 
 export type ScreenshotSize = "small" | "medium" | "large";
@@ -65,7 +67,16 @@ function rectsIntersectArea(
 }
 
 function shapeQualifiesForRegion(
-  bb: { minX: number; minY: number; maxX: number; maxY: number; width: number; height: number; midX: number; midY: number },
+  bb: {
+    minX: number;
+    minY: number;
+    maxX: number;
+    maxY: number;
+    width: number;
+    height: number;
+    midX: number;
+    midY: number;
+  },
   region: CanvasAgentBounds,
 ): boolean {
   const r = {
@@ -75,27 +86,66 @@ function shapeQualifiesForRegion(
     maxY: region.y + region.h,
   };
   const centerInside =
-    bb.midX >= r.minX && bb.midX <= r.maxX && bb.midY >= r.minY && bb.midY <= r.maxY;
+    bb.midX >= r.minX &&
+    bb.midX <= r.maxX &&
+    bb.midY >= r.minY &&
+    bb.midY <= r.maxY;
   if (centerInside) return true;
   const area = Math.max(1, bb.width * bb.height);
   const overlap = rectsIntersectArea(bb, r);
   return overlap / area >= 0.5;
 }
 
+/** Require every id to exist and live on the current page (screenshotable). */
+function requireScreenshotableIds(editor: Editor, ids: readonly string[]): TLShape[] {
+  const pageShapeIds = new Set(
+    editor.getCurrentPageShapes().map((s) => s.id as string),
+  );
+  return ids.map((id) => {
+    const shape = editor.getShape(id as TLShapeId);
+    if (!shape) {
+      throw new CanvasAgentError(
+        "STALE_SHAPE_ID",
+        `Shape ${id} does not exist; re-run get_state and retry.`,
+        true,
+      );
+    }
+    if (!pageShapeIds.has(id)) {
+      throw new CanvasAgentError(
+        "VALIDATION_ARG",
+        `Shape ${id} is not on the current page and cannot be screenshotted. Switch pages or pass current-page ids.`,
+        false,
+      );
+    }
+    return shape;
+  });
+}
+
 function resolveRegion(
   editor: Editor,
   args: Record<string, unknown>,
-  getAgentViewBounds?: () => CanvasAgentBounds | null,
+  getAgentViewBounds: (() => CanvasAgentBounds | null) | undefined,
+  includeChrome: boolean,
 ): CanvasAgentBounds {
   const padding = nonNegativeNumberOr(args.padding, AGENT_VIEW_PADDING);
   const x = optionalNumber(args.x);
   const y = optionalNumber(args.y);
   const w = optionalNumber(args.w);
   const h = optionalNumber(args.h);
-  const hasBox =
+  const anyBoundField =
+    x !== undefined || y !== undefined || w !== undefined || h !== undefined;
+  const hasCompleteBox =
     x !== undefined && y !== undefined && w !== undefined && h !== undefined;
 
-  if (hasBox) {
+  if (anyBoundField && !hasCompleteBox) {
+    throw new CanvasAgentError(
+      "VALIDATION_ARG",
+      "screenshot bounds require all of x, y, w, and h (or omit all four)",
+      false,
+    );
+  }
+
+  if (hasCompleteBox) {
     if (!(w! > 0) || !(h! > 0)) {
       throw new CanvasAgentError(
         "VALIDATION_ARG",
@@ -109,7 +159,7 @@ function resolveRegion(
   const idsRaw = args.ids ?? args.center_ids;
   if (idsRaw !== undefined && idsRaw !== null) {
     const ids = requireIds(idsRaw);
-    requireExistingShapes(editor, ids);
+    requireScreenshotableIds(editor, ids);
     const union = unionShapePageBounds(editor, ids);
     if (!union) {
       throw new CanvasAgentError(
@@ -136,20 +186,22 @@ function resolveRegion(
         true,
       );
     }
-    // Agent view already includes its own padding from set-agent-view.
     return view;
   }
 
-  // Default: union of all non-chrome shapes currently on the page (agent drawing surface).
+  // Default region: union of shapes on the current page.
+  // When include_widgets is false, skip Atmos chrome; when true, include them.
   const contentIds: string[] = [];
   for (const shape of editor.getCurrentPageShapes()) {
-    if (ATMOS_CHROME_TYPES.has(shape.type)) continue;
+    if (!includeChrome && ATMOS_CHROME_TYPES.has(shape.type)) continue;
     contentIds.push(shape.id);
   }
   if (contentIds.length === 0) {
     throw new CanvasAgentError(
       "VALIDATION_ARG",
-      "No non-chrome shapes to screenshot. Draw first or pass an explicit region.",
+      includeChrome
+        ? "No shapes to screenshot on the current page."
+        : "No non-chrome shapes to screenshot. Draw first, pass an explicit region, or use --include-widgets.",
       true,
     );
   }
@@ -170,17 +222,15 @@ function selectShapesForRegion(
   includeChrome: boolean,
   explicitIds?: string[],
 ): TLShape[] {
-  const shapes = editor.getCurrentPageShapes();
   if (explicitIds && explicitIds.length) {
-    const set = new Set(explicitIds);
-    return shapes.filter((s) => {
-      if (!set.has(s.id)) return false;
+    // Already validated as current-page shapes in resolveRegion / call site.
+    return requireScreenshotableIds(editor, explicitIds).filter((s) => {
       if (!includeChrome && ATMOS_CHROME_TYPES.has(s.type)) return false;
       return true;
     });
   }
 
-  return shapes.filter((shape) => {
+  return editor.getCurrentPageShapes().filter((shape) => {
     if (!includeChrome && ATMOS_CHROME_TYPES.has(shape.type)) return false;
     const bb = getShapePageBoundsBox(editor, shape.id);
     if (!bb) return false;
@@ -201,13 +251,23 @@ export async function runCanvasAgentScreenshot(
     args.includeWidgets === true ||
     args.include_chrome === true;
 
-  const region = resolveRegion(editor, args, options?.getAgentViewBounds);
+  const region = resolveRegion(
+    editor,
+    args,
+    options?.getAgentViewBounds,
+    includeChrome,
+  );
 
   const idsRaw = args.ids ?? args.center_ids;
   const explicitIds =
     idsRaw !== undefined && idsRaw !== null ? requireIds(idsRaw) : undefined;
 
-  const selected = selectShapesForRegion(editor, region, includeChrome, explicitIds);
+  const selected = selectShapesForRegion(
+    editor,
+    region,
+    includeChrome,
+    explicitIds,
+  );
   if (selected.length === 0) {
     throw new CanvasAgentError(
       "VALIDATION_ARG",
@@ -251,7 +311,6 @@ export async function runCanvasAgentScreenshot(
     );
   }
 
-  // Soft size guard: if payload is huge, re-export smaller (agent JSON path).
   const approxBytes = Math.ceil((result.url.length * 3) / 4);
   if (approxBytes > 900_000 && size !== "small") {
     const retry = await editor.toImageDataUrl(

--- a/apps/web/src/features/canvas/lib/canvas-agent-screenshot.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-screenshot.ts
@@ -1,0 +1,285 @@
+import { Box, type Editor, type TLShape, type TLShapeId } from "tldraw";
+
+import { getShapePageBoundsBox } from "./canvas-agent-bounds";
+import { CanvasAgentError } from "./canvas-agent-errors";
+import {
+  nonNegativeNumberOr,
+  optionalNumber,
+  requireExistingShapes,
+  requireIds,
+  unionShapePageBounds,
+} from "./canvas-agent-bus-helpers";
+import {
+  AGENT_VIEW_PADDING,
+  expandBounds,
+  type CanvasAgentBounds,
+} from "./canvas-agent-view-bounds";
+/** String literals avoid heavy shape-util imports on the agent path. */
+const CANVAS_TERMINAL_SHAPE_TYPE = "canvas-terminal";
+const CANVAS_WIDGET_SHAPE_TYPE = "canvas-widget";
+
+/**
+ * Screenshot only the agent-drawn region so product widgets / terminals
+ * elsewhere on the canvas do not pollute visual verification.
+ *
+ * Shape inclusion rules (when region is known):
+ * 1. Never include Atmos chrome: `canvas-terminal`, `canvas-widget`.
+ * 2. Include a shape only if its center lies inside the region, OR ≥50% of
+ *    its area intersects the region (so edge-grazing terminals stay out).
+ * 3. Crop export with `bounds` so off-region paint is clipped.
+ */
+
+export type ScreenshotSize = "small" | "medium" | "large";
+
+const MAX_EDGE: Record<ScreenshotSize, number> = {
+  small: 768,
+  medium: 1280,
+  large: 2048,
+};
+
+const ATMOS_CHROME_TYPES = new Set<string>([
+  CANVAS_TERMINAL_SHAPE_TYPE,
+  CANVAS_WIDGET_SHAPE_TYPE,
+]);
+
+function parseSize(value: unknown): ScreenshotSize {
+  const s = String(value ?? "medium").trim().toLowerCase();
+  if (s === "small" || s === "medium" || s === "large") return s;
+  throw new CanvasAgentError(
+    "VALIDATION_ARG",
+    'size must be "small", "medium", or "large"',
+    false,
+  );
+}
+
+function rectsIntersectArea(
+  a: { minX: number; minY: number; maxX: number; maxY: number },
+  b: { minX: number; minY: number; maxX: number; maxY: number },
+): number {
+  const x1 = Math.max(a.minX, b.minX);
+  const y1 = Math.max(a.minY, b.minY);
+  const x2 = Math.min(a.maxX, b.maxX);
+  const y2 = Math.min(a.maxY, b.maxY);
+  if (x2 <= x1 || y2 <= y1) return 0;
+  return (x2 - x1) * (y2 - y1);
+}
+
+function shapeQualifiesForRegion(
+  bb: { minX: number; minY: number; maxX: number; maxY: number; width: number; height: number; midX: number; midY: number },
+  region: CanvasAgentBounds,
+): boolean {
+  const r = {
+    minX: region.x,
+    minY: region.y,
+    maxX: region.x + region.w,
+    maxY: region.y + region.h,
+  };
+  const centerInside =
+    bb.midX >= r.minX && bb.midX <= r.maxX && bb.midY >= r.minY && bb.midY <= r.maxY;
+  if (centerInside) return true;
+  const area = Math.max(1, bb.width * bb.height);
+  const overlap = rectsIntersectArea(bb, r);
+  return overlap / area >= 0.5;
+}
+
+function resolveRegion(
+  editor: Editor,
+  args: Record<string, unknown>,
+  getAgentViewBounds?: () => CanvasAgentBounds | null,
+): CanvasAgentBounds {
+  const padding = nonNegativeNumberOr(args.padding, AGENT_VIEW_PADDING);
+  const x = optionalNumber(args.x);
+  const y = optionalNumber(args.y);
+  const w = optionalNumber(args.w);
+  const h = optionalNumber(args.h);
+  const hasBox =
+    x !== undefined && y !== undefined && w !== undefined && h !== undefined;
+
+  if (hasBox) {
+    if (!(w! > 0) || !(h! > 0)) {
+      throw new CanvasAgentError(
+        "VALIDATION_ARG",
+        "w and h must be positive for screenshot bounds",
+        false,
+      );
+    }
+    return expandBounds({ x: x!, y: y!, w: w!, h: h! }, padding);
+  }
+
+  const idsRaw = args.ids ?? args.center_ids;
+  if (idsRaw !== undefined && idsRaw !== null) {
+    const ids = requireIds(idsRaw);
+    requireExistingShapes(editor, ids);
+    const union = unionShapePageBounds(editor, ids);
+    if (!union) {
+      throw new CanvasAgentError(
+        "VALIDATION_ARG",
+        "screenshot ids have no measurable bounds",
+        true,
+      );
+    }
+    return expandBounds(union, padding);
+  }
+
+  const useAgentView =
+    args.use_agent_view === true ||
+    args.useAgentView === true ||
+    args.region === "agent_view" ||
+    args.region === "agent-view";
+
+  if (useAgentView) {
+    const view = getAgentViewBounds?.() ?? null;
+    if (!view || !(view.w > 0) || !(view.h > 0)) {
+      throw new CanvasAgentError(
+        "VALIDATION_ARG",
+        "No agent view is set. Call set-agent-view first, or pass --ids / --x --y --w --h.",
+        true,
+      );
+    }
+    // Agent view already includes its own padding from set-agent-view.
+    return view;
+  }
+
+  // Default: union of all non-chrome shapes currently on the page (agent drawing surface).
+  const contentIds: string[] = [];
+  for (const shape of editor.getCurrentPageShapes()) {
+    if (ATMOS_CHROME_TYPES.has(shape.type)) continue;
+    contentIds.push(shape.id);
+  }
+  if (contentIds.length === 0) {
+    throw new CanvasAgentError(
+      "VALIDATION_ARG",
+      "No non-chrome shapes to screenshot. Draw first or pass an explicit region.",
+      true,
+    );
+  }
+  const union = unionShapePageBounds(editor, contentIds);
+  if (!union) {
+    throw new CanvasAgentError(
+      "VALIDATION_ARG",
+      "Could not measure content bounds for screenshot",
+      true,
+    );
+  }
+  return expandBounds(union, padding);
+}
+
+function selectShapesForRegion(
+  editor: Editor,
+  region: CanvasAgentBounds,
+  includeChrome: boolean,
+  explicitIds?: string[],
+): TLShape[] {
+  const shapes = editor.getCurrentPageShapes();
+  if (explicitIds && explicitIds.length) {
+    const set = new Set(explicitIds);
+    return shapes.filter((s) => {
+      if (!set.has(s.id)) return false;
+      if (!includeChrome && ATMOS_CHROME_TYPES.has(s.type)) return false;
+      return true;
+    });
+  }
+
+  return shapes.filter((shape) => {
+    if (!includeChrome && ATMOS_CHROME_TYPES.has(shape.type)) return false;
+    const bb = getShapePageBoundsBox(editor, shape.id);
+    if (!bb) return false;
+    return shapeQualifiesForRegion(bb, region);
+  });
+}
+
+export async function runCanvasAgentScreenshot(
+  editor: Editor,
+  args: Record<string, unknown>,
+  options?: {
+    getAgentViewBounds?: () => CanvasAgentBounds | null;
+  },
+): Promise<Record<string, unknown>> {
+  const size = parseSize(args.size);
+  const includeChrome =
+    args.include_widgets === true ||
+    args.includeWidgets === true ||
+    args.include_chrome === true;
+
+  const region = resolveRegion(editor, args, options?.getAgentViewBounds);
+
+  const idsRaw = args.ids ?? args.center_ids;
+  const explicitIds =
+    idsRaw !== undefined && idsRaw !== null ? requireIds(idsRaw) : undefined;
+
+  const selected = selectShapesForRegion(editor, region, includeChrome, explicitIds);
+  if (selected.length === 0) {
+    throw new CanvasAgentError(
+      "VALIDATION_ARG",
+      "No shapes qualify inside the screenshot region (chrome widgets are excluded by default).",
+      true,
+    );
+  }
+
+  const longest = Math.max(region.w, region.h, 1);
+  const maxEdge = MAX_EDGE[size];
+  const pixelRatio = Math.min(2, maxEdge / longest);
+
+  const boundsBox = new Box(region.x, region.y, region.w, region.h);
+
+  let result: { url: string; width: number; height: number };
+  try {
+    result = await editor.toImageDataUrl(
+      selected.map((s) => s.id as TLShapeId),
+      {
+        format: "jpeg",
+        quality: 0.82,
+        background: true,
+        padding: 8,
+        pixelRatio,
+        bounds: boundsBox,
+      },
+    );
+  } catch (err) {
+    throw new CanvasAgentError(
+      "INTERNAL_ERROR",
+      `Screenshot export failed: ${err instanceof Error ? err.message : String(err)}`,
+      true,
+    );
+  }
+
+  if (!result?.url?.startsWith("data:")) {
+    throw new CanvasAgentError(
+      "INTERNAL_ERROR",
+      "Screenshot export returned an empty image",
+      true,
+    );
+  }
+
+  // Soft size guard: if payload is huge, re-export smaller (agent JSON path).
+  const approxBytes = Math.ceil((result.url.length * 3) / 4);
+  if (approxBytes > 900_000 && size !== "small") {
+    const retry = await editor.toImageDataUrl(
+      selected.map((s) => s.id as TLShapeId),
+      {
+        format: "jpeg",
+        quality: 0.72,
+        background: true,
+        padding: 8,
+        pixelRatio: Math.min(1.25, MAX_EDGE.small / longest),
+        bounds: new Box(region.x, region.y, region.w, region.h),
+      },
+    );
+    if (retry?.url?.startsWith("data:")) {
+      result = retry;
+    }
+  }
+
+  return {
+    schema: "canvas_agent_screenshot.v1",
+    format: "jpeg",
+    data_url: result.url,
+    width: result.width,
+    height: result.height,
+    region,
+    shape_ids: selected.map((s) => s.id),
+    shape_count: selected.length,
+    excluded_chrome: !includeChrome,
+    size,
+  };
+}

--- a/apps/web/src/features/canvas/lib/canvas-agent-spawn.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-spawn.ts
@@ -1,0 +1,89 @@
+import type { Editor } from "tldraw";
+
+import { collectContentOccupiedRects } from "./canvas-agent-lint";
+
+export const DEFAULT_SPAWN_GAP = 28;
+/** Default geo size used when creating without explicit w/h. */
+export const DEFAULT_GEO_SIZE = { w: 200, h: 200 };
+export const DEFAULT_NOTE_SIZE = { w: 200, h: 200 };
+export const DEFAULT_FRAME_SIZE = { w: 640, h: 440 };
+
+type Rect = { x: number; y: number; w: number; h: number };
+
+function rectsOverlap(a: Rect, b: Rect, gap: number): boolean {
+  return !(
+    a.x + a.w + gap <= b.x ||
+    b.x + b.w + gap <= a.x ||
+    a.y + a.h + gap <= b.y ||
+    b.y + b.h + gap <= a.y
+  );
+}
+
+function fits(candidate: Rect, occupied: Rect[], gap: number): boolean {
+  return !occupied.some((rect) => rectsOverlap(candidate, rect, gap));
+}
+
+/**
+ * Find a page-space top-left for a new shape that does not overlap existing
+ * content/widgets. Prefers the viewport center, then spirals outward.
+ *
+ * This replaces the old fixed 120×80 grid (which was smaller than default
+ * geo 200×200 and caused guaranteed stacking).
+ */
+export function findNonOverlappingSpawn(
+  editor: Editor,
+  size: { w: number; h: number },
+  options?: {
+    gap?: number;
+    excludeIds?: ReadonlySet<string>;
+  },
+): { x: number; y: number } {
+  const gap = options?.gap ?? DEFAULT_SPAWN_GAP;
+  const w = Math.max(8, size.w);
+  const h = Math.max(8, size.h);
+  const occupied = collectContentOccupiedRects(editor, options?.excludeIds);
+
+  const viewport = editor.getViewportPageBounds();
+  const originX = viewport.center.x - w / 2;
+  const originY = viewport.center.y - h / 2;
+
+  const first: Rect = { x: originX, y: originY, w, h };
+  if (fits(first, occupied, gap)) {
+    return { x: originX, y: originY };
+  }
+
+  // Spiral search in steps of (size + gap), covering expanding rings.
+  const stepX = w + gap;
+  const stepY = h + gap;
+  const maxRing = 24;
+
+  for (let ring = 1; ring <= maxRing; ring++) {
+    for (let dy = -ring; dy <= ring; dy++) {
+      for (let dx = -ring; dx <= ring; dx++) {
+        if (Math.max(Math.abs(dx), Math.abs(dy)) !== ring) continue;
+        const x = originX + dx * stepX;
+        const y = originY + dy * stepY;
+        const candidate: Rect = { x, y, w, h };
+        if (fits(candidate, occupied, gap)) {
+          return { x, y };
+        }
+      }
+    }
+  }
+
+  // Fallback: place below the union of all occupied content.
+  if (occupied.length) {
+    let maxY = -Infinity;
+    let minX = Infinity;
+    for (const r of occupied) {
+      if (r.y + r.h > maxY) maxY = r.y + r.h;
+      if (r.x < minX) minX = r.x;
+    }
+    return {
+      x: Number.isFinite(minX) ? minX : originX,
+      y: (Number.isFinite(maxY) ? maxY : originY) + gap,
+    };
+  }
+
+  return { x: originX, y: originY };
+}

--- a/apps/web/src/features/canvas/lib/canvas-agent-spawn.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-spawn.ts
@@ -8,9 +8,9 @@ export const DEFAULT_GEO_SIZE = { w: 200, h: 200 };
 export const DEFAULT_NOTE_SIZE = { w: 200, h: 200 };
 export const DEFAULT_FRAME_SIZE = { w: 640, h: 440 };
 
-type Rect = { x: number; y: number; w: number; h: number };
+export type SpawnRect = { x: number; y: number; w: number; h: number };
 
-function rectsOverlap(a: Rect, b: Rect, gap: number): boolean {
+export function rectsOverlap(a: SpawnRect, b: SpawnRect, gap: number): boolean {
   return !(
     a.x + a.w + gap <= b.x ||
     b.x + b.w + gap <= a.x ||
@@ -19,7 +19,7 @@ function rectsOverlap(a: Rect, b: Rect, gap: number): boolean {
   );
 }
 
-function fits(candidate: Rect, occupied: Rect[], gap: number): boolean {
+function fits(candidate: SpawnRect, occupied: SpawnRect[], gap: number): boolean {
   return !occupied.some((rect) => rectsOverlap(candidate, rect, gap));
 }
 
@@ -47,7 +47,7 @@ export function findNonOverlappingSpawn(
   const originX = viewport.center.x - w / 2;
   const originY = viewport.center.y - h / 2;
 
-  const first: Rect = { x: originX, y: originY, w, h };
+  const first: SpawnRect = { x: originX, y: originY, w, h };
   if (fits(first, occupied, gap)) {
     return { x: originX, y: originY };
   }
@@ -63,7 +63,7 @@ export function findNonOverlappingSpawn(
         if (Math.max(Math.abs(dx), Math.abs(dy)) !== ring) continue;
         const x = originX + dx * stepX;
         const y = originY + dy * stepY;
-        const candidate: Rect = { x, y, w, h };
+        const candidate: SpawnRect = { x, y, w, h };
         if (fits(candidate, occupied, gap)) {
           return { x, y };
         }

--- a/apps/web/src/features/canvas/lib/canvas-agent-view-bounds.ts
+++ b/apps/web/src/features/canvas/lib/canvas-agent-view-bounds.ts
@@ -52,6 +52,26 @@ export function shapeIdsFromAgentResult(data: unknown): string[] {
   if (!data || typeof data !== "object") return [];
   const d = data as Record<string, unknown>;
   if (typeof d.id === "string") return [d.id];
+
+  // `apply` returns `{ results: [{ data: { id } }, …] }`.
+  if (Array.isArray(d.results)) {
+    const fromApply: string[] = [];
+    for (const step of d.results) {
+      if (!step || typeof step !== "object") continue;
+      const stepData = (step as { data?: unknown }).data;
+      if (stepData && typeof stepData === "object") {
+        const id = (stepData as { id?: unknown }).id;
+        if (typeof id === "string" && id.length) fromApply.push(id);
+      }
+    }
+    if (fromApply.length) return fromApply;
+  }
+
+  // `screenshot` returns the shapes that were rendered.
+  if (Array.isArray(d.shape_ids)) {
+    return d.shape_ids.filter((v): v is string => typeof v === "string" && v.length > 0);
+  }
+
   const arrayKeys = [
     "ids",
     "laid_out",

--- a/apps/web/src/features/terminal/components/Terminal.tsx
+++ b/apps/web/src/features/terminal/components/Terminal.tsx
@@ -33,6 +33,7 @@ import {
   ensureTerminalFontsLoaded,
   extractCommandName,
   isFindShortcut,
+  isInlineMouseTuiCommand,
   isTerminalContainerVisible,
   isTerminalEmulatorReport,
   isUsableTerminalGrid,
@@ -300,12 +301,18 @@ const Terminal = ({
     pendingWriteRef.current = [];
     outputTextDecoderRef.current = new TextDecoder();
     const useAlternateScreen = snapshot.alternate === true;
+    // capture-pane restores cells, not DEC mouse modes. Prefer backend flag
+    // (alternate or inline mouse-TUI whitelist like Grok).
+    const restoreMouseTracking =
+      typeof snapshot.restore_mouse_tracking === "boolean"
+        ? snapshot.restore_mouse_tracking
+        : useAlternateScreen;
     const screenMode = useAlternateScreen ? "\x1b[?1049h" : "\x1b[?1049l";
     const clearScrollback = useAlternateScreen ? "" : "\x1b[3J";
     const clearScreen = `${screenMode}\x1b[H\x1b[2J${clearScrollback}`;
     const data = normalizeSnapshotData(snapshot.data);
     const cursorRestore = `\x1b[${snapshot.cursor_y + 1};${snapshot.cursor_x + 1}H`;
-    const mouseRestore = useAlternateScreen ? ENABLE_TUI_MOUSE_TRACKING : "";
+    const mouseRestore = restoreMouseTracking ? ENABLE_TUI_MOUSE_TRACKING : "";
     term.reset();
     if (
       isUsableTerminalGrid(snapshot.cols, snapshot.rows) &&
@@ -727,6 +734,13 @@ const Terminal = ({
 
       if (metaType === "CMD_START") {
         const title = extractCommandName(payload);
+        // Belt-and-suspenders for reattach: inject_initial_title sends
+        // CMD_START:<pane_current_command>. Inline mouse TUIs (Grok) may not
+        // use alt-screen, so snapshot.alternate alone is not enough — re-enable
+        // mouse when the running command matches the whitelist.
+        if (isInlineMouseTuiCommand(payload) || isInlineMouseTuiCommand(title)) {
+          terminal.write(ENABLE_TUI_MOUSE_TRACKING);
+        }
         // Cancel any previous pending CMD_START
         if (cmdStartTimerRef.current) {
           clearTimeout(cmdStartTimerRef.current);

--- a/apps/web/src/features/terminal/lib/terminal-runtime-utils.ts
+++ b/apps/web/src/features/terminal/lib/terminal-runtime-utils.ts
@@ -19,6 +19,15 @@ const MIN_TERMINAL_ROWS = 8;
 export const ENABLE_TUI_MOUSE_TRACKING = "\x1b[?1000h\x1b[?1002h\x1b[?1006h";
 export const DISABLE_TUI_MOUSE_TRACKING = "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l";
 
+/** Keep in sync with @atmos/shared and core-engine inline mouse TUI whitelist. */
+export function isInlineMouseTuiCommand(cmd: string): boolean {
+  const trimmed = cmd.trim();
+  if (!trimmed) return false;
+  const parts = trimmed.split(/[/\\]/);
+  const name = parts[parts.length - 1] || trimmed;
+  return name === "grok" || name.startsWith("grok-");
+}
+
 let terminalFontLoadPromise: Promise<void> | null = null;
 
 export class SafeClipboardProvider implements IClipboardProvider {

--- a/apps/web/src/features/terminal/types/index.ts
+++ b/apps/web/src/features/terminal/types/index.ts
@@ -225,6 +225,8 @@ export interface TerminalSnapshot {
   cols: number;
   rows: number;
   alternate?: boolean;
+  /** Re-enable TUI mouse tracking after reattach (backend-computed). */
+  restore_mouse_tracking?: boolean;
 }
 
 export interface WsTerminalCreated {

--- a/apps/web/src/shared/components/image-preview-overlay.tsx
+++ b/apps/web/src/shared/components/image-preview-overlay.tsx
@@ -33,8 +33,14 @@ export function ImagePreviewOverlay({
       role="dialog"
       aria-modal="true"
       aria-label={alt}
+      data-image-preview-overlay=""
       className="fixed inset-0 z-[2147483647] flex cursor-zoom-out items-center justify-center bg-black/80 backdrop-blur-sm"
       onClick={onClose}
+      onPointerDown={event => {
+        // Keep parent popovers/islands open: their outside-dismiss listeners
+        // run in capture phase and would treat this portal click as "outside".
+        event.stopPropagation();
+      }}
     >
       {/* eslint-disable-next-line @next/next/no-img-element -- previews use local object/data URLs and must not go through Next image optimization. */}
       <img

--- a/apps/web/src/shared/components/image-preview-overlay.tsx
+++ b/apps/web/src/shared/components/image-preview-overlay.tsx
@@ -36,11 +36,6 @@ export function ImagePreviewOverlay({
       data-image-preview-overlay=""
       className="fixed inset-0 z-[2147483647] flex cursor-zoom-out items-center justify-center bg-black/80 backdrop-blur-sm"
       onClick={onClose}
-      onPointerDown={event => {
-        // Keep parent popovers/islands open: their outside-dismiss listeners
-        // run in capture phase and would treat this portal click as "outside".
-        event.stopPropagation();
-      }}
     >
       {/* eslint-disable-next-line @next/next/no-img-element -- previews use local object/data URLs and must not go through Next image optimization. */}
       <img

--- a/apps/web/src/shared/stores/use-ui-pref-hooks.ts
+++ b/apps/web/src/shared/stores/use-ui-pref-hooks.ts
@@ -331,7 +331,7 @@ export interface CanvasUiPrefs {
   agentFollow: boolean;
 }
 
-const DEFAULT_CANVAS_PREFS: CanvasUiPrefs = {
+export const DEFAULT_CANVAS_PREFS: CanvasUiPrefs = {
   sessionByBoard: {},
   lastPinnedByBoard: {},
   agentClientId: null,

--- a/apps/web/src/shared/stores/use-ui-pref-hooks.ts
+++ b/apps/web/src/shared/stores/use-ui-pref-hooks.ts
@@ -324,6 +324,11 @@ export interface CanvasUiPrefs {
   lastPinnedByBoard: Record<string, CanvasLastPinnedTerminal>;
   agentClientId: string | null;
   acceptsCommands: boolean;
+  /**
+   * When true, camera pans/zooms to shapes the canvas agent touches.
+   * Turn off when drawing alongside the agent.
+   */
+  agentFollow: boolean;
 }
 
 const DEFAULT_CANVAS_PREFS: CanvasUiPrefs = {
@@ -331,6 +336,7 @@ const DEFAULT_CANVAS_PREFS: CanvasUiPrefs = {
   lastPinnedByBoard: {},
   agentClientId: null,
   acceptsCommands: false,
+  agentFollow: true,
 };
 
 /** Merge persisted canvas prefs with defaults (older saves omit new fields). */
@@ -454,20 +460,27 @@ export function writeCanvasSession(
 }
 
 export function useCanvasAgentBridgePrefs(): [
-  { clientId: string | null; acceptsCommands: boolean },
+  { clientId: string | null; acceptsCommands: boolean; agentFollow: boolean },
   {
     setClientId: (id: string) => void;
     setAcceptsCommands: (value: boolean) => void;
+    setAgentFollow: (value: boolean) => void;
   },
 ] {
   const [prefs, setPrefs] = useInstanceSlice('canvas', DEFAULT_CANVAS_PREFS);
   return [
-    { clientId: prefs.agentClientId, acceptsCommands: prefs.acceptsCommands },
+    {
+      clientId: prefs.agentClientId,
+      acceptsCommands: prefs.acceptsCommands,
+      agentFollow: prefs.agentFollow !== false,
+    },
     {
       setClientId: id =>
         setPrefs(prev => ({ ...prev, agentClientId: id })),
       setAcceptsCommands: value =>
         setPrefs(prev => ({ ...prev, acceptsCommands: value })),
+      setAgentFollow: value =>
+        setPrefs(prev => ({ ...prev, agentFollow: value })),
     },
   ];
 }

--- a/crates/core-engine/src/lib.rs
+++ b/crates/core-engine/src/lib.rs
@@ -26,6 +26,7 @@ pub use local_services::{
 pub use search::{search_content, SearchMatch, SearchResult};
 pub use test_engine::TestEngine;
 pub use tmux::{
-    TmuxEngine, TmuxInstallPlan, TmuxPaneCapturePage, TmuxPaneSnapshot, TmuxSessionInfo,
-    TmuxVersion, TmuxWindowAtmosMetadata, TmuxWindowInfo,
+    is_inline_mouse_tui_command, is_shell_command, pane_command_basename,
+    should_restore_tui_mouse_tracking, TmuxEngine, TmuxInstallPlan, TmuxPaneCapturePage,
+    TmuxPaneSnapshot, TmuxSessionInfo, TmuxVersion, TmuxWindowAtmosMetadata, TmuxWindowInfo,
 };

--- a/crates/core-engine/src/tmux/capture.rs
+++ b/crates/core-engine/src/tmux/capture.rs
@@ -1,6 +1,8 @@
 use crate::error::Result;
 
-use super::{TmuxEngine, TmuxPaneCapturePage, TmuxPaneSnapshot};
+use super::{
+    should_restore_tui_mouse_tracking, TmuxEngine, TmuxPaneCapturePage, TmuxPaneSnapshot,
+};
 
 #[derive(Debug, Clone, Copy)]
 pub(super) struct PaneMetadata {
@@ -226,6 +228,11 @@ impl TmuxEngine {
             && lines_returned > 0
             && lines_returned >= take as u32
             && (history_size == 0 || consumed < history_size as i32);
+        let current_command = self
+            .get_pane_current_command(session_name, window_index)
+            .unwrap_or_default();
+        let restore_mouse_tracking =
+            should_restore_tui_mouse_tracking(metadata.alternate, &current_command);
 
         Ok(TmuxPaneCapturePage {
             snapshot: TmuxPaneSnapshot {
@@ -235,6 +242,7 @@ impl TmuxEngine {
                 cols: metadata.cols,
                 rows: metadata.rows,
                 alternate: metadata.alternate,
+                restore_mouse_tracking,
             },
             skip_from_bottom: skip,
             lines_returned,
@@ -270,6 +278,11 @@ impl TmuxEngine {
             capture_lines,
             metadata.alternate,
         )?;
+        let current_command = self
+            .get_pane_current_command(session_name, window_index)
+            .unwrap_or_default();
+        let restore_mouse_tracking =
+            should_restore_tui_mouse_tracking(metadata.alternate, &current_command);
 
         Ok(TmuxPaneSnapshot {
             data,
@@ -278,6 +291,7 @@ impl TmuxEngine {
             cols: metadata.cols,
             rows: metadata.rows,
             alternate: metadata.alternate,
+            restore_mouse_tracking,
         })
     }
 }

--- a/crates/core-engine/src/tmux/mod.rs
+++ b/crates/core-engine/src/tmux/mod.rs
@@ -23,8 +23,9 @@ use crate::error::{EngineError, Result};
 use locale::apply_utf8_env;
 
 pub use types::{
-    TmuxInstallPlan, TmuxPaneCapturePage, TmuxPaneSnapshot, TmuxSessionInfo, TmuxVersion,
-    TmuxWindowAtmosMetadata, TmuxWindowInfo,
+    is_inline_mouse_tui_command, is_shell_command, pane_command_basename,
+    should_restore_tui_mouse_tracking, TmuxInstallPlan, TmuxPaneCapturePage, TmuxPaneSnapshot,
+    TmuxSessionInfo, TmuxVersion, TmuxWindowAtmosMetadata, TmuxWindowInfo,
 };
 
 /// Default socket path for Atmos tmux server

--- a/crates/core-engine/src/tmux/types.rs
+++ b/crates/core-engine/src/tmux/types.rs
@@ -37,6 +37,57 @@ pub struct TmuxPaneSnapshot {
     pub cols: u32,
     pub rows: u32,
     pub alternate: bool,
+    /// Whether the frontend should re-enable TUI mouse tracking after reattach.
+    ///
+    /// `capture-pane` restores cells, not DEC modes. Restore when:
+    /// - the pane is on the alternate screen (standard full-screen TUIs), or
+    /// - the foreground is a known **inline** mouse TUI (see
+    ///   [`is_inline_mouse_tui_command`]) that enables mouse reporting without
+    ///   alt-screen.
+    ///
+    /// Do **not** enable for arbitrary non-shell processes: that steals the
+    /// wheel from xterm scrollback (`npm run dev`, non-mouse agent TUIs, etc.).
+    #[serde(default)]
+    pub restore_mouse_tracking: bool,
+}
+
+/// Shell names treated as "idle at prompt" for title/mouse restore heuristics.
+pub fn is_shell_command(cmd: &str) -> bool {
+    matches!(
+        cmd.trim(),
+        "zsh" | "bash" | "fish" | "sh" | "dash" | "ksh" | "tcsh" | "csh"
+    )
+}
+
+/// Basename of `pane_current_command` (handles absolute paths).
+pub fn pane_command_basename(cmd: &str) -> &str {
+    let trimmed = cmd.trim();
+    std::path::Path::new(trimmed)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(trimmed)
+}
+
+/// Interactive TUIs that enable mouse reporting **without** always entering the
+/// alternate screen (e.g. Grok under tmux control mode / `alt_screen=auto`).
+///
+/// Keep this list tight: each entry opts the process into mouse mode on reattach,
+/// which disables xterm wheel scrollback until the app exits or sends disable.
+///
+/// Grok's installed binary is versioned (`grok-0.2.103-macos-aarch64`); the
+/// `grok` PATH entry is only a symlink. tmux `#{pane_current_command}` reports
+/// that versioned basename (sometimes truncated), not `grok`.
+pub fn is_inline_mouse_tui_command(cmd: &str) -> bool {
+    let name = pane_command_basename(cmd);
+    name == "grok" || name.starts_with("grok-")
+}
+
+/// Decide whether reattach hydration should re-enable xterm mouse tracking.
+pub fn should_restore_tui_mouse_tracking(alternate: bool, current_command: &str) -> bool {
+    if alternate {
+        return true;
+    }
+    is_inline_mouse_tui_command(current_command)
 }
 
 /// One page of tmux scrollback for canvas `extract-text` pagination.
@@ -78,7 +129,10 @@ pub struct TmuxInstallPlan {
 
 #[cfg(test)]
 mod tests {
-    use super::TmuxVersion;
+    use super::{
+        is_inline_mouse_tui_command, is_shell_command, pane_command_basename,
+        should_restore_tui_mouse_tracking, TmuxVersion,
+    };
 
     #[test]
     fn test_version_at_least() {
@@ -92,5 +146,70 @@ mod tests {
         assert!(v.at_least(2, 9));
         assert!(!v.at_least(3, 5));
         assert!(!v.at_least(4, 0));
+    }
+
+    #[test]
+    fn shell_commands_are_recognized() {
+        assert!(is_shell_command("zsh"));
+        assert!(is_shell_command(" bash "));
+        assert!(!is_shell_command("grok"));
+        assert!(!is_shell_command("opencode"));
+        assert!(!is_shell_command("node"));
+    }
+
+    #[test]
+    fn pane_command_basename_strips_path() {
+        assert_eq!(pane_command_basename("grok"), "grok");
+        assert_eq!(pane_command_basename("/Users/me/.grok/bin/grok"), "grok");
+        assert_eq!(pane_command_basename("  /usr/bin/node  "), "node");
+    }
+
+    #[test]
+    fn inline_mouse_tui_whitelist_is_tight() {
+        assert!(is_inline_mouse_tui_command("grok"));
+        assert!(is_inline_mouse_tui_command("/Users/me/.grok/bin/grok"));
+        // Versioned install binary (and tmux-truncated form).
+        assert!(is_inline_mouse_tui_command("grok-0.2.103-macos-aarch64"));
+        assert!(is_inline_mouse_tui_command("grok-0.2.103-ma"));
+        assert!(is_inline_mouse_tui_command(
+            "/Users/me/.grok/downloads/grok-0.2.103-macos-aarch64"
+        ));
+        assert!(!is_inline_mouse_tui_command("opencode"));
+        assert!(!is_inline_mouse_tui_command("claude"));
+        assert!(!is_inline_mouse_tui_command("node"));
+        assert!(!is_inline_mouse_tui_command("npm"));
+        assert!(!is_inline_mouse_tui_command("zsh"));
+        assert!(!is_inline_mouse_tui_command("grokker"));
+    }
+
+    #[test]
+    fn mouse_restore_for_alternate_or_inline_mouse_tui_only() {
+        // Alternate screen: always restore (OpenCode, vim, htop, …).
+        assert!(should_restore_tui_mouse_tracking(true, "zsh"));
+        assert!(should_restore_tui_mouse_tracking(true, "opencode"));
+        assert!(should_restore_tui_mouse_tracking(true, "npm"));
+
+        // Inline mouse TUI whitelist (Grok without alt-screen).
+        assert!(should_restore_tui_mouse_tracking(false, "grok"));
+        assert!(should_restore_tui_mouse_tracking(
+            false,
+            "/Users/me/.grok/bin/grok"
+        ));
+        assert!(should_restore_tui_mouse_tracking(
+            false,
+            "grok-0.2.103-ma"
+        ));
+        assert!(should_restore_tui_mouse_tracking(
+            false,
+            "grok-0.2.103-macos-aarch64"
+        ));
+
+        // Everything else without alt-screen: keep xterm wheel scrollback.
+        assert!(!should_restore_tui_mouse_tracking(false, "opencode"));
+        assert!(!should_restore_tui_mouse_tracking(false, "claude"));
+        assert!(!should_restore_tui_mouse_tracking(false, "node"));
+        assert!(!should_restore_tui_mouse_tracking(false, "npm"));
+        assert!(!should_restore_tui_mouse_tracking(false, "zsh"));
+        assert!(!should_restore_tui_mouse_tracking(false, ""));
     }
 }

--- a/crates/core-service/src/service/terminal.rs
+++ b/crates/core-service/src/service/terminal.rs
@@ -973,9 +973,6 @@ impl TerminalService {
         window_index: u32,
         output_tx: &mpsc::UnboundedSender<Vec<u8>>,
     ) {
-        // Known shell names — if pane_current_command matches one of these, the shell is idle
-        const SHELLS: &[&str] = &["zsh", "bash", "fish", "sh", "dash", "ksh", "tcsh", "csh"];
-
         let current_cmd = match self
             .tmux_engine
             .get_pane_current_command(tmux_session, window_index)
@@ -987,7 +984,7 @@ impl TerminalService {
             }
         };
 
-        let osc = if SHELLS.contains(&current_cmd.as_str()) {
+        let osc = if core_engine::is_shell_command(&current_cmd) {
             // Shell is idle at prompt — show the current working directory
             match self
                 .tmux_engine

--- a/docs/adr/004-terminal-tmux-control-mode.md
+++ b/docs/adr/004-terminal-tmux-control-mode.md
@@ -36,7 +36,7 @@ Atmos 的 tmux-backed terminal 统一改为 **tmux control mode** transport：
 - 用户输入用 `send-keys -H` hex command 写入目标 pane；terminal report 用 `refresh-client` report path 回传给 tmux/pane。
 - resize 用 `resize-window` 固定目标 tmux window grid，再用 `refresh-client -C <cols>x<rows>` 同步 control client 尺寸。
 - reattach 时只用 snapshot 做 hydration，不再做命令结束后的 scrollback resync。snapshot 包含当前可见 grid、cursor、cols/rows、alternate flag。
-- 如果 snapshot 是 alternate screen，前端在重放后恢复 TUI mouse tracking mode；收到 `CMD_END` 时关闭这些 mode，避免影响普通 shell。
+- 如果 snapshot 需要 TUI 鼠标交互，前端在重放后恢复 TUI mouse tracking mode：`alternate` 为真，或前台命令命中 **inline mouse TUI 白名单**（当前为 `grok`——在 control mode / inline 策略下不进 alt-screen 但仍启用 mouse reporting）。不对任意非 shell 进程开 mouse，否则 `npm run dev`、无 alt 的 agent 输出等会丢掉滚轮 scrollback。收到 `CMD_END` 时关闭这些 mode，避免影响普通 shell。
 
 核心原则是：**live path 必须是唯一可信的 terminal state 来源；snapshot 只用于刷新/重连时的初始可见画面。**
 
@@ -147,7 +147,7 @@ API terminal WebSocket 改为：
   - 根据 `snapshot.alternate` 进入/退出 alternate screen。
   - 写入 snapshot data。
   - 恢复 cursor。
-  - alternate screen 下恢复 mouse tracking mode。
+  - 当 `restore_mouse_tracking`（或兼容旧字段时的 `alternate`）为真时恢复 mouse tracking mode。
   - CMD_END 时关闭 TUI mouse tracking mode。
 
 ### 5. Snapshot 策略
@@ -184,7 +184,7 @@ snapshot 只用于刷新/重连 hydration：
 | snapshot reattach 与 live state 不一致 | 中 | 中 | snapshot 只做 hydration；live output 仍是唯一可信状态来源；alternate screen 特化 viewport capture |
 | WebSocket binary/text 混用导致前端处理遗漏 | 中 | 低 | WS hook 明确区分 binary terminal output 和 JSON control message |
 | 多 client resize 互相影响 | 中 | 中 | 使用 per-connection client session；窗口尺寸策略保持显式，后续可加 active-client policy |
-| TUI mouse mode 在 reattach 后丢失 | 中 | 中 | alternate snapshot hydration 后恢复 mouse tracking，CMD_END 时关闭 |
+| TUI mouse mode 在 reattach 后丢失 | 中 | 中 | snapshot 在 alternate 或 inline mouse TUI 白名单前台时设置 `restore_mouse_tracking`；hydration 后恢复 mouse tracking，CMD_END 时关闭 |
 
 ## 验证 (Validation)
 

--- a/packages/shared/src/terminal/protocol.ts
+++ b/packages/shared/src/terminal/protocol.ts
@@ -8,6 +8,14 @@ export type TerminalSnapshot = TerminalSize & {
   cursor_x: number;
   cursor_y: number;
   alternate: boolean;
+  /**
+   * Re-enable TUI mouse tracking after reattach hydration.
+   * Set by the backend when the pane is on the alternate screen, or the
+   * foreground is a known inline mouse TUI (e.g. Grok). Not set for arbitrary
+   * non-shell processes so wheel scrollback stays usable.
+   * Older servers omit this; clients fall back to `alternate`.
+   */
+  restore_mouse_tracking?: boolean;
 };
 
 export type TerminalOpenMessage = {

--- a/packages/shared/src/terminal/snapshot.test.ts
+++ b/packages/shared/src/terminal/snapshot.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  ENABLE_TUI_MOUSE_TRACKING,
+  buildTerminalSnapshotRestorePayload,
+  isInlineMouseTuiCommand,
+  shouldRestoreTuiMouseTracking,
+} from "./snapshot";
+import type { TerminalSnapshot } from "./protocol";
+
+function baseSnapshot(
+  overrides: Partial<TerminalSnapshot> = {},
+): TerminalSnapshot {
+  return {
+    data: "hello",
+    cursor_x: 0,
+    cursor_y: 0,
+    cols: 80,
+    rows: 24,
+    alternate: false,
+    ...overrides,
+  };
+}
+
+describe("isInlineMouseTuiCommand", () => {
+  test("matches grok and versioned install binaries", () => {
+    expect(isInlineMouseTuiCommand("grok")).toBe(true);
+    expect(isInlineMouseTuiCommand("/Users/me/.grok/bin/grok")).toBe(true);
+    expect(isInlineMouseTuiCommand("grok-0.2.103-macos-aarch64")).toBe(true);
+    expect(isInlineMouseTuiCommand("grok-0.2.103-ma")).toBe(true);
+    expect(isInlineMouseTuiCommand("opencode")).toBe(false);
+    expect(isInlineMouseTuiCommand("node")).toBe(false);
+    expect(isInlineMouseTuiCommand("grokker")).toBe(false);
+  });
+});
+
+describe("shouldRestoreTuiMouseTracking", () => {
+  test("falls back to alternate when backend omits restore_mouse_tracking", () => {
+    expect(shouldRestoreTuiMouseTracking({ alternate: true })).toBe(true);
+    expect(shouldRestoreTuiMouseTracking({ alternate: false })).toBe(false);
+  });
+
+  test("honors explicit restore_mouse_tracking for inline TUIs", () => {
+    expect(
+      shouldRestoreTuiMouseTracking({
+        alternate: false,
+        restore_mouse_tracking: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRestoreTuiMouseTracking({
+        alternate: true,
+        restore_mouse_tracking: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("buildTerminalSnapshotRestorePayload", () => {
+  test("restores mouse tracking for non-alternate inline TUI snapshots", () => {
+    const { payload, useAlternateScreen, restoreMouseTracking } =
+      buildTerminalSnapshotRestorePayload(
+        baseSnapshot({
+          alternate: false,
+          restore_mouse_tracking: true,
+        }),
+      );
+
+    expect(useAlternateScreen).toBe(false);
+    expect(restoreMouseTracking).toBe(true);
+    expect(payload.endsWith(ENABLE_TUI_MOUSE_TRACKING)).toBe(true);
+    expect(payload.includes("\x1b[?1049l")).toBe(true);
+  });
+
+  test("restores mouse tracking for alternate-screen TUI snapshots", () => {
+    const { payload, useAlternateScreen, restoreMouseTracking } =
+      buildTerminalSnapshotRestorePayload(
+        baseSnapshot({
+          alternate: true,
+          restore_mouse_tracking: true,
+        }),
+      );
+
+    expect(useAlternateScreen).toBe(true);
+    expect(restoreMouseTracking).toBe(true);
+    expect(payload.includes("\x1b[?1049h")).toBe(true);
+    expect(payload.endsWith(ENABLE_TUI_MOUSE_TRACKING)).toBe(true);
+  });
+
+  test("skips mouse restore for idle shell snapshots", () => {
+    const { payload, restoreMouseTracking } = buildTerminalSnapshotRestorePayload(
+      baseSnapshot({
+        alternate: false,
+        restore_mouse_tracking: false,
+      }),
+    );
+
+    expect(restoreMouseTracking).toBe(false);
+    expect(payload.includes(ENABLE_TUI_MOUSE_TRACKING)).toBe(false);
+  });
+});

--- a/packages/shared/src/terminal/snapshot.ts
+++ b/packages/shared/src/terminal/snapshot.ts
@@ -27,21 +27,59 @@ export function isTerminalSnapshot(value: unknown): value is TerminalSnapshot {
   );
 }
 
+/**
+ * Basename of a pane command (handles absolute paths).
+ * Matches backend `pane_command_basename`.
+ */
+export function paneCommandBasename(cmd: string): string {
+  const trimmed = cmd.trim();
+  if (!trimmed) return "";
+  const parts = trimmed.split(/[/\\]/);
+  return parts[parts.length - 1] || trimmed;
+}
+
+/**
+ * Inline mouse TUIs that enable mouse reporting without alt-screen.
+ * Keep in sync with core-engine `is_inline_mouse_tui_command`.
+ *
+ * Grok installs as a versioned binary (`grok-0.2.103-macos-aarch64`); tmux
+ * `pane_current_command` reports that name (sometimes truncated), not `grok`.
+ */
+export function isInlineMouseTuiCommand(cmd: string): boolean {
+  const name = paneCommandBasename(cmd);
+  return name === "grok" || name.startsWith("grok-");
+}
+
+/** Whether reattach hydration should re-enable xterm mouse tracking modes. */
+export function shouldRestoreTuiMouseTracking(snapshot: Pick<
+  TerminalSnapshot,
+  "alternate" | "restore_mouse_tracking"
+>): boolean {
+  if (typeof snapshot.restore_mouse_tracking === "boolean") {
+    return snapshot.restore_mouse_tracking;
+  }
+  // Older backends only set `alternate`; keep that heuristic as fallback.
+  return snapshot.alternate === true;
+}
+
 export function buildTerminalSnapshotRestorePayload(snapshot: TerminalSnapshot): {
   payload: string;
   useAlternateScreen: boolean;
+  restoreMouseTracking: boolean;
 } {
   const useAlternateScreen = snapshot.alternate === true;
+  const restoreMouseTracking = shouldRestoreTuiMouseTracking(snapshot);
   const screenMode = useAlternateScreen ? "\x1b[?1049h" : "\x1b[?1049l";
   const clearScrollback = useAlternateScreen ? "" : "\x1b[3J";
   const clearScreen = `${screenMode}\x1b[H\x1b[2J${clearScrollback}`;
   const data = normalizeSnapshotData(snapshot.data);
   const cursorRestore = `\x1b[${snapshot.cursor_y + 1};${snapshot.cursor_x + 1}H`;
-  const mouseRestore = useAlternateScreen ? ENABLE_TUI_MOUSE_TRACKING : "";
+  const mouseRestore = restoreMouseTracking ? ENABLE_TUI_MOUSE_TRACKING : "";
 
   return {
     payload: `${clearScreen}\x1b[?7l${data}\x1b[?7h\x1b[0m${cursorRestore}${mouseRestore}`,
     useAlternateScreen,
+    restoreMouseTracking,
   };
 }
 

--- a/skills/atmos-canvas-agent/SKILL.md
+++ b/skills/atmos-canvas-agent/SKILL.md
@@ -1,91 +1,143 @@
 ---
 name: atmos-canvas-agent
-version: "1.2.1"
+version: "1.4.0"
 description: 'Drive the user''s open Atmos Canvas (tldraw whiteboard) via the `atmos canvas` CLI. Use whenever the user asks to sketch, draw, diagram, lay out, arrange, label, move, resize, recolor, or delete anything on the canvas — including architecture/flow diagrams, sticky notes, frames, geo shapes, arrows, grids of cards, or viewport changes.'
 license: MIT
 ---
 
 # Atmos Canvas Agent Skill
 
-This skill teaches agents that can run the `atmos` CLI **how** to drive the Atmos Canvas with layouts that stay stable (page-bounds math + tldraw native align/stack).
+Drive the open Atmos Canvas with **stable layouts** (absolute coordinates first,
+page-bounds math, smart lint, region screenshots).
 
 ---
 
-## Prerequisites the agent must check
+## Prerequisites (always, in order)
 
-Always probe in this order (cheaper checks first):
-
-1. **`atmos` CLI** is on `PATH` (`atmos --version`).
-2. **A live Canvas tab is registered** — run `atmos canvas status`.
-3. **Bridge is enabled** — Canvas Bot popover → **Enable bridge** ON. Mutating commands fail with `BRIDGE_DISABLED` until this is on.
+1. **`atmos` CLI** on `PATH` (`atmos --version`).
+2. **Live Canvas tab** — `atmos canvas status` (at least one accepting client).
+3. **Bridge ON** — Canvas Bot popover → **Enable bridge**. Mutating verbs fail with `BRIDGE_DISABLED` until enabled.
 
 ---
 
-## Diagram workflow (read this before drawing)
+## Quality bar (why diagrams look good)
 
-For multi-shape diagrams (feature grids, architecture maps, slide-like layouts):
+Atmos agents produce clean diagrams when they follow this contract:
 
-1. **`get-state`** — note `viewport`, shape ids/types/bounds (no terminal pane text).
-2. **Plan regions** — title band, card grid, footer. Prefer explicit `--x --y` or `place` over blind stacking.
-3. **Containers first** — `create-frame` for sections; fixed-size cards use **`create-geo`** (`rectangle`) with `--w --h --text`, not `create-note`.
-4. **Create content** — always pass coordinates, or omit **both** `x` and `y` to get staggered auto-placement (never one without the other).
-5. **Layout with native tools** (preferred over hand-tuned coordinates):
-   - `align` — line up edges/centers (`top`, `bottom`, `left`, `right`, `center-horizontal`, `center-vertical`).
-   - `stack` — horizontal/vertical row with gap.
-   - `distribute` — even spacing (needs ≥3 shapes).
-   - `layout-grid` / `layout-row` / `layout-column` — uses **page bounds**, not raw `props.w/h`.
-   - `place` — put shape B beside shape A (`--side top|bottom|left|right`, `--align start|center|end`).
-6. **Arrows last** — `create-arrow --from-id … --to-id …` so bindings survive moves.
-7. **`lint` anytime** — run after layout batches or risky edits to catch overlaps /
-   unbound arrows; fix issues and **keep working**. Do **not** send `set-status idle`
-   right after `lint` — you will call `lint` many times per turn.
-8. **`set-status --status idle`** — once, only when you are completely done with **all**
-   canvas commands for this turn (no more mutating/layout/lint planned).
+| Rule | Why |
+|------|-----|
+| **Create at final coordinates** | Never pile shapes at the same `(x,y)` hoping a later layout will fix it |
+| **Gutters ≥ 24px** | Avoid edge kissing / visual collision |
+| **Arrows use `--from-id` / `--to-id`** | Bindings survive moves |
+| **`lint` error_count = 0 before idle** | Smart lint only reports *real* card-on-card problems |
+| **Screenshot the agent region** | Verify without Atmos terminals/widgets polluting the crop |
 
-Use **`apply`** to batch up to 32 mutating steps in one HTTP round-trip when building many shapes.
+---
+
+## Diagram workflow
+
+### 1. Plan regions (page space)
+
+Example bands for a product intro / architecture slide:
+
+```text
+title:   y = 0    .. 80     full width
+body:    y = 120  .. …      cards, gap 24, col_w ~ 300–340
+footer:  y = body_bottom+48
+gutter:  24–40 between cards
+```
+
+Prefer **`set-agent-view --x --y --w --h`** once at the start so later `screenshot --use-agent-view` crops exactly that board.
+
+### 2. Create content (absolute coords preferred)
+
+- Fixed cards / labels → **`create-geo`** (`rectangle`) with `--w --h --text --x --y`
+- Sticky notes → **`create-note`** (auto height; no `--h`)
+- Section boxes → **`create-frame`**
+- **Always pass both `--x` and `--y`, or omit both** (never only one)
+- If you omit both, the bus **collision-spawns** (non-overlapping). Still prefer explicit coords for multi-shape diagrams.
+
+### 3. Layout polish (optional)
+
+After creates with real positions, refine with:
+
+- `align` / `stack` / `distribute`
+- `layout-row` / `layout-column` / `layout-grid` (page bounds)
+- `place` (relative to another shape)
+
+### 4. Arrows last
+
+```bash
+atmos canvas create-arrow --from-id "$A" --to-id "$B" --text "next"
+```
+
+### 5. Lint → fix → lint
+
+```bash
+atmos canvas lint --fix-suggestions
+# Apply every remediable error via suggested `move` / `update_shape` commands
+# warn unbound_arrow: fix for diagrams; OK for decorative strokes
+```
+
+`fix_suggestions[]` entries are CLI-ready:
+
+```json
+{
+  "command": "move",
+  "args": { "ids": ["shape:…"], "dx": 48, "dy": 0 },
+  "reason": "Separate shape:a and shape:b by moving the latter (dx=48)."
+}
+```
+
+Replay with `atmos canvas move --ids … --dx … --dy …` or batch via `apply`.
+
+### 6. Screenshot verify (agent region only)
+
+```bash
+# After set-agent-view for the drawing board:
+atmos canvas screenshot --use-agent-view --out /tmp/canvas-verify.jpg
+
+# Or crop to specific shapes you created:
+atmos canvas screenshot --ids "$ID1,$ID2,$ID3" --out /tmp/canvas-verify.jpg
+```
+
+A successful `screenshot` also shows a **thumbnail on the Canvas Agent Island**
+(bottom-right). Click it to enlarge. Prefer `--use-agent-view` so the island
+preview matches the agent board.
+
+**Chrome exclusion (default):** `canvas-terminal` and `canvas-widget` are **not** included, so remote terminals / workspace widgets do not pollute the JPEG. Pass `--include-widgets` only if you truly need them.
+
+### 7. End the turn
+
+```bash
+atmos canvas set-status --status idle
+```
+
+`set-status idle` returns `lints_summary` and `ready_to_idle`.  
+**If `ready_to_idle` is false / `error_count > 0`, keep fixing — do not stop.**
 
 ---
 
 ## Command reference
 
-CLI form: `atmos canvas <verb> [--flags…]`
+CLI: `atmos canvas <verb> [--flags…]`
 
 ```json
 { "ok": true,  "request_id": "<uuid>", "data": { … } }
-{ "ok": false, "request_id": "<uuid>", "error": { "code": "STABLE_CODE", "message": "human text", "recoverable": true } }
+{ "ok": false, "request_id": "<uuid>", "error": { "code": "…", "message": "…", "recoverable": true } }
 ```
 
 ### Diagnostics & read
 
 | Verb | Args | Notes |
 |------|------|-------|
-| `status` | — | Registered tabs + bridge state. |
-| `get-state` | `--page-id` (optional) | `canvas_agent_state.v1` + per-shape `bounds` + `lints` (no terminal pane text). |
-| `extract-text` | `--ids` (optional), `--older-offset` (terminals) | On-demand text for any shape (notes, geo, **terminals via tmux capture**, …). Uses selection when `--ids` omitted. |
-| `lint` | — | Overlap + unbound-arrow report only. Safe to call repeatedly mid-turn. |
+| `status` | — | Registered tabs + bridge state |
+| `get-state` | `--page-id` optional | Shapes + **`bounds`** + **`text_preview`** + `lints` + `lints_summary` |
+| `extract-text` | `--ids` optional | Full text / terminal tmux capture |
+| `lint` | `--fix-suggestions` | Smart lints + `summary`; with flag, also `fix_suggestions[]` |
+| `screenshot` | see below | JPEG of agent region (excludes Atmos chrome); Island thumb preview |
 
-**Do not expect shape text in `get-state`.** When you need content, call `extract-text --ids <id>` (comma-separated) or select shapes and run `extract-text` with no args. Terminal shapes return metadata plus a tmux pane snapshot; line count is capped by the user’s Canvas setting **Terminal context lines** (default 300).
-
-**Terminal pagination:** Each terminal entry may include `terminal_page`:
-
-```json
-"terminal_page": {
-  "skip_lines": 0,
-  "lines_returned": 300,
-  "has_more_older": true,
-  "next_older_offset": 300
-}
-```
-
-When `has_more_older` is true and you still need earlier output, call again with `--older-offset <next_older_offset>` (same `--ids`). Repeat until `has_more_older` is false.
-
-Each shape in `get-state` may include:
-
-```json
-"bounds": { "min_x": 80, "min_y": 80, "w": 200, "h": 120 }
-```
-
-Use **`bounds`** for spacing math — not `props.w/h` on notes or arrows.
+`get-state` **includes** `text_preview` for notes/geo/frames (not terminal pane text). Use it for layout math. Use `extract-text` for full terminal scrollback.
 
 ### Create
 
@@ -94,13 +146,21 @@ Use **`bounds`** for spacing math — not `props.w/h` on notes or arrows.
 | `create-note` | `--text` | `--x --y --w --color` (**no `--h`**) |
 | `create-frame` | `--w --h` | `--title --x --y` |
 | `create-geo` | `--kind --w --h` | `--x --y --text --color --fill --size` |
-| `create-arrow` | coords **or** bindings | `--x1 --y1 --x2 --y2 --from-id --to-id --color --size --text` |
-| `create-draw` | `--points` or `--points-file` | `--color --size --closed` |
+| `create-arrow` | coords **or** bindings | `--from-id --to-id --x1 --y1 --x2 --y2 --color --size --text` |
+| `create-draw` | `--points` | `--color --size --closed` |
 
-- **Sticky notes** (`create-note`): auto-height; width via `--w` → internal `scale`. For fixed card boxes with labels, use **`create-geo --kind rectangle`**.
-- **Readable text / code blocks**: prefer **`create-geo --text`** or **`create-note --text`** (selectable, wraps). `create-draw` is for strokes/sketches only.
-- **Colors** (geo/arrow/draw): `black`, `grey`, `light-violet`, `violet`, `blue`, `light-blue`, `yellow`, `orange`, `green`, `light-green`, `light-red`, `red`, `white`. Do **not** invent tokens like `light-orange` (use `orange`).
-- **Arrows**: For diagrams, always pass `--from-id` and `--to-id`. Coordinates are optional when bindings resolve shape centers.
+Create responses include:
+
+```json
+{
+  "id": "shape:…",
+  "type": "geo",
+  "bounds": { "min_x": 0, "min_y": 0, "w": 220, "h": 120 },
+  "warnings": ["text_may_overflow"]
+}
+```
+
+If `warnings` contains `text_may_overflow`, increase `--h`/`--w` or shorten text immediately.
 
 ### Selection & transform
 
@@ -111,130 +171,104 @@ Use **`bounds`** for spacing math — not `props.w/h` on notes or arrows.
 | `move` | `--ids … --dx --dy` |
 | `delete` | `--ids … --confirm` |
 
-### Layout (prefer these over manual x/y)
+### Layout
 
 | Verb | Args |
 |------|------|
 | `align` | `--ids … --alignment top\|bottom\|left\|right\|center-horizontal\|center-vertical` |
 | `stack` | `--ids … --direction horizontal\|vertical [--gap 24]` |
-| `distribute` | `--ids … --direction horizontal\|vertical` (≥3 ids) |
-| `place` | `--id … --reference-id … --side … [--align center] [--side-offset 0] [--align-offset 0]` |
-| `layout-row` | `--ids … [--gap 24] [--y pin]` |
-| `layout-column` | `--ids … [--gap 24] [--x pin]` |
-| `layout-grid` | `--ids … --cols n --rows n [--gap 24]` |
+| `distribute` | `--ids … --direction horizontal\|vertical` (≥3) |
+| `place` | `--id … --reference-id … --side … [--align center]` |
+| `layout-row` / `layout-column` / `layout-grid` | page-bounds packing |
 
-`layout-*` commands position shapes by **visible page bounds** (works for notes, geo, frames).
-
-### Agent view frame
+### Agent view & screenshot
 
 | Verb | Args |
 |------|------|
-| `set-agent-view` | `--x --y --w --h` **or** `--center-ids <id,…>` `[--padding 48]` `[--zoom]` |
-
-Sets the dashed **Agent view** rectangle precisely (like official `setMyView`). Prefer this before laying out a diagram region, then `apply` creates inside that area.
+| `set-agent-view` | `--x --y --w --h` **or** `--center-ids …` `[--padding 48]` `[--zoom]` |
+| `screenshot` | `--use-agent-view` **or** `--ids …` **or** `--x --y --w --h` · `--size small\|medium\|large` · `--out path` · `--include-widgets` |
 
 ```bash
-atmos canvas set-agent-view --x 0 --y 0 --w 900 --h 520 --padding 32
-atmos canvas set-agent-view --center-ids "$TITLE_ID,$CARD1,$CARD2" --zoom
+atmos canvas set-agent-view --x 0 --y 0 --w 1100 --h 900 --padding 32
+# … create shapes inside that board …
+atmos canvas screenshot --use-agent-view --size medium --out /tmp/verify.jpg
 ```
 
-### Session status
+### Session
 
 | Verb | Args |
 |------|------|
-| `set-status` | `--status idle\|active` (default `idle`) |
+| `set-status` | `--status idle\|active` |
 
-Send **`set-status --status idle` exactly once** at the end of the turn — after
-you have finished every canvas command (including any final `lint` / `get-state`
-you choose to run). Never pair `idle` with an intermediate `lint`.
-
-Use `--status active` only when you are waiting on the user and have no further
-canvas commands until they reply; follow with `idle` when you resume or finish.
-
-```bash
-# … create, layout, lint (as needed), more edits …
-atmos canvas set-status --status idle
-```
+Send **`idle` exactly once** when the whole canvas turn is finished (after final lint/screenshot). Never pair `idle` with a mid-turn lint.
 
 ### Batch
 
 | Verb | Args |
 |------|------|
-| `apply` | `--commands '<json array>'` or `--commands-file path` |
+| `apply` | `--commands '<json>'` or `--commands-file` · **max 64 steps** |
 
-Example:
-
-```json
-[
-  { "command": "create_geo", "args": { "kind": "rectangle", "w": 220, "h": 140, "text": "API", "x": 0, "y": 0 } },
-  { "command": "create_geo", "args": { "kind": "rectangle", "w": 220, "h": 140, "text": "DB", "x": 280, "y": 0 } },
-  { "command": "align", "args": { "ids": ["shape:a", "shape:b"], "alignment": "top" } }
-]
-```
-
-Stops on first failure; response includes `partial: true` and `failed_at` index.
-
-### Update & viewport
-
-- `update-shape --id … --patch '<json>'` — allow-listed keys only; notes reject `h`.
-- `viewport [--zoom] [--pan-x] [--pan-y] [--center-ids …]`
+Collect ids from `data.results[i].data.id` after apply.
 
 ---
 
-## Argument value conventions
-
-tldraw **named tokens** only (no hex/CSS):
-
-- `--color`: `black`, `grey`, `light-violet`, `violet`, `blue`, `light-blue`, `yellow`, `orange`, `green`, `light-green`, `light-red`, `red`, `white`
-- `--fill`: `none`, `semi`, `solid`, `pattern`, `fill`, `lined-fill`
-- `--size`: `s`, `m`, `l`, `xl`
-- `--font` (`update-shape`): `draw`, `sans`, `serif`, `mono`
-
----
-
-## Example: title + 3×2 feature grid (geo cards)
+## Good example: title + 3×2 grid (final coords)
 
 ```bash
+atmos canvas set-agent-view --x 0 --y 0 --w 760 --h 420 --padding 24
+
 atmos canvas apply --commands '[
-  {"command":"create_geo","args":{"kind":"rectangle","w":720,"h":64,"text":"tldraw 5.0","x":0,"y":0,"color":"blue","fill":"solid"}},
+  {"command":"create_geo","args":{"kind":"rectangle","w":720,"h":64,"text":"Product","x":0,"y":0,"color":"black","fill":"semi"}},
   {"command":"create_geo","args":{"kind":"rectangle","w":220,"h":120,"text":"Feature 1","x":0,"y":96,"color":"light-blue","fill":"semi"}},
-  {"command":"create_geo","args":{"kind":"rectangle","w":220,"h":120,"text":"Feature 2","x":0,"y":96,"color":"light-green","fill":"semi"}},
-  {"command":"create_geo","args":{"kind":"rectangle","w":220,"h":120,"text":"Feature 3","x":0,"y":96,"color":"yellow","fill":"semi"}},
-  {"command":"create_geo","args":{"kind":"rectangle","w":220,"h":120,"text":"Feature 4","x":0,"y":96,"color":"orange","fill":"semi"}},
-  {"command":"create_geo","args":{"kind":"rectangle","w":220,"h":120,"text":"Feature 5","x":0,"y":96,"color":"violet","fill":"semi"}},
-  {"command":"create_geo","args":{"kind":"rectangle","w":220,"h":120,"text":"Feature 6","x":0,"y":96,"color":"light-red","fill":"semi"}}
+  {"command":"create_geo","args":{"kind":"rectangle","w":220,"h":120,"text":"Feature 2","x":244,"y":96,"color":"light-green","fill":"semi"}},
+  {"command":"create_geo","args":{"kind":"rectangle","w":220,"h":120,"text":"Feature 3","x":488,"y":96,"color":"yellow","fill":"semi"}},
+  {"command":"create_geo","args":{"kind":"rectangle","w":220,"h":120,"text":"Feature 4","x":0,"y":240,"color":"orange","fill":"semi"}},
+  {"command":"create_geo","args":{"kind":"rectangle","w":220,"h":120,"text":"Feature 5","x":244,"y":240,"color":"violet","fill":"semi"}},
+  {"command":"create_geo","args":{"kind":"rectangle","w":220,"h":120,"text":"Feature 6","x":488,"y":240,"color":"light-red","fill":"semi"}}
 ]'
-# Then layout-grid with ids from the apply response, or cache ids from a follow-up get-state:
-atmos canvas layout-grid --ids "$IDS" --cols 3 --rows 2 --gap 24
-atmos canvas align --ids "$IDS" --alignment center-horizontal
-atmos canvas lint
-# … fix any lints, then when the whole turn is done:
+
+atmos canvas lint --fix-suggestions
+# optional: apply fix_suggestions via move / update-shape, then lint again
+atmos canvas screenshot --use-agent-view --out /tmp/grid.jpg
 atmos canvas set-status --status idle
 ```
 
+**Do not** create six cards at the same `x,y` then rely on `layout-grid` alone — if id collection fails, the board stays piled.
+
 ---
 
-## Idempotency
+## Lint semantics (smart)
 
-| Verb | Safe to retry? |
-|------|----------------|
-| `create-*` | ❌ duplicates — check `get-state` after timeout |
-| `move` | ❌ deltas stack |
-| `update-shape`, `layout-*`, `align`, `stack`, `distribute`, `place` | ✅ |
-| `apply` | ❌ if partial — inspect `failed_at` before retrying whole batch |
+| type | severity | Meaning |
+|------|----------|---------|
+| `overlap` | error | Two **content** shapes collide (not parent/child, not containment). Arrows / frames / Atmos chrome ignored. |
+| `text_overflow` | error if collides, else warn | Geo label likely exceeds box |
+| `unbound_arrow` | warn | Missing start/end binding |
+
+`summary.clean === true` means **zero errors** (warns OK).
 
 ---
 
 ## Anti-patterns
 
-- ❌ Guessing pixel coordinates for every card when `layout-grid` + `align` exist.
-- ❌ `create-note` for fixed-size labeled boxes (use `create-geo`).
-- ❌ `create-note --h` (rejected).
-- ❌ Free-floating arrows in diagrams (use `--from-id` / `--to-id`).
-- ❌ Ignoring `lints` / overlaps when `lint` reports them.
-- ❌ `set-status --status idle` immediately after `lint` (lint is mid-turn; `idle` is turn-end only).
-- ❌ CSS / hex colors.
-- ❌ Retrying `create-*` or `move` blindly after `RELAY_TIMEOUT`.
+- ❌ Same `(x,y)` for many shapes “then layout later”
+- ❌ Ignoring `lints_summary.error_count` and still sending `idle`
+- ❌ `create-note` for fixed-size labeled cards (use `create-geo`)
+- ❌ Free-floating diagram arrows (use bindings)
+- ❌ Guessing CSS/hex colors (tldraw tokens only)
+- ❌ Retrying `create-*` after `RELAY_TIMEOUT` without `get-state`
+- ❌ Screenshot of full page with terminals/widgets when verifying a diagram (use `--use-agent-view` / `--ids`)
+- ❌ `set-status idle` right after an intermediate `lint`
+
+---
+
+## Colors / style tokens
+
+- `--color`: `black`, `grey`, `light-violet`, `violet`, `blue`, `light-blue`, `yellow`, `orange`, `green`, `light-green`, `light-red`, `red`, `white`
+- `--fill`: `none`, `semi`, `solid`, `pattern`, `fill`, `lined-fill`
+- `--size`: `s`, `m`, `l`, `xl`
+
+Do **not** invent tokens like `light-orange` (use `orange`).
 
 ---
 
@@ -245,5 +279,5 @@ atmos canvas set-status --status idle
 | `CANVAS_BRIDGE_OFFLINE` | Open Canvas tab |
 | `BRIDGE_DISABLED` | Enable bridge in Bot popover |
 | `STALE_SHAPE_ID` | `get-state` and refresh ids |
-| `VALIDATION_ARG` | Fix args (see error message) |
-| `RELAY_TIMEOUT` | Retry after `get-state` |
+| `VALIDATION_ARG` | Fix args (see message) |
+| `RELAY_TIMEOUT` | `get-state` then retry carefully |


### PR DESCRIPTION
## Summary

Improve Atmos Canvas agent drawing quality and operator UX:

- **Smart lint**: content-only overlap detection (skip arrows/frames/chrome), text overflow, unbound-arrow warnings, and `lint --fix-suggestions` with CLI-ready `move` / `update_shape` fixes
- **Collision-aware spawn**: stop stacking default 200×200 shapes on a too-small grid
- **Region screenshot**: `atmos canvas screenshot` crops the agent-drawn area (excludes terminal/widget chrome); skill **v1.4.0** documents the workflow
- **Agent Follow**: popover toggle to pan/zoom to agent-touched shapes (default on; turn off when drawing nearby)
- **Shape pulse**: reuse `CanvasFocusPulse` when the agent mutates shapes
- **Island UX**: `TextShimmer` for working status; screenshot rows use Camera icon + thumbnail after the title; click opens `ImagePreviewOverlay` without closing the island popover

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] `bun test` canvas-agent unit tests (lint / spawn / feed)
- [x] `cargo check -p atmos`
- [x] Local CLI install smoke (`screenshot` / `lint --fix-suggestions` help)

## Checklist

- [x] I updated documentation if behavior changed (`skills/atmos-canvas-agent` v1.4.0)
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

## Notes

- Restart API/Desktop to sync system skill (version-based update to `~/.atmos/skills/.system/atmos-canvas-agent/`)
- CLI binary must be rebuilt for new subcommands (`screenshot`, `lint --fix-suggestions`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Canvas agent diagram quality and verification UX with smart lint, collision-aware spawn, region screenshots with preview, and an optional Agent Follow mode; also restores TUI mouse tracking after terminal reattach for Grok/alt-screen panes. Rebuild the CLI and restart API/Desktop to sync `atmos-canvas-agent` v1.4.0; new `agentFollow` pref defaults on.

- **New Features**
  - Smart lint: content-only overlap checks, text overflow, and unbound-arrow warnings; `lint --fix-suggestions` returns CLI-ready `move`/`update_shape`; state includes `lints_summary`.
  - Collision-aware spawn: finds non-overlapping positions and better estimates sticky-note height.
  - Region screenshots: `atmos canvas screenshot` crops to agent-drawn shapes, validates bounds and current page, honors `include_widgets`, returns `shape_ids`, and shows a thumbnail in the feed (rows are not merged).
  - Agent Follow toggle: auto pan/zoom to agent-touched shapes; pulse timing aligned with CanvasFocusPulse.
  - Increased apply capacity: `MAX_APPLY_STEPS` raised to 64.
  - CLI: `lint` accepts args; added `screenshot`.

- **Bug Fixes**
  - Terminal: restore TUI mouse tracking after reattach for alternate-screen panes and known inline mouse TUIs (Grok); keep wheel scrollback for other processes.
  - Canvas feed/screenshots: clear stale thumbs on request ID reuse, keep each screenshot row separate with its own thumb, and filter explicit `shape_ids` to the captured region.

<sup>Written for commit 55974deaa6ef094195150ab8ad3c073a0980cded. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Canvas screenshots with region selection, sizing options, previews, and optional file export.
  * Added richer canvas linting for overlaps, text overflow, and unbound arrows, including fix suggestions and summaries.
  * Added an “Follow Agent” control for camera tracking and improved agent activity highlighting.
  * Improved shape placement to avoid overlapping existing content.
  * Added screenshot previews and clearer activity indicators to the Canvas Agent panel.

* **Bug Fixes**
  * Prevented screenshot previews from closing unexpectedly.
  * Improved text-overflow warnings and screenshot activity handling.

* **Documentation**
  * Updated Canvas Agent guidance for linting, screenshots, layouts, and workflow limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->