### PR TITLE
fix(skills): parse YAML block scalar descriptions in frontmatter

### DIFF
--- a/apps/api/src/api/system/skills.rs
+++ b/apps/api/src/api/system/skills.rs
@@ -3,7 +3,12 @@ use tokio::fs;
 
 const DEFAULT_BEST_FOR: &str = "Code review tasks configured in system skills";
 
-/// Parse field from YAML frontmatter (standard single-line format)
+/// Parse a scalar field from YAML frontmatter.
+///
+/// Supports:
+/// - plain / quoted single-line values: `description: "hello"`
+/// - folded block scalars: `description: >-` / `>` / `>+` (continuation lines joined with spaces)
+/// - literal block scalars: `description: |` / `|-` / `|+` (newlines preserved)
 fn parse_frontmatter_field(content: &str, field: &str) -> Option<String> {
     // Find frontmatter block
     let content = content.trim_start();
@@ -12,17 +17,54 @@ fn parse_frontmatter_field(content: &str, field: &str) -> Option<String> {
     let frontmatter = &rest[..second_dash];
     let field_with_colon = format!("{field}:");
 
-    // Look for field: "value" or field: value
-    for line in frontmatter.lines() {
-        let trimmed = line.trim();
-        if let Some(rest) = trimmed.strip_prefix(&field_with_colon) {
-            let rest = rest.trim();
-            if !rest.is_empty() {
-                return Some(rest.trim_matches('"').trim_matches('\'').to_string());
+    let lines: Vec<&str> = frontmatter.lines().collect();
+    let mut i = 0;
+    while i < lines.len() {
+        let trimmed = lines[i].trim();
+        if let Some(value) = trimmed.strip_prefix(&field_with_colon) {
+            let val = value.trim();
+
+            // YAML block scalars: `>`, `>-`, `>+`, `|`, `|-`, `|+`
+            if is_yaml_block_scalar_indicator(val) {
+                let folded = val.starts_with('>');
+                let mut collected = Vec::new();
+                i += 1;
+                while i < lines.len() {
+                    let line = lines[i];
+                    // Block content is indented or blank; the next top-level key ends it.
+                    if line.is_empty() || line.starts_with(' ') || line.starts_with('\t') {
+                        collected.push(line.trim());
+                        i += 1;
+                    } else {
+                        break;
+                    }
+                }
+                let joined = if folded {
+                    collected
+                        .into_iter()
+                        .filter(|s| !s.is_empty())
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                } else {
+                    collected.join("\n").trim().to_string()
+                };
+                if !joined.is_empty() {
+                    return Some(joined);
+                }
+                continue;
+            }
+
+            if !val.is_empty() {
+                return Some(val.trim_matches('"').trim_matches('\'').to_string());
             }
         }
+        i += 1;
     }
     None
+}
+
+fn is_yaml_block_scalar_indicator(val: &str) -> bool {
+    matches!(val, ">" | ">-" | ">+" | "|" | "|-" | "|+")
 }
 
 /// Scan the code_review_skills directory and return structured skill metadata.
@@ -376,6 +418,48 @@ bestForExtended: "Do not use this either"
 
         assert_eq!(parse_frontmatter_field(content, "description"), None);
         assert_eq!(parse_frontmatter_field(content, "bestFor"), None);
+    }
+
+    #[test]
+    fn parses_folded_block_scalar_description() {
+        let content = r#"---
+name: demo-skill
+description: >-
+  Expert reviewer for multi-line
+  skill descriptions and best practices.
+bestFor: >-
+  Large PRs across
+  frontend and backend.
+---
+
+# Skill
+"#;
+
+        assert_eq!(
+            parse_frontmatter_field(content, "description"),
+            Some("Expert reviewer for multi-line skill descriptions and best practices.".to_string())
+        );
+        assert_eq!(
+            parse_frontmatter_field(content, "bestFor"),
+            Some("Large PRs across frontend and backend.".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_literal_block_scalar_description() {
+        let content = r#"---
+description: |
+  line one
+  line two
+---
+
+# Skill
+"#;
+
+        assert_eq!(
+            parse_frontmatter_field(content, "description"),
+            Some("line one\nline two".to_string())
+        );
     }
 
     #[test]

--- a/apps/web/src/features/wiki/lib/__tests__/wiki-frontmatter.test.ts
+++ b/apps/web/src/features/wiki/lib/__tests__/wiki-frontmatter.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+import { parseFrontmatter } from "../wiki-utils";
+
+describe("parseFrontmatter", () => {
+  it("parses plain single-line fields", () => {
+    const md = `---
+title: Hello Wiki
+level: beginner
+reading_time: 5
+---
+
+# Body
+`;
+    const { frontmatter, body } = parseFrontmatter(md);
+    expect(frontmatter.title).toBe("Hello Wiki");
+    expect(frontmatter.level).toBe("beginner");
+    expect(frontmatter.reading_time).toBe("5");
+    expect(body).toContain("# Body");
+  });
+
+  it("parses folded block scalar title (>-)", () => {
+    const md = `---
+title: >-
+  A multi-line wiki title
+  that should fold into one line
+section: getting-started
+level: intermediate
+---
+
+# Content
+`;
+    const { frontmatter } = parseFrontmatter(md);
+    expect(frontmatter.title).toBe(
+      "A multi-line wiki title that should fold into one line",
+    );
+    expect(frontmatter.section).toBe("getting-started");
+  });
+
+  it("parses literal block scalar (|) keeping newlines", () => {
+    const md = `---
+title: |
+  line one
+  line two
+level: advanced
+---
+
+body
+`;
+    const { frontmatter } = parseFrontmatter(md);
+    expect(frontmatter.title).toBe("line one\nline two");
+  });
+
+  it("parses multi-line sources list", () => {
+    const md = `---
+title: Sources page
+sources:
+  - src/a.ts
+  - src/b.ts
+level: beginner
+---
+
+# Body
+`;
+    const { frontmatter } = parseFrontmatter(md);
+    expect(frontmatter.sources).toEqual(["src/a.ts", "src/b.ts"]);
+  });
+
+  it("does not treat block indicator as the field value", () => {
+    const md = `---
+title: >-
+  Real title text
+---
+
+body
+`;
+    const { frontmatter } = parseFrontmatter(md);
+    expect(frontmatter.title).not.toBe(">-");
+    expect(frontmatter.title).toBe("Real title text");
+  });
+});

--- a/apps/web/src/features/wiki/lib/wiki-utils.ts
+++ b/apps/web/src/features/wiki/lib/wiki-utils.ts
@@ -251,6 +251,51 @@ export interface ParsedFrontmatter {
   [key: string]: unknown;
 }
 
+const YAML_BLOCK_SCALAR = /^(?:>|>-|>+|\||\|-|\|+)$/;
+
+function stripYamlQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function isYamlBlockContinuation(line: string): boolean {
+  return line === "" || line.startsWith(" ") || line.startsWith("\t");
+}
+
+/**
+ * Parse YAML-like frontmatter scalars, including folded (`>`, `>-`) and literal
+ * (`|`, `|-`) block scalars. Without this, `title: >-` would surface as `>-`.
+ */
+function parseYamlScalarLines(lines: string[], startIndex: number, rawValue: string): {
+  value: string;
+  nextIndex: number;
+} {
+  const indicator = rawValue.trim();
+  if (YAML_BLOCK_SCALAR.test(indicator)) {
+    const folded = indicator.startsWith(">");
+    const collected: string[] = [];
+    let i = startIndex + 1;
+    while (i < lines.length) {
+      const line = lines[i];
+      if (!isYamlBlockContinuation(line)) break;
+      collected.push(line.trim());
+      i += 1;
+    }
+    const value = folded
+      ? collected.filter(Boolean).join(" ")
+      : collected.join("\n").trim();
+    return { value, nextIndex: i };
+  }
+
+  return { value: stripYamlQuotes(rawValue), nextIndex: startIndex + 1 };
+}
+
 export function parseFrontmatter(markdown: string): {
   frontmatter: ParsedFrontmatter;
   body: string;
@@ -262,26 +307,66 @@ export function parseFrontmatter(markdown: string): {
   const [, raw, body] = match;
   const frontmatter: ParsedFrontmatter = {};
   if (raw) {
-    for (const line of raw.split(/\r?\n/)) {
+    const lines = raw.split(/\r?\n/);
+    let i = 0;
+    while (i < lines.length) {
+      const line = lines[i];
       const keyMatch = line.match(/^([a-z_]+):\s*(.*)$/);
-      if (keyMatch) {
-        const key = keyMatch[1];
-        const val = keyMatch[2].trim();
-        if (val.startsWith("[") && val.endsWith("]")) {
-          try {
-            (frontmatter as Record<string, unknown>)[key] = JSON.parse(val);
-          } catch {
-            (frontmatter as Record<string, unknown>)[key] = val;
+      if (!keyMatch) {
+        i += 1;
+        continue;
+      }
+
+      const key = keyMatch[1];
+      const rawVal = keyMatch[2].trim();
+
+      if (key === "sources") {
+        // Multi-line list: sources:\n  - a\n  - b
+        // Inline list: sources: ["a", "b"] or sources: []
+        if (!rawVal || rawVal === "[]") {
+          const items: string[] = [];
+          let j = i + 1;
+          while (j < lines.length) {
+            const itemLine = lines[j];
+            const itemMatch = itemLine.match(/^\s+-\s+(.+)$/);
+            if (!itemMatch) break;
+            items.push(itemMatch[1].trim().replace(/^['"]|['"]$/g, ""));
+            j += 1;
           }
-        } else if (val) {
-          (frontmatter as Record<string, unknown>)[key] = val;
+          if (items.length > 0) {
+            frontmatter.sources = items;
+          } else if (rawVal === "[]") {
+            frontmatter.sources = [];
+          }
+          i = j;
+          continue;
+        }
+        if (rawVal.startsWith("[") && rawVal.endsWith("]")) {
+          try {
+            frontmatter.sources = JSON.parse(rawVal) as string[];
+          } catch {
+            frontmatter.sources = [rawVal];
+          }
+          i += 1;
+          continue;
         }
       }
-    }
-    const sourcesMatch = raw.match(/sources:\r?\n((?:\s+-\s+[^\n]+\r?\n?)+)/);
-    if (sourcesMatch) {
-      const items = sourcesMatch[1].match(/-\s+(.+)/g)?.map((s) => s.replace(/^-\s+/, "").trim()) ?? [];
-      frontmatter.sources = items;
+
+      if (rawVal.startsWith("[") && rawVal.endsWith("]")) {
+        try {
+          (frontmatter as Record<string, unknown>)[key] = JSON.parse(rawVal);
+        } catch {
+          (frontmatter as Record<string, unknown>)[key] = rawVal;
+        }
+        i += 1;
+        continue;
+      }
+
+      const { value, nextIndex } = parseYamlScalarLines(lines, i, rawVal);
+      if (value) {
+        (frontmatter as Record<string, unknown>)[key] = value;
+      }
+      i = nextIndex;
     }
   }
   return { frontmatter, body };

--- a/crates/core-service/src/service/skill/metadata.rs
+++ b/crates/core-service/src/service/skill/metadata.rs
@@ -62,17 +62,107 @@ pub(super) fn strip_frontmatter(content: &str) -> (&str, Option<&str>) {
 }
 
 pub(super) fn extract_from_frontmatter(frontmatter: &str, field: &str) -> Option<String> {
-    for line in frontmatter.lines() {
-        let trimmed = line.trim();
+    let lines: Vec<&str> = frontmatter.lines().collect();
+    let mut i = 0;
+    while i < lines.len() {
+        let trimmed = lines[i].trim();
         if let Some(rest) = trimmed.strip_prefix(field) {
             if let Some(value) = rest.strip_prefix(':') {
                 let val = value.trim();
+
+                // YAML block scalars: `>`, `>-`, `>+`, `|`, `|-`, `|+`
+                // Folded (`>`) joins continuation lines with spaces; literal (`|`) keeps newlines.
+                // Without this, `description: >-` would surface as the literal string `>-`.
+                if is_yaml_block_scalar_indicator(val) {
+                    let folded = val.starts_with('>');
+                    let mut collected = Vec::new();
+                    i += 1;
+                    while i < lines.len() {
+                        let line = lines[i];
+                        // Block content is indented or blank; the next top-level key ends it.
+                        if line.is_empty() || line.starts_with(' ') || line.starts_with('\t') {
+                            collected.push(line.trim());
+                            i += 1;
+                        } else {
+                            break;
+                        }
+                    }
+                    let joined = if folded {
+                        collected
+                            .into_iter()
+                            .filter(|s| !s.is_empty())
+                            .collect::<Vec<_>>()
+                            .join(" ")
+                    } else {
+                        collected.join("\n").trim().to_string()
+                    };
+                    if !joined.is_empty() {
+                        return Some(joined);
+                    }
+                    continue;
+                }
+
                 let val = val.trim_matches('"').trim_matches('\'');
                 if !val.is_empty() {
                     return Some(val.to_string());
                 }
             }
         }
+        i += 1;
     }
     None
+}
+
+fn is_yaml_block_scalar_indicator(val: &str) -> bool {
+    matches!(val, ">" | ">-" | ">+" | "|" | "|-" | "|+")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_plain_description() {
+        let fm = "name: demo\ndescription: Hello world\nversion: \"1.0\"";
+        assert_eq!(
+            extract_from_frontmatter(fm, "description").as_deref(),
+            Some("Hello world")
+        );
+    }
+
+    #[test]
+    fn extracts_quoted_description() {
+        let fm = "description: \"Drive canvas via CLI\"\n";
+        assert_eq!(
+            extract_from_frontmatter(fm, "description").as_deref(),
+            Some("Drive canvas via CLI")
+        );
+    }
+
+    #[test]
+    fn extracts_folded_block_scalar_description() {
+        let fm = "name: atmos-canvas-agent\ndescription: >-\n  Drive the user's open Atmos Canvas via CLI:\n  diagrams, layout, and screenshots.\nlicense: MIT\n";
+        assert_eq!(
+            extract_from_frontmatter(fm, "description").as_deref(),
+            Some("Drive the user's open Atmos Canvas via CLI: diagrams, layout, and screenshots.")
+        );
+    }
+
+    #[test]
+    fn extracts_literal_block_scalar_description() {
+        let fm = "description: |\n  line one\n  line two\n";
+        assert_eq!(
+            extract_from_frontmatter(fm, "description").as_deref(),
+            Some("line one\nline two")
+        );
+    }
+
+    #[test]
+    fn extract_description_prefers_frontmatter_over_body() {
+        let content = "---\nname: x\ndescription: >-\n  Folded frontmatter desc\n  continues here.\n---\n\n# Title\n\nBody paragraph should not win.\n";
+        assert_eq!(
+            extract_description(content),
+            "Folded frontmatter desc continues here."
+        );
+    }
 }

--- a/skills/atmos-canvas-agent/SKILL.md
+++ b/skills/atmos-canvas-agent/SKILL.md
@@ -1,12 +1,7 @@
 ---
 name: atmos-canvas-agent
 version: "2.3.0"
-description: >-
-  Drive the user's open Atmos Canvas via `atmos canvas` CLI: diagrams, layout,
-  screenshots, local .atmos.tldr documents, and (when needed) durable document
-  scripts or one-shot exec. Use for sketch/draw/diagram/layout requests, and
-  for interactive surfaces or clickable UI only when the user asks for that
-  behavior.
+description: "Drive the user's open Atmos Canvas via `atmos canvas` CLI: diagrams, layout, screenshots, local .atmos.tldr documents, and (when needed) durable document scripts or one-shot exec. Use for sketch/draw/diagram/layout requests, and for interactive surfaces or clickable UI only when the user asks for that behavior."
 license: MIT
 ---
 

--- a/skills/project-wiki/scripts/validate_frontmatter.py
+++ b/skills/project-wiki/scripts/validate_frontmatter.py
@@ -56,53 +56,78 @@ def parse_frontmatter(content: str) -> tuple[dict | None, str | None, str]:
     yaml_block = match.group(1).strip()
     body = rest[match.end() :].lstrip("\n")
 
-    # Simple YAML parsing (no PyYAML dependency)
+    # Simple YAML parsing (no PyYAML dependency). Supports:
+    # - plain / quoted single-line scalars
+    # - folded block scalars: >, >-, >+
+    # - literal block scalars: |, |-, |+
+    # - sources lists (inline or multi-line)
     frontmatter: dict = {}
-    in_sources = False
-    sources: list[str] = []
+    lines = yaml_block.split("\n")
+    i = 0
+    block_indicators = {">", ">-", ">+", "|", "|-", "|+"}
 
-    for line in yaml_block.split("\n"):
-        if in_sources:
-            if line.strip().startswith("-"):
-                item = line.strip()[1:].strip().strip("'\"")
-                sources.append(item)
-            else:
-                frontmatter["sources"] = sources
-                in_sources = False
-                # Parse current line as key: value (e.g. updated_at: ...)
-                colon_idx = line.find(":")
-                if colon_idx > 0 and not line[:colon_idx].strip().startswith("-"):
-                    key = line[:colon_idx].strip()
-                    val = line[colon_idx + 1 :].strip()
-                    if key and key != "sources":
-                        if val.startswith("'") and val.endswith("'"):
-                            val = val[1:-1]
-                        elif val.startswith('"') and val.endswith('"'):
-                            val = val[1:-1]
-                        frontmatter[key] = val
+    while i < len(lines):
+        line = lines[i]
+        colon_idx = line.find(":")
+        if colon_idx <= 0 or line[:colon_idx].strip().startswith("-"):
+            i += 1
             continue
 
-        colon_idx = line.find(":")
-        if colon_idx > 0 and not line[:colon_idx].strip().startswith("-"):
-            key = line[:colon_idx].strip()
-            val = line[colon_idx + 1 :].strip()
-            if key == "sources":
-                in_sources = True
-                sources = []
-                if val and val != "[]":
-                    for m in re.finditer(r"['\"]?([^,\]\s]+)['\"]?", val):
-                        s = m.group(1).strip("'\"")
-                        if s and s not in ("[", "]"):
-                            sources.append(s)
-            else:
-                if val.startswith("'") and val.endswith("'"):
-                    val = val[1:-1]
-                elif val.startswith('"') and val.endswith('"'):
-                    val = val[1:-1]
-                frontmatter[key] = val
+        key = line[:colon_idx].strip()
+        val = line[colon_idx + 1 :].strip()
 
-    if in_sources:
-        frontmatter["sources"] = sources
+        if key == "sources":
+            sources: list[str] = []
+            if val and val != "[]":
+                for m in re.finditer(r"['\"]?([^,\]\s]+)['\"]?", val):
+                    s = m.group(1).strip("'\"")
+                    if s and s not in ("[", "]"):
+                        sources.append(s)
+                frontmatter["sources"] = sources
+                i += 1
+                continue
+
+            # Multi-line list under sources:
+            j = i + 1
+            while j < len(lines):
+                item_line = lines[j]
+                stripped = item_line.strip()
+                if stripped.startswith("-"):
+                    sources.append(stripped[1:].strip().strip("'\""))
+                    j += 1
+                else:
+                    break
+            frontmatter["sources"] = sources
+            i = j
+            continue
+
+        if val in block_indicators:
+            folded = val.startswith(">")
+            collected: list[str] = []
+            j = i + 1
+            while j < len(lines):
+                cont = lines[j]
+                # Block content is indented or blank; next top-level key ends it.
+                if cont == "" or cont.startswith(" ") or cont.startswith("\t"):
+                    collected.append(cont.strip())
+                    j += 1
+                else:
+                    break
+            if folded:
+                joined = " ".join(s for s in collected if s)
+            else:
+                joined = "\n".join(collected).strip()
+            if joined:
+                frontmatter[key] = joined
+            i = j
+            continue
+
+        if val.startswith("'") and val.endswith("'"):
+            val = val[1:-1]
+        elif val.startswith('"') and val.endswith('"'):
+            val = val[1:-1]
+        frontmatter[key] = val
+        i += 1
 
     return frontmatter, None, body
 


### PR DESCRIPTION
fix yaml format

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix YAML frontmatter parsing so folded and literal block scalar descriptions render correctly instead of showing the indicator (e.g., `>-`). Applies across skill scanners and the wiki.

- **Bug Fixes**
  - API and core service: handle folded (`>`, `>-`, `>+`) and literal (`|`, `|-`, `|+`) scalars for fields like `description` and `bestFor`; join lines for folded, preserve newlines for literal.
  - Web wiki parser: parse block scalars and multi-line `sources` lists; do not treat the block indicator as the value.
  - Validation script: add block scalar support and more robust `sources` parsing (inline and multi-line).
  - Tests: add coverage for folded/literal scalars and array parsing in both web and Rust.
  - Content: normalize `atmos-canvas-agent` skill description to a single quoted line.

<sup>Written for commit 08f655e30b89dd63c0cc9e1de67f107f73b34fcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved skill and wiki frontmatter parsing for folded and literal multi-line YAML values.
  * Added support for multi-line source lists and inline arrays.
  * Preserved formatting for literal content while normalizing folded text.

* **Bug Fixes**
  * Prevented YAML block indicators from being incorrectly displayed as field values.
  * Improved extraction of multi-line skill descriptions and metadata.

* **Documentation**
  * Updated skill metadata formatting for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->