### PR TITLE
fix: restore TUI terminal sessions after app restart

### DIFF
--- a/apps/api/src/api/ws/terminal_handler.rs
+++ b/apps/api/src/api/ws/terminal_handler.rs
@@ -253,69 +253,87 @@ async fn handle_terminal_socket(socket: WebSocket, config: TerminalSessionConfig
             }
         }
     } else if attach_requested && (tmux_window.is_some() || tmux_window_name.is_some()) {
-        match terminal_service
-            .attach_session(AttachSessionParams {
-                session_id: session_id.clone(),
-                workspace_id: workspace_id.clone(),
-                tmux_window_index: tmux_window,
-                tmux_window_name,
-                cols: initial_cols,
-                rows: initial_rows,
-                project_name: project_name.clone(),
-                workspace_name: workspace_name.clone(),
-            })
-            .await
-        {
-            Ok((rx, snapshot)) => {
+        // Retry attach a couple times before failing. After app restart, tmux /
+        // session resolution can briefly lag; silent create would orphan a live
+        // TUI agent, but hard-failing on the first attempt is also too brittle.
+        const ATTACH_MAX_ATTEMPTS: u8 = 3;
+        let mut last_error = None;
+        let mut attached_result = None;
+        for attempt in 1..=ATTACH_MAX_ATTEMPTS {
+            match terminal_service
+                .attach_session(AttachSessionParams {
+                    session_id: session_id.clone(),
+                    workspace_id: workspace_id.clone(),
+                    tmux_window_index: tmux_window,
+                    tmux_window_name: tmux_window_name.clone(),
+                    cols: initial_cols,
+                    rows: initial_rows,
+                    project_name: project_name.clone(),
+                    workspace_name: workspace_name.clone(),
+                })
+                .await
+            {
+                Ok((rx, snapshot)) => {
+                    if attempt > 1 {
+                        info!(
+                            "Attached terminal session {} on attempt {}/{}",
+                            session_id, attempt, ATTACH_MAX_ATTEMPTS
+                        );
+                    }
+                    attached_result = Some((rx, snapshot));
+                    break;
+                }
+                Err(e) => {
+                    warn!(
+                        "Attach attempt {}/{} failed for session {} window {:?}/{:?}: {}",
+                        attempt,
+                        ATTACH_MAX_ATTEMPTS,
+                        session_id,
+                        tmux_window,
+                        requested_tmux_window_name,
+                        e
+                    );
+                    last_error = Some(e);
+                    if attempt < ATTACH_MAX_ATTEMPTS {
+                        tokio::time::sleep(std::time::Duration::from_millis(
+                            150 * attempt as u64,
+                        ))
+                        .await;
+                    }
+                }
+            }
+        }
+
+        match attached_result {
+            Some((rx, snapshot)) => {
                 actually_attached = true;
                 (rx, snapshot)
             }
-            Err(e) => {
-                warn!(
-                    "Failed to attach terminal session ({}). Falling back to creating a new one.",
+            None => {
+                let e = last_error
+                    .map(|err| err.to_string())
+                    .unwrap_or_else(|| "unknown attach failure".to_string());
+                error!(
+                    "Failed to attach terminal session {} to window {:?}/{:?} after {} attempts: {}",
+                    session_id,
+                    tmux_window,
+                    requested_tmux_window_name,
+                    ATTACH_MAX_ATTEMPTS,
                     e
                 );
-                match terminal_service
-                    .create_session(CreateSessionParams {
-                        session_id: session_id.clone(),
-                        workspace_id: workspace_id.clone(),
-                        shell: shell.clone(),
-                        cols: initial_cols,
-                        rows: initial_rows,
-                        project_name: project_name.clone(),
-                        workspace_name: workspace_name.clone(),
-                        window_name: terminal_name
-                            .clone()
-                            .or_else(|| requested_tmux_window_name.clone()),
-                        cwd: cwd.clone(),
-                        terminal_kind: terminal_kind.clone(),
-                        side_chat_id: side_chat_id.clone(),
-                        source_pane_id: source_pane_id.clone(),
-                        source_tmux_window_name: source_tmux_window_name.clone(),
-                    })
-                    .await
-                {
-                    Ok((rx, snapshot)) => {
-                        actually_attached = false;
-                        (rx, snapshot)
-                    }
-                    Err(e) => {
-                        error!(
-                            "Failed to create terminal session after attach failure: {}",
-                            e
-                        );
-                        let error_response = TerminalResponse::TerminalError {
-                            session_id: Some(session_id),
-                            error: e.to_string(),
-                        };
-                        let _ = ws_sender
-                            .send(Message::Text(
-                                serde_json::to_string(&error_response).unwrap().into(),
-                            ))
-                            .await;
-                        return;
-                    }
-                }
+                let error_response = TerminalResponse::TerminalError {
+                    session_id: Some(session_id),
+                    error: format!(
+                        "Failed to attach existing terminal session after {} attempts: {}",
+                        ATTACH_MAX_ATTEMPTS, e
+                    ),
+                };
+                let _ = ws_sender
+                    .send(Message::Text(
+                        serde_json::to_string(&error_response).unwrap().into(),
+                    ))
+                    .await;
+                return;
             }
         }
     } else {

--- a/apps/web/src/features/canvas/components/CanvasAddAtmosWidgetDialog.tsx
+++ b/apps/web/src/features/canvas/components/CanvasAddAtmosWidgetDialog.tsx
@@ -138,7 +138,8 @@ function buildWorkspaceContext(project: Project, workspace: Workspace): CanvasCo
     projectId: project.id,
     workspaceId: workspace.id,
     projectName: project.name,
-    workspaceName: workspace.displayName || workspace.name,
+    // Stable workspace handle for tmux session naming (not display label).
+    workspaceName: workspace.name,
     localPath: workspace.localPath,
     repoPath: workspace.localPath,
   };

--- a/apps/web/src/features/terminal/components/Terminal.tsx
+++ b/apps/web/src/features/terminal/components/Terminal.tsx
@@ -199,9 +199,10 @@ const Terminal = ({
   const lastSelectionAnchorRef = useRef<{ x: number; y: number } | null>(null);
   // Prefer "connected" when this session was already live (warm remount / tab re-show)
   // so the full-screen Connecting overlay does not flash.
-  const [status, setStatus] = useState<"connecting" | "connected" | "reconnecting" | "disconnected">(
+  const [status, setStatus] = useState<"connecting" | "connected" | "reconnecting" | "disconnected" | "error">(
     () => (wasTerminalSessionLive(sessionId) ? "connected" : "connecting"),
   );
+  const [attachError, setAttachError] = useState<string | null>(null);
   // Ref to hold sendResize so handleConnected can call it without circular dependency
   const sendResizeRef = useRef<(size: { cols: number; rows: number }) => void>(() => {});
   const { resolvedTheme } = useTheme();
@@ -307,6 +308,7 @@ const Terminal = ({
 
   const handleConnected = useCallback(() => {
     markTerminalSessionLive(sessionId);
+    setAttachError(null);
     setStatus("connected");
     outputTextDecoderRef.current = new TextDecoder();
     resetInputReady();
@@ -337,14 +339,18 @@ const Terminal = ({
   const handleError = useCallback(
     (error: string) => {
       onSessionError?.(sessionId, error);
-      // Only show errors in terminal after initial connection (not during connecting phase)
-      // The loading overlay handles the connecting state
+      // Surface attach/create failures so the user can manually retry instead of
+      // being left on a blank "connecting" or silent disconnected state.
+      setAttachError(error);
+      setStatus("error");
+      resetInputReady();
     },
-    [sessionId, onSessionError]
+    [sessionId, onSessionError, resetInputReady]
   );
 
   const handleAttached = useCallback((snapshot?: TerminalSnapshot | null) => {
     markTerminalSessionLive(sessionId);
+    setAttachError(null);
     setStatus("connected");
     const term = terminalRef.current;
     if (!term || !snapshot) {
@@ -395,6 +401,14 @@ const Terminal = ({
       onAttached: handleAttached,
     });
 
+  const handleRetryAttach = useCallback(() => {
+    setAttachError(null);
+    setStatus("connecting");
+    disconnect();
+    // Fresh connect after a failed attach; backend already retried a few times.
+    connect();
+  }, [connect, disconnect]);
+
   // Keep refs in sync (breaks circular dependencies with handleConnected)
   useEffect(() => {
     sendResizeRef.current = sendResize;
@@ -403,13 +417,15 @@ const Terminal = ({
   // Prefer live WS / recent-live session marker over "connecting" so warm re-show
   // does not flash the full-screen Connecting overlay (use light reconnecting if mid-handshake).
   const uiStatus =
-    isReconnecting
-      ? "reconnecting"
-      : isConnected
-        ? "connected"
-        : status === "connecting" && wasTerminalSessionLive(sessionId)
-          ? "reconnecting"
-          : status;
+    status === "error"
+      ? "error"
+      : isReconnecting
+        ? "reconnecting"
+        : isConnected
+          ? "connected"
+          : status === "connecting" && wasTerminalSessionLive(sessionId)
+            ? "reconnecting"
+            : status;
 
   const setCurrentSelectionSnapshot = useCallback((snapshot: TerminalSelectionSnapshot | null) => {
     setSelectionSnapshot(snapshot);
@@ -487,13 +503,6 @@ const Terminal = ({
       y: rect.top + (cursorY + 0.5) * cellHeight,
     };
   }, []);
-
-  // Update terminal when reconnecting
-  useEffect(() => {
-    if (isReconnecting) {
-      terminalRef.current?.write("\r\n\x1b[33m[Reconnecting...]\x1b[0m\r\n");
-    }
-  }, [isReconnecting]);
 
   // Expose terminal methods via ref (React 19 style)
   useImperativeHandle(
@@ -1158,6 +1167,8 @@ const Terminal = ({
       terminalScale={normalizedTerminalScale}
       uiStatus={uiStatus}
       workspaceId={workspaceId}
+      errorMessage={attachError}
+      onRetry={status === "error" ? handleRetryAttach : undefined}
       selectionToolbar={
         onAddSelectionAsContext ? (
           <TerminalSelectionToolbar

--- a/apps/web/src/features/terminal/components/TerminalChrome.tsx
+++ b/apps/web/src/features/terminal/components/TerminalChrome.tsx
@@ -4,7 +4,7 @@ import type { CSSProperties, ReactNode, RefObject } from "react";
 import type { ITheme } from "@xterm/xterm";
 import { isFindShortcut } from "../lib/terminal-runtime-utils";
 
-type TerminalUiStatus = "connecting" | "connected" | "reconnecting" | "disconnected";
+type TerminalUiStatus = "connecting" | "connected" | "reconnecting" | "disconnected" | "error";
 
 interface TerminalChromeProps {
   className?: string;
@@ -30,6 +30,8 @@ interface TerminalChromeProps {
   terminalScale?: number;
   uiStatus: TerminalUiStatus;
   workspaceId: string;
+  errorMessage?: string | null;
+  onRetry?: () => void;
 }
 
 export function TerminalChrome({
@@ -56,6 +58,8 @@ export function TerminalChrome({
   terminalScale = 1,
   uiStatus,
   workspaceId,
+  errorMessage,
+  onRetry,
 }: TerminalChromeProps) {
   const normalizedTerminalScale =
     Number.isFinite(terminalScale) && terminalScale > 0 ? terminalScale : 1;
@@ -142,6 +146,43 @@ export function TerminalChrome({
           color="#ef4444"
         />
       )}
+      {uiStatus === "error" && (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            zIndex: 20,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            backgroundColor: "var(--background)",
+            gap: "12px",
+            padding: "16px",
+            textAlign: "center",
+          }}
+        >
+          <span
+            style={{
+              fontSize: "13px",
+              color: isDark ? "#fca5a5" : "#dc2626",
+              maxWidth: "360px",
+            }}
+          >
+            {errorMessage || "Failed to restore terminal session"}
+          </span>
+          {onRetry && (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={onRetry}
+            >
+              Retry
+            </Button>
+          )}
+        </div>
+      )}
       {isSearchVisible && (
         <TerminalSearchOverlay
           closeSearch={closeSearch}
@@ -164,7 +205,7 @@ export function TerminalChrome({
           height: "100%",
           // Only hide xterm during true first-connect. Soft reconnect (warm remount)
           // uses "reconnecting" badge and keeps buffer visible.
-          opacity: uiStatus === "connecting" ? 0 : 1,
+          opacity: uiStatus === "connecting" || uiStatus === "error" ? 0 : 1,
           backgroundColor: currentTheme.background,
         }}
         data-session-id={sessionId}

--- a/apps/web/src/features/terminal/components/TerminalGrid.tsx
+++ b/apps/web/src/features/terminal/components/TerminalGrid.tsx
@@ -218,7 +218,10 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
       if (workspace) {
         return {
           projectName: project.name,
-          workspaceName: workspace.displayName || workspace.name,
+          // tmux session names must use the stable workspace handle (`name`),
+          // not the mutable display label. Display names can diverge after rename
+          // and cause reattach to open a brand-new empty shell.
+          workspaceName: workspace.name,
           localPath: workspace.localPath,
         };
       }

--- a/apps/web/src/features/terminal/lib/terminal-ws-url.ts
+++ b/apps/web/src/features/terminal/lib/terminal-ws-url.ts
@@ -93,8 +93,9 @@ export function buildTerminalWsUrl({
     if (nameForNewWindow) {
       wsParams.set("terminal_name", nameForNewWindow);
     }
-  } else if (tmuxWindowName) {
-    wsParams.set("tmux_window_name", tmuxWindowName);
+  } else if (tmuxWindowName || terminalName) {
+    // Reattach path: always prefer attach by window name over create.
+    wsParams.set("tmux_window_name", tmuxWindowName || terminalName || "");
   }
 
   return `${baseWsUrl}?${wsParams.toString()}`;

--- a/apps/web/src/features/terminal/store/__tests__/hydrate-reattach.test.ts
+++ b/apps/web/src/features/terminal/store/__tests__/hydrate-reattach.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { hydratePersistedTab } from "../terminal-store-helpers";
+import type { PersistedTerminalTabDocument } from "../../lib/terminal-layout-document";
+
+describe("hydratePersistedTab reattach preference", () => {
+  it("marks panes with a known window name as attachable even when tmux list is empty", () => {
+    const tab = {
+      id: "term",
+      title: "Term",
+      layout: "pane-1",
+      panes: {
+        "pane-1": {
+          id: "pane-1",
+          label: "3",
+          tmuxWindowName: "3",
+          workspaceId: "ws-1",
+        },
+      },
+      maximizedTerminalId: null,
+    } as unknown as PersistedTerminalTabDocument;
+
+    const hydrated = hydratePersistedTab("ws-1", tab, new Set());
+    expect(hydrated).not.toBeNull();
+    expect(hydrated?.panes["pane-1"].isNewPane).toBe(false);
+    expect(hydrated?.panes["pane-1"].tmuxWindowName).toBe("3");
+  });
+});

--- a/apps/web/src/features/terminal/store/terminal-store-helpers.ts
+++ b/apps/web/src/features/terminal/store/terminal-store-helpers.ts
@@ -407,7 +407,10 @@ export function hydratePersistedTab(
       tmuxWindowName: windowName,
       // Always mint a new frontend session id (WS attach identity).
       sessionId: uuidv4(),
-      isNewPane: liveByWindow ? false : !windowExists,
+      // Prefer attach when we have a stable window name. Listing can race with
+      // API/tmux startup after app restart; treating unknown windows as "new"
+      // forces create and can orphan a still-running TUI agent.
+      isNewPane: liveByWindow ? false : windowName ? false : !windowExists,
       // dynamicTitle is display-only and not written to layout persistence —
       // keep the warm in-memory value across a hydrate rewrite.
       dynamicTitle: liveByWindow?.dynamicTitle,

--- a/crates/core-engine/src/tmux/session.rs
+++ b/crates/core-engine/src/tmux/session.rs
@@ -74,6 +74,21 @@ impl TmuxEngine {
         self.create_session_internal(&session_name, cwd, shell_command, env_vars)
     }
 
+    /// Create/open a tmux session by an already-resolved stable name.
+    ///
+    /// Used when the service layer has already canonicalized the session name
+    /// (e.g. from DB project/workspace names) and must not re-derive it from
+    /// potentially display-name based frontend params.
+    pub fn create_named_session(
+        &self,
+        session_name: &str,
+        cwd: Option<&str>,
+        shell_command: Option<&[String]>,
+        env_vars: Option<&[(&str, &str)]>,
+    ) -> Result<String> {
+        self.create_session_internal(session_name, cwd, shell_command, env_vars)
+    }
+
     /// Internal function to create tmux session
     fn create_session_internal(
         &self,

--- a/crates/core-service/src/service/terminal.rs
+++ b/crates/core-service/src/service/terminal.rs
@@ -10,6 +10,7 @@
 
 use crate::error::{Result, ServiceError};
 use core_engine::{TmuxEngine, TmuxPaneSnapshot, TmuxWindowAtmosMetadata};
+use infra::db::repo::{ProjectRepo, WorkspaceRepo};
 use sea_orm::DatabaseConnection;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -217,6 +218,74 @@ impl TerminalService {
         TmuxEngine::get_version().map_err(|e| ServiceError::Processing(e.to_string()))
     }
 
+    /// Resolve the stable master tmux session for a workspace.
+    ///
+    /// Prefer the canonical `{project.name}_{workspace.name}` form from the DB
+    /// so transient frontend display names (or missing query params during early
+    /// hydration) cannot create a second empty session and lose the live TUI
+    /// agent that is still running in the real session.
+    async fn resolve_tmux_session_name(
+        &self,
+        workspace_id: &str,
+        project_name: Option<&str>,
+        workspace_name: Option<&str>,
+    ) -> String {
+        let mut candidates = Vec::new();
+
+        if let Some(db) = self.db.as_ref() {
+            let workspace_repo = WorkspaceRepo::new(db);
+            if let Ok(Some(workspace)) = workspace_repo.find_by_guid(workspace_id).await {
+                let project_repo = ProjectRepo::new(db);
+                if let Ok(Some(project)) = project_repo.find_by_guid(&workspace.project_guid).await {
+                    candidates.push(
+                        self.tmux_engine
+                            .get_session_name_from_names(&project.name, &workspace.name),
+                    );
+                }
+            }
+        }
+
+        if let (Some(project), Some(workspace)) = (project_name, workspace_name) {
+            candidates.push(
+                self.tmux_engine
+                    .get_session_name_from_names(project, workspace),
+            );
+        }
+
+        candidates.push(self.tmux_engine.get_session_name(workspace_id));
+        // Preserve priority order: DB canonical name, then frontend names, then
+        // workspace-id fallback. Only drop exact duplicates.
+        let mut deduped = Vec::new();
+        for candidate in candidates {
+            if !deduped.iter().any(|existing| existing == &candidate) {
+                deduped.push(candidate);
+            }
+        }
+        let candidates = deduped;
+
+        if let Ok(sessions) = self.tmux_engine.list_sessions() {
+            for candidate in &candidates {
+                if sessions.iter().any(|session| session.name == *candidate) {
+                    if Some(candidate) != candidates.first() {
+                        info!(
+                            "Resolved workspace {} to existing tmux session {} (preferred candidate was {:?})",
+                            workspace_id,
+                            candidate,
+                            candidates.first()
+                        );
+                    }
+                    return candidate.clone();
+                }
+            }
+        }
+
+        candidates
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| self.tmux_engine.get_session_name(workspace_id))
+    }
+
+
     /// Detect the best available tmux installation plan for the current API host.
     pub fn get_tmux_install_plan(&self) -> core_engine::TmuxInstallPlan {
         TmuxEngine::detect_install_plan()
@@ -262,12 +331,13 @@ impl TerminalService {
         }
 
         // Compute tmux session name (without creating it yet) so we can acquire lock first
-        let tmux_session_name =
-            if let (Some(ref proj), Some(ref ws)) = (&project_name, &workspace_name) {
-                self.tmux_engine.get_session_name_from_names(proj, ws)
-            } else {
-                self.tmux_engine.get_session_name(&workspace_id)
-            };
+        let tmux_session_name = self
+            .resolve_tmux_session_name(
+                &workspace_id,
+                project_name.as_deref(),
+                workspace_name.as_deref(),
+            )
+            .await;
 
         // Acquire per-workspace creation lock BEFORE creating session to prevent race conditions
         // This ensures only one session/window creation happens at a time per workspace
@@ -352,31 +422,19 @@ impl TerminalService {
             // Codex hooks cell is reserved/inert today; set for forward-compat.
             ("GROK_CODEX_HOOKS_ENABLED", "0"),
         ];
-        let tmux_session = if let (Some(ref proj), Some(ref ws)) = (&project_name, &workspace_name)
-        {
-            self.tmux_engine
-                .create_session_with_names(
-                    proj,
-                    ws,
-                    cwd.as_deref(),
-                    shell_command.as_deref(),
-                    Some(&session_env_vars),
-                )
-                .map_err(|e| {
-                    ServiceError::Processing(format!("Failed to create tmux session: {}", e))
-                })?
-        } else {
-            self.tmux_engine
-                .create_session(
-                    &workspace_id,
-                    cwd.as_deref(),
-                    shell_command.as_deref(),
-                    Some(&session_env_vars),
-                )
-                .map_err(|e| {
-                    ServiceError::Processing(format!("Failed to create tmux session: {}", e))
-                })?
-        };
+        // Always open the already-resolved stable session name. Do not re-derive
+        // from potentially display-name based frontend params.
+        let tmux_session = self
+            .tmux_engine
+            .create_named_session(
+                &tmux_session_name,
+                cwd.as_deref(),
+                shell_command.as_deref(),
+                Some(&session_env_vars),
+            )
+            .map_err(|e| {
+                ServiceError::Processing(format!("Failed to create tmux session: {}", e))
+            })?;
 
         // Create a new tmux window for this terminal pane
         // If a window_name is provided and already exists in tmux, ATTACH to it instead of creating a new one
@@ -676,12 +734,13 @@ impl TerminalService {
             workspace_name,
         } = params;
         // Compute tmux session name so we can acquire lock
-        let tmux_session_name =
-            if let (Some(ref proj), Some(ref ws)) = (&project_name, &workspace_name) {
-                self.tmux_engine.get_session_name_from_names(proj, ws)
-            } else {
-                self.tmux_engine.get_session_name(&workspace_id)
-            };
+        let tmux_session_name = self
+            .resolve_tmux_session_name(
+                &workspace_id,
+                project_name.as_deref(),
+                workspace_name.as_deref(),
+            )
+            .await;
 
         // Acquire workspace lock to prevent race conditions during attachment
         let creation_lock = self.get_creation_lock(&tmux_session_name).await;
@@ -722,13 +781,14 @@ impl TerminalService {
         let cols = cols.unwrap_or(self.default_cols);
         let rows = rows.unwrap_or(self.default_rows);
 
-        // Use human-readable session name if provided, otherwise fall back to workspace_id
-        let tmux_session = if let (Some(ref proj), Some(ref ws)) = (&project_name, &workspace_name)
-        {
-            self.tmux_engine.get_session_name_from_names(proj, ws)
-        } else {
-            self.tmux_engine.get_session_name(&workspace_id)
-        };
+        // Resolve the stable master session (DB canonical name first) before attaching.
+        let tmux_session = self
+            .resolve_tmux_session_name(
+                &workspace_id,
+                project_name.as_deref(),
+                workspace_name.as_deref(),
+            )
+            .await;
         self.tmux_engine.ensure_standard_config();
 
         // Save window name for metadata before it gets consumed
@@ -1078,5 +1138,29 @@ mod tests {
         let service = TerminalService::new();
         let available = service.is_tmux_available();
         println!("tmux available: {}", available);
+    }
+
+    #[tokio::test]
+    async fn resolve_tmux_session_name_prefers_existing_named_session() {
+        let service = TerminalService::new();
+        // Without DB/live sessions this falls back to the provided names.
+        let resolved = service
+            .resolve_tmux_session_name("ws-guid", Some("Atmos"), Some("Main"))
+            .await;
+        assert_eq!(resolved, service.tmux_engine.get_session_name_from_names("Atmos", "Main"));
+    }
+
+    #[tokio::test]
+    async fn resolve_tmux_session_name_falls_back_to_workspace_id() {
+        let service = TerminalService::new();
+        let resolved = service
+            .resolve_tmux_session_name("13c75c87-516a-40ab-b7b8-bda46c0e3e3e", None, None)
+            .await;
+        assert_eq!(
+            resolved,
+            service
+                .tmux_engine
+                .get_session_name("13c75c87-516a-40ab-b7b8-bda46c0e3e3e")
+        );
     }
 }

--- a/crates/core-service/src/service/terminal/management.rs
+++ b/crates/core-service/src/service/terminal/management.rs
@@ -45,15 +45,13 @@ impl TerminalService {
             .unwrap_or(DEFAULT_SIDE_PROMPT_BYTES)
             .clamp(MIN_SIDE_PROMPT_BYTES, MAX_SIDE_PROMPT_BYTES);
 
-        let primary_tmux_session = if let (Some(project), Some(workspace)) = (
-            params.project_name.as_deref(),
-            params.workspace_name.as_deref(),
-        ) {
-            self.tmux_engine
-                .get_session_name_from_names(project, workspace)
-        } else {
-            self.tmux_engine.get_session_name(&workspace_id)
-        };
+        let primary_tmux_session = self
+            .resolve_tmux_session_name(
+                &workspace_id,
+                params.project_name.as_deref(),
+                params.workspace_name.as_deref(),
+            )
+            .await;
 
         let capture_target = if let Some(source_session_id) = params
             .source_session_id
@@ -373,10 +371,34 @@ impl TerminalService {
         skip_from_bottom: i32,
         take_lines: i32,
     ) -> Result<TmuxPaneCapturePage> {
-        let tmux_session = if let (Some(proj), Some(ws)) = (project_name, workspace_name) {
-            self.tmux_engine.get_session_name_from_names(proj, ws)
+        // Sync helper: resolve with the same candidate priority as async path,
+        // but without awaiting. Prefer names first, then workspace id, then any
+        // existing session that contains the requested window.
+        let mut candidates = Vec::new();
+        if let (Some(proj), Some(ws)) = (project_name, workspace_name) {
+            candidates.push(self.tmux_engine.get_session_name_from_names(proj, ws));
+        }
+        candidates.push(self.tmux_engine.get_session_name(workspace_id));
+        let mut deduped = Vec::new();
+        for candidate in candidates {
+            if !deduped.iter().any(|existing| existing == &candidate) {
+                deduped.push(candidate);
+            }
+        }
+        let candidates = deduped;
+
+        let tmux_session = if let Ok(sessions) = self.tmux_engine.list_sessions() {
+            candidates
+                .iter()
+                .find(|candidate| sessions.iter().any(|session| session.name == **candidate))
+                .cloned()
+                .or_else(|| candidates.first().cloned())
+                .unwrap_or_else(|| self.tmux_engine.get_session_name(workspace_id))
         } else {
-            self.tmux_engine.get_session_name(workspace_id)
+            candidates
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| self.tmux_engine.get_session_name(workspace_id))
         };
 
         let window_index = self


### PR DESCRIPTION
## Summary
- Canonicalize tmux session resolution from DB workspace names so reattach no longer creates a second empty shell after app restart.
- Prefer attach over create during hydration, retry attach a few times, and surface a manual Retry path instead of silently spawning a fresh shell.
- Keep terminal status in chrome only (chip / error overlay), and stop writing reconnect text into the xterm buffer that can corrupt TUI agents.

## Root Cause
After restart, incomplete frontend params or display-name-based session naming could open a different tmux session. Attach-fail fallback then created a new shell, which made running agents like claude/grok appear lost.

## Validation
- `cargo check -p core-service -p api -p core-engine`
- `bun test src/features/terminal/store/__tests__/hydrate-reattach.test.ts`
- `bun test src/features/terminal/store/__tests__/terminal-store-new-tab.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores TUI terminal sessions after app restart by canonicalizing tmux session names and preferring reattach with retries over silently creating a new shell. Prevents second empty shells and keeps agents like claude/grok alive.

- **Bug Fixes**
  - Canonical session resolution: prefer DB `{project.name}_{workspace.name}`, then frontend names, then `workspace_id`; reuse existing sessions when present.
  - Attach over create: backend retries attach 3x and surfaces a terminal error instead of creating a new session; UI shows an error overlay with a Retry button.
  - Stable workspace handle: use `workspace.name` (not `displayName`) for session naming across the web app.
  - Reattach-first URLs: when restoring panes, always send `tmux_window_name` to attach by window name.
  - Hydration: panes with a known `tmuxWindowName` are treated as attachable even if tmux listing is empty.
  - No buffer pollution: remove reconnect text writes to `xterm`; status is shown in chrome only.

- **Refactors**
  - Added `create_named_session` in the tmux engine and used it to open the resolved canonical session.
  - Centralized session name logic in `TerminalService::resolve_tmux_session_name`; used across create, attach, management, and capture.
  - Added tests for hydrate reattach and session name resolution.

<sup>Written for commit b646a6269c6a0f13014b80678a5ca2a06b22313d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal reattachment reliability with automatic retries and clearer failure handling.
  * Added a visible terminal error state with a **Retry** option when connections fail.
  * Preserved terminal panes during startup and reattachment races.
  * Improved session and window matching after workspace renames.
  * Fixed terminal context to consistently use stable workspace names.

* **Tests**
  * Added coverage for persisted terminal tab reattachment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->