### PR TITLE
feat(landing): point build CTA to download and polish install UI

### DIFF
--- a/apps/landing/src/components/blocks/hero-section.tsx
+++ b/apps/landing/src/components/blocks/hero-section.tsx
@@ -100,7 +100,7 @@ const HeroSection = () => {
 
           <MotionPreset fade slide blur transition={{ duration: 0.5 }} delay={1.7} className="flex-shrink-0">
             <div className="flex">
-              <CraftButton className="rounded-full shadow-lg h-auto px-5 py-2.5 md:px-6 md:py-3 lg:px-8 lg:py-3.5" asChild>
+              <CraftButton className="rounded-full shadow-lg h-12 px-5 md:h-14 md:px-6 lg:h-14 lg:px-8" asChild>
                 <Link
                   href='#ready-download'
                   onClick={(e) => {

--- a/apps/landing/src/components/blocks/ready-download.tsx
+++ b/apps/landing/src/components/blocks/ready-download.tsx
@@ -14,7 +14,8 @@ import {
   DropdownMenuTrigger,
 } from '@workspace/ui/components/ui/dropdown-menu'
 
-import { Tabs, TabsList, TabsTrigger } from '@workspace/ui/components/ui/tabs'
+import { TabsSubtle, TabsSubtleItem } from '@workspace/ui/components/ui/tabs-subtle'
+import type { ComponentType } from 'react'
 import { MotionPreset } from '@workspace/ui/components/ui/motion-preset'
 import { TextShimmer } from '@workspace/ui/components/ui/text-shimmer'
 import { GithubIcon } from '@workspace/ui/components/icons/github-icon'
@@ -25,6 +26,24 @@ import { OsIcon } from '@/components/os-icon'
 
 const RELEASES_URL = 'https://github.com/AruNi-01/atmos/releases'
 const APP_URL = 'https://app.atmos.land'
+
+type TabIcon = ComponentType<{ size?: number; strokeWidth?: number; className?: string }>
+
+const HomebrewIcon: TabIcon = ({ size = 16, className }) => (
+  <img
+    src='/icons/homebrew.svg'
+    alt=''
+    width={size}
+    height={size}
+    className={className}
+    style={{ width: size, height: size }}
+  />
+)
+
+const DESKTOP_TABS = [
+  { id: 'bash', labelKey: 'tabs.bash', icon: TerminalIcon },
+  { id: 'homebrew', labelKey: 'tabs.homebrew', icon: HomebrewIcon },
+] as const
 
 type DownloadLinks = {
   macAppleSilicon: string
@@ -43,7 +62,8 @@ const createDefaultDownloadLinks = (): DownloadLinks => ({
 const ReadyDownload = () => {
   const t = useTranslations('readyDownload')
   const [copied, setCopied] = useState('')
-  const [desktopTab, setDesktopTab] = useState('bash')
+  const [desktopTabIndex, setDesktopTabIndex] = useState(0)
+  const desktopTab = DESKTOP_TABS[desktopTabIndex]?.id ?? 'bash'
   const [downloadLinks, setDownloadLinks] = useState<DownloadLinks>(createDefaultDownloadLinks)
 
   useEffect(() => {
@@ -95,7 +115,7 @@ const ReadyDownload = () => {
 
           <div className='flex flex-col items-center gap-4 pt-4 sm:flex-row'>
             <div className='flex items-center isolate overflow-hidden rounded-lg relative ring-2 ring-primary/60 w-full sm:w-72'>
-              <Button size='lg' className='flex-1 h-14 rounded-r-none px-6 text-base font-medium hover:bg-primary transition-colors border-r border-primary-foreground/20' asChild>
+              <Button size='lg' className='flex-1 h-14 sm:h-14 rounded-r-none px-6 text-base font-medium hover:bg-primary transition-colors border-r border-primary-foreground/20' asChild>
                 <Link href={downloadLinks.macAppleSilicon} target='_blank' rel='noopener noreferrer'>
                   <OsIcon os='apple' className='size-5' />
                   {t('primaryCta')}
@@ -104,7 +124,7 @@ const ReadyDownload = () => {
 
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button size='lg' className='h-14 rounded-l-none px-3 border-none ring-0 hover:bg-primary transition-colors hover:text-primary-foreground'>
+                  <Button size='lg' className='h-14 sm:h-14 rounded-l-none px-3 border-none ring-0 hover:bg-primary transition-colors hover:text-primary-foreground'>
                     <ChevronDownIcon className='size-5' />
                     <span className='sr-only'>{t('moreOptions')}</span>
                   </Button>
@@ -147,7 +167,7 @@ const ReadyDownload = () => {
               </DropdownMenu>
             </div>
 
-            <Button size='lg' variant='ghost' className='h-14 px-8 text-base' asChild>
+            <Button size='lg' variant='ghost' className='h-14 sm:h-14 px-8 text-base' asChild>
               <Link href={APP_URL} target='_blank' rel='noopener noreferrer' className='group'>
                 {t('openInBrowser')}
                 <ArrowRightIcon className='ml-2 size-4 transition-transform group-hover:translate-x-1' />
@@ -161,12 +181,21 @@ const ReadyDownload = () => {
               <div className='flex items-center gap-2'>
                 <OsIcon os='apple' className='size-4 text-muted-foreground' />
                 <h3 className='text-sm font-medium text-muted-foreground'>{t('desktopApp')}</h3>
-                <Tabs value={desktopTab} onValueChange={setDesktopTab} className='w-fit'>
-                  <TabsList className='grid w-fit grid-cols-2'>
-                    <TabsTrigger value='bash'>{t('tabs.bash')}</TabsTrigger>
-                    <TabsTrigger value='homebrew'>{t('tabs.homebrew')}</TabsTrigger>
-                  </TabsList>
-                </Tabs>
+                <TabsSubtle
+                  idPrefix='desktop-install'
+                  activeLabel
+                  selectedIndex={desktopTabIndex}
+                  onSelect={setDesktopTabIndex}
+                >
+                  {DESKTOP_TABS.map((tab, index) => (
+                    <TabsSubtleItem
+                      key={tab.id}
+                      index={index}
+                      label={t(tab.labelKey)}
+                      icon={tab.icon}
+                    />
+                  ))}
+                </TabsSubtle>
               </div>
 
               {desktopTab === 'homebrew' && (

--- a/apps/landing/src/components/layout/header.tsx
+++ b/apps/landing/src/components/layout/header.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type MouseEvent } from 'react'
 
 import { Hammer } from 'lucide-react'
 import { useTranslations } from 'next-intl'
@@ -47,6 +47,14 @@ const Header = ({ className }: HeaderProps) => {
 
   const leftScaleY = useTransform(scaleX, [leftTrigger, leftTrigger + 0.05], [0, 1])
   const rightScaleY = useTransform(scaleX, [rightTrigger, rightTrigger + 0.05], [0, 1])
+
+  const scrollToDownload = (event: MouseEvent<HTMLAnchorElement>) => {
+    const el = document.getElementById('ready-download') || document.getElementById('download')
+    if (!el) return
+
+    event.preventDefault()
+    el.scrollIntoView({ behavior: 'smooth' })
+  }
 
   useEffect(() => {
     const handleScroll = () => {
@@ -114,18 +122,24 @@ const Header = ({ className }: HeaderProps) => {
           <ModeToggle />
           {/* Actions */}
           <Button variant='outline' className='rounded-full px-4! max-sm:hidden' asChild>
-            <Link href='https://github.com/AruNi-01/atmos' target='_blank' rel='noopener noreferrer'>
+            <IntlLink
+              href={{ pathname: '/', hash: 'ready-download' }}
+              onClick={scrollToDownload}
+            >
               {t('build')} <Hammer className='size-4' />
-            </Link>
+            </IntlLink>
           </Button>
 
           <Tooltip>
             <TooltipTrigger asChild>
               <Button variant='outline' size='icon' className='rounded-full px-4! sm:hidden' asChild>
-                <Link href='https://github.com/AruNi-01/atmos' target='_blank' rel='noopener noreferrer'>
+                <IntlLink
+                  href={{ pathname: '/', hash: 'ready-download' }}
+                  onClick={scrollToDownload}
+                >
                   <span className='sr-only'>{t('build')}</span>
                   <Hammer className='size-4' />
-                </Link>
+                </IntlLink>
               </Button>
             </TooltipTrigger>
             <TooltipContent>{t('build')}</TooltipContent>


### PR DESCRIPTION
## Summary
- Point the landing header “Let’s Build” CTA to the download section instead of GitHub.
- Switch the desktop Bash/Homebrew install switcher to the shared `TabsSubtle` component used in onboarding, with Terminal and Homebrew icons.
- Keep the Get Started / download CTAs slightly taller with stable heights across breakpoints.

## Why
Make the primary CTA convert to install more directly, and keep the landing download UI aligned with the product onboarding design language.

## Impact
Landing visitors can jump straight to downloads from the header, and the install method switcher matches the onboarding tabs interaction/style.

## Validation
- Inspected landing header/download component changes.
- Landing typecheck previously passed for the TabsSubtle switch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route the landing “Let’s Build” header CTA to the download section and polish the install UI to match onboarding. This makes it easier to install and keeps the design consistent.

- New Features
  - The header CTA now smooth-scrolls to `#ready-download` via `IntlLink` (desktop and mobile).
  - Replaced the Bash/Homebrew switcher with shared `TabsSubtle` and icons (Terminal, Homebrew).
  - Standardized CTA heights across breakpoints for consistent button sizing.

<sup>Written for commit 17e8369283c3515ea055edfeff9e0b23c48f48ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added desktop installation tabs for switching between available installation methods.
  * Build actions now smoothly scroll to the installation section instead of opening an external page.
* **Style**
  * Updated landing-page button sizing, spacing, and visual styling for improved consistency across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->