### PR TITLE
fix(web): improve composer @ file search and popover keyboard scroll

### DIFF
--- a/apps/web/src/features/welcome/components/SlashCommandPopover.tsx
+++ b/apps/web/src/features/welcome/components/SlashCommandPopover.tsx
@@ -15,6 +15,7 @@ import {
 import type { SkillInfo } from "@/api/ws-api";
 import { AgentIcon } from "@/features/agent/components/AgentIcon";
 import type { SlashCommandOption } from "@/features/welcome/hooks/use-welcome-slash-navigation";
+import { scrollActiveListItemIntoView } from "@/features/welcome/lib/popover-list-scroll";
 import type { AgentMenuOption } from "@/features/welcome/lib/welcome-page-helpers";
 
 type ExpandedSections = {
@@ -112,6 +113,7 @@ export function SlashCommandPopover({
   const disableT = useTranslations("skills.composerDisable");
   const [disableActiveIndex, setDisableActiveIndex] = React.useState(0);
   const disableItemRefs = React.useRef<Array<HTMLElement | null>>([]);
+  const disableListScrollRef = React.useRef<HTMLDivElement | null>(null);
 
   const disableFilter = disableSkills?.filter.trim().toLowerCase() ?? "";
   const disableList = React.useMemo(() => {
@@ -132,8 +134,9 @@ export function SlashCommandPopover({
 
   React.useEffect(() => {
     if (view !== "disable_skills") return;
-    const active = disableItemRefs.current[disableActiveIndex];
-    active?.scrollIntoView({ block: "nearest" });
+    const container = disableListScrollRef.current;
+    if (!container) return;
+    scrollActiveListItemIntoView(container, disableItemRefs.current, disableActiveIndex, 3);
   }, [disableActiveIndex, view]);
 
   React.useEffect(() => {
@@ -220,7 +223,7 @@ export function SlashCommandPopover({
   };
 
   const menuContent = (
-    <div className="max-h-80 overflow-y-auto p-1">
+    <div ref={listRef} className="max-h-80 overflow-y-auto p-1">
       {showCommands && visibleCommands.length > 0 ? (
         <>
           <div className="px-2 py-1 text-xs font-medium text-muted-foreground">
@@ -509,7 +512,7 @@ export function SlashCommandPopover({
           {disableT("title")}
         </p>
       </div>
-      <div className="min-h-0 flex-1 overflow-y-auto p-1.5">
+      <div ref={disableListScrollRef} className="min-h-0 flex-1 overflow-y-auto p-1.5">
         {disableSkills?.loading ? (
           <div className="flex items-center gap-2 px-2.5 py-3 text-xs text-muted-foreground">
             <Loader2 className="size-3.5 animate-spin" />
@@ -586,7 +589,6 @@ export function SlashCommandPopover({
     <>
       <div className="fixed inset-0 z-[2147483646]" onMouseDown={handleBackdrop} />
       <div
-        ref={listRef}
         className={cn(
           "fixed z-[2147483647] overflow-hidden rounded-md border border-border/70 bg-popover text-sm text-popover-foreground shadow-md transition-[width] duration-250 ease-out",
           view === "disable_skills" ? "w-[min(92vw,380px)]" : "w-[min(90vw,460px)]",

--- a/apps/web/src/features/welcome/components/WelcomeMentionPopover.tsx
+++ b/apps/web/src/features/welcome/components/WelcomeMentionPopover.tsx
@@ -18,6 +18,7 @@ import {
   Loader2,
 } from "lucide-react";
 import type { GithubIssuePayload, GithubPrPayload } from "@/api/ws-api";
+import { splitHighlightParts } from "@/features/welcome/lib/mention-file-search";
 import type { MentionFileCandidate } from "@/features/welcome/lib/welcome-page-helpers";
 
 export type MentionPopoverState = {
@@ -32,6 +33,42 @@ export type MentionNavItem =
   | { type: "issue"; issue: GithubIssuePayload }
   | { type: "pr"; pr: GithubPrPayload }
   | { type: "file"; file: MentionFileCandidate };
+
+function MentionHighlightText({
+  text,
+  query,
+  className,
+}: {
+  text: string;
+  query: string;
+  className?: string;
+}) {
+  const parts = splitHighlightParts(text, query);
+  return (
+    <span className={className}>
+      {parts.map((part, index) =>
+        part.match ? (
+          <mark
+            key={`${part.text}-${index}`}
+            className="rounded-sm bg-primary/20 px-0.5 text-foreground"
+          >
+            {part.text}
+          </mark>
+        ) : (
+          <React.Fragment key={`${part.text}-${index}`}>{part.text}</React.Fragment>
+        ),
+      )}
+    </span>
+  );
+}
+
+/** Name segment after the last `/` — what name-only search actually matches. */
+function mentionNameHighlightQuery(rawQuery: string): string {
+  const query = rawQuery.trim().replace(/\\/g, "/");
+  const slashIndex = query.lastIndexOf("/");
+  if (slashIndex < 0) return query;
+  return query.slice(slashIndex + 1).trim();
+}
 
 export function WelcomeMentionPopover({
   activeIndex,
@@ -64,6 +101,7 @@ export function WelcomeMentionPopover({
   const issueIndex = issuePreview ? 0 : -1;
   const prIndex = prPreview ? (issuePreview ? 1 : 0) : -1;
   const githubCount = (issuePreview ? 1 : 0) + (prPreview ? 1 : 0);
+  const nameHighlightQuery = mentionNameHighlightQuery(popover.query);
 
   return createPortal(
     <>
@@ -191,9 +229,11 @@ export function WelcomeMentionPopover({
                   >
                     {/* eslint-disable-next-line @next/next/no-img-element -- file icons are tiny decorative SVG/data assets from the UI package. */}
                     <img {...iconProps} alt="" />
-                    <span className="min-w-0 flex-1 truncate">
-                      {item.name}
-                    </span>
+                    <MentionHighlightText
+                      text={item.name}
+                      query={nameHighlightQuery}
+                      className="min-w-0 flex-1 truncate"
+                    />
                     <span className="ml-2 max-w-[55%] shrink truncate text-right text-[11px] text-muted-foreground">
                       {item.relativePath}
                     </span>

--- a/apps/web/src/features/welcome/hooks/__tests__/use-welcome-mention-search.test.ts
+++ b/apps/web/src/features/welcome/hooks/__tests__/use-welcome-mention-search.test.ts
@@ -1,7 +1,10 @@
 // @ts-expect-error bun:test is available at runtime but not in tsconfig types
 import { describe, expect, it } from "bun:test";
 
-import { filterMentionFileCandidates } from "@/features/welcome/lib/mention-file-search";
+import {
+  filterMentionFileCandidates,
+  splitHighlightParts,
+} from "@/features/welcome/lib/mention-file-search";
 import type { MentionFileCandidate } from "@/features/welcome/lib/welcome-page-helpers";
 
 function candidate(
@@ -25,6 +28,14 @@ describe("filterMentionFileCandidates", () => {
     candidate("pages/styles.css"),
     candidate("pages/sub/script-helper.ts"),
     candidate("src/script.ts"),
+    candidate("apps/desktop-electron/native/appshot-shift/appshot_shift.c"),
+    candidate("apps/desktop-electron/resources/bin/libatmos_appshot_shift.dylib"),
+    candidate("apps/desktop-electron/resources/runtime/__next._full.txt"),
+    candidate("apps/desktop-electron/resources/runtime/__next.appshot-permissions.txt"),
+    candidate(".github/workflows/appshot.yml", { isHidden: true }),
+    candidate(".appshot-config", { isHidden: true }),
+    candidate("docs/unrelated.md"),
+    candidate("zz_end_appshot"),
   ];
 
   it("lists files under the typed directory when the query ends with a slash", () => {
@@ -36,7 +47,7 @@ describe("filterMentionFileCandidates", () => {
       ]);
   });
 
-  it("searches only inside the directory before the last slash", () => {
+  it("searches only inside the directory before the last slash, matching names", () => {
     const paths = filterMentionFileCandidates(entries, "pages/script").map(
       (item) => item.relativePath,
     );
@@ -44,5 +55,78 @@ describe("filterMentionFileCandidates", () => {
     expect(paths).toContain("pages/script.ts");
     expect(paths).toContain("pages/sub/script-helper.ts");
     expect(paths).not.toContain("src/script.ts");
+  });
+
+  it("matches names with left and right free (`*query*`), not only prefixes", () => {
+    const names = filterMentionFileCandidates(entries, "appshot").map((item) => item.name);
+
+    // prefix
+    expect(names).toContain("appshot_shift.c");
+    expect(names).toContain("appshot.yml");
+    // left free (suffix / mid)
+    expect(names).toContain("libatmos_appshot_shift.dylib");
+    expect(names).toContain("__next.appshot-permissions.txt");
+    expect(names).toContain("zz_end_appshot");
+    expect(names).toContain(".appshot-config");
+    // path-only noise must not match
+    expect(names).not.toContain("__next._full.txt");
+    expect(names).not.toContain("unrelated.md");
+  });
+
+  it("returns all matches with no result limit", () => {
+    const crowded: MentionFileCandidate[] = [];
+    for (let i = 0; i < 50; i++) {
+      crowded.push(candidate(`prefix/appshot_file_${i}.ts`));
+    }
+    crowded.push(candidate("bin/libatmos_appshot_shift.dylib"));
+    crowded.push(candidate("misc/zz_end_appshot"));
+    crowded.push(candidate("docs/unrelated.md"));
+
+    const names = filterMentionFileCandidates(crowded, "appshot").map((item) => item.name);
+
+    expect(names).toHaveLength(52);
+    expect(names).toContain("libatmos_appshot_shift.dylib");
+    expect(names).toContain("zz_end_appshot");
+    expect(names).not.toContain("unrelated.md");
+  });
+
+  it("is case-insensitive", () => {
+    const names = filterMentionFileCandidates(entries, "AppShot").map((item) => item.name);
+    expect(names).toContain("appshot_shift.c");
+    expect(names).toContain("libatmos_appshot_shift.dylib");
+  });
+
+  it("ranks exact/prefix before mid-string contains", () => {
+    const names = filterMentionFileCandidates(entries, "appshot").map((item) => item.name);
+    const prefixIdx = names.indexOf("appshot_shift.c");
+    const midIdx = names.indexOf("libatmos_appshot_shift.dylib");
+    expect(prefixIdx).toBeGreaterThanOrEqual(0);
+    expect(midIdx).toBeGreaterThanOrEqual(0);
+    expect(prefixIdx).toBeLessThan(midIdx);
+  });
+});
+
+describe("splitHighlightParts", () => {
+  it("returns the full string when query is empty", () => {
+    expect(splitHighlightParts("appshot_shift.c", "")).toEqual([
+      { text: "appshot_shift.c", match: false },
+    ]);
+  });
+
+  it("highlights mid-string matches so left/right free matching is visible", () => {
+    expect(splitHighlightParts("libatmos_appshot_shift.dylib", "AppShot")).toEqual([
+      { text: "libatmos_", match: false },
+      { text: "appshot", match: true },
+      { text: "_shift.dylib", match: false },
+    ]);
+  });
+
+  it("handles multiple matches in one name", () => {
+    expect(splitHighlightParts("foo-foo-bar", "foo")).toEqual([
+      { text: "foo", match: true },
+      { text: "-", match: false },
+      { text: "foo", match: true },
+      { text: "-bar", match: false },
+    ]);
   });
 });

--- a/apps/web/src/features/welcome/hooks/use-welcome-mention-search.ts
+++ b/apps/web/src/features/welcome/hooks/use-welcome-mention-search.ts
@@ -16,6 +16,7 @@ import {
   type MentionFileCandidate,
 } from "@/features/welcome/lib/welcome-page-helpers";
 import { filterMentionFileCandidates } from "@/features/welcome/lib/mention-file-search";
+import { scrollActiveListItemIntoView } from "@/features/welcome/lib/popover-list-scroll";
 
 export function useWelcomeMentionSearch({
   issuePreview,
@@ -89,9 +90,13 @@ export function useWelcomeMentionSearch({
   React.useEffect(() => {
     if (!popover) return;
     const container = mentionPopoverListRef.current;
-    const activeItem = mentionItemRefs.current[activeMentionFileIndex];
-    if (!container || !activeItem) return;
-    activeItem.scrollIntoView({ block: "nearest" });
+    if (!container) return;
+    scrollActiveListItemIntoView(
+      container,
+      mentionItemRefs.current,
+      activeMentionFileIndex,
+      3,
+    );
   }, [activeMentionFileIndex, popover]);
 
   React.useEffect(() => {

--- a/apps/web/src/features/welcome/hooks/use-welcome-slash-navigation.ts
+++ b/apps/web/src/features/welcome/hooks/use-welcome-slash-navigation.ts
@@ -2,6 +2,7 @@
 
 import React from "react";
 import type { SkillInfo } from "@/api/ws-api";
+import { scrollActiveListItemIntoView } from "@/features/welcome/lib/popover-list-scroll";
 import type { AgentMenuOption } from "@/features/welcome/lib/welcome-page-helpers";
 
 export type WelcomeSlashPopoverState = {
@@ -113,9 +114,8 @@ export function useWelcomeSlashNavigation<Project>({
   React.useEffect(() => {
     if (!popover) return;
     const container = listRef.current;
-    const activeItem = itemRefs.current[activeIndex];
-    if (!container || !activeItem) return;
-    activeItem.scrollIntoView({ block: "nearest" });
+    if (!container) return;
+    scrollActiveListItemIntoView(container, itemRefs.current, activeIndex, 3);
   }, [activeIndex, popover]);
 
   React.useEffect(() => {

--- a/apps/web/src/features/welcome/lib/mention-file-search.ts
+++ b/apps/web/src/features/welcome/lib/mention-file-search.ts
@@ -1,26 +1,96 @@
-import Fuse from "fuse.js";
-
 import type { MentionFileCandidate } from "@/features/welcome/lib/welcome-page-helpers";
 
-const MENTION_FILE_FUSE_OPTIONS = {
-  keys: [
-    { name: "name", weight: 0.68 },
-    { name: "relativePath", weight: 0.32 },
-  ],
-  threshold: 0.32,
-  ignoreLocation: true,
+/** Case-insensitive substring split for UI highlight. */
+export type HighlightPart = { text: string; match: boolean };
+
+/**
+ * Split `text` so every occurrence of `query` (case-insensitive) is a match
+ * part. Empty query returns the whole string as a non-match.
+ */
+export function splitHighlightParts(text: string, rawQuery: string): HighlightPart[] {
+  const query = rawQuery.trim();
+  if (!query) return [{ text, match: false }];
+
+  const lowerText = text.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+  const parts: HighlightPart[] = [];
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const index = lowerText.indexOf(lowerQuery, cursor);
+    if (index < 0) {
+      parts.push({ text: text.slice(cursor), match: false });
+      break;
+    }
+    if (index > cursor) {
+      parts.push({ text: text.slice(cursor, index), match: false });
+    }
+    parts.push({ text: text.slice(index, index + query.length), match: true });
+    cursor = index + query.length;
+  }
+
+  return parts.length > 0 ? parts : [{ text, match: false }];
+}
+
+type RankedMentionFile = MentionFileCandidate & {
+  /** Lower is better. */
+  score: number;
+  matchIndex: number;
 };
 
-function sortMentionFileCandidates(items: MentionFileCandidate[]) {
+/**
+ * Score a name against a lowercase query.
+ * Matching is case-insensitive **contains** (`*query*`) — left and right of the
+ * keyword may be anything. Prefix / exact only affect ranking, not eligibility.
+ */
+function rankNameMatch(name: string, queryLower: string): RankedMentionFile["score"] | null {
+  const lower = name.toLowerCase();
+  const matchIndex = lower.indexOf(queryLower);
+  if (matchIndex < 0) return null;
+
+  // Exact name (ignoring common single extension) ranks highest.
+  if (lower === queryLower) return 0;
+  const dot = lower.lastIndexOf(".");
+  if (dot > 0 && lower.slice(0, dot) === queryLower) return 1;
+
+  // Prefix match — still contains, just better rank.
+  if (matchIndex === 0) return 10 + name.length * 0.001;
+
+  // Suffix match (…query or …query.ext)
+  if (lower.endsWith(queryLower)) return 20 + matchIndex * 0.01;
+  if (dot > matchIndex && lower.slice(0, dot).endsWith(queryLower)) {
+    return 21 + matchIndex * 0.01;
+  }
+
+  // Mid-string contains — left and right both free (`*query*`).
+  return 30 + matchIndex * 0.01 + name.length * 0.0001;
+}
+
+function sortRankedMentionFiles(items: RankedMentionFile[]) {
   return [...items].sort((a, b) => {
+    if (a.score !== b.score) return a.score - b.score;
+
     const bucket = (item: MentionFileCandidate) =>
       item.isHidden ? 2 : item.isDir ? 1 : 0;
     const bucketDiff = bucket(a) - bucket(b);
     if (bucketDiff !== 0) return bucketDiff;
+
     return a.relativePath.localeCompare(b.relativePath);
   });
 }
 
+/**
+ * Filter project file/folder candidates for the composer `@` mention popover.
+ *
+ * Matching rules:
+ * - Only the file/folder **name** is searched (not the full relative path).
+ * - Case-insensitive **contains** match (`*keyword*`) — characters on either
+ *   side of the keyword are allowed; prefix is not required.
+ * - Hidden files/folders (names starting with `.`) are included when present
+ *   in the candidate list (caller loads the tree with `showHidden: true`).
+ * - A trailing path prefix (`dir/`) still scopes results under that directory;
+ *   the segment after the last `/` is matched against names only.
+ */
 export function filterMentionFileCandidates(
   entries: MentionFileCandidate[],
   rawQuery: string,
@@ -42,11 +112,30 @@ export function filterMentionFileCandidates(
       );
     });
     searchQuery = query.slice(slashIndex + 1).trim();
-    if (!searchQuery) return sortMentionFileCandidates(searchEntries).slice(0, 12);
+    if (!searchQuery) {
+      return [...searchEntries].sort((a, b) => {
+        const bucket = (item: MentionFileCandidate) =>
+          item.isHidden ? 2 : item.isDir ? 1 : 0;
+        const bucketDiff = bucket(a) - bucket(b);
+        if (bucketDiff !== 0) return bucketDiff;
+        return a.relativePath.localeCompare(b.relativePath);
+      });
+    }
   }
 
-  const fuse = new Fuse(searchEntries, MENTION_FILE_FUSE_OPTIONS);
-  return sortMentionFileCandidates(
-    fuse.search(searchQuery, { limit: 60 }).map((r) => r.item),
-  ).slice(0, 12);
+  const queryLower = searchQuery.toLowerCase();
+  const ranked: RankedMentionFile[] = [];
+  for (const item of searchEntries) {
+    const score = rankNameMatch(item.name, queryLower);
+    if (score === null) continue;
+    ranked.push({
+      ...item,
+      score,
+      matchIndex: item.name.toLowerCase().indexOf(queryLower),
+    });
+  }
+
+  return sortRankedMentionFiles(ranked).map(
+    ({ score: _score, matchIndex: _matchIndex, ...item }) => item,
+  );
 }

--- a/apps/web/src/features/welcome/lib/popover-list-scroll.ts
+++ b/apps/web/src/features/welcome/lib/popover-list-scroll.ts
@@ -1,0 +1,46 @@
+/**
+ * Scroll the active popover row into view while keeping `paddingItems` extra
+ * rows visible past it (both directions). When arrowing down, the selection
+ * sits about 4th-from-bottom so the next few results stay readable.
+ *
+ * Shared by composer `@` mentions and `/` slash menus (including Terminal AI input).
+ */
+export function scrollActiveListItemIntoView(
+  container: HTMLElement,
+  itemEls: Array<HTMLElement | null>,
+  activeIndex: number,
+  paddingItems = 3,
+): void {
+  const activeItem = itemEls[activeIndex];
+  if (!activeItem) return;
+
+  const lastIndex = itemEls.length - 1;
+  let lookAheadIndex = Math.min(activeIndex + paddingItems, lastIndex);
+  let lookBehindIndex = Math.max(activeIndex - paddingItems, 0);
+  while (lookAheadIndex > activeIndex && !itemEls[lookAheadIndex]) lookAheadIndex -= 1;
+  while (lookBehindIndex < activeIndex && !itemEls[lookBehindIndex]) lookBehindIndex += 1;
+
+  const lookAhead = itemEls[lookAheadIndex] ?? activeItem;
+  const lookBehind = itemEls[lookBehindIndex] ?? activeItem;
+
+  const containerRect = container.getBoundingClientRect();
+  const aheadBottom = lookAhead.getBoundingClientRect().bottom;
+  if (aheadBottom > containerRect.bottom) {
+    container.scrollTop += aheadBottom - containerRect.bottom;
+  }
+
+  const behindTop = lookBehind.getBoundingClientRect().top;
+  const containerTop = container.getBoundingClientRect().top;
+  if (behindTop < containerTop) {
+    container.scrollTop += behindTop - containerTop;
+  }
+
+  // Guarantee the active row itself is fully visible (tall rows / edge cases).
+  const activeRect = activeItem.getBoundingClientRect();
+  const nextContainerRect = container.getBoundingClientRect();
+  if (activeRect.top < nextContainerRect.top) {
+    container.scrollTop += activeRect.top - nextContainerRect.top;
+  } else if (activeRect.bottom > nextContainerRect.bottom) {
+    container.scrollTop += activeRect.bottom - nextContainerRect.bottom;
+  }
+}


### PR DESCRIPTION
## Summary

Optimize composer `@` mention file search and shared popover keyboard scrolling (Welcome + Terminal AI input):

- **`@` file search**: match only file/folder **names** with case-insensitive substring (`*keyword*`), including hidden names (`.…`); drop Fuse fuzzy matching on full paths that produced irrelevant hits
- **No result cap**: return every name match (still ranked: exact → prefix → contains)
- **Keyword highlight**: highlight matched segments in the result file name so why it hit is obvious
- **Keyboard scroll padding**: when arrowing through `@` and `/` lists, keep **3 peek rows** below/above the active item (selection ~4th from bottom); shared helper used by mention + slash (Terminal reuses the same hooks)

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [x] `bun test src/features/welcome/hooks/__tests__/use-welcome-mention-search.test.ts` (apps/web)
- [ ] `just fmt`
- [ ] Additional checks (describe below)

## Checklist

- [ ] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves composer `@` file mention search to match case-insensitive name substrings with clearer ranking and highlighting. Also smooths keyboard navigation in `@` and `/` popovers by keeping 3 items visible around the selection with a shared scroll helper.

- **Bug Fixes**
  - `@` file search now matches name substrings only (case-insensitive), includes hidden names, removes fuzzy full-path noise, returns all matches, and ranks exact/prefix before contains.
  - Keyboard navigation in `@` and `/` popovers keeps 3 peek rows around the active item for steadier scrolling.

- **Refactors**
  - Extracted shared `scrollActiveListItemIntoView` for popover lists (Welcome and Terminal).
  - Highlighted matched segments in result names via `splitHighlightParts` to show why each item matched.

<sup>Written for commit ecc84d0a7bf86a68ed8b8ffacc926606b13ba92b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File mention search now supports case-insensitive substring matching with improved ranking.
  * Matching text is highlighted in file names.
  * Search results can include all relevant matches without an artificial limit.

* **Bug Fixes**
  * Improved keyboard navigation by keeping active slash-command and file-mention items visible while scrolling.
  * Improved matching behavior for directory paths, hidden files, and varied query patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->