### PR TITLE
feat(canvas): open compact add-widget UI on empty marquee select

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2644,6 +2644,21 @@
         "description": "Open a live terminal widget on the canvas."
       }
     },
+    "emptyBrushAddWidget": {
+      "title": "Add widget",
+      "sizeHint": "{width} × {height}",
+      "contextPlaceholder": "Project / workspace",
+      "contextNone": "No context",
+      "contextOptional": "Optional for global widgets",
+      "contextSelected": "Selected",
+      "contextButtonPlaceholder": "Select project or workspace",
+      "contextButtonHint": "Click to search and choose a context",
+      "contextRequired": "Select a project or workspace for this widget.",
+      "componentSearchPlaceholder": "Search components",
+      "clearComponentSearchAria": "Clear component search",
+      "componentEmptyTitle": "No matching components",
+      "componentEmptyDescription": "Try a different search."
+    },
     "unsupportedInteraction": {
       "dialogAria": "Unsupported canvas interaction",
       "title": "Not available on the canvas",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2644,6 +2644,21 @@
         "description": "在画布上打开一个实时终端 Widget。"
       }
     },
+    "emptyBrushAddWidget": {
+      "title": "添加 Widget",
+      "sizeHint": "{width} × {height}",
+      "contextPlaceholder": "项目 / 工作区",
+      "contextNone": "无上下文",
+      "contextOptional": "全局 Widget 可不选",
+      "contextSelected": "已选择",
+      "contextButtonPlaceholder": "选择项目或工作区",
+      "contextButtonHint": "点击搜索并选择上下文",
+      "contextRequired": "此 Widget 需要选择项目或工作区。",
+      "componentSearchPlaceholder": "搜索组件",
+      "clearComponentSearchAria": "清除组件搜索",
+      "componentEmptyTitle": "没有匹配的组件",
+      "componentEmptyDescription": "试试其他搜索词。"
+    },
     "unsupportedInteraction": {
       "dialogAria": "画布不支持的交互",
       "title": "画布中暂不可用",

--- a/apps/web/src/features/canvas/__tests__/canvas-empty-brush.test.ts
+++ b/apps/web/src/features/canvas/__tests__/canvas-empty-brush.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  isEmptyBrushRegionEligible,
+  normalizeCanvasPageRect,
+  shouldOpenEmptyBrushAddWidget,
+  EMPTY_BRUSH_MIN_PAGE_SIZE,
+} from "../lib/canvas-empty-brush";
+
+describe("normalizeCanvasPageRect", () => {
+  it("normalizes negative width/height into a positive origin+size rect", () => {
+    expect(
+      normalizeCanvasPageRect({
+        x: 200,
+        y: 100,
+        w: -80,
+        h: -40,
+      }),
+    ).toEqual({
+      x: 120,
+      y: 60,
+      w: 80,
+      h: 40,
+    });
+  });
+
+  it("returns null for invalid numbers", () => {
+    expect(normalizeCanvasPageRect({ x: Number.NaN, y: 0, w: 10, h: 10 })).toBeNull();
+    expect(normalizeCanvasPageRect(null)).toBeNull();
+    expect(normalizeCanvasPageRect(undefined)).toBeNull();
+  });
+});
+
+describe("isEmptyBrushRegionEligible", () => {
+  it("requires both dimensions to meet the minimum", () => {
+    expect(
+      isEmptyBrushRegionEligible({
+        x: 0,
+        y: 0,
+        w: EMPTY_BRUSH_MIN_PAGE_SIZE,
+        h: EMPTY_BRUSH_MIN_PAGE_SIZE,
+      }),
+    ).toBe(true);
+    expect(
+      isEmptyBrushRegionEligible({
+        x: 0,
+        y: 0,
+        w: EMPTY_BRUSH_MIN_PAGE_SIZE - 1,
+        h: EMPTY_BRUSH_MIN_PAGE_SIZE,
+      }),
+    ).toBe(false);
+    expect(isEmptyBrushRegionEligible(null)).toBe(false);
+  });
+});
+
+describe("shouldOpenEmptyBrushAddWidget", () => {
+  const eligibleBrush = {
+    x: 10,
+    y: 20,
+    w: EMPTY_BRUSH_MIN_PAGE_SIZE + 40,
+    h: EMPTY_BRUSH_MIN_PAGE_SIZE + 20,
+  };
+
+  it("opens only for a completed empty marquee of sufficient size", () => {
+    expect(
+      shouldOpenEmptyBrushAddWidget({
+        wasBrushing: true,
+        selectedShapeIds: [],
+        brush: eligibleBrush,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not open when shapes were selected (default selection path)", () => {
+    expect(
+      shouldOpenEmptyBrushAddWidget({
+        wasBrushing: true,
+        selectedShapeIds: ["shape:1"],
+        brush: eligibleBrush,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not open when the brush was cancelled or never started", () => {
+    expect(
+      shouldOpenEmptyBrushAddWidget({
+        wasBrushing: true,
+        cancelled: true,
+        selectedShapeIds: [],
+        brush: eligibleBrush,
+      }),
+    ).toBe(false);
+    expect(
+      shouldOpenEmptyBrushAddWidget({
+        wasBrushing: false,
+        selectedShapeIds: [],
+        brush: eligibleBrush,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not open for tiny brushes", () => {
+    expect(
+      shouldOpenEmptyBrushAddWidget({
+        wasBrushing: true,
+        selectedShapeIds: [],
+        brush: { x: 0, y: 0, w: 12, h: 12 },
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/features/canvas/components/CanvasEmptyBrushAddWidget.tsx
+++ b/apps/web/src/features/canvas/components/CanvasEmptyBrushAddWidget.tsx
@@ -1,0 +1,850 @@
+"use client";
+
+import React from "react";
+import { useTranslations } from "next-intl";
+import {
+  Check,
+  ChevronsUpDown,
+  Folder,
+  FolderGit2,
+  Loader2,
+  Plus,
+  Search,
+  SquareTerminal,
+  X,
+} from "lucide-react";
+import { useEditor, type Editor, type TLShapeId } from "tldraw";
+import {
+  Button,
+  Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  cn,
+  toastManager,
+} from "@workspace/ui";
+
+import {
+  useProjects,
+  useProjectsLoading,
+} from "@/features/project/hooks/use-project-bootstrap-query";
+import type { Project, Workspace } from "@/shared/types/domain";
+import {
+  findFrameContainingPageRect,
+  normalizeCanvasPageRect,
+  shouldOpenEmptyBrushAddWidget,
+  type CanvasPageRect,
+} from "@/features/canvas/lib/canvas-empty-brush";
+import type { CanvasContextRef } from "@/features/canvas/lib/canvas-widget-shape";
+import {
+  ADDABLE_CANVAS_WIDGET_TYPES,
+  CANVAS_WIDGET_GROUPS,
+  CANVAS_WIDGET_REGISTRY,
+  type AddableCanvasWidgetType,
+} from "@/features/canvas/lib/canvas-widget-registry";
+import { CANVAS_TERMINAL_DEFAULT_SIZE } from "@/features/canvas/lib/canvas-terminal-shape";
+import { useAddCanvasTerminal } from "@/features/canvas/hooks/use-add-canvas-terminal";
+import { useAddAtmosWidget } from "@/features/canvas/hooks/use-add-atmos-widget";
+import { focusCanvasShapes } from "@/features/canvas/lib/canvas-shape-focus";
+import { useCanvasRuntimeStore } from "@/features/canvas/store/canvas-runtime-store";
+
+const CANVAS_TERMINAL_ADD_ITEM_TYPE = "terminal" as const;
+
+type AddableCanvasItemType = AddableCanvasWidgetType | typeof CANVAS_TERMINAL_ADD_ITEM_TYPE;
+
+const CANVAS_TERMINAL_ADD_ITEM = {
+  group: "workspace" as const,
+  label: "",
+  description: "",
+  icon: SquareTerminal,
+  defaultSize: CANVAS_TERMINAL_DEFAULT_SIZE,
+  requiresContext: true,
+};
+
+const ADDABLE_CANVAS_ITEM_TYPES: AddableCanvasItemType[] = [
+  "center",
+  CANVAS_TERMINAL_ADD_ITEM_TYPE,
+  "workspace-context",
+  ...ADDABLE_CANVAS_WIDGET_TYPES.filter(
+    (type) => type !== "center" && type !== "workspace-context",
+  ),
+];
+
+type ContextOption = {
+  value: string;
+  kind: "project" | "workspace";
+  label: string;
+  detail: string;
+  searchText: string;
+  context: CanvasContextRef;
+};
+
+function isCanvasWidgetAddItemType(
+  type: AddableCanvasItemType,
+): type is AddableCanvasWidgetType {
+  return type !== CANVAS_TERMINAL_ADD_ITEM_TYPE;
+}
+
+function getCanvasAddItemEntry(type: AddableCanvasItemType) {
+  return type === CANVAS_TERMINAL_ADD_ITEM_TYPE
+    ? CANVAS_TERMINAL_ADD_ITEM
+    : CANVAS_WIDGET_REGISTRY[type];
+}
+
+function buildSearchText(parts: string[]): string {
+  return parts.join(" ").toLocaleLowerCase();
+}
+
+function normalizeQuery(query: string): string {
+  return query.trim().toLocaleLowerCase();
+}
+
+function buildProjectContext(project: Project): CanvasContextRef {
+  return {
+    contextScope: "project",
+    projectId: project.id,
+    workspaceId: null,
+    projectName: project.name,
+    workspaceName: null,
+    localPath: project.mainFilePath,
+    repoPath: project.mainFilePath,
+  };
+}
+
+function buildWorkspaceContext(project: Project, workspace: Workspace): CanvasContextRef {
+  return {
+    contextScope: "workspace",
+    projectId: project.id,
+    workspaceId: workspace.id,
+    projectName: project.name,
+    workspaceName: workspace.name,
+    localPath: workspace.localPath,
+    repoPath: workspace.localPath,
+  };
+}
+
+function buildContextOptions(projects: Project[]): ContextOption[] {
+  return projects.flatMap((project) => {
+    const projectOption: ContextOption = {
+      value: `project:${project.id}`,
+      kind: "project",
+      label: project.name,
+      detail: project.mainFilePath,
+      searchText: buildSearchText([project.name, project.mainFilePath, project.targetBranch ?? ""]),
+      context: buildProjectContext(project),
+    };
+    const workspaceOptions = project.workspaces.map(
+      (workspace): ContextOption => ({
+        value: `workspace:${workspace.id}`,
+        kind: "workspace",
+        label: workspace.displayName || workspace.name,
+        detail: `${project.name} / ${workspace.branch}`,
+        searchText: buildSearchText([
+          workspace.displayName ?? "",
+          workspace.name,
+          workspace.branch,
+          workspace.localPath,
+          project.name,
+          project.mainFilePath,
+        ]),
+        context: buildWorkspaceContext(project, workspace),
+      }),
+    );
+    return [projectOption, ...workspaceOptions];
+  });
+}
+
+function rectToViewportStyle(
+  editor: Editor,
+  rect: CanvasPageRect,
+): { left: number; top: number; width: number; height: number } | null {
+  try {
+    const topLeft = editor.pageToViewport({ x: rect.x, y: rect.y });
+    const bottomRight = editor.pageToViewport({
+      x: rect.x + rect.w,
+      y: rect.y + rect.h,
+    });
+    return {
+      left: Math.min(topLeft.x, bottomRight.x),
+      top: Math.min(topLeft.y, bottomRight.y),
+      width: Math.abs(bottomRight.x - topLeft.x),
+      height: Math.abs(bottomRight.y - topLeft.y),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detects empty select-tool marquee gestures and offers a compact Add Widget UI
+ * sized to the brushed region.
+ */
+/** Keep the anchor mounted long enough for Radix popover exit animation. */
+const EMPTY_BRUSH_POPOVER_EXIT_MS = 160;
+
+export function CanvasEmptyBrushAddWidget() {
+  const editor = useEditor();
+  const [region, setRegion] = React.useState<CanvasPageRect | null>(null);
+  const [open, setOpen] = React.useState(false);
+  const regionRef = React.useRef<CanvasPageRect | null>(null);
+  const openRef = React.useRef(false);
+  const wasBrushingRef = React.useRef(false);
+  const lastBrushRef = React.useRef<CanvasPageRect | null>(null);
+  const cancelledRef = React.useRef(false);
+  const openFrameRef = React.useRef<number | null>(null);
+  const exitTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  regionRef.current = region;
+  openRef.current = open;
+
+  const clearExitTimeout = React.useCallback(() => {
+    if (exitTimeoutRef.current != null) {
+      clearTimeout(exitTimeoutRef.current);
+      exitTimeoutRef.current = null;
+    }
+  }, []);
+
+  const dismiss = React.useCallback(() => {
+    setOpen(false);
+    clearExitTimeout();
+    exitTimeoutRef.current = setTimeout(() => {
+      exitTimeoutRef.current = null;
+      setRegion(null);
+    }, EMPTY_BRUSH_POPOVER_EXIT_MS);
+  }, [clearExitTimeout]);
+
+  const present = React.useCallback(
+    (nextRegion: CanvasPageRect) => {
+      clearExitTimeout();
+      setRegion(nextRegion);
+      setOpen(true);
+    },
+    [clearExitTimeout],
+  );
+
+  React.useEffect(() => {
+    return () => {
+      clearExitTimeout();
+      if (openFrameRef.current != null) {
+        cancelAnimationFrame(openFrameRef.current);
+      }
+    };
+  }, [clearExitTimeout]);
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+      if (editor.isIn("select.brushing") || editor.isIn("select.scribble_brushing")) {
+        cancelledRef.current = true;
+      }
+      if (openRef.current) {
+        dismiss();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [dismiss, editor]);
+
+  React.useEffect(() => {
+    const cleanup = editor.store.listen(
+      () => {
+        const isBrushing = editor.isIn("select.brushing");
+        const brush = normalizeCanvasPageRect(editor.getInstanceState().brush);
+
+        if (isBrushing) {
+          wasBrushingRef.current = true;
+          if (brush) {
+            lastBrushRef.current = brush;
+          }
+          // A new brush cancels any open empty-region popover.
+          if (openRef.current) {
+            dismiss();
+          }
+          return;
+        }
+
+        if (!wasBrushingRef.current) {
+          // Close if the user selects existing shapes while the popover is open.
+          if (openRef.current && editor.getSelectedShapeIds().length > 0) {
+            dismiss();
+          }
+          return;
+        }
+
+        wasBrushingRef.current = false;
+        const finishedBrush = lastBrushRef.current ?? brush;
+        lastBrushRef.current = null;
+        const cancelled = cancelledRef.current;
+        cancelledRef.current = false;
+
+        if (openFrameRef.current != null) {
+          cancelAnimationFrame(openFrameRef.current);
+        }
+
+        // Wait one frame so selection/brush session state settles after brush exit.
+        openFrameRef.current = requestAnimationFrame(() => {
+          openFrameRef.current = null;
+          const shouldOpen = shouldOpenEmptyBrushAddWidget({
+            wasBrushing: true,
+            cancelled,
+            selectedShapeIds: editor.getSelectedShapeIds(),
+            brush: finishedBrush,
+          });
+          if (shouldOpen && finishedBrush) {
+            present(finishedBrush);
+          }
+        });
+      },
+      { scope: "session" },
+    );
+
+    return cleanup;
+  }, [dismiss, editor, present]);
+
+  if (!region) {
+    return null;
+  }
+
+  return (
+    <CanvasEmptyBrushAddWidgetPopover
+      editor={editor}
+      region={region}
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          dismiss();
+        }
+      }}
+    />
+  );
+}
+
+function CanvasEmptyBrushAddWidgetPopover({
+  editor,
+  region,
+  open,
+  onOpenChange,
+}: {
+  editor: Editor;
+  region: CanvasPageRect;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const t = useTranslations("canvas.addWidgetDialog");
+  const tEmpty = useTranslations("canvas.emptyBrushAddWidget");
+  const projects = useProjects();
+  const isLoadingProjects = useProjectsLoading();
+  const setFocusPulseShapeIds = useCanvasRuntimeStore((state) => state.setFocusPulseShapeIds);
+  const addWidget = useAddAtmosWidget(editor);
+  const addTerminal = useAddCanvasTerminal(editor);
+
+  const [selectedContextValue, setSelectedContextValue] = React.useState<string | null>(null);
+  const [selectedItemType, setSelectedItemType] = React.useState<AddableCanvasItemType | null>(
+    null,
+  );
+  const [contextPickerOpen, setContextPickerOpen] = React.useState(false);
+  const [contextQuery, setContextQuery] = React.useState("");
+  const [componentQuery, setComponentQuery] = React.useState("");
+  const [isAdding, setIsAdding] = React.useState(false);
+  const [viewportRect, setViewportRect] = React.useState(() =>
+    rectToViewportStyle(editor, region),
+  );
+  const componentSearchRef = React.useRef<HTMLInputElement | null>(null);
+  const contextSearchRef = React.useRef<HTMLInputElement | null>(null);
+
+  React.useEffect(() => {
+    setSelectedContextValue(null);
+    setSelectedItemType(null);
+    setContextPickerOpen(false);
+    setContextQuery("");
+    setComponentQuery("");
+    setIsAdding(false);
+  }, [region.x, region.y, region.w, region.h]);
+
+  React.useEffect(() => {
+    if (!open) {
+      setContextPickerOpen(false);
+      return;
+    }
+    const frame = requestAnimationFrame(() => {
+      componentSearchRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [open, region.x, region.y]);
+
+  React.useEffect(() => {
+    if (!contextPickerOpen) {
+      return;
+    }
+    const frame = requestAnimationFrame(() => {
+      contextSearchRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [contextPickerOpen]);
+
+  React.useEffect(() => {
+    const sync = () => {
+      setViewportRect(rectToViewportStyle(editor, region));
+    };
+    sync();
+    const cleanup = editor.store.listen(sync, { scope: "session" });
+    return cleanup;
+  }, [editor, region]);
+
+  const contextOptions = React.useMemo(() => buildContextOptions(projects), [projects]);
+  const selectedContext = contextOptions.find((option) => option.value === selectedContextValue);
+  const frameId = React.useMemo(
+    () => findFrameContainingPageRect(editor, region),
+    [editor, region],
+  );
+
+  const getEntryLabel = React.useCallback(
+    (type: AddableCanvasItemType) =>
+      type === CANVAS_TERMINAL_ADD_ITEM_TYPE ? t("terminal.label") : getCanvasAddItemEntry(type).label,
+    [t],
+  );
+  const getEntryDescription = React.useCallback(
+    (type: AddableCanvasItemType) =>
+      type === CANVAS_TERMINAL_ADD_ITEM_TYPE
+        ? t("terminal.description")
+        : getCanvasAddItemEntry(type).description,
+    [t],
+  );
+
+  const filteredContextOptions = React.useMemo(() => {
+    const query = normalizeQuery(contextQuery);
+    if (!query) {
+      return contextOptions;
+    }
+    return contextOptions.filter((option) => option.searchText.includes(query));
+  }, [contextOptions, contextQuery]);
+
+  const filteredItemTypes = React.useMemo(() => {
+    const query = normalizeQuery(componentQuery);
+    if (!query) {
+      return ADDABLE_CANVAS_ITEM_TYPES;
+    }
+    return ADDABLE_CANVAS_ITEM_TYPES.filter((type) => {
+      const label = getEntryLabel(type);
+      const description = getEntryDescription(type);
+      return buildSearchText([label, description, type]).includes(query);
+    });
+  }, [componentQuery, getEntryDescription, getEntryLabel]);
+
+  const groupedItemTypes = React.useMemo(() => {
+    return CANVAS_WIDGET_GROUPS.map((group) => ({
+      group,
+      itemTypes: filteredItemTypes.filter(
+        (type) => getCanvasAddItemEntry(type).group === group.id,
+      ),
+    })).filter((entry) => entry.itemTypes.length > 0);
+  }, [filteredItemTypes]);
+
+  const selectedEntry = selectedItemType ? getCanvasAddItemEntry(selectedItemType) : null;
+  const needsContext = Boolean(selectedEntry?.requiresContext);
+  const canAdd = Boolean(
+    editor && selectedItemType && (!needsContext || selectedContext) && !isAdding,
+  );
+
+  const handleAdd = async () => {
+    if (!selectedItemType || !canAdd || isAdding) {
+      return;
+    }
+
+    setIsAdding(true);
+    const size = { w: region.w, h: region.h };
+    const position = { x: region.x, y: region.y };
+    let createdShapeId: TLShapeId | null = null;
+
+    try {
+      createdShapeId = isCanvasWidgetAddItemType(selectedItemType)
+        ? addWidget({
+            widgetType: selectedItemType,
+            context: selectedContext?.context ?? null,
+            frameId,
+            position,
+            size,
+            select: false,
+          })
+        : await addTerminal({
+            context: selectedContext?.context ?? null,
+            frameId,
+            position,
+            size,
+            select: false,
+          });
+
+      if (!createdShapeId) {
+        throw new Error(t("toast.couldNotAddNamed", { itemName: getEntryLabel(selectedItemType) }));
+      }
+
+      focusCanvasShapes(editor, [createdShapeId], {
+        getFocusPulseShapeIds: () => useCanvasRuntimeStore.getState().focusPulseShapeIds,
+        setFocusPulseShapeIds,
+      });
+      onOpenChange(false);
+    } catch (error) {
+      if (createdShapeId) {
+        editor.deleteShapes([createdShapeId]);
+      }
+      toastManager.add({
+        title: t("toast.title"),
+        description: error instanceof Error ? error.message : t("toast.addFailed"),
+        type: "error",
+      });
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  // Keep ghost positioning when the viewport rect is available; panel itself is
+  // always centered so large marquees do not squeeze the UI off-screen.
+  const showGhost = open && viewportRect;
+
+  const selectContext = (value: string | null) => {
+    setSelectedContextValue(value);
+    setContextPickerOpen(false);
+    setContextQuery("");
+    // Match main Add Widget: without context, context-bound widgets are unselectable.
+    if (value == null && selectedItemType && getCanvasAddItemEntry(selectedItemType).requiresContext) {
+      setSelectedItemType(null);
+    }
+  };
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-[var(--tl-layer-panels,300)]">
+      {showGhost && viewportRect ? (
+        <div
+          className={cn(
+            "pointer-events-none absolute rounded-md border border-dashed border-primary/55 bg-primary/5",
+            "animate-in fade-in-0 zoom-in-95 duration-150",
+          )}
+          style={{
+            left: viewportRect.left,
+            top: viewportRect.top,
+            width: viewportRect.width,
+            height: viewportRect.height,
+          }}
+        />
+      ) : null}
+
+      {/* Fixed center of the canvas viewport — independent of marquee size. */}
+      <div
+        className={cn(
+          "absolute inset-0 flex items-center justify-center p-4 transition-[opacity,transform] duration-200 ease-out",
+          open
+            ? "pointer-events-none opacity-100 scale-100"
+            : "pointer-events-none opacity-0 scale-95",
+        )}
+      >
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={tEmpty("title")}
+          className={cn(
+            "pointer-events-auto flex w-[min(32rem,calc(100vw-1.5rem))] max-h-[min(40rem,calc(100vh-1.5rem))] flex-col overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-md outline-none",
+          )}
+          onPointerDown={(event) => event.stopPropagation()}
+        >
+          <div className="flex shrink-0 items-start justify-between gap-3 border-b border-border/70 px-4 py-3">
+            <div className="min-w-0">
+              <div className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
+                <Plus className="size-3.5 shrink-0 text-muted-foreground" />
+                <span className="truncate">{tEmpty("title")}</span>
+              </div>
+              <div className="mt-1 text-xs tabular-nums text-muted-foreground">
+                {tEmpty("sizeHint", {
+                  width: Math.round(region.w),
+                  height: Math.round(region.h),
+                })}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              aria-label={t("actions.cancel")}
+            >
+              <X className="size-3.5" />
+            </button>
+          </div>
+
+          <div className="min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain p-4 [scrollbar-gutter:stable]">
+            <section className="space-y-2">
+              <div className="flex items-center justify-between gap-2">
+                <div className="text-xs font-medium text-muted-foreground">
+                  {t("sections.projectWorkspace")}
+                </div>
+                <span className="text-[11px] text-muted-foreground">
+                  {selectedContext ? tEmpty("contextSelected") : tEmpty("contextOptional")}
+                </span>
+              </div>
+
+              <Popover open={contextPickerOpen} onOpenChange={setContextPickerOpen}>
+                <PopoverTrigger asChild>
+                  <button
+                    type="button"
+                    className={cn(
+                      "flex min-h-11 w-full items-center gap-2.5 rounded-md border border-border/70 bg-muted/35 px-3 py-2 text-left transition-colors",
+                      "hover:border-foreground/30 hover:bg-accent/60 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/45",
+                    )}
+                  >
+                    <span className="flex size-7 shrink-0 items-center justify-center rounded-md border border-border/70 bg-muted/50">
+                      {selectedContext?.kind === "workspace" ? (
+                        <FolderGit2 className="size-3.5 text-muted-foreground" />
+                      ) : (
+                        <Folder className="size-3.5 text-muted-foreground" />
+                      )}
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-medium text-foreground">
+                        {selectedContext
+                          ? selectedContext.label
+                          : isLoadingProjects
+                            ? t("contextPicker.loadingContexts")
+                            : tEmpty("contextButtonPlaceholder")}
+                      </span>
+                      <span className="mt-0.5 block truncate text-[11px] text-muted-foreground">
+                        {selectedContext
+                          ? selectedContext.detail
+                          : tEmpty("contextButtonHint")}
+                      </span>
+                    </span>
+                    <ChevronsUpDown className="size-4 shrink-0 text-muted-foreground" />
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent
+                  align="start"
+                  side="bottom"
+                  sideOffset={6}
+                  className="z-[1001] w-[var(--radix-popover-trigger-width)] max-w-[calc(100vw-2rem)] overflow-hidden p-0"
+                  onOpenAutoFocus={(event) => event.preventDefault()}
+                >
+                  <div className="border-b border-border/70 p-2">
+                    <div className="relative">
+                      <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+                      <Input
+                        ref={contextSearchRef}
+                        value={contextQuery}
+                        onChange={(event) => setContextQuery(event.target.value)}
+                        placeholder={t("contextPicker.searchPlaceholder")}
+                        className="h-9 border-border/80 bg-muted/30 pl-8 pr-8 text-sm"
+                      />
+                      {contextQuery ? (
+                        <button
+                          type="button"
+                          aria-label={t("contextPicker.clearSearchAria")}
+                          onClick={() => {
+                            setContextQuery("");
+                            contextSearchRef.current?.focus();
+                          }}
+                          className="absolute right-2 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+                        >
+                          <X className="size-3.5" />
+                        </button>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  <div className="max-h-[min(40vh,280px)] space-y-1 overflow-y-auto p-1.5">
+                    <button
+                      type="button"
+                      onClick={() => selectContext(null)}
+                      className={cn(
+                        "flex w-full items-center justify-between gap-2 rounded-md px-2.5 py-2 text-left text-sm transition-colors",
+                        "hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/45",
+                        selectedContextValue == null && "bg-accent text-accent-foreground",
+                      )}
+                    >
+                      <span className="truncate">{tEmpty("contextNone")}</span>
+                      {selectedContextValue == null ? (
+                        <Check className="size-3.5 shrink-0 text-success" />
+                      ) : null}
+                    </button>
+
+                    {isLoadingProjects ? (
+                      <div className="flex items-center gap-2 px-2.5 py-3 text-xs text-muted-foreground">
+                        <Loader2 className="size-3.5 animate-spin" />
+                        {t("contextPicker.loadingProjectsAndWorkspaces")}
+                      </div>
+                    ) : filteredContextOptions.length > 0 ? (
+                      filteredContextOptions.map((option) => {
+                        const active = option.value === selectedContextValue;
+                        return (
+                          <button
+                            key={option.value}
+                            type="button"
+                            onClick={() => selectContext(option.value)}
+                            className={cn(
+                              "flex w-full items-start gap-2 rounded-md px-2.5 py-2 text-left transition-colors",
+                              "hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/45",
+                              active && "bg-accent text-accent-foreground",
+                            )}
+                          >
+                            <span className="flex size-7 shrink-0 items-center justify-center rounded-md border border-border/70 bg-background/80">
+                              {option.kind === "workspace" ? (
+                                <FolderGit2 className="size-3.5 text-muted-foreground" />
+                              ) : (
+                                <Folder className="size-3.5 text-muted-foreground" />
+                              )}
+                            </span>
+                            <span className="min-w-0 flex-1">
+                              <span className="flex min-w-0 items-center gap-1.5">
+                                <span className="truncate text-sm font-medium">{option.label}</span>
+                                <span className="shrink-0 rounded border border-border/70 bg-muted/50 px-1 py-px text-[10px] font-medium text-muted-foreground">
+                                  {option.kind === "project"
+                                    ? t("contextPicker.projectKind")
+                                    : t("contextPicker.workspaceKind")}
+                                </span>
+                              </span>
+                              <span className="mt-0.5 block truncate text-[11px] text-muted-foreground">
+                                {option.detail}
+                              </span>
+                            </span>
+                            {active ? (
+                              <Check className="mt-0.5 size-3.5 shrink-0 text-success" />
+                            ) : null}
+                          </button>
+                        );
+                      })
+                    ) : (
+                      <div className="px-2.5 py-4 text-center text-xs text-muted-foreground">
+                        {t("contextPicker.emptyTitle")}
+                      </div>
+                    )}
+                  </div>
+                </PopoverContent>
+              </Popover>
+            </section>
+
+            <section className="space-y-2">
+              <div className="flex items-center justify-between gap-2">
+                <div className="text-xs font-medium text-muted-foreground">
+                  {t("sections.component")}
+                </div>
+                {selectedItemType ? (
+                  <span className="truncate text-[11px] text-muted-foreground">
+                    {getEntryLabel(selectedItemType)}
+                  </span>
+                ) : !selectedContext ? (
+                  <span className="text-[11px] text-muted-foreground">
+                    {t("globalWidgetsAvailable")}
+                  </span>
+                ) : null}
+              </div>
+
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  ref={componentSearchRef}
+                  value={componentQuery}
+                  onChange={(event) => setComponentQuery(event.target.value)}
+                  placeholder={tEmpty("componentSearchPlaceholder")}
+                  className="h-9 border-border/80 bg-muted/30 pl-8 pr-8 text-sm"
+                />
+                {componentQuery ? (
+                  <button
+                    type="button"
+                    aria-label={tEmpty("clearComponentSearchAria")}
+                    onClick={() => {
+                      setComponentQuery("");
+                      componentSearchRef.current?.focus();
+                    }}
+                    className="absolute right-2 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+                  >
+                    <X className="size-3.5" />
+                  </button>
+                ) : null}
+              </div>
+
+              <div className="space-y-3 rounded-md border border-dashed border-border/80 p-2.5">
+                {groupedItemTypes.length > 0 ? (
+                  groupedItemTypes.map(({ group, itemTypes }) => (
+                    <div key={group.id} className="space-y-1.5">
+                      <div className="px-0.5 text-[11px] font-medium text-muted-foreground">
+                        {group.label}
+                      </div>
+                      <div className="grid grid-cols-2 gap-1.5">
+                        {itemTypes.map((type) => {
+                          const entry = getCanvasAddItemEntry(type);
+                          const Icon = entry.icon;
+                          const active = selectedItemType === type;
+                          const disabled = entry.requiresContext && !selectedContext;
+                          const label = getEntryLabel(type);
+                          const description = getEntryDescription(type);
+
+                          return (
+                            <button
+                              key={type}
+                              type="button"
+                              aria-pressed={active}
+                              disabled={disabled}
+                              title={disabled ? `${label} — ${tEmpty("contextRequired")}` : label}
+                              onClick={() =>
+                                setSelectedItemType((prev) => (prev === type ? null : type))
+                              }
+                              className={cn(
+                                "flex min-h-[4.25rem] items-start gap-2.5 rounded-md bg-muted/35 p-2.5 text-left transition-colors",
+                                "enabled:hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/45",
+                                "disabled:cursor-not-allowed disabled:bg-muted/20 disabled:opacity-45",
+                                active && "bg-accent",
+                              )}
+                            >
+                              <Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                              <span className="min-w-0 flex-1">
+                                <span className="flex min-w-0 items-center justify-between gap-2 text-sm font-medium text-foreground">
+                                  <span className="min-w-0 truncate">{label}</span>
+                                  {active ? (
+                                    <Check className="size-3.5 shrink-0 text-success" />
+                                  ) : null}
+                                </span>
+                                <span className="mt-0.5 line-clamp-2 text-[11px] leading-snug text-muted-foreground">
+                                  {description}
+                                </span>
+                              </span>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ))
+                ) : (
+                  <div className="rounded-md px-2 py-6 text-center">
+                    <div className="text-sm font-medium text-foreground">
+                      {tEmpty("componentEmptyTitle")}
+                    </div>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {tEmpty("componentEmptyDescription")}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {needsContext && !selectedContext ? (
+                <p className="text-[11px] text-muted-foreground">{tEmpty("contextRequired")}</p>
+              ) : null}
+            </section>
+          </div>
+
+          <div className="flex shrink-0 items-center justify-end gap-2 border-t border-border/70 px-4 py-2.5">
+            <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+              {t("actions.cancel")}
+            </Button>
+            <Button size="sm" className="gap-1.5" disabled={!canAdd} onClick={handleAdd}>
+              {isLoadingProjects || isAdding ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : null}
+              {selectedItemType === CANVAS_TERMINAL_ADD_ITEM_TYPE
+                ? t("actions.addTerminal")
+                : t("actions.addWidget")}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/web/src/features/canvas/components/CanvasView.tsx
+++ b/apps/web/src/features/canvas/components/CanvasView.tsx
@@ -92,6 +92,7 @@ import { CanvasAgentOnCanvas } from "./CanvasAgentOnCanvas";
 import { CanvasAgentIsland } from "./CanvasAgentIsland";
 import { CanvasFocusPulse } from "./CanvasFocusPulse";
 import { CanvasShapeCopyOverlay } from "./CanvasShapeCopyOverlay";
+import { CanvasEmptyBrushAddWidget } from "./CanvasEmptyBrushAddWidget";
 import { CanvasUnsupportedInteractionDialog } from "./CanvasUnsupportedInteractionDialog";
 import {
   CanvasTerminalRefProvider,
@@ -334,7 +335,15 @@ export const CanvasView: React.FC = () => {
     () => <CanvasAgentOnCanvas bridge={canvasAgentBridgeRef.current} />,
     [],
   );
-  const ShapeCopySlot = React.useCallback(() => <CanvasShapeCopyOverlay />, []);
+  const ShapeCopySlot = React.useCallback(
+    () => (
+      <>
+        <CanvasShapeCopyOverlay />
+        <CanvasEmptyBrushAddWidget />
+      </>
+    ),
+    [],
+  );
   const tldrawComponents = React.useMemo<TLComponents>(
     () => ({
       MenuPanel: CanvasMenuPanel,

--- a/apps/web/src/features/canvas/hooks/use-add-atmos-widget.ts
+++ b/apps/web/src/features/canvas/hooks/use-add-atmos-widget.ts
@@ -110,6 +110,7 @@ export function useAddAtmosWidget(editor: Editor | null) {
       context?: CanvasContextRef | null;
       frameId: TLShapeId | null;
       position?: { x: number; y: number };
+      size?: { w: number; h: number };
       select?: boolean;
     }) => {
       if (!editor) {
@@ -126,7 +127,7 @@ export function useAddAtmosWidget(editor: Editor | null) {
         input.widgetType,
         input.context ?? createGlobalCanvasContextRef(),
       );
-      const size = CANVAS_WIDGET_REGISTRY[widgetType].defaultSize;
+      const size = input.size ?? CANVAS_WIDGET_REGISTRY[widgetType].defaultSize;
       const shapeId = createShapeId();
       const { x, y } =
         input.position ??
@@ -143,6 +144,8 @@ export function useAddAtmosWidget(editor: Editor | null) {
           widgetType,
           source,
           frameId: input.frameId,
+          w: size.w,
+          h: size.h,
         }),
       });
       reparentCanvasShapeToFrame(editor, shapeId, input.frameId);

--- a/apps/web/src/features/canvas/hooks/use-add-canvas-terminal.ts
+++ b/apps/web/src/features/canvas/hooks/use-add-canvas-terminal.ts
@@ -39,6 +39,7 @@ export function useAddCanvasTerminal(editor: Editor | null) {
       context?: CanvasContextRef | null;
       frameId: TLShapeId | null;
       position?: { x: number; y: number };
+      size?: { w: number; h: number };
       select?: boolean;
     }) => {
       if (!editor || !input.context) {
@@ -66,9 +67,10 @@ export function useAddCanvasTerminal(editor: Editor | null) {
         contextId,
         tmuxWindowName,
       );
+      const size = input.size ?? CANVAS_TERMINAL_DEFAULT_SIZE;
       const position = input.position ?? findCanvasWidgetPlacement(
         editor,
-        CANVAS_TERMINAL_DEFAULT_SIZE,
+        size,
         { frameId: input.frameId },
       );
 
@@ -91,6 +93,8 @@ export function useAddCanvasTerminal(editor: Editor | null) {
           isPinned: true,
           pinKey,
           lastAttachedAt: attachedAt,
+          w: size.w,
+          h: size.h,
         }),
       });
       reparentCanvasShapeToFrame(editor, shapeId, input.frameId);

--- a/apps/web/src/features/canvas/lib/canvas-empty-brush.ts
+++ b/apps/web/src/features/canvas/lib/canvas-empty-brush.ts
@@ -1,0 +1,97 @@
+import type { Editor, TLShapeId } from "tldraw";
+
+/** Page-space rectangle from a finished select-tool brush. */
+export type CanvasPageRect = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+};
+
+/**
+ * Minimum brush size in page units before we treat an empty marquee as an
+ * intentional "add widget here" gesture (avoids tiny accidental drags).
+ */
+export const EMPTY_BRUSH_MIN_PAGE_SIZE = 64;
+
+export function normalizeCanvasPageRect(
+  brush: { x: number; y: number; w: number; h: number } | null | undefined,
+): CanvasPageRect | null {
+  if (!brush) {
+    return null;
+  }
+  const w = Math.abs(brush.w);
+  const h = Math.abs(brush.h);
+  if (!Number.isFinite(brush.x) || !Number.isFinite(brush.y) || !Number.isFinite(w) || !Number.isFinite(h)) {
+    return null;
+  }
+  return {
+    x: brush.w < 0 ? brush.x + brush.w : brush.x,
+    y: brush.h < 0 ? brush.y + brush.h : brush.y,
+    w,
+    h,
+  };
+}
+
+export function isEmptyBrushRegionEligible(brush: CanvasPageRect | null | undefined): boolean {
+  if (!brush) {
+    return false;
+  }
+  return brush.w >= EMPTY_BRUSH_MIN_PAGE_SIZE && brush.h >= EMPTY_BRUSH_MIN_PAGE_SIZE;
+}
+
+/**
+ * After a select-tool brush ends: open the compact add-widget popover only when
+ * nothing was selected (empty area) and the marquee was large enough.
+ */
+export function shouldOpenEmptyBrushAddWidget(options: {
+  selectedShapeIds: readonly string[];
+  brush: CanvasPageRect | null;
+  wasBrushing: boolean;
+  cancelled?: boolean;
+}): boolean {
+  if (!options.wasBrushing || options.cancelled) {
+    return false;
+  }
+  if (options.selectedShapeIds.length > 0) {
+    return false;
+  }
+  return isEmptyBrushRegionEligible(options.brush);
+}
+
+/**
+ * Prefer the smallest frame that fully contains the marquee so widgets land
+ * inside the frame the user was drawing over.
+ */
+export function findFrameContainingPageRect(
+  editor: Editor,
+  rect: CanvasPageRect,
+): TLShapeId | null {
+  let bestId: TLShapeId | null = null;
+  let bestArea = Number.POSITIVE_INFINITY;
+
+  for (const shape of editor.getCurrentPageShapes()) {
+    if (shape.type !== "frame") {
+      continue;
+    }
+    const bounds = editor.getShapePageBounds(shape);
+    if (!bounds) {
+      continue;
+    }
+    const contains =
+      bounds.minX <= rect.x &&
+      bounds.minY <= rect.y &&
+      bounds.maxX >= rect.x + rect.w &&
+      bounds.maxY >= rect.y + rect.h;
+    if (!contains) {
+      continue;
+    }
+    const area = bounds.w * bounds.h;
+    if (area < bestArea) {
+      bestArea = area;
+      bestId = shape.id;
+    }
+  }
+
+  return bestId;
+}

--- a/apps/web/src/features/canvas/lib/canvas-terminal-shape.ts
+++ b/apps/web/src/features/canvas/lib/canvas-terminal-shape.ts
@@ -168,6 +168,8 @@ export function buildCanvasTerminalPinKey(
 
 export function createCanvasTerminalShapeProps(
   props: Omit<CanvasTerminalShapeProps, "w" | "h" | "isPinned" | "pinKey" | "lastAttachedAt"> & {
+    w?: number;
+    h?: number;
     isPinned?: boolean;
     pinKey?: string;
     lastAttachedAt?: number | null;
@@ -176,6 +178,8 @@ export function createCanvasTerminalShapeProps(
   return {
     ...CANVAS_TERMINAL_DEFAULT_SIZE,
     ...props,
+    w: props.w ?? CANVAS_TERMINAL_DEFAULT_SIZE.w,
+    h: props.h ?? CANVAS_TERMINAL_DEFAULT_SIZE.h,
     sourceTerminalTabId: props.sourceTerminalTabId ?? "terminal",
     paneAgent: props.paneAgent,
     isPinned: props.isPinned ?? false,


### PR DESCRIPTION
## Summary

- Detect select-tool empty marquee gestures and open a centered Add Widget panel sized to the brushed region
- Medium UI: context picker button with nested search popover, component search, grouped widget cards, enter/exit animation, and selection ghost
- Match main Add Widget rules: context-bound widgets are disabled until a project/workspace is selected; create hooks accept custom size/position (and auto-frame when applicable)

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] `bun test src/features/canvas/__tests__/canvas-empty-brush.test.ts` (7 pass)

## Checklist

- [ ] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a compact add-widget panel after finishing a large empty marquee with the select tool. The panel centers on the viewport, matches the brushed size, and adds the chosen widget or terminal at that size and position.

- **New Features**
  - Open only on empty, completed brushes ≥64 in both dimensions; ignore if canceled or shapes were selected.
  - Context picker with search; context-bound widgets remain disabled until a project/workspace is selected.
  - Create widgets/terminals using the brushed region size/position; auto-frame when inside a frame; show a selection ghost and focus the new shape.

- **Refactors**
  - `use-add-atmos-widget` and `use-add-canvas-terminal` accept optional `size` and set `w/h` on create.
  - New `canvas-empty-brush` helpers and tests for normalization, eligibility, and open conditions; find containing frame for placement.
  - Added `CanvasEmptyBrushAddWidget` and wired it into `CanvasView`; updated i18n strings (en/zh).

<sup>Written for commit 05f8bfa469154b115c8d06882cf2c28378449862. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an empty-area canvas gesture that opens an “Add widget” dialog.
  * Users can choose a context, search available components, and add widgets or terminals sized to the selected region.
  * Added localized English and Chinese labels, hints, and empty-state messaging.

* **Bug Fixes**
  * Improved handling of cancelled, invalid, undersized, or shape-containing selections.
  * Added safeguards to clean up partially created items when adding widgets fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->