### PR TITLE
feat(terminal): native OSC 0/2 title suffix (APP-047)

### DIFF
--- a/apps/mobile/src/api/terminal-ws-client.test.ts
+++ b/apps/mobile/src/api/terminal-ws-client.test.ts
@@ -101,6 +101,45 @@ describe("TerminalWsClient", () => {
     expect(client.isOpen()).toBe(false);
   });
 
+  test("does not reconnect after terminal_error (attach exhausted)", () => {
+    const timers: TimerCall[] = [];
+    FakeTerminalWebSocket.instances = [];
+    const errors: string[] = [];
+    const states: TerminalWsState[] = [];
+
+    const client = new TerminalWsClient("wss://relay.example/ws/terminal", {
+      WebSocketCtor: FakeTerminalWebSocket,
+      clearTimeout: () => {},
+      reconnectInitialDelayMs: 100,
+      reconnectMaxDelayMs: 1_000,
+      setTimeout: (callback, delayMs) => {
+        timers.push({ callback, delayMs });
+        return timers.length as unknown as ReturnType<typeof setTimeout>;
+      },
+    });
+
+    client.onState((state) => states.push(state));
+    client.onError((error) => errors.push(error));
+
+    client.connect();
+    FakeTerminalWebSocket.instances[0]!.open();
+    FakeTerminalWebSocket.instances[0]!.onmessage?.({
+      data: JSON.stringify({
+        type: "terminal_error",
+        session_id: "session",
+        error: "Failed to attach existing terminal session after 3 attempts: not found",
+      }),
+    });
+    FakeTerminalWebSocket.instances[0]!.closeFromServer();
+
+    expect(errors).toContain(
+      "Failed to attach existing terminal session after 3 attempts: not found",
+    );
+    expect(states).toContain("error");
+    expect(timers).toHaveLength(0);
+    expect(FakeTerminalWebSocket.instances).toHaveLength(1);
+  });
+
   test("does not queue input while reconnecting", () => {
     const timers: TimerCall[] = [];
     FakeTerminalWebSocket.instances = [];

--- a/apps/mobile/src/api/terminal-ws-client.ts
+++ b/apps/mobile/src/api/terminal-ws-client.ts
@@ -91,6 +91,15 @@ export class TerminalWsClient {
     this.socket.onmessage = (event) => {
       try {
         const message = JSON.parse(String(event.data)) as TerminalServerMessage;
+        // Attach/create failures are terminal for this connection: server already
+        // exhausted retries and will close the socket. Auto-reconnect would loop
+        // forever because onopen resets reconnectAttempt.
+        if (message.type === "terminal_error") {
+          this.shouldReconnect = false;
+          this.clearReconnectTimer();
+          this.setState("error");
+          this.errorListeners.forEach((listener) => listener(message.error));
+        }
         this.listeners.forEach((listener) => listener(message));
       } catch {
         this.errorListeners.forEach((listener) => listener("Invalid terminal message"));

--- a/apps/mobile/src/features/terminal/TerminalDomView.tsx
+++ b/apps/mobile/src/features/terminal/TerminalDomView.tsx
@@ -13,6 +13,7 @@ import {
   extractCommandName,
   isTerminalSnapshot,
   isUsableTerminalGrid,
+  sanitizeNativeOscTitle,
   shortenPath,
   type TerminalSnapshot,
   type TerminalThemeTokens,
@@ -43,6 +44,7 @@ type Props = {
   onReady: (cols: number, rows: number) => Promise<void>;
   onRendererError: (message: string) => Promise<void>;
   onTitleChange: (title: string) => Promise<void>;
+  onOscTitleChange?: (title: string | undefined) => Promise<void>;
   ref?: React.Ref<TerminalDomHandle>;
   theme: TerminalThemeTokens;
   dom?: DOMProps;
@@ -68,18 +70,20 @@ export default function TerminalDomView({
   onResize,
   theme,
   onTitleChange,
+  onOscTitleChange,
   ref,
 }: Props) {
   const mountRef = useRef<HTMLDivElement | null>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
-  const callbacksRef = useRef({ onInput, onReady, onRendererError, onResize, onTitleChange });
+  const callbacksRef = useRef({ onInput, onReady, onRendererError, onResize, onTitleChange, onOscTitleChange });
   const cmdStartTimerRef = useRef<number | null>(null);
   const connectedRef = useRef(connected);
   const lastTitleRef = useRef<string | null>(null);
+  const lastOscTitleRef = useRef<string | undefined>(undefined);
 
   connectedRef.current = connected;
-  callbacksRef.current = { onInput, onReady, onRendererError, onResize, onTitleChange };
+  callbacksRef.current = { onInput, onReady, onRendererError, onResize, onTitleChange, onOscTitleChange };
 
   useEffect(() => {
     let isDisposed = false;
@@ -174,6 +178,17 @@ export default function TerminalDomView({
         void callbacksRef.current.onResize(cols, rows).catch(reportError);
       });
 
+      const emitOscTitle = (raw: string | undefined) => {
+        const next = sanitizeNativeOscTitle(raw) || undefined;
+        if (next === lastOscTitleRef.current) return;
+        lastOscTitleRef.current = next;
+        const handler = callbacksRef.current.onOscTitleChange;
+        if (handler) void handler(next).catch(reportError);
+      };
+      const titleChangeDisposable = terminal.onTitleChange((raw) => {
+        emitOscTitle(raw);
+      });
+
       const CMD_START_DELAY_MS = 150;
       terminal.parser.registerOscHandler(9999, (data: string) => {
         const colonIdx = data.indexOf(":");
@@ -202,6 +217,7 @@ export default function TerminalDomView({
             window.clearTimeout(cmdStartTimerRef.current);
             cmdStartTimerRef.current = null;
           }
+          emitOscTitle(undefined);
           const nextTitle = shortenPath(payload);
           if (nextTitle !== lastTitleRef.current) {
             lastTitleRef.current = nextTitle;
@@ -231,6 +247,7 @@ export default function TerminalDomView({
         mount.removeEventListener("touchstart", focusTerminal, passiveFocusOptions);
         mount.removeEventListener("click", focusTerminal, focusOptions);
         resizeObserver?.disconnect();
+        titleChangeDisposable.dispose();
         webglContextLossDisposable?.dispose();
         webglAddon?.dispose();
         onData.dispose();

--- a/apps/mobile/src/features/terminal/TerminalScreen.tsx
+++ b/apps/mobile/src/features/terminal/TerminalScreen.tsx
@@ -167,6 +167,14 @@ export function TerminalScreen({
     [activeEntry?.id, updateEntry, workspaceId],
   );
 
+  const handleOscTitleChange = useCallback(
+    (nextTitle: string | undefined) => {
+      if (!activeEntry) return;
+      updateEntry(workspaceId, activeEntry.id, { oscTitle: nextTitle });
+    },
+    [activeEntry?.id, updateEntry, workspaceId],
+  );
+
   const handleShortcut = useCallback(
     (shortcut: TerminalShortcut) => {
       const input = getTerminalShortcutInput(shortcut);
@@ -247,6 +255,7 @@ export function TerminalScreen({
             onRendererError={setTerminalError}
             onResize={(size) => sendTerminalResize(size.cols, size.rows)}
             onTitleChange={handleTitleChange}
+            onOscTitleChange={handleOscTitleChange}
             sessionId={activeSessionId}
           />
         </View>
@@ -272,6 +281,7 @@ function getMobileTerminalDisplayMeta(
     baseTitle: entry.label,
     configuredAgents: MOBILE_TERMINAL_AGENTS,
     dynamicTitle: entry.dynamicTitle,
+    oscTitle: entry.oscTitle,
     contestedOwners,
   });
 }

--- a/apps/mobile/src/features/terminal/TerminalWebView.tsx
+++ b/apps/mobile/src/features/terminal/TerminalWebView.tsx
@@ -30,9 +30,10 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, {
   onRendererError?: (message: string) => void;
   onResize?: (size: { cols: number; rows: number }) => void;
   onTitleChange?: (title: string) => void;
+  onOscTitleChange?: (title: string | undefined) => void;
   sessionId: string;
 }>(function TerminalWebView(
-  { connected, onInput, onReady, onRendererError, onResize, onTitleChange, sessionId },
+  { connected, onInput, onReady, onRendererError, onResize, onTitleChange, onOscTitleChange, sessionId },
   ref,
 ) {
   const isIos = process.env.EXPO_OS === "ios";
@@ -154,6 +155,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, {
         onResize={async (cols, rows) => onResize?.({ cols, rows })}
         theme={terminalTheme}
         onTitleChange={async (nextTitle) => onTitleChange?.(nextTitle)}
+        onOscTitleChange={async (nextTitle) => onOscTitleChange?.(nextTitle)}
         dom={{
           contentInsetAdjustmentBehavior: "never",
           keyboardDisplayRequiresUserAction: true,

--- a/apps/mobile/src/features/terminal/use-terminal-candidates.ts
+++ b/apps/mobile/src/features/terminal/use-terminal-candidates.ts
@@ -70,6 +70,7 @@ function sameTerminalEntries(left: MobileTerminalEntry[], right: MobileTerminalE
       entry.tmuxWindowName === next.tmuxWindowName &&
       entry.tmuxWindowIndex === next.tmuxWindowIndex &&
       entry.dynamicTitle === next.dynamicTitle &&
+      entry.oscTitle === next.oscTitle &&
       entry.isNew === next.isNew
     );
   });

--- a/apps/mobile/src/stores/terminal-store.ts
+++ b/apps/mobile/src/stores/terminal-store.ts
@@ -10,6 +10,8 @@ export type MobileTerminalEntry = {
   sessionId?: string;
   agentLabel?: string;
   dynamicTitle?: string;
+  /** Native OSC 0/2 title; transient display-only (APP-047). */
+  oscTitle?: string;
   isNew?: boolean;
 };
 

--- a/apps/web/src/app-shell/CenterStageTabBar.tsx
+++ b/apps/web/src/app-shell/CenterStageTabBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { createPortal } from "react-dom";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -412,6 +413,10 @@ function TerminalExtraTab({
   const [menuPos, setMenuPos] = React.useState<{ x: number; y: number } | null>(null);
   const [renameDraft, setRenameDraft] = React.useState(tab.customTitle ?? "");
   const skipBlurCommitRef = React.useRef(false);
+  const [menuMounted, setMenuMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMenuMounted(true);
+  }, []);
 
   React.useEffect(() => {
     if (menuPos) {
@@ -523,50 +528,56 @@ function TerminalExtraTab({
       </TooltipContent>
     </Tooltip>
 
-    <DropdownMenu
-      open={!!menuPos}
-      onOpenChange={(open) => {
-        if (!open) setMenuPos(null);
-      }}
-    >
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          aria-hidden
-          tabIndex={-1}
-          className="fixed size-0 pointer-events-none"
-          style={{ left: menuPos?.x ?? -9999, top: menuPos?.y ?? -9999 }}
-        />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" sideOffset={4} className="w-56">
-        <DropdownMenuSub>
-          <DropdownMenuSubTrigger className="cursor-pointer">
-            <Pencil className="size-4 mr-2 text-muted-foreground" />
-            <span>{t("centerStageTabBar.renameTab")}</span>
-          </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent className="w-64 p-2">
-            <Input
-              ref={focusRenameInput}
-              value={renameDraft}
-              placeholder={t("centerStageTabBar.renameTabPlaceholder")}
-              onChange={(event) => setRenameDraft(event.target.value)}
-              onKeyDown={(event) => {
-                event.stopPropagation();
-                if (event.key === "Enter") {
-                  event.preventDefault();
-                  commitRename();
-                } else if (event.key === "Escape") {
-                  event.preventDefault();
-                  cancelRename();
-                }
-              }}
-              onBlur={handleRenameBlur}
-              className="h-8 text-sm"
-            />
-          </DropdownMenuSubContent>
-        </DropdownMenuSub>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    {menuMounted
+      ? createPortal(
+          <DropdownMenu
+            open={!!menuPos}
+            onOpenChange={(open) => {
+              if (!open) setMenuPos(null);
+            }}
+          >
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-hidden
+                tabIndex={-1}
+                className="fixed size-0 pointer-events-none"
+                style={{ left: menuPos?.x ?? -9999, top: menuPos?.y ?? -9999 }}
+              />
+            </DropdownMenuTrigger>
+            {/* Portal whole menu to body so app-shell transforms don't offset fixed anchors. */}
+            <DropdownMenuContent align="start" sideOffset={4} className="z-[90] w-56">
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger className="cursor-pointer">
+                  <Pencil className="size-4 mr-2 text-muted-foreground" />
+                  <span>{t("centerStageTabBar.renameTab")}</span>
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent className="w-64 p-2">
+                  <Input
+                    ref={focusRenameInput}
+                    value={renameDraft}
+                    placeholder={t("centerStageTabBar.renameTabPlaceholder")}
+                    onChange={(event) => setRenameDraft(event.target.value)}
+                    onKeyDown={(event) => {
+                      event.stopPropagation();
+                      if (event.key === "Enter") {
+                        event.preventDefault();
+                        commitRename();
+                      } else if (event.key === "Escape") {
+                        event.preventDefault();
+                        cancelRename();
+                      }
+                    }}
+                    onBlur={handleRenameBlur}
+                    className="h-8 text-sm"
+                  />
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+            </DropdownMenuContent>
+          </DropdownMenu>,
+          document.body,
+        )
+      : null}
     </>
   );
 }

--- a/apps/web/src/app-shell/center-stage-file-menu.tsx
+++ b/apps/web/src/app-shell/center-stage-file-menu.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import React from "react";
+import { createPortal } from "react-dom";
 import { useTranslations } from "next-intl";
 import {
   DropdownMenu,
@@ -36,6 +38,10 @@ export function CenterStageFileTabContextMenu({
   closeFilesSafely: (files: OpenFile[]) => void;
 }) {
   const t = useTranslations("appShell.fileTabContextMenu");
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const copyToClipboard = async (value: string) => {
     try {
@@ -49,7 +55,11 @@ export function CenterStageFileTabContextMenu({
     }
   };
 
-  return (
+  // Always use viewport-fixed coords + body portal (ignore absolute anchors).
+  // Parent transforms in center stage make non-portaled fixed anchors drift.
+  void anchorPosition;
+
+  const menu = (
     <DropdownMenu
       open={!!tabContextMenu}
       onOpenChange={(open) => {
@@ -60,18 +70,14 @@ export function CenterStageFileTabContextMenu({
         <button
           type="button"
           aria-hidden
-          className={
-            anchorPosition === "fixed"
-              ? "fixed size-0 pointer-events-none"
-              : "absolute size-0 pointer-events-none"
-          }
+          className="fixed size-0 pointer-events-none"
           style={{
             left: tabContextMenu?.x ?? -9999,
             top: tabContextMenu?.y ?? -9999,
           }}
         />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" sideOffset={4} className="w-52">
+      <DropdownMenuContent align="start" sideOffset={4} className="z-[90] w-52">
         {(() => {
           const target = openFiles.find((file) => file.path === tabContextMenu?.filePath);
           if (!target) return null;
@@ -151,4 +157,7 @@ export function CenterStageFileTabContextMenu({
       </DropdownMenuContent>
     </DropdownMenu>
   );
+
+  if (!mounted) return null;
+  return createPortal(menu, document.body);
 }

--- a/apps/web/src/app-shell/sidebar/ProjectItem.tsx
+++ b/apps/web/src/app-shell/sidebar/ProjectItem.tsx
@@ -468,12 +468,18 @@ export const ProjectItem = React.memo<ProjectItemProps>(function ProjectItem({
               "absolute right-2 top-1/2 z-10 flex -translate-y-1/2 items-center justify-end",
             )}
           >
+            {/*
+              Match terminal mosaic toolbar action-rail motion:
+              fixed open width (not max-width) + cubic-bezier expand + short opacity fade.
+              Stay open while the ··· menu is open so the rail doesn't collapse under a portaled menu.
+            */}
             <div
               className={cn(
-                "flex items-center overflow-hidden pl-2 transition-all duration-200 ease-out",
+                "flex items-center overflow-hidden",
+                "[transition:width_0.22s_cubic-bezier(0.22,1,0.36,1),opacity_0.16s_ease]",
                 isProjectMenuOpen
-                  ? "ml-1 max-w-24 opacity-100"
-                  : "max-w-0 opacity-0 group-hover/project:ml-1 group-hover/project:max-w-24 group-hover/project:opacity-100",
+                  ? "w-[44px] opacity-100"
+                  : "w-0 opacity-0 pointer-events-none group-hover/project:w-[44px] group-hover/project:opacity-100 group-hover/project:pointer-events-auto group-focus-within/project:w-[44px] group-focus-within/project:opacity-100 group-focus-within/project:pointer-events-auto",
               )}
             >
               <TooltipProvider>

--- a/apps/web/src/features/canvas/components/CanvasTerminalCard.tsx
+++ b/apps/web/src/features/canvas/components/CanvasTerminalCard.tsx
@@ -127,7 +127,7 @@ function CanvasTerminalCardInner({ shape }: { shape: CanvasTerminalShape }) {
     [contextScope, workspaceId, tmuxWindowName],
   );
 
-  const { displayTitle, toolbarAgent, onTitleChange } = useTerminalToolbarTitle({
+  const { displayTitle, toolbarAgent, onTitleChange, onOscTitleChange } = useTerminalToolbarTitle({
     baseTitle: shape.props.terminalName,
     configuredAgents,
     pinnedAgent: shape.props.paneAgent,
@@ -548,6 +548,7 @@ function CanvasTerminalCardInner({ shape }: { shape: CanvasTerminalShape }) {
               }}
               onSessionReady={handleSessionReady}
               onTitleChange={onTitleChange}
+              onOscTitleChange={onOscTitleChange}
               onSessionError={(_, error) => {
                 setIsTerminalReady(false);
                 toastManager.add({

--- a/apps/web/src/features/canvas/components/widgets/CanvasCenterWidget.tsx
+++ b/apps/web/src/features/canvas/components/widgets/CanvasCenterWidget.tsx
@@ -55,7 +55,6 @@ import {
   removeCanvasCenterTab,
   type CanvasCenterTab,
 } from "@/features/canvas/lib/canvas-center-tabs";
-import { clientPointToLocalElementPoint } from "@/shared/lib/dom-position";
 import {
   CANVAS_WIDGET_SHAPE_TYPE,
   getCanvasContextId,
@@ -362,14 +361,10 @@ function CanvasCenterWidgetBody({
                     event.stopPropagation();
                     editor.markEventAsHandled(event);
                     handleTabChange(tab.id);
-                    const point = clientPointToLocalElementPoint(
-                      rootRef.current,
-                      event.clientX,
-                      event.clientY,
-                    );
+                    // Viewport coords: menu is portaled to body with position:fixed.
                     setTabContextMenu({
-                      x: point.x,
-                      y: point.y,
+                      x: event.clientX,
+                      y: event.clientY,
                       filePath: tab.path,
                     });
                   }}

--- a/apps/web/src/features/disk-analyzer/components/DiskUsageChart.tsx
+++ b/apps/web/src/features/disk-analyzer/components/DiskUsageChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import dynamic from "next/dynamic";
 import type { EChartsOption } from "echarts";
 import { FolderInput, Trash2 } from "lucide-react";
@@ -560,53 +561,58 @@ export function DiskUsageChart({
           },
         }}
       />
-      <DropdownMenu
-        open={!!menu}
-        onOpenChange={(open) => {
-          if (!open) setMenu(null);
-        }}
-      >
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            aria-hidden
-            className="pointer-events-none fixed size-0"
-            style={{
-              left: menu?.x ?? -9999,
-              top: menu?.y ?? -9999,
-            }}
-          />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" sideOffset={4} className="min-w-44">
-          {menu?.isDir ? (
-            <DropdownMenuItem
-              onClick={() => {
-                if (!menu) return;
-                onSelectPath(menu.path);
-                onDrillPath(menu.path);
-                setMenu(null);
+      {typeof document !== "undefined"
+        ? createPortal(
+            <DropdownMenu
+              open={!!menu}
+              onOpenChange={(open) => {
+                if (!open) setMenu(null);
               }}
             >
-              <FolderInput className="size-4" />
-              {enterDirectoryLabel}
-            </DropdownMenuItem>
-          ) : null}
-          {menu?.canDelete ? (
-            <DropdownMenuItem
-              variant="destructive"
-              onClick={() => {
-                if (!menu) return;
-                onSelectPath(menu.path);
-                onRequestDelete(menu.path);
-                setMenu(null);
-              }}
-            >
-              <Trash2 className="size-4" />
-              {deleteLabel}
-            </DropdownMenuItem>
-          ) : null}
-        </DropdownMenuContent>
-      </DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  aria-hidden
+                  className="pointer-events-none fixed size-0"
+                  style={{
+                    left: menu?.x ?? -9999,
+                    top: menu?.y ?? -9999,
+                  }}
+                />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" sideOffset={4} className="z-[90] min-w-44">
+                {menu?.isDir ? (
+                  <DropdownMenuItem
+                    onClick={() => {
+                      if (!menu) return;
+                      onSelectPath(menu.path);
+                      onDrillPath(menu.path);
+                      setMenu(null);
+                    }}
+                  >
+                    <FolderInput className="size-4" />
+                    {enterDirectoryLabel}
+                  </DropdownMenuItem>
+                ) : null}
+                {menu?.canDelete ? (
+                  <DropdownMenuItem
+                    variant="destructive"
+                    onClick={() => {
+                      if (!menu) return;
+                      onSelectPath(menu.path);
+                      onRequestDelete(menu.path);
+                      setMenu(null);
+                    }}
+                  >
+                    <Trash2 className="size-4" />
+                    {deleteLabel}
+                  </DropdownMenuItem>
+                ) : null}
+              </DropdownMenuContent>
+            </DropdownMenu>,
+            document.body,
+          )
+        : null}
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/CodeMirrorEditor.tsx
+++ b/apps/web/src/features/editor/components/CodeMirrorEditor.tsx
@@ -23,7 +23,7 @@ import { Loader2 as LucideLoader2, Eye, FileText, Settings2, ChevronRight, Folde
 import { useEditorStore, OpenFile } from '@/features/editor/store/use-editor-store';
 import { invalidateGitQueries } from '@/features/git/hooks/use-git-changed-files-query';
 import { useFileTreeStore } from '@/features/files/store/use-file-tree-store';
-import { useFileTreeQuery } from '@/features/files/hooks/use-file-tree-query';
+import { useFileTreeQuery, useListDirQuery } from '@/features/files/hooks/use-file-tree-query';
 import { MarkdownRenderer } from '@/shared/components/markdown/MarkdownRenderer';
 import { MarkdownToc } from '@/shared/components/markdown/MarkdownToc';
 import { BaseCodeMirrorEditor } from './BaseCodeMirrorEditor';
@@ -40,6 +40,22 @@ import { useProjects } from '@/features/project/hooks/use-project-bootstrap-quer
 import { type FileTreeNode } from '@/api/ws-api';
 import { FileTree } from '@/features/files/components/FileTree';
 import { tryRelativePathUnderRoot } from '@/shared/lib/path-under-root';
+
+/** Strip trailing slashes only — keep a leading `/` for absolute paths. */
+function stripTrailingSlashes(path: string): string {
+  if (!path) return path;
+  const trimmed = path.replace(/\/+$/, '');
+  return trimmed.length > 0 ? trimmed : '/';
+}
+
+function parentDirPath(path: string, fallbackRoot: string | null): string {
+  const normalized = stripTrailingSlashes(path);
+  const idx = normalized.lastIndexOf('/');
+  if (idx <= 0) {
+    return fallbackRoot && fallbackRoot.length > 0 ? stripTrailingSlashes(fallbackRoot) : '/';
+  }
+  return normalized.slice(0, idx) || '/';
+}
 
 interface CodeMirrorEditorProps {
   file: OpenFile;
@@ -137,10 +153,8 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
     if (settingsModalOpen) setSettingsOpen(false);
   }, [settingsModalOpen]);
   const [openBreadcrumbIndex, setOpenBreadcrumbIndex] = useState<number | null>(null);
-  const fileTreeRootPath = useFileTreeStore((s) => s.rootPath);
+  const storeFileTreeRootPath = useFileTreeStore((s) => s.rootPath);
   const fileTreeShowHidden = useFileTreeStore((s) => s.showHidden);
-  const fileTreeQuery = useFileTreeQuery(fileTreeRootPath, fileTreeShowHidden);
-  const fileTreeData = fileTreeQuery.data?.tree ?? [];
   const editorViewRef = useRef<EditorView | null>(null);
 
   // Get relative path for breadcrumbs (strict root boundary + longest project prefix)
@@ -176,11 +190,31 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
       };
     }
 
+    // Last resort: walk up from the file until we still have a path (for canvas
+    // opens where sidebar file-tree context was never set).
+    const abs = stripTrailingSlashes(fullPath.replace(/\\/g, '/'));
+    const lastSlash = abs.lastIndexOf('/');
+    if (lastSlash > 0) {
+      return {
+        relativePath: abs.slice(lastSlash + 1),
+        projectRoot: abs.slice(0, lastSlash),
+      };
+    }
+
     return {
       relativePath: fullPath,
       projectRoot: '',
     };
   }, [file.path, currentProjectPath, projects]);
+
+  // Canvas / keepMounted editors must not depend on the left sidebar Files panel
+  // having set useFileTreeStore.rootPath — query the open file's project root.
+  const breadcrumbTreeRoot =
+    (projectRoot && projectRoot.length > 0 ? projectRoot : null) ?? storeFileTreeRootPath;
+
+  const fileTreeQuery = useFileTreeQuery(breadcrumbTreeRoot, fileTreeShowHidden);
+  const fileTreeData = fileTreeQuery.data?.tree ?? [];
+  const fileTreeRootPath = breadcrumbTreeRoot;
 
   const breadcrumbParts = useMemo(() => {
     return relativePath.split('/').filter(Boolean);
@@ -198,41 +232,62 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
   const getBreadcrumbPath = useCallback((index: number) => {
     const parts = relativePath.split('/').filter(Boolean);
     const relevantParts = parts.slice(0, index + 1);
-    return projectRoot ? `${projectRoot}/${relevantParts.join('/')}` : relevantParts.join('/');
+    if (!projectRoot) return relevantParts.join('/');
+    const joined = relevantParts.join('/');
+    return joined ? `${stripTrailingSlashes(projectRoot)}/${joined}` : stripTrailingSlashes(projectRoot);
   }, [relativePath, projectRoot]);
+
+  // Parent dir of the open breadcrumb segment — used for listDir fallback when
+  // the recursive tree is empty / not synced (common on canvas).
+  const openBreadcrumbParentPath = useMemo(() => {
+    if (openBreadcrumbIndex == null || !fileTreeRootPath) return null;
+    const segmentPath = getBreadcrumbPath(openBreadcrumbIndex);
+    return parentDirPath(segmentPath, fileTreeRootPath);
+  }, [openBreadcrumbIndex, fileTreeRootPath, getBreadcrumbPath]);
+
+  const breadcrumbListDirQuery = useListDirQuery(openBreadcrumbParentPath, {
+    dirsOnly: false,
+    showHidden: fileTreeShowHidden,
+  });
 
   // Get the sibling files/directories for a breadcrumb path (same level)
   const getBreadcrumbSiblings = useCallback((targetPath: string): FileTreeNode[] => {
+    // Prefer a live listDir for the open popover's parent — independent of
+    // whether the left Files panel has loaded this project.
+    if (
+      openBreadcrumbParentPath &&
+      breadcrumbListDirQuery.data?.entries &&
+      parentDirPath(targetPath, fileTreeRootPath) === stripTrailingSlashes(openBreadcrumbParentPath)
+    ) {
+      return breadcrumbListDirQuery.data.entries.map((entry) => ({
+        name: entry.name,
+        path: entry.path,
+        is_dir: entry.is_dir,
+        is_symlink: entry.is_symlink,
+        is_ignored: entry.is_ignored,
+        symlink_target: entry.symlink_target,
+      }));
+    }
+
     if (!fileTreeData.length || !fileTreeRootPath) return [];
 
-    // Normalize paths to ensure consistent comparison
-    const normalizePath = (path: string) => path.replace(/\/+$/, '').replace(/^\/+/, '');
+    // Normalize for comparison only (strip trailing slash + unify separators).
+    const normalizePath = (path: string) =>
+      stripTrailingSlashes(path.replace(/\\/g, '/')).replace(/^\/+/, '');
 
-    const normalizedTargetPath = normalizePath(targetPath);
-
-    // Get the parent directory of the target path
-    const getParentPath = (path: string): string => {
-      const parts = path.split('/').filter(Boolean);
-      parts.pop(); // Remove the last part
-      return parts.length > 0 ? parts.join('/') : fileTreeRootPath || '/';
-    };
-
-    const parentPath = getParentPath(normalizedTargetPath);
+    const parentPath = parentDirPath(targetPath, fileTreeRootPath);
     const normalizedParentPath = normalizePath(parentPath);
     const normalizedTreeRootPath = normalizePath(fileTreeRootPath);
 
-    // `list_project_files` returns immediate children of `root_path` only — no node whose
-    // `path` equals the project root. Siblings under the workspace root live at `fileTreeData`.
+    // Top-level list_project_files payload is the children of the project root.
     if (normalizedParentPath === normalizedTreeRootPath) {
       return fileTreeData;
     }
 
-    // Helper function to find the parent directory and return its children
     const findSiblings = (nodes: FileTreeNode[], targetParentPath: string): FileTreeNode[] => {
       for (const node of nodes) {
         const normalizedNodePath = normalizePath(node.path);
         if (normalizedNodePath === targetParentPath && node.children) {
-          // Found the parent directory, return its children (siblings)
           return node.children;
         }
         if (node.children) {
@@ -244,7 +299,12 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
     };
 
     return findSiblings(fileTreeData, normalizedParentPath);
-  }, [fileTreeData, fileTreeRootPath]);
+  }, [
+    breadcrumbListDirQuery.data?.entries,
+    fileTreeData,
+    fileTreeRootPath,
+    openBreadcrumbParentPath,
+  ]);
 
   // Handle search button click (trigger Cmd+F)
   const handleSearchClick = useCallback(() => {
@@ -698,6 +758,12 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
                   {breadcrumbParts.map((part, index, array) => {
                     const breadcrumbPath = getBreadcrumbPath(index);
                     const siblingsData = getBreadcrumbSiblings(breadcrumbPath);
+                    const siblingRootPath =
+                      parentDirPath(breadcrumbPath, fileTreeRootPath) || fileTreeRootPath;
+                    const isListDirLoading =
+                      openBreadcrumbIndex === index &&
+                      breadcrumbListDirQuery.isLoading &&
+                      siblingsData.length === 0;
                     const segmentClass =
                       index === array.length - 1
                         ? 'text-foreground font-medium cursor-default truncate flex items-center gap-1'
@@ -730,15 +796,25 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
                             sideOffset={4}
                             className="z-[80] w-80 max-h-96 overflow-y-auto p-0"
                           >
-                            {siblingsData.length === 0 ? (
+                            {isListDirLoading ? (
+                              <div className="flex items-center justify-center px-2 py-4 text-muted-foreground">
+                                <LucideLoader2 className="size-3.5 animate-spin" />
+                              </div>
+                            ) : siblingsData.length === 0 ? (
                               <div className="text-xs text-muted-foreground px-2 py-4 text-center">
                                 {t('codeMirror.noFilesFound')}
                               </div>
                             ) : (
                               <FileTree
                                 data={siblingsData}
-                                rootPath={breadcrumbPath}
-                                onRefresh={() => {}}
+                                rootPath={siblingRootPath}
+                                showHidden={fileTreeShowHidden}
+                                contextId={editorContextId}
+                                currentProjectPath={projectRoot || null}
+                                onRefresh={() => {
+                                  void breadcrumbListDirQuery.refetch();
+                                  void fileTreeQuery.refetch();
+                                }}
                                 beforeOpenFile={() => {
                                   flushSync(() => setOpenBreadcrumbIndex(null));
                                 }}

--- a/apps/web/src/features/terminal/components/Terminal.tsx
+++ b/apps/web/src/features/terminal/components/Terminal.tsx
@@ -336,7 +336,9 @@ const Terminal = ({
   const handleDisconnected = useCallback(() => {
     // Grace clear so warm remount within ~2s does not flash Connecting overlay.
     scheduleTerminalSessionDead(sessionId);
-    setStatus("disconnected");
+    // Keep attach/create error UI after the socket closes — otherwise a brief
+    // "error" flash is replaced by a generic Disconnected badge and Retry is lost.
+    setStatus((prev) => (prev === "error" ? prev : "disconnected"));
     resetInputReady();
     onSessionClose?.(sessionId);
   }, [resetInputReady, sessionId, onSessionClose]);
@@ -413,6 +415,45 @@ const Terminal = ({
     // Fresh connect after a failed attach; backend already retried a few times.
     connect();
   }, [connect, disconnect]);
+
+  const handleCreateNew = useCallback(() => {
+    setAttachError(null);
+    setStatus("connecting");
+    disconnect();
+    // Create a new tmux window instead of re-attaching the missing one so the
+    // user is not stuck when the stored window no longer exists.
+    const createUrl = buildTerminalWsUrl({
+      cwd,
+      isNewPane: true,
+      noTmux,
+      projectName,
+      sessionId,
+      sideChatId,
+      sourcePaneId,
+      sourceTmuxWindowName,
+      terminalKind,
+      terminalName: terminalName || tmuxWindowName,
+      tmuxWindowName,
+      workspaceId,
+      workspaceName,
+    });
+    connect(createUrl);
+  }, [
+    connect,
+    cwd,
+    disconnect,
+    noTmux,
+    projectName,
+    sessionId,
+    sideChatId,
+    sourcePaneId,
+    sourceTmuxWindowName,
+    terminalKind,
+    terminalName,
+    tmuxWindowName,
+    workspaceId,
+    workspaceName,
+  ]);
 
   // Keep refs in sync (breaks circular dependencies with handleConnected)
   useEffect(() => {
@@ -1193,6 +1234,7 @@ const Terminal = ({
       uiStatus={uiStatus}
       workspaceId={workspaceId}
       errorMessage={attachError}
+      onCreateNew={status === "error" ? handleCreateNew : undefined}
       onRetry={status === "error" ? handleRetryAttach : undefined}
       selectionToolbar={
         onAddSelectionAsContext ? (

--- a/apps/web/src/features/terminal/components/Terminal.tsx
+++ b/apps/web/src/features/terminal/components/Terminal.tsx
@@ -674,6 +674,8 @@ const Terminal = ({
     let linkProvider: { dispose: () => void } | null = null;
     let selectionChangeDisposable: { dispose: () => void } | null = null;
     let titleChangeDisposable: { dispose: () => void } | null = null;
+    let osc0HandlerDisposable: { dispose: () => void } | null = null;
+    let osc2HandlerDisposable: { dispose: () => void } | null = null;
     let selectionAnchorCleanup: (() => void) | null = null;
     let visibilityPollTimer: ReturnType<typeof setTimeout> | null = null;
     let connectRafId = 0;
@@ -833,20 +835,34 @@ const Terminal = ({
       };
     }
 
-    // Native OSC 0/2 titles from agent CLIs (Codex/Claude/…). xterm maps these
-    // to onTitleChange. Never feed this path into agent detection (APP-047).
-    // Reset dedup state on every xterm recreate so a new session's first title
-    // is not suppressed when it equals the previous pane's title.
-    lastOscTitleRef.current = undefined;
+    // Native OSC 0/2 titles from agent CLIs (Codex/Claude/…). Capture via both
+    // onTitleChange and explicit OSC handlers — under tmux some builds only hit one path.
+    // Never feed this into agent detection (APP-047).
+    // Do NOT reset lastOscTitleRef here: a warm remount must not drop a title that
+    // was already restored from the pane store before this effect re-ran.
     lastTitleRef.current = "";
     const emitOscTitle = (raw: string | undefined) => {
-      const next = sanitizeNativeOscTitle(raw) || undefined;
+      // Empty / whitespace → clear. Meaningful text is sanitized; shell path noise
+      // is filtered later in setOscTitle so we still deliver it (to overwrite).
+      const cleaned = raw == null ? undefined : sanitizeNativeOscTitle(raw);
+      const next = cleaned && cleaned.length > 0 ? cleaned : undefined;
       if (next === lastOscTitleRef.current) return;
       lastOscTitleRef.current = next;
       onOscTitleChangeRef.current?.(next);
     };
     titleChangeDisposable = terminal.onTitleChange((raw) => {
       emitOscTitle(raw);
+    });
+    // Explicit handlers: return false so xterm default title handling still runs.
+    osc0HandlerDisposable = terminal.parser.registerOscHandler(0, (data) => {
+      // OSC 0 is "icon name ; window title" or just title
+      const title = data.includes(";") ? data.slice(data.indexOf(";") + 1) : data;
+      emitOscTitle(title);
+      return false;
+    });
+    osc2HandlerDisposable = terminal.parser.registerOscHandler(2, (data) => {
+      emitOscTitle(data);
+      return false;
     });
 
     // Register OSC 9999 handler for dynamic tab title updates.
@@ -896,8 +912,10 @@ const Terminal = ({
           clearTimeout(cmdStartTimerRef.current);
           cmdStartTimerRef.current = null;
         }
-        // Shell idle: drop agent-native OSC suffix so panes don't keep stale topics.
-        emitOscTitle(undefined);
+        // Do NOT clear OSC here. Reattach injects synthetic CMD_END on every
+        // refresh and was wiping persisted agent session topics before they
+        // could paint. Shell path OSC (user@host:cwd) overwrites via setOscTitle
+        // noise filter; empty OSC 0/2 clears explicitly.
         const title = shortenPath(payload);
         if (title !== lastTitleRef.current) {
           lastTitleRef.current = title;
@@ -1142,6 +1160,8 @@ const Terminal = ({
       selectionAnchorCleanup?.();
       selectionChangeDisposable?.dispose();
       titleChangeDisposable?.dispose();
+      osc0HandlerDisposable?.dispose();
+      osc2HandlerDisposable?.dispose();
       setCurrentSelectionSnapshot(null);
       if (resizeRafIdRef.current) {
         cancelAnimationFrame(resizeRafIdRef.current);

--- a/apps/web/src/features/terminal/components/Terminal.tsx
+++ b/apps/web/src/features/terminal/components/Terminal.tsx
@@ -794,6 +794,10 @@ const Terminal = ({
 
     // Native OSC 0/2 titles from agent CLIs (Codex/Claude/…). xterm maps these
     // to onTitleChange. Never feed this path into agent detection (APP-047).
+    // Reset dedup state on every xterm recreate so a new session's first title
+    // is not suppressed when it equals the previous pane's title.
+    lastOscTitleRef.current = undefined;
+    lastTitleRef.current = "";
     const emitOscTitle = (raw: string | undefined) => {
       const next = sanitizeNativeOscTitle(raw) || undefined;
       if (next === lastOscTitleRef.current) return;

--- a/apps/web/src/features/terminal/components/Terminal.tsx
+++ b/apps/web/src/features/terminal/components/Terminal.tsx
@@ -62,6 +62,7 @@ import {
 import type { TerminalSelectionSnapshot } from "../types";
 import { createAgentHookInterruptInference } from "@/features/agent/lib/agent-hook-interrupt-inference";
 import { useAgentHooksStore } from "@/features/agent/store/agent-hooks-store";
+import { sanitizeNativeOscTitle } from "@atmos/shared/terminal";
 
 export interface TerminalRef {
   focus: () => void;
@@ -129,6 +130,7 @@ const Terminal = ({
   terminalScale,
   onInputWhileReadOnly,
   onTitleChange,
+  onOscTitleChange,
   onSelectionSnapshotChange,
   onAddSelectionAsContext,
   onStartSideChatForSelection,
@@ -149,9 +151,12 @@ const Terminal = ({
   // this over reading layout so hop does not force reflow for hidden xterms.
   const surfaceActiveRef = useRef(surfaceActive);
   surfaceActiveRef.current = surfaceActive;
-  // Keep onTitleChange callback ref in sync to avoid stale closures in the OSC handler
+  // Keep title callbacks in sync to avoid stale closures in OSC handlers
   const onTitleChangeRef = useRef(onTitleChange);
   useEffect(() => { onTitleChangeRef.current = onTitleChange; });
+  const onOscTitleChangeRef = useRef(onOscTitleChange);
+  useEffect(() => { onOscTitleChangeRef.current = onOscTitleChange; });
+  const lastOscTitleRef = useRef<string | undefined>(undefined);
   const onSelectionSnapshotChangeRef = useRef(onSelectionSnapshotChange);
   useEffect(() => { onSelectionSnapshotChangeRef.current = onSelectionSnapshotChange; });
   const sourceSessionIdRef = useRef(sessionId);
@@ -627,6 +632,7 @@ const Terminal = ({
     let cancelled = false;
     let linkProvider: { dispose: () => void } | null = null;
     let selectionChangeDisposable: { dispose: () => void } | null = null;
+    let titleChangeDisposable: { dispose: () => void } | null = null;
     let selectionAnchorCleanup: (() => void) | null = null;
     let visibilityPollTimer: ReturnType<typeof setTimeout> | null = null;
     let connectRafId = 0;
@@ -786,6 +792,18 @@ const Terminal = ({
       };
     }
 
+    // Native OSC 0/2 titles from agent CLIs (Codex/Claude/…). xterm maps these
+    // to onTitleChange. Never feed this path into agent detection (APP-047).
+    const emitOscTitle = (raw: string | undefined) => {
+      const next = sanitizeNativeOscTitle(raw) || undefined;
+      if (next === lastOscTitleRef.current) return;
+      lastOscTitleRef.current = next;
+      onOscTitleChangeRef.current?.(next);
+    };
+    titleChangeDisposable = terminal.onTitleChange((raw) => {
+      emitOscTitle(raw);
+    });
+
     // Register OSC 9999 handler for dynamic tab title updates.
     // The shell shim emits: \033]9999;CMD_START:<command>\007
     //                    or: \033]9999;CMD_END:<cwd>\007
@@ -833,6 +851,8 @@ const Terminal = ({
           clearTimeout(cmdStartTimerRef.current);
           cmdStartTimerRef.current = null;
         }
+        // Shell idle: drop agent-native OSC suffix so panes don't keep stale topics.
+        emitOscTitle(undefined);
         const title = shortenPath(payload);
         if (title !== lastTitleRef.current) {
           lastTitleRef.current = title;
@@ -1076,6 +1096,7 @@ const Terminal = ({
       if (connectRafId) cancelAnimationFrame(connectRafId);
       selectionAnchorCleanup?.();
       selectionChangeDisposable?.dispose();
+      titleChangeDisposable?.dispose();
       setCurrentSelectionSnapshot(null);
       if (resizeRafIdRef.current) {
         cancelAnimationFrame(resizeRafIdRef.current);

--- a/apps/web/src/features/terminal/components/TerminalChrome.tsx
+++ b/apps/web/src/features/terminal/components/TerminalChrome.tsx
@@ -32,6 +32,8 @@ interface TerminalChromeProps {
   workspaceId: string;
   errorMessage?: string | null;
   onRetry?: () => void;
+  /** Create a fresh terminal instead of re-attaching the missing window. */
+  onCreateNew?: () => void;
 }
 
 export function TerminalChrome({
@@ -60,6 +62,7 @@ export function TerminalChrome({
   workspaceId,
   errorMessage,
   onRetry,
+  onCreateNew,
 }: TerminalChromeProps) {
   const normalizedTerminalScale =
     Number.isFinite(terminalScale) && terminalScale > 0 ? terminalScale : 1;
@@ -171,15 +174,36 @@ export function TerminalChrome({
           >
             {errorMessage || "Failed to restore terminal session"}
           </span>
-          {onRetry && (
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              onClick={onRetry}
+          {(onCreateNew || onRetry) && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: "8px",
+              }}
             >
-              Retry
-            </Button>
+              {onCreateNew && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="default"
+                  onClick={onCreateNew}
+                >
+                  New
+                </Button>
+              )}
+              {onRetry && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={onRetry}
+                >
+                  Retry
+                </Button>
+              )}
+            </div>
           )}
         </div>
       )}

--- a/apps/web/src/features/terminal/components/TerminalGrid.tsx
+++ b/apps/web/src/features/terminal/components/TerminalGrid.tsx
@@ -146,6 +146,7 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
     toggleMaximize,
     getMaximizedTerminalId,
     setDynamicTitle,
+    setOscTitle,
     setPaneAgent,
     markPaneAttached,
     setPaneCustomLabel,
@@ -159,6 +160,7 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
     initProjectWikiWorkspace,
     getProjectWikiPaneIdByTmuxWindowName,
     setProjectWikiDynamicTitle,
+    setProjectWikiOscTitle,
     setProjectWikiPaneAgent,
     markProjectWikiPaneAttached,
     toggleProjectWikiMaximize,
@@ -173,6 +175,7 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
     initCodeReviewWorkspace,
     getCodeReviewPaneIdByTmuxWindowName,
     setCodeReviewDynamicTitle,
+    setCodeReviewOscTitle,
     setCodeReviewPaneAgent,
     markCodeReviewPaneAttached,
     toggleCodeReviewMaximize,
@@ -515,6 +518,11 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
     : isProjectWiki
     ? setProjectWikiDynamicTitle
     : setDynamicTitle;
+  const setOscTitleForScope = isCodeReview
+    ? setCodeReviewOscTitle
+    : isProjectWiki
+    ? setProjectWikiOscTitle
+    : setOscTitle;
   const setPaneAgentForScope = isCodeReview
     ? setCodeReviewPaneAgent
     : isProjectWiki
@@ -911,6 +919,7 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
         pendingRunsRef={pendingRunsRef}
         deliverPendingRunForPane={deliverPendingRunForPane}
         setDynamicTitle={setDynamicTitleForScope}
+        setOscTitle={setOscTitleForScope}
         setPaneAgent={setPaneAgentForScope}
         markPaneAttached={isCodeReview ? markCodeReviewPaneAttached : markProjectWikiPaneAttached}
         surfaceActive={isSurfaceActive}
@@ -927,6 +936,7 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
     workspaceId,
     onToggleMaximize,
     setDynamicTitleForScope,
+    setOscTitleForScope,
     setPaneAgentForScope,
     actions,
     configuredAgents,

--- a/apps/web/src/features/terminal/components/TerminalGrid.tsx
+++ b/apps/web/src/features/terminal/components/TerminalGrid.tsx
@@ -713,9 +713,11 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
   }, []);
 
   const handleSplitMenuLeave = useCallback(() => {
+    // Grace period to reach the portaled dropdown from the split trigger.
+    // Keep in mind with toolbar hover leave delay (useToolbarHoverExpand).
     splitMenuTimeoutRef.current = setTimeout(() => {
       setSplitMenuKey(null);
-    }, 120);
+    }, 280);
   }, []);
 
   const handleContextSplitSubmenuEnter = useCallback((key: "row" | "column") => {

--- a/apps/web/src/features/terminal/components/TerminalGridContextMenu.tsx
+++ b/apps/web/src/features/terminal/components/TerminalGridContextMenu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { createPortal } from "react-dom";
 import { useTranslations } from "next-intl";
 import {
   Checkbox,
@@ -93,6 +94,10 @@ export function TerminalGridContextMenu({
   onContextSplitWithAgent,
 }: TerminalGridContextMenuProps) {
   const t = useTranslations("Terminal.chrome");
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
 
   // Local draft for the rename input; reset whenever the menu (re)opens.
   const [renameDraft, setRenameDraft] = React.useState(paneCustomLabel);
@@ -209,7 +214,10 @@ export function TerminalGridContextMenu({
     );
   };
 
-  return (
+  // Portal the whole menu (trigger + content root) to body so app-shell
+  // transforms / zoom cannot turn position:fixed into a mis-offset containing
+  // block (same pattern as FileTreeContextMenu).
+  const menu = (
     <DropdownMenu
       open={!!contextMenu}
       onOpenChange={onOpenChange}
@@ -225,7 +233,7 @@ export function TerminalGridContextMenu({
           }}
         />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" sideOffset={4} className="w-56">
+      <DropdownMenuContent align="start" sideOffset={4} className="z-[90] w-56">
         <DropdownMenuItem onClick={() => onAction("new-tab")} className="cursor-pointer">
           <SquareTerminal className="size-4 mr-2 text-muted-foreground" />
           <span>{t("contextMenu.newTerminalTab")}</span>
@@ -385,4 +393,7 @@ export function TerminalGridContextMenu({
       </DropdownMenuContent>
     </DropdownMenu>
   );
+
+  if (!mounted) return null;
+  return createPortal(menu, document.body);
 }

--- a/apps/web/src/features/terminal/components/__tests__/terminal-title.test.ts
+++ b/apps/web/src/features/terminal/components/__tests__/terminal-title.test.ts
@@ -359,4 +359,63 @@ describe("native OSC 0/2 title suffix (APP-047)", () => {
     expect(appendNativeOscTitle("Claude Code", undefined)).toBe("Claude Code");
     expect(appendNativeOscTitle("Claude Code", "   ")).toBe("Claude Code");
   });
+
+  it("filters shell user@host:cwd and path-only OSC noise", () => {
+    const shellTitle =
+      "aarynlu@AarynLuDeMacBook-Air:~/.atmos/workspaces/atmos/abra";
+    expect(
+      getTerminalDisplayMeta({
+        baseTitle: "1",
+        dynamicTitle: ".../atmos/abra",
+        oscTitle: shellTitle,
+      }).displayTitle,
+    ).toBe(".../atmos/abra");
+    expect(
+      getTerminalDisplayMeta({
+        baseTitle: "1",
+        dynamicTitle: "/Users/me/proj",
+        oscTitle: "/Users/me/proj",
+      }).displayTitle,
+    ).toBe("/Users/me/proj");
+    expect(
+      appendNativeOscTitle("atmos/abra", shellTitle),
+    ).toBe("atmos/abra");
+  });
+
+  it("hides OSC that only repeats the agent command or brand", () => {
+    const claude = {
+      id: "claude",
+      label: "Claude Code",
+      command: "claude",
+      iconType: "built-in" as const,
+    };
+    expect(
+      getTerminalDisplayMeta({
+        baseTitle: "Claude Code",
+        dynamicTitle: "claude",
+        agent: claude,
+        configuredAgents: [claude],
+        oscTitle: "claude",
+      }).displayTitle,
+    ).toBe("Claude Code");
+    expect(
+      getTerminalDisplayMeta({
+        baseTitle: "Claude Code",
+        dynamicTitle: "claude",
+        agent: claude,
+        configuredAgents: [claude],
+        oscTitle: "Claude Code",
+      }).displayTitle,
+    ).toBe("Claude Code");
+    // Meaningful session topic still appends.
+    expect(
+      getTerminalDisplayMeta({
+        baseTitle: "Claude Code",
+        dynamicTitle: "claude",
+        agent: claude,
+        configuredAgents: [claude],
+        oscTitle: "debugging auth",
+      }).displayTitle,
+    ).toBe("Claude Code | debugging auth");
+  });
 });

--- a/apps/web/src/features/terminal/components/__tests__/terminal-title.test.ts
+++ b/apps/web/src/features/terminal/components/__tests__/terminal-title.test.ts
@@ -349,4 +349,14 @@ describe("native OSC 0/2 title suffix (APP-047)", () => {
       }).displayTitle,
     ).toBe("Claude Code");
   });
+
+  // Documents clear-on-empty / post-clear composition (S6 unit; S7/S8 are inspection).
+  it("appendNativeOscTitle returns auto-only after clear (empty/undefined osc)", () => {
+    expect(appendNativeOscTitle("Claude Code", "debugging auth")).toBe(
+      "Claude Code | debugging auth",
+    );
+    expect(appendNativeOscTitle("Claude Code", "")).toBe("Claude Code");
+    expect(appendNativeOscTitle("Claude Code", undefined)).toBe("Claude Code");
+    expect(appendNativeOscTitle("Claude Code", "   ")).toBe("Claude Code");
+  });
 });

--- a/apps/web/src/features/terminal/components/__tests__/terminal-title.test.ts
+++ b/apps/web/src/features/terminal/components/__tests__/terminal-title.test.ts
@@ -1,9 +1,12 @@
 // @ts-expect-error bun:test is available at runtime but not in tsconfig types
 import { describe, expect, it } from "bun:test";
 import {
+  appendNativeOscTitle,
   getTerminalDisplayMeta,
   isDynamicTitleDowngrade,
+  MAX_NATIVE_OSC_TITLE_CHARS,
   resolveAgentForTitle,
+  sanitizeNativeOscTitle,
 } from "@atmos/shared/terminal";
 import type { TerminalPaneAgent } from "../../types";
 
@@ -267,5 +270,83 @@ describe("terminal title APP-036 unique + contested agent matching", () => {
         contestedOwners: { agent: "unknown" },
       }).toolbarAgent?.id,
     ).toBe("cursor");
+  });
+});
+
+describe("native OSC 0/2 title suffix (APP-047)", () => {
+  it("sanitizes control characters and collapses whitespace", () => {
+    expect(sanitizeNativeOscTitle("  Project\t|\nWorking\x1b\x07 ")).toBe("Project | Working");
+    expect(sanitizeNativeOscTitle("   ")).toBe("");
+    expect(sanitizeNativeOscTitle(undefined)).toBe("");
+  });
+
+  it("caps long native titles", () => {
+    const long = "a".repeat(MAX_NATIVE_OSC_TITLE_CHARS + 20);
+    expect(sanitizeNativeOscTitle(long).length).toBe(MAX_NATIVE_OSC_TITLE_CHARS);
+  });
+
+  it("appends OSC title with | after the auto display title", () => {
+    expect(
+      getTerminalDisplayMeta({
+        baseTitle: "Claude Code",
+        dynamicTitle: "claude",
+        configuredAgents: agents,
+        agent: { id: "claude", label: "Claude Code", command: "claude", iconType: "built-in" },
+        oscTitle: "debugging auth",
+      }),
+    ).toMatchObject({
+      displayTitle: "Claude Code | debugging auth",
+      toolbarAgent: expect.objectContaining({ id: "claude" }),
+    });
+  });
+
+  it("shows OSC alone when auto title is empty", () => {
+    expect(appendNativeOscTitle("", "session topic")).toBe("session topic");
+    expect(
+      getTerminalDisplayMeta({
+        baseTitle: undefined,
+        dynamicTitle: undefined,
+        oscTitle: "session topic",
+      }).displayTitle,
+    ).toBe("session topic");
+  });
+
+  it("never uses OSC text for agent detection", () => {
+    const meta = getTerminalDisplayMeta({
+      baseTitle: "1",
+      dynamicTitle: "codex",
+      configuredAgents: agents,
+      agent: { id: "codex", label: "Codex", command: "codex", iconType: "built-in" },
+      // Looks like another agent brand — must not rebrand the pane.
+      oscTitle: "Hermes Agent",
+    });
+    expect(meta.displayTitle).toBe("Codex | Hermes Agent");
+    expect(meta.toolbarAgent?.id).toBe("codex");
+    expect(meta.toolbarAgent?.id).not.toBe("hermes");
+  });
+
+  it("suppresses OSC when custom label is set", () => {
+    expect(
+      getTerminalDisplayMeta({
+        baseTitle: "Claude Code",
+        dynamicTitle: "claude",
+        configuredAgents: agents,
+        agent: { id: "claude", label: "Claude Code", command: "claude", iconType: "built-in" },
+        oscTitle: "debugging auth",
+        suppressOscTitle: true,
+      }).displayTitle,
+    ).toBe("Claude Code");
+    expect(appendNativeOscTitle("My Pane", "debugging auth", true)).toBe("My Pane");
+  });
+
+  it("drops the suffix when OSC is cleared", () => {
+    expect(
+      getTerminalDisplayMeta({
+        baseTitle: "Claude Code",
+        dynamicTitle: "claude",
+        agent: { id: "claude", label: "Claude Code", command: "claude", iconType: "built-in" },
+        oscTitle: "",
+      }).displayTitle,
+    ).toBe("Claude Code");
   });
 });

--- a/apps/web/src/features/terminal/components/__tests__/terminal-title.test.ts
+++ b/apps/web/src/features/terminal/components/__tests__/terminal-title.test.ts
@@ -193,11 +193,27 @@ describe("terminal title APP-036 unique + contested agent matching", () => {
           configuredAgents: agents,
           contestedOwners: { agent: "unknown" },
         }),
-      ).toEqual({
+      ).toMatchObject({
         displayTitle: "agent",
+        primaryTitle: "agent",
+        oscSuffix: "",
         toolbarAgent: undefined,
       });
     }
+  });
+
+  it("splits primary title and OSC suffix for toolbar marquee", () => {
+    const meta = getTerminalDisplayMeta({
+      baseTitle: "Claude Code",
+      dynamicTitle: "claude",
+      agent: { id: "claude", label: "Claude Code", command: "claude", iconType: "built-in" },
+      oscTitle: "debugging a very long session topic for marquee",
+    });
+    expect(meta.primaryTitle).toBe("Claude Code");
+    expect(meta.oscSuffix).toBe("debugging a very long session topic for marquee");
+    expect(meta.displayTitle).toBe(
+      "Claude Code | debugging a very long session topic for marquee",
+    );
   });
 
   it("matches command lines with executable paths or path-valued arguments", () => {

--- a/apps/web/src/features/terminal/components/__tests__/terminal-title.test.ts
+++ b/apps/web/src/features/terminal/components/__tests__/terminal-title.test.ts
@@ -398,6 +398,17 @@ describe("native OSC 0/2 title suffix (APP-047)", () => {
     ).toBe("atmos/abra");
   });
 
+  it("keeps multi-word OSC topics that contain slashes (not bare paths)", () => {
+    expect(
+      getTerminalDisplayMeta({
+        baseTitle: "Claude Code",
+        dynamicTitle: "claude",
+        agent: { id: "claude", label: "Claude Code", command: "claude", iconType: "built-in" },
+        oscTitle: "fix src/api auth",
+      }).oscSuffix,
+    ).toBe("fix src/api auth");
+  });
+
   it("hides OSC that only repeats the agent command or brand", () => {
     const claude = {
       id: "claude",

--- a/apps/web/src/features/terminal/components/terminal-grid.css
+++ b/apps/web/src/features/terminal/components/terminal-grid.css
@@ -178,18 +178,26 @@
   bottom: calc(100% - 56%);
 }
 
-/* Custom Toolbar */
+/* Custom Toolbar
+ *
+ *   [ title (flex, minmax 0) | end: agent status + collapsible actions ]
+ *
+ * Actions use a fixed open width (not max-width/transform overlay) so the
+ * title column is truly squeezed and the OSC marquee can remeasure.
+ */
 .terminal-mosaic-toolbar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 6px;
   height: 100%;
   width: 100%;
+  min-width: 0;
   padding: 0 8px;
   background: transparent;
   cursor: grab;
   user-select: none;
   pointer-events: auto;
+  overflow: hidden;
 }
 
 .terminal-mosaic-toolbar:active {
@@ -200,9 +208,25 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  flex: 1 1 auto;
+  flex: 1 1 0%;
   min-width: 0;
   overflow: hidden;
+}
+
+/*
+ * Agent status (always, when active) + action buttons (hover/focus/maximized).
+ * Opaque background + soft left fade so OSC text never reads as painted under
+ * this rail when the title column is squeezed.
+ */
+.terminal-mosaic-toolbar-end {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 6px;
+  z-index: 1;
+  padding-left: 8px;
+  background: var(--background);
+  box-shadow: -12px 0 12px 0 var(--background);
 }
 
 .terminal-mosaic-title {
@@ -210,8 +234,7 @@
   font-weight: 500;
   color: var(--foreground);
   opacity: 0.9;
-  /* Same role as pre-marquee: fill remaining toolbar width, clip overflow. */
-  flex: 1 1 auto;
+  flex: 1 1 0%;
   min-width: 0;
   max-width: 100%;
   overflow: hidden;
@@ -252,14 +275,14 @@
 }
 
 /*
- * Marquee container: takes remaining width.
- * IMPORTANT: flex-basis 0 + min-width > 0 so short OSC still paints, and long
- * OSC gets a real measured width for overflow detection (was collapsing to 0).
+ * Marquee container: takes remaining width inside the title row.
+ * min-width:0 is required so nowrap text cannot force the flex item wider
+ * than the squeezed title column (otherwise it paints under the end rail).
  */
 .terminal-title-marquee {
   position: relative;
   flex: 1 1 0%;
-  min-width: 3rem;
+  min-width: 0;
   overflow: hidden;
   white-space: nowrap;
 }
@@ -267,16 +290,20 @@
 .terminal-title-marquee-text {
   display: inline-block;
   white-space: nowrap;
-  /* When not overflowing, text simply sits at start and is fully visible. */
 }
 
 .terminal-title-marquee-text.is-overflowing {
   padding-right: 1.5rem;
-  /* animation starts at 0% = translateX(0); remount on text change restarts it */
   animation: terminal-title-marquee-scroll var(--marquee-duration, 10s) linear infinite;
-  animation-delay: 0.8s;
+  /* Short lead-in so agent OSC updates still get a chance to scroll. */
+  animation-delay: 0.35s;
   animation-fill-mode: both;
   will-change: transform;
+}
+
+.terminal-title-marquee:has(.is-overflowing) {
+  mask-image: linear-gradient(to right, #000 0%, #000 88%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to right, #000 0%, #000 88%, transparent 100%);
 }
 
 .terminal-title-marquee:hover .terminal-title-marquee-text.is-overflowing {
@@ -295,34 +322,33 @@
 }
 
 /*
- * Right toolbar: collapsed (no layout space) until hover/focus-within.
- * Slide in from the right; reverse on hide. Maximized panes keep it expanded.
+ * Action buttons: collapsed with width:0 (layout-participating).
+ * Fixed open width so flex can shrink the title column reliably.
+ *
+ * Expand via .is-toolbar-expanded (JS: hover with leave-delay, open split
+ * menu, maximized) or :focus-within — not pure :hover, so the rail stays up
+ * while the pointer travels to a portaled split-agent menu.
  */
 .terminal-mosaic-toolbar-right {
   display: flex;
   align-items: center;
   gap: 2px;
-  flex-shrink: 0;
-  max-width: 0;
-  margin-left: 0;
+  flex: 0 0 auto;
+  box-sizing: border-box;
+  width: 0;
   opacity: 0;
   overflow: hidden;
-  transform: translateX(10px);
   pointer-events: none;
   transition:
-    max-width 0.22s cubic-bezier(0.22, 1, 0.36, 1),
-    margin-left 0.22s cubic-bezier(0.22, 1, 0.36, 1),
-    opacity 0.18s ease,
-    transform 0.22s cubic-bezier(0.22, 1, 0.36, 1);
+    width 0.22s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.16s ease;
 }
 
-.terminal-mosaic-toolbar:hover .terminal-mosaic-toolbar-right,
-.terminal-mosaic-toolbar:focus-within .terminal-mosaic-toolbar-right,
-.terminal-mosaic-toolbar.is-toolbar-expanded .terminal-mosaic-toolbar-right {
-  max-width: 168px;
-  margin-left: 6px;
+.terminal-mosaic-toolbar.is-toolbar-expanded .terminal-mosaic-toolbar-right,
+.terminal-mosaic-toolbar:focus-within .terminal-mosaic-toolbar-right {
+  /* pin + 2 splits + maximize + close (+ gaps / close margin) */
+  width: 124px;
   opacity: 1;
-  transform: translateX(0);
   pointer-events: auto;
 }
 

--- a/apps/web/src/features/terminal/components/terminal-grid.css
+++ b/apps/web/src/features/terminal/components/terminal-grid.css
@@ -210,65 +210,70 @@
   font-weight: 500;
   color: var(--foreground);
   opacity: 0.9;
-  min-width: 0;
+  /* Same role as pre-marquee: fill remaining toolbar width, clip overflow. */
   flex: 1 1 auto;
+  min-width: 0;
   max-width: 100%;
+  overflow: hidden;
 }
 
-/* Title row: icon + primary + optional | OSC marquee */
+/*
+ * Title row layout (must not collapse OSC to 0 width):
+ *   [icon][primary fixed][|][osc grows + marquee if needed]
+ * Using flex with min-width:0 on the growing marquee child only.
+ */
 .terminal-title-row {
   display: flex;
   align-items: center;
-  min-width: 0;
-  max-width: 100%;
   width: 100%;
+  min-width: 0;
   gap: 0.25rem;
+  overflow: hidden;
 }
 
 .terminal-title-icon {
   display: inline-flex;
-  flex-shrink: 0;
+  flex: 0 0 auto;
   align-items: center;
 }
 
+/* Fixed left segment — never grows into the OSC area. */
 .terminal-title-primary {
-  min-width: 0;
+  flex: 0 1 auto;
+  max-width: 45%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.terminal-title-primary.has-osc {
-  flex: 0 1 auto;
-  max-width: 42%;
-}
-
 .terminal-title-sep {
-  flex-shrink: 0;
+  flex: 0 0 auto;
   color: color-mix(in srgb, var(--muted-foreground) 70%, transparent);
 }
 
-/* OSC session topic: always visible; marquee only when wider than the slot */
-.terminal-title-osc,
+/*
+ * Marquee container: takes remaining width.
+ * IMPORTANT: flex-basis 0 + min-width > 0 so short OSC still paints, and long
+ * OSC gets a real measured width for overflow detection (was collapsing to 0).
+ */
 .terminal-title-marquee {
   position: relative;
-  flex: 1 1 0;
-  min-width: 2.5rem;
+  flex: 1 1 0%;
+  min-width: 3rem;
   overflow: hidden;
-  mask-image: linear-gradient(to right, #000 0%, #000 90%, transparent 100%);
-  -webkit-mask-image: linear-gradient(to right, #000 0%, #000 90%, transparent 100%);
+  white-space: nowrap;
 }
 
 .terminal-title-marquee-text {
   display: inline-block;
-  max-width: none;
   white-space: nowrap;
-  vertical-align: bottom;
+  /* When not overflowing, text simply sits at start and is fully visible. */
 }
 
 .terminal-title-marquee-text.is-overflowing {
+  padding-right: 1.5rem;
   animation: terminal-title-marquee-scroll var(--marquee-duration, 10s) linear infinite;
-  animation-delay: 0.6s;
+  animation-delay: 0.8s;
   will-change: transform;
 }
 
@@ -278,10 +283,10 @@
 
 @keyframes terminal-title-marquee-scroll {
   0%,
-  12% {
+  15% {
     transform: translateX(0);
   }
-  88%,
+  85%,
   100% {
     transform: translateX(calc(-1 * var(--marquee-distance, 0px)));
   }

--- a/apps/web/src/features/terminal/components/terminal-grid.css
+++ b/apps/web/src/features/terminal/components/terminal-grid.css
@@ -200,6 +200,8 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  flex: 1 1 auto;
+  min-width: 0;
   overflow: hidden;
 }
 
@@ -210,13 +212,75 @@
   opacity: 0.9;
   white-space: nowrap;
   overflow: hidden;
-  text-overflow: ellipsis;
+  min-width: 0;
+  flex: 1 1 auto;
 }
 
+/* OSC session topic: marquee only when wider than the slot */
+.terminal-title-marquee {
+  position: relative;
+  min-width: 0;
+  overflow: hidden;
+  mask-image: linear-gradient(to right, #000 0%, #000 88%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to right, #000 0%, #000 88%, transparent 100%);
+}
+
+.terminal-title-marquee-text {
+  display: inline-block;
+  white-space: nowrap;
+  will-change: transform;
+}
+
+.terminal-title-marquee-text.is-overflowing {
+  animation: terminal-title-marquee-scroll var(--marquee-duration, 10s) linear infinite;
+  animation-delay: 0.6s;
+}
+
+.terminal-title-marquee:hover .terminal-title-marquee-text.is-overflowing {
+  animation-play-state: paused;
+}
+
+@keyframes terminal-title-marquee-scroll {
+  0%,
+  12% {
+    transform: translateX(0);
+  }
+  88%,
+  100% {
+    transform: translateX(calc(-1 * var(--marquee-distance, 0px)));
+  }
+}
+
+/*
+ * Right toolbar: collapsed (no layout space) until hover/focus-within.
+ * Slide in from the right; reverse on hide. Maximized panes keep it expanded.
+ */
 .terminal-mosaic-toolbar-right {
   display: flex;
   align-items: center;
   gap: 2px;
+  flex-shrink: 0;
+  max-width: 0;
+  margin-left: 0;
+  opacity: 0;
+  overflow: hidden;
+  transform: translateX(10px);
+  pointer-events: none;
+  transition:
+    max-width 0.22s cubic-bezier(0.22, 1, 0.36, 1),
+    margin-left 0.22s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.18s ease,
+    transform 0.22s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.terminal-mosaic-toolbar:hover .terminal-mosaic-toolbar-right,
+.terminal-mosaic-toolbar:focus-within .terminal-mosaic-toolbar-right,
+.terminal-mosaic-toolbar.is-toolbar-expanded .terminal-mosaic-toolbar-right {
+  max-width: 168px;
+  margin-left: 6px;
+  opacity: 1;
+  transform: translateX(0);
+  pointer-events: auto;
 }
 
 .terminal-mosaic-btn {

--- a/apps/web/src/features/terminal/components/terminal-grid.css
+++ b/apps/web/src/features/terminal/components/terminal-grid.css
@@ -272,8 +272,10 @@
 
 .terminal-title-marquee-text.is-overflowing {
   padding-right: 1.5rem;
+  /* animation starts at 0% = translateX(0); remount on text change restarts it */
   animation: terminal-title-marquee-scroll var(--marquee-duration, 10s) linear infinite;
   animation-delay: 0.8s;
+  animation-fill-mode: both;
   will-change: transform;
 }
 

--- a/apps/web/src/features/terminal/components/terminal-grid.css
+++ b/apps/web/src/features/terminal/components/terminal-grid.css
@@ -210,30 +210,66 @@
   font-weight: 500;
   color: var(--foreground);
   opacity: 0.9;
-  white-space: nowrap;
-  overflow: hidden;
   min-width: 0;
   flex: 1 1 auto;
+  max-width: 100%;
 }
 
-/* OSC session topic: marquee only when wider than the slot */
-.terminal-title-marquee {
-  position: relative;
+/* Title row: icon + primary + optional | OSC marquee */
+.terminal-title-row {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  max-width: 100%;
+  width: 100%;
+  gap: 0.25rem;
+}
+
+.terminal-title-icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+}
+
+.terminal-title-primary {
   min-width: 0;
   overflow: hidden;
-  mask-image: linear-gradient(to right, #000 0%, #000 88%, transparent 100%);
-  -webkit-mask-image: linear-gradient(to right, #000 0%, #000 88%, transparent 100%);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.terminal-title-primary.has-osc {
+  flex: 0 1 auto;
+  max-width: 42%;
+}
+
+.terminal-title-sep {
+  flex-shrink: 0;
+  color: color-mix(in srgb, var(--muted-foreground) 70%, transparent);
+}
+
+/* OSC session topic: always visible; marquee only when wider than the slot */
+.terminal-title-osc,
+.terminal-title-marquee {
+  position: relative;
+  flex: 1 1 0;
+  min-width: 2.5rem;
+  overflow: hidden;
+  mask-image: linear-gradient(to right, #000 0%, #000 90%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to right, #000 0%, #000 90%, transparent 100%);
 }
 
 .terminal-title-marquee-text {
   display: inline-block;
+  max-width: none;
   white-space: nowrap;
-  will-change: transform;
+  vertical-align: bottom;
 }
 
 .terminal-title-marquee-text.is-overflowing {
   animation: terminal-title-marquee-scroll var(--marquee-duration, 10s) linear infinite;
   animation-delay: 0.6s;
+  will-change: transform;
 }
 
 .terminal-title-marquee:hover .terminal-title-marquee-text.is-overflowing {

--- a/apps/web/src/features/terminal/components/terminal-mosaic-scoped-pane-window.tsx
+++ b/apps/web/src/features/terminal/components/terminal-mosaic-scoped-pane-window.tsx
@@ -28,6 +28,7 @@ import {
 import type { TerminalPaneAgent, TerminalPaneProps } from "../types/index";
 import { useContestedCliOwners } from "../hooks/use-contested-cli-owners";
 import { useTerminalSideChats } from "../hooks/use-terminal-side-chats";
+import { useToolbarHoverExpand } from "../hooks/use-toolbar-hover-expand";
 import type { PendingTerminalRun } from "../lib/terminal-agent-run-delivery";
 import { resolveTerminalAgentSubmitMode } from "../lib/terminal-runtime-utils";
 import { TerminalPaneAgentStatus } from "./terminal-mosaic-workspace-pane-window";
@@ -124,6 +125,11 @@ export function TerminalMosaicScopedPaneWindow({
 }: ScopedPaneWindowProps) {
   const t = useTranslations("Terminal.chrome");
   const contestedOwners = useContestedCliOwners();
+  const { toolbarHovered, onToolbarMouseEnter, onToolbarMouseLeave } = useToolbarHoverExpand(400);
+  const splitMenuOpenForPane =
+    splitMenuKey === `${id}:row` || splitMenuKey === `${id}:column`;
+  const toolbarExpanded =
+    maximizedId === id || toolbarHovered || splitMenuOpenForPane;
   const { displayTitle, primaryTitle, oscSuffix, toolbarAgent } = getTerminalDisplayMeta({
     baseTitle: pane.label,
     dynamicTitle: pane.dynamicTitle,
@@ -218,8 +224,10 @@ export function TerminalMosaicScopedPaneWindow({
           <div
             className={cn(
               "terminal-mosaic-toolbar group/toolbar",
-              maximizedId === id && "is-toolbar-expanded",
+              toolbarExpanded && "is-toolbar-expanded",
             )}
+            onMouseEnter={onToolbarMouseEnter}
+            onMouseLeave={onToolbarMouseLeave}
           >
             <div className="terminal-mosaic-toolbar-left">
               {displayTitle ? (
@@ -231,10 +239,11 @@ export function TerminalMosaicScopedPaneWindow({
                   className="terminal-mosaic-title gap-1.5"
                 />
               ) : null}
-              <TerminalPaneAgentStatus paneId={pane.tmuxWindowName ? `${workspaceId}:${pane.tmuxWindowName}` : pane.sessionId} contextId={workspaceId} />
             </div>
 
-            {(actions.split || actions.maximize || actions.close) && (
+            <div className="terminal-mosaic-toolbar-end">
+              <TerminalPaneAgentStatus paneId={pane.tmuxWindowName ? `${workspaceId}:${pane.tmuxWindowName}` : pane.sessionId} contextId={workspaceId} />
+              {(actions.split || actions.maximize || actions.close) && (
               <div className="terminal-mosaic-toolbar-right">
                 <button
                   type="button"
@@ -363,7 +372,8 @@ export function TerminalMosaicScopedPaneWindow({
                   )}
                 </div>
               </div>
-            )}
+              )}
+            </div>
           </div>
         );
       }}

--- a/apps/web/src/features/terminal/components/terminal-mosaic-scoped-pane-window.tsx
+++ b/apps/web/src/features/terminal/components/terminal-mosaic-scoped-pane-window.tsx
@@ -79,6 +79,7 @@ type ScopedPaneWindowProps = {
   pendingRunsRef: React.MutableRefObject<Map<string, PendingTerminalRun>>;
   deliverPendingRunForPane: (paneId: string) => void;
   setDynamicTitle: (workspaceId: string, paneId: string, title: string) => void;
+  setOscTitle: (workspaceId: string, paneId: string, title: string | undefined) => void;
   setPaneAgent: (workspaceId: string, paneId: string, agent: TerminalPaneAgent) => void;
   markPaneAttached: (workspaceId: string, paneId: string) => void;
   surfaceActive?: boolean;
@@ -116,6 +117,7 @@ export function TerminalMosaicScopedPaneWindow({
   pendingRunsRef,
   deliverPendingRunForPane,
   setDynamicTitle,
+  setOscTitle,
   setPaneAgent,
   markPaneAttached,
   surfaceActive = true,
@@ -128,6 +130,8 @@ export function TerminalMosaicScopedPaneWindow({
     configuredAgents,
     agent: pane.agent,
     contestedOwners,
+    oscTitle: pane.oscTitle,
+    suppressOscTitle: !!pane.customLabel?.trim(),
   });
   const [isTerminalReady, setIsTerminalReady] = React.useState(false);
 
@@ -411,6 +415,9 @@ export function TerminalMosaicScopedPaneWindow({
             if (detectedAgent) {
               setPaneAgent(workspaceId, id, detectedAgent);
             }
+          }}
+          onOscTitleChange={(title) => {
+            setOscTitle(workspaceId, id, title);
           }}
           onSessionReady={() => {
             readyPanesRef.current.add(id);

--- a/apps/web/src/features/terminal/components/terminal-mosaic-scoped-pane-window.tsx
+++ b/apps/web/src/features/terminal/components/terminal-mosaic-scoped-pane-window.tsx
@@ -124,7 +124,7 @@ export function TerminalMosaicScopedPaneWindow({
 }: ScopedPaneWindowProps) {
   const t = useTranslations("Terminal.chrome");
   const contestedOwners = useContestedCliOwners();
-  const { displayTitle, toolbarAgent } = getTerminalDisplayMeta({
+  const { displayTitle, primaryTitle, oscSuffix, toolbarAgent } = getTerminalDisplayMeta({
     baseTitle: pane.label,
     dynamicTitle: pane.dynamicTitle,
     configuredAgents,
@@ -215,11 +215,18 @@ export function TerminalMosaicScopedPaneWindow({
       onDragEnd={() => setIsPaneDragging(false)}
       renderToolbar={() => {
         return (
-          <div className="terminal-mosaic-toolbar group/toolbar">
+          <div
+            className={cn(
+              "terminal-mosaic-toolbar group/toolbar",
+              maximizedId === id && "is-toolbar-expanded",
+            )}
+          >
             <div className="terminal-mosaic-toolbar-left">
               {displayTitle ? (
                 <TerminalTitleWithAgent
                   displayTitle={displayTitle}
+                  primaryTitle={primaryTitle}
+                  oscSuffix={oscSuffix}
                   toolbarAgent={toolbarAgent}
                   className="terminal-mosaic-title gap-1.5"
                 />
@@ -232,7 +239,7 @@ export function TerminalMosaicScopedPaneWindow({
                 <button
                   type="button"
                   className={cn(
-                    "terminal-mosaic-btn transition-opacity opacity-0 group-hover/toolbar:opacity-100",
+                    "terminal-mosaic-btn",
                     isPanePinned && "cursor-default text-primary hover:text-primary",
                   )}
                   onClick={() => {
@@ -247,7 +254,7 @@ export function TerminalMosaicScopedPaneWindow({
                 </button>
                 <div className="flex items-center gap-0.5">
                   {actions.split && (
-                    <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover/toolbar:opacity-100">
+                    <div className="flex items-center gap-0.5">
                       <DropdownMenu
                         open={splitMenuKey === `${id}:row`}
                         onOpenChange={(open) => setSplitMenuKey(open ? `${id}:row` : null)}
@@ -323,7 +330,7 @@ export function TerminalMosaicScopedPaneWindow({
                     </div>
                   )}
                   {(actions.maximize || actions.close) && (
-                    <div className={cn("flex items-center gap-0.5 transition-opacity", maximizedId === id ? "opacity-100" : "opacity-0 group-hover/toolbar:opacity-100")}>
+                    <div className="flex items-center gap-0.5">
                       {actions.maximize && (
                         <button
                           className={cn(

--- a/apps/web/src/features/terminal/components/terminal-mosaic-workspace-pane-window.tsx
+++ b/apps/web/src/features/terminal/components/terminal-mosaic-workspace-pane-window.tsx
@@ -150,7 +150,7 @@ export function TerminalMosaicWorkspacePaneWindow(props: TerminalMosaicWorkspace
     [workspaceId, id, terminalTabId],
   );
 
-  const { displayTitle, toolbarAgent, onTitleChange } = useTerminalToolbarTitle({
+  const { displayTitle, toolbarAgent, onTitleChange, onOscTitleChange } = useTerminalToolbarTitle({
     baseTitle: pane.label,
     configuredAgents,
     storeWrite,
@@ -466,6 +466,7 @@ export function TerminalMosaicWorkspacePaneWindow(props: TerminalMosaicWorkspace
           projectRootPath={activeProject?.mainFilePath}
           surfaceActive={surfaceActive}
           onTitleChange={onTitleChange}
+          onOscTitleChange={onOscTitleChange}
           onAddSelectionAsContext={(snapshot) => {
             setActivePaneId(id);
             agentInputOverlayRefsMap.current.get(id)?.addTerminalSelectionContext(snapshot);

--- a/apps/web/src/features/terminal/components/terminal-mosaic-workspace-pane-window.tsx
+++ b/apps/web/src/features/terminal/components/terminal-mosaic-workspace-pane-window.tsx
@@ -56,7 +56,7 @@ export function TerminalPaneAgentStatus({ paneId }: { paneId: string; contextId:
     <AgentHookStatusIndicator
       state={paneState}
       variant="full"
-      className="ml-2"
+      className="ml-2 shrink-0"
     />
   );
 }
@@ -150,14 +150,15 @@ export function TerminalMosaicWorkspacePaneWindow(props: TerminalMosaicWorkspace
     [workspaceId, id, terminalTabId],
   );
 
-  const { displayTitle, toolbarAgent, onTitleChange, onOscTitleChange } = useTerminalToolbarTitle({
-    baseTitle: pane.label,
-    configuredAgents,
-    storeWrite,
-    customLabel: pane.customLabel,
-    keepAgentName: pane.keepAgentName,
-    keepCwd: pane.keepCwd,
-  });
+  const { displayTitle, primaryTitle, oscSuffix, toolbarAgent, onTitleChange, onOscTitleChange } =
+    useTerminalToolbarTitle({
+      baseTitle: pane.label,
+      configuredAgents,
+      storeWrite,
+      customLabel: pane.customLabel,
+      keepAgentName: pane.keepAgentName,
+      keepCwd: pane.keepCwd,
+    });
   const [isTerminalReady, setIsTerminalReady] = React.useState(false);
 
   React.useEffect(() => {
@@ -270,11 +271,18 @@ export function TerminalMosaicWorkspacePaneWindow(props: TerminalMosaicWorkspace
       onDragEnd={() => setIsPaneDragging(false)}
       renderToolbar={() => {
         return (
-          <div className="terminal-mosaic-toolbar group/toolbar">
+          <div
+            className={cn(
+              "terminal-mosaic-toolbar group/toolbar",
+              maximizedId === id && "is-toolbar-expanded",
+            )}
+          >
             <div className="terminal-mosaic-toolbar-left">
               {displayTitle ? (
                 <TerminalTitleWithAgent
                   displayTitle={displayTitle}
+                  primaryTitle={primaryTitle}
+                  oscSuffix={oscSuffix}
                   toolbarAgent={toolbarAgent}
                   className="terminal-mosaic-title gap-1.5"
                 />
@@ -287,7 +295,7 @@ export function TerminalMosaicWorkspacePaneWindow(props: TerminalMosaicWorkspace
                 <button
                   type="button"
                   className={cn(
-                    "terminal-mosaic-btn transition-opacity opacity-0 group-hover/toolbar:opacity-100",
+                    "terminal-mosaic-btn",
                     isPanePinned && "cursor-default text-primary hover:text-primary",
                   )}
                   onClick={() => {
@@ -303,7 +311,7 @@ export function TerminalMosaicWorkspacePaneWindow(props: TerminalMosaicWorkspace
                 </button>
                 <div className="flex items-center gap-0.5">
                   {actions.split && (
-                    <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover/toolbar:opacity-100">
+                    <div className="flex items-center gap-0.5">
                       <DropdownMenu
                         open={splitMenuKey === `${id}:row`}
                         onOpenChange={(open) => setSplitMenuKey(open ? `${id}:row` : null)}
@@ -383,12 +391,7 @@ export function TerminalMosaicWorkspacePaneWindow(props: TerminalMosaicWorkspace
                     </div>
                   )}
                   {(actions.maximize || actions.close) && (
-                    <div
-                      className={cn(
-                        "flex items-center gap-0.5 transition-opacity",
-                        maximizedId === id ? "opacity-100" : "opacity-0 group-hover/toolbar:opacity-100",
-                      )}
-                    >
+                    <div className="flex items-center gap-0.5">
                       {actions.maximize && (
                         <button
                           type="button"

--- a/apps/web/src/features/terminal/components/terminal-mosaic-workspace-pane-window.tsx
+++ b/apps/web/src/features/terminal/components/terminal-mosaic-workspace-pane-window.tsx
@@ -25,6 +25,7 @@ import {
 import { TerminalTitleWithAgent } from "./terminal-title";
 import type { TerminalPaneAgent, TerminalPaneProps } from "../types/index";
 import { useTerminalToolbarTitle } from "../hooks/use-terminal-toolbar-title";
+import { useToolbarHoverExpand } from "../hooks/use-toolbar-hover-expand";
 import { useTerminalSideChats, type SpawnTerminalRequest } from "../hooks/use-terminal-side-chats";
 import type { PendingTerminalRun } from "../lib/terminal-agent-run-delivery";
 import { resolveTerminalAgentSubmitMode } from "../lib/terminal-runtime-utils";
@@ -56,7 +57,7 @@ export function TerminalPaneAgentStatus({ paneId }: { paneId: string; contextId:
     <AgentHookStatusIndicator
       state={paneState}
       variant="full"
-      className="ml-2 shrink-0"
+      className="shrink-0"
     />
   );
 }
@@ -138,6 +139,12 @@ export function TerminalMosaicWorkspacePaneWindow(props: TerminalMosaicWorkspace
     spawnTerminalWithRun,
     surfaceActive = true,
   } = props;
+
+  const { toolbarHovered, onToolbarMouseEnter, onToolbarMouseLeave } = useToolbarHoverExpand(400);
+  const splitMenuOpenForPane =
+    splitMenuKey === `${id}:row` || splitMenuKey === `${id}:column`;
+  const toolbarExpanded =
+    maximizedId === id || toolbarHovered || splitMenuOpenForPane;
 
   const storeWrite = useMemo(
     () =>
@@ -274,8 +281,10 @@ export function TerminalMosaicWorkspacePaneWindow(props: TerminalMosaicWorkspace
           <div
             className={cn(
               "terminal-mosaic-toolbar group/toolbar",
-              maximizedId === id && "is-toolbar-expanded",
+              toolbarExpanded && "is-toolbar-expanded",
             )}
+            onMouseEnter={onToolbarMouseEnter}
+            onMouseLeave={onToolbarMouseLeave}
           >
             <div className="terminal-mosaic-toolbar-left">
               {displayTitle ? (
@@ -287,10 +296,11 @@ export function TerminalMosaicWorkspacePaneWindow(props: TerminalMosaicWorkspace
                   className="terminal-mosaic-title gap-1.5"
                 />
               ) : null}
-              <TerminalPaneAgentStatus paneId={pane.tmuxWindowName ? `${workspaceId}:${pane.tmuxWindowName}` : pane.sessionId} contextId={workspaceId} />
             </div>
 
-            {(actions.split || actions.maximize || actions.close) && (
+            <div className="terminal-mosaic-toolbar-end">
+              <TerminalPaneAgentStatus paneId={pane.tmuxWindowName ? `${workspaceId}:${pane.tmuxWindowName}` : pane.sessionId} contextId={workspaceId} />
+              {(actions.split || actions.maximize || actions.close) && (
               <div className="terminal-mosaic-toolbar-right">
                 <button
                   type="button"
@@ -425,7 +435,8 @@ export function TerminalMosaicWorkspacePaneWindow(props: TerminalMosaicWorkspace
                   )}
                 </div>
               </div>
-            )}
+              )}
+            </div>
           </div>
         );
       }}

--- a/apps/web/src/features/terminal/components/terminal-title.tsx
+++ b/apps/web/src/features/terminal/components/terminal-title.tsx
@@ -22,6 +22,10 @@ export {
 /**
  * Show `text` normally; if it overflows the available width, scroll it as a marquee.
  * Parent must provide a bounded width (`min-w-0` + flex/grid child).
+ *
+ * OSC titles often update rapidly while an agent is running. We always paint the
+ * latest text immediately, but only remount/restart the scroll after the string
+ * has been stable briefly — otherwise the animation is stuck in its start delay.
  */
 export function TerminalTitleMarquee({
   text,
@@ -33,13 +37,34 @@ export function TerminalTitleMarquee({
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLSpanElement>(null);
   const [overflowPx, setOverflowPx] = useState(0);
-  // Bump on every text change so the animating node remounts at translateX(0)
-  // instead of continuing mid-scroll from the previous title.
+  // Bump to remount the animating node at translateX(0).
   const [animKey, setAnimKey] = useState(0);
+  const lastRestartAtRef = useRef(0);
+  const isFirstTextRef = useRef(true);
 
   useEffect(() => {
-    setOverflowPx(0);
-    setAnimKey((k) => k + 1);
+    // Skip the initial mount — nothing to "restart" yet.
+    if (isFirstTextRef.current) {
+      isFirstTextRef.current = false;
+      return;
+    }
+
+    // Immediate restart if we haven't just restarted; otherwise wait for a quiet
+    // window. Agent OSC can update many times per second and would otherwise
+    // keep the marquee stuck in its lead-in delay forever.
+    const RESTART_GAP_MS = 450;
+    const elapsed = Date.now() - lastRestartAtRef.current;
+    if (elapsed >= RESTART_GAP_MS) {
+      lastRestartAtRef.current = Date.now();
+      setAnimKey((k) => k + 1);
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      lastRestartAtRef.current = Date.now();
+      setAnimKey((k) => k + 1);
+    }, RESTART_GAP_MS - elapsed);
+    return () => window.clearTimeout(timer);
   }, [text]);
 
   useEffect(() => {
@@ -48,15 +73,13 @@ export function TerminalTitleMarquee({
     if (!container || !content) return;
 
     const measure = () => {
-      // Force start position before measuring (in case animation already advanced).
-      content.style.transform = "translateX(0)";
+      // transform does not affect layout metrics; do not reset it on resize
+      // (toolbar expand / agent-status mount) or a running marquee is interrupted.
       const overflow = Math.max(0, content.scrollWidth - container.clientWidth);
-      setOverflowPx(overflow);
+      setOverflowPx((prev) => (prev === overflow ? prev : overflow));
       container.style.setProperty("--marquee-distance", `${overflow}px`);
       const durationSec = overflow > 0 ? Math.min(28, Math.max(6, overflow / 40)) : 0;
       container.style.setProperty("--marquee-duration", `${durationSec}s`);
-      // Clear inline transform so CSS animation owns it again.
-      content.style.transform = "";
     };
 
     measure();
@@ -77,7 +100,7 @@ export function TerminalTitleMarquee({
       title={text}
     >
       <span
-        key={`${animKey}:${text}`}
+        key={animKey}
         ref={contentRef}
         className={cn(
           "terminal-title-marquee-text",

--- a/apps/web/src/features/terminal/components/terminal-title.tsx
+++ b/apps/web/src/features/terminal/components/terminal-title.tsx
@@ -21,7 +21,8 @@ export {
 
 /**
  * Horizontal marquee for overflow text (OSC session topics in the pane toolbar).
- * Only animates when the content is wider than the available slot.
+ * Only animates when the content is wider than the available slot; short titles
+ * always stay fully visible (no 0-width flex collapse).
  */
 export function TerminalTitleMarquee({
   text,
@@ -40,19 +41,24 @@ export function TerminalTitleMarquee({
     if (!container || !content) return;
 
     const measure = () => {
+      // Use offset/scroll widths so we measure real paint size, not flex guess.
       const overflow = Math.max(0, content.scrollWidth - container.clientWidth);
       setOverflowPx(overflow);
       container.style.setProperty("--marquee-distance", `${overflow}px`);
-      // ~40px/s with a floor so short overflows still read, and a ceiling for long titles.
       const durationSec = overflow > 0 ? Math.min(28, Math.max(6, overflow / 40)) : 0;
       container.style.setProperty("--marquee-duration", `${durationSec}s`);
     };
 
     measure();
+    // Re-measure after layout settles (flex parents often report 0 on first paint).
+    const raf = requestAnimationFrame(() => measure());
     const ro = new ResizeObserver(measure);
     ro.observe(container);
     ro.observe(content);
-    return () => ro.disconnect();
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+    };
   }, [text]);
 
   return (
@@ -94,9 +100,24 @@ export function TerminalTitleWithAgent({
   const primary = (primaryTitle ?? displayTitle).trim();
   const osc = oscSuffix?.trim() ?? "";
 
+  // Fallback: if callers only pass a combined displayTitle ("A | B"), still show B.
+  const parsed =
+    !osc && primary.includes(" | ")
+      ? (() => {
+          const idx = primary.indexOf(" | ");
+          return {
+            left: primary.slice(0, idx).trim(),
+            right: primary.slice(idx + 3).trim(),
+          };
+        })()
+      : { left: primary, right: osc };
+
+  const left = parsed.left || primary;
+  const right = parsed.right;
+
   return (
-    <div className={cn("flex min-w-0 items-center", className)}>
-      <span className="inline-flex shrink-0 items-center">
+    <div className={cn("terminal-title-row", className)}>
+      <span className="terminal-title-icon">
         {toolbarAgent?.iconType === "built-in" ? (
           <AgentIcon registryId={toolbarAgent.id} name={toolbarAgent.label} size={14} />
         ) : toolbarAgent?.iconType === "custom" ? (
@@ -105,20 +126,13 @@ export function TerminalTitleWithAgent({
           <TerminalIcon className="size-3.5 text-muted-foreground" />
         )}
       </span>
-      <span
-        className={cn(
-          "ml-0.5 truncate",
-          osc ? "max-w-[42%] shrink-0" : "min-w-0",
-        )}
-      >
-        {primary}
-      </span>
-      {osc ? (
+      <span className={cn("terminal-title-primary", right && "has-osc")}>{left}</span>
+      {right ? (
         <>
-          <span className="mx-1 shrink-0 text-muted-foreground/70" aria-hidden>
+          <span className="terminal-title-sep" aria-hidden>
             |
           </span>
-          <TerminalTitleMarquee text={osc} className="min-w-0 flex-1" />
+          <TerminalTitleMarquee text={right} className="terminal-title-osc" />
         </>
       ) : null}
     </div>

--- a/apps/web/src/features/terminal/components/terminal-title.tsx
+++ b/apps/web/src/features/terminal/components/terminal-title.tsx
@@ -20,9 +20,8 @@ export {
 };
 
 /**
- * Horizontal marquee for overflow text (OSC session topics in the pane toolbar).
- * Only animates when the content is wider than the available slot; short titles
- * always stay fully visible (no 0-width flex collapse).
+ * Show `text` normally; if it overflows the available width, scroll it as a marquee.
+ * Parent must provide a bounded width (`min-w-0` + flex/grid child).
  */
 export function TerminalTitleMarquee({
   text,
@@ -41,7 +40,6 @@ export function TerminalTitleMarquee({
     if (!container || !content) return;
 
     const measure = () => {
-      // Use offset/scroll widths so we measure real paint size, not flex guess.
       const overflow = Math.max(0, content.scrollWidth - container.clientWidth);
       setOverflowPx(overflow);
       container.style.setProperty("--marquee-distance", `${overflow}px`);
@@ -50,8 +48,7 @@ export function TerminalTitleMarquee({
     };
 
     measure();
-    // Re-measure after layout settles (flex parents often report 0 on first paint).
-    const raf = requestAnimationFrame(() => measure());
+    const raf = requestAnimationFrame(measure);
     const ro = new ResizeObserver(measure);
     ro.observe(container);
     ro.observe(content);
@@ -82,14 +79,24 @@ export function TerminalTitleMarquee({
 
 interface TerminalTitleWithAgentProps {
   displayTitle: string;
-  /** Atmos primary title (agent/command/path). Falls back to displayTitle. */
+  /** Atmos primary title (agent/command/path). Optional; used to keep left side fixed. */
   primaryTitle?: string;
-  /** Filtered OSC suffix; when set, shown after `|` with marquee on overflow. */
+  /** Filtered OSC suffix. Optional; marquee when long. */
   oscSuffix?: string;
   toolbarAgent: TerminalPaneAgent | undefined;
   className?: string;
 }
 
+/**
+ * Pane toolbar title.
+ *
+ * Pre-marquee behavior (always worked): icon + single `displayTitle` string
+ * including `primary | osc`. We keep that as the source of truth for content.
+ *
+ * Marquee behavior: when `primaryTitle` + `oscSuffix` are available, keep the
+ * primary fixed and only marquee the OSC segment. Fall back to marquee on the
+ * full displayTitle string if structured props are missing.
+ */
 export function TerminalTitleWithAgent({
   displayTitle,
   primaryTitle,
@@ -97,44 +104,38 @@ export function TerminalTitleWithAgent({
   toolbarAgent,
   className,
 }: TerminalTitleWithAgentProps) {
-  const primary = (primaryTitle ?? displayTitle).trim();
-  const osc = oscSuffix?.trim() ?? "";
+  const icon =
+    toolbarAgent?.iconType === "built-in" ? (
+      <AgentIcon registryId={toolbarAgent.id} name={toolbarAgent.label} size={14} />
+    ) : toolbarAgent?.iconType === "custom" ? (
+      <Bot className="size-3.5 text-muted-foreground" />
+    ) : (
+      <TerminalIcon className="size-3.5 text-muted-foreground" />
+    );
 
-  // Fallback: if callers only pass a combined displayTitle ("A | B"), still show B.
-  const parsed =
-    !osc && primary.includes(" | ")
-      ? (() => {
-          const idx = primary.indexOf(" | ");
-          return {
-            left: primary.slice(0, idx).trim(),
-            right: primary.slice(idx + 3).trim(),
-          };
-        })()
-      : { left: primary, right: osc };
+  const primary = (primaryTitle ?? "").trim();
+  const osc = (oscSuffix ?? "").trim();
 
-  const left = parsed.left || primary;
-  const right = parsed.right;
+  // Structured path: fixed primary + marquee OSC (requested UX).
+  if (primary && osc) {
+    return (
+      <div className={cn("terminal-title-row", className)} title={`${primary} | ${osc}`}>
+        <span className="terminal-title-icon">{icon}</span>
+        <span className="terminal-title-primary">{primary}</span>
+        <span className="terminal-title-sep" aria-hidden>
+          |
+        </span>
+        <TerminalTitleMarquee text={osc} />
+      </div>
+    );
+  }
 
+  // Fallback identical to pre-marquee: one string (may already contain " | ").
+  const text = displayTitle.trim() || primary || osc;
   return (
-    <div className={cn("terminal-title-row", className)}>
-      <span className="terminal-title-icon">
-        {toolbarAgent?.iconType === "built-in" ? (
-          <AgentIcon registryId={toolbarAgent.id} name={toolbarAgent.label} size={14} />
-        ) : toolbarAgent?.iconType === "custom" ? (
-          <Bot className="size-3.5 text-muted-foreground" />
-        ) : (
-          <TerminalIcon className="size-3.5 text-muted-foreground" />
-        )}
-      </span>
-      <span className={cn("terminal-title-primary", right && "has-osc")}>{left}</span>
-      {right ? (
-        <>
-          <span className="terminal-title-sep" aria-hidden>
-            |
-          </span>
-          <TerminalTitleMarquee text={right} className="terminal-title-osc" />
-        </>
-      ) : null}
+    <div className={cn("terminal-title-row", className)} title={text}>
+      <span className="terminal-title-icon">{icon}</span>
+      <TerminalTitleMarquee text={text} />
     </div>
   );
 }

--- a/apps/web/src/features/terminal/components/terminal-title.tsx
+++ b/apps/web/src/features/terminal/components/terminal-title.tsx
@@ -33,6 +33,14 @@ export function TerminalTitleMarquee({
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLSpanElement>(null);
   const [overflowPx, setOverflowPx] = useState(0);
+  // Bump on every text change so the animating node remounts at translateX(0)
+  // instead of continuing mid-scroll from the previous title.
+  const [animKey, setAnimKey] = useState(0);
+
+  useEffect(() => {
+    setOverflowPx(0);
+    setAnimKey((k) => k + 1);
+  }, [text]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -40,11 +48,15 @@ export function TerminalTitleMarquee({
     if (!container || !content) return;
 
     const measure = () => {
+      // Force start position before measuring (in case animation already advanced).
+      content.style.transform = "translateX(0)";
       const overflow = Math.max(0, content.scrollWidth - container.clientWidth);
       setOverflowPx(overflow);
       container.style.setProperty("--marquee-distance", `${overflow}px`);
       const durationSec = overflow > 0 ? Math.min(28, Math.max(6, overflow / 40)) : 0;
       container.style.setProperty("--marquee-duration", `${durationSec}s`);
+      // Clear inline transform so CSS animation owns it again.
+      content.style.transform = "";
     };
 
     measure();
@@ -56,7 +68,7 @@ export function TerminalTitleMarquee({
       cancelAnimationFrame(raf);
       ro.disconnect();
     };
-  }, [text]);
+  }, [text, animKey]);
 
   return (
     <div
@@ -65,6 +77,7 @@ export function TerminalTitleMarquee({
       title={text}
     >
       <span
+        key={`${animKey}:${text}`}
         ref={contentRef}
         className={cn(
           "terminal-title-marquee-text",

--- a/apps/web/src/features/terminal/components/terminal-title.tsx
+++ b/apps/web/src/features/terminal/components/terminal-title.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Bot, Terminal as TerminalIcon } from "lucide-react";
 import { cn } from "@workspace/ui";
 import {
@@ -19,27 +19,108 @@ export {
   resolveAgentForTitle,
 };
 
+/**
+ * Horizontal marquee for overflow text (OSC session topics in the pane toolbar).
+ * Only animates when the content is wider than the available slot.
+ */
+export function TerminalTitleMarquee({
+  text,
+  className,
+}: {
+  text: string;
+  className?: string;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLSpanElement>(null);
+  const [overflowPx, setOverflowPx] = useState(0);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const content = contentRef.current;
+    if (!container || !content) return;
+
+    const measure = () => {
+      const overflow = Math.max(0, content.scrollWidth - container.clientWidth);
+      setOverflowPx(overflow);
+      container.style.setProperty("--marquee-distance", `${overflow}px`);
+      // ~40px/s with a floor so short overflows still read, and a ceiling for long titles.
+      const durationSec = overflow > 0 ? Math.min(28, Math.max(6, overflow / 40)) : 0;
+      container.style.setProperty("--marquee-duration", `${durationSec}s`);
+    };
+
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(container);
+    ro.observe(content);
+    return () => ro.disconnect();
+  }, [text]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn("terminal-title-marquee", className)}
+      title={text}
+    >
+      <span
+        ref={contentRef}
+        className={cn(
+          "terminal-title-marquee-text",
+          overflowPx > 0 && "is-overflowing",
+        )}
+      >
+        {text}
+      </span>
+    </div>
+  );
+}
+
 interface TerminalTitleWithAgentProps {
   displayTitle: string;
+  /** Atmos primary title (agent/command/path). Falls back to displayTitle. */
+  primaryTitle?: string;
+  /** Filtered OSC suffix; when set, shown after `|` with marquee on overflow. */
+  oscSuffix?: string;
   toolbarAgent: TerminalPaneAgent | undefined;
   className?: string;
 }
 
 export function TerminalTitleWithAgent({
   displayTitle,
+  primaryTitle,
+  oscSuffix,
   toolbarAgent,
   className,
 }: TerminalTitleWithAgentProps) {
+  const primary = (primaryTitle ?? displayTitle).trim();
+  const osc = oscSuffix?.trim() ?? "";
+
   return (
-    <div className={cn("flex items-center", className)}>
-      {toolbarAgent?.iconType === "built-in" ? (
-        <AgentIcon registryId={toolbarAgent.id} name={toolbarAgent.label} size={14} />
-      ) : toolbarAgent?.iconType === "custom" ? (
-        <Bot className="size-3.5 text-muted-foreground" />
-      ) : (
-        <TerminalIcon className="size-3.5 text-muted-foreground" />
-      )}
-      <span className="ml-0.5">{displayTitle}</span>
+    <div className={cn("flex min-w-0 items-center", className)}>
+      <span className="inline-flex shrink-0 items-center">
+        {toolbarAgent?.iconType === "built-in" ? (
+          <AgentIcon registryId={toolbarAgent.id} name={toolbarAgent.label} size={14} />
+        ) : toolbarAgent?.iconType === "custom" ? (
+          <Bot className="size-3.5 text-muted-foreground" />
+        ) : (
+          <TerminalIcon className="size-3.5 text-muted-foreground" />
+        )}
+      </span>
+      <span
+        className={cn(
+          "ml-0.5 truncate",
+          osc ? "max-w-[42%] shrink-0" : "min-w-0",
+        )}
+      >
+        {primary}
+      </span>
+      {osc ? (
+        <>
+          <span className="mx-1 shrink-0 text-muted-foreground/70" aria-hidden>
+            |
+          </span>
+          <TerminalTitleMarquee text={osc} className="min-w-0 flex-1" />
+        </>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/terminal/hooks/use-terminal-grid-canvas-pins.ts
+++ b/apps/web/src/features/terminal/hooks/use-terminal-grid-canvas-pins.ts
@@ -163,6 +163,8 @@ export function useTerminalGridCanvasPins({
               configuredAgents,
               agent: pane.agent,
               contestedOwners,
+              oscTitle: pane.oscTitle,
+              suppressOscTitle: !!pane.customLabel?.trim(),
             });
             // Contested freehand `agent` can pin before identity resolves. Prefer
             // the pane's known launch agent over baking a raw `agent` label.

--- a/apps/web/src/features/terminal/hooks/use-terminal-toolbar-title.ts
+++ b/apps/web/src/features/terminal/hooks/use-terminal-toolbar-title.ts
@@ -10,7 +10,7 @@ import {
   FIXED_TERMINAL_TAB_VALUE,
 } from "@/features/terminal/store/use-terminal-store";
 import { getTerminalDisplayMeta, resolveAgentForTitle } from "@/features/terminal/components/terminal-title";
-import { isPathLikeTitle, shortenPath } from "@atmos/shared/terminal";
+import { isPathLikeTitle, sanitizeNativeOscTitle, shortenPath } from "@atmos/shared/terminal";
 import type { TerminalPaneAgent } from "@/features/terminal/types/index";
 import { useContestedCliOwners } from "./use-contested-cli-owners";
 
@@ -22,8 +22,8 @@ export type TerminalToolbarStoreWrite =
 
 /**
  * Shared terminal tab title: subscribe to the same zustand fields as the center mosaic,
- * merge OSC/local titles, run {@link getTerminalDisplayMeta}, and emit a single onTitleChange
- * that persists dynamic title + detected agent like {@link TerminalGrid}.
+ * merge shim dynamic titles + native OSC 0/2 titles, run {@link getTerminalDisplayMeta},
+ * and emit onTitleChange / onOscTitleChange that persist display state like {@link TerminalGrid}.
  */
 export function useTerminalToolbarTitle(options: {
   baseTitle: string;
@@ -35,6 +35,7 @@ export function useTerminalToolbarTitle(options: {
   keepCwd?: boolean;
 }) {
   const [localOscTitle, setLocalOscTitle] = useState<string | undefined>();
+  const [localNativeOscTitle, setLocalNativeOscTitle] = useState<string | undefined>();
   const { storeWrite, configuredAgents, baseTitle, pinnedAgent, customLabel, keepAgentName, keepCwd } = options;
   const contestedOwners = useContestedCliOwners();
 
@@ -50,7 +51,11 @@ export function useTerminalToolbarTitle(options: {
       }
       if (storeWrite.kind === "tmux-window") {
         if (storeWrite.contextScope !== "workspace" && storeWrite.contextScope !== "project") {
-          return { dynamicTitle: undefined as string | undefined, agent: undefined as TerminalPaneAgent | undefined };
+          return {
+            dynamicTitle: undefined as string | undefined,
+            oscTitle: undefined as string | undefined,
+            agent: undefined as TerminalPaneAgent | undefined,
+          };
         }
         return getWorkspacePaneLiveFieldsByTmuxWindow(s, storeWrite.workspaceId, storeWrite.tmuxWindowName);
       }
@@ -63,6 +68,7 @@ export function useTerminalToolbarTitle(options: {
       setLocalOscTitle(title);
       if (storeWrite.kind === "none") return;
       const { setDynamicTitle, setPaneAgent } = useTerminalStore.getState();
+      // Agent detection uses shim dynamic titles only — never native OSC (APP-047).
       const detected = resolveAgentForTitle(title, configuredAgents, { contestedOwners });
       if (storeWrite.kind === "mosaic-pane") {
         setDynamicTitle(
@@ -99,39 +105,67 @@ export function useTerminalToolbarTitle(options: {
     [storeWrite, configuredAgents, contestedOwners],
   );
 
+  const onOscTitleChange = useCallback(
+    (title: string | undefined) => {
+      const next = sanitizeNativeOscTitle(title) || undefined;
+      setLocalNativeOscTitle(next);
+      if (storeWrite.kind === "none") return;
+      const { setOscTitle } = useTerminalStore.getState();
+      if (storeWrite.kind === "mosaic-pane") {
+        setOscTitle(
+          storeWrite.workspaceId,
+          storeWrite.paneId,
+          next,
+          storeWrite.terminalTabId ?? FIXED_TERMINAL_TAB_VALUE,
+        );
+        return;
+      }
+      if (storeWrite.kind === "tmux-window") {
+        if (storeWrite.contextScope !== "workspace" && storeWrite.contextScope !== "project") return;
+        const hit = findWorkspacePaneIdsByTmuxWindowName(
+          useTerminalStore.getState(),
+          storeWrite.workspaceId,
+          storeWrite.tmuxWindowName,
+          storeWrite.contextScope === "project",
+        );
+        if (!hit) return;
+        setOscTitle(storeWrite.workspaceId, hit.paneId, next, hit.terminalTabId);
+      }
+    },
+    [storeWrite],
+  );
+
   const { displayTitle, toolbarAgent } = useMemo(() => {
     const mergedDynamic = storeLive.dynamicTitle ?? localOscTitle;
+    const mergedNativeOsc = storeLive.oscTitle ?? localNativeOscTitle;
     const shapeAgent =
       pinnedAgent ??
       configuredAgents.find(
         (agent) => agent.label.trim().toLowerCase() === baseTitle.trim().toLowerCase(),
       );
     const mergedAgent = storeLive.agent ?? shapeAgent;
+    const hasCustom = !!customLabel?.trim();
     const auto = getTerminalDisplayMeta({
       baseTitle,
       dynamicTitle: mergedDynamic,
       configuredAgents,
       agent: mergedAgent,
       contestedOwners,
+      oscTitle: mergedNativeOsc,
+      suppressOscTitle: hasCustom,
     });
 
-    const custom = customLabel?.trim();
-    if (!custom) {
+    if (!hasCustom) {
       return auto;
     }
 
+    const custom = customLabel!.trim();
     // Flags default to on: `undefined` is treated as `true`.
     const wantAgent = keepAgentName !== false;
     const wantCwd = keepCwd !== false;
 
-    // The suffix after the custom label mirrors the default (non-custom)
-    // display exactly; the flags only decide whether it is kept. Agent
-    // detection uses `auto.toolbarAgent` (derived from the *current* OSC
-    // title), so entering an agent shows the agent name and leaving it falls
-    // back to the CWD — identical to the pre-custom behavior.
+    // Custom labels suppress native OSC suffixes entirely (APP-047 / APP-033).
     const showAgent = wantAgent && !!auto.toolbarAgent;
-    // Agent wins over CWD: only show a CWD suffix when no agent is shown.
-    // "Keep CWD" preserves the dynamic CWD/command title — shorten paths, keep commands as-is.
     const cwdSuffix =
       !showAgent && wantCwd && mergedDynamic
         ? isPathLikeTitle(mergedDynamic)
@@ -154,12 +188,14 @@ export function useTerminalToolbarTitle(options: {
     pinnedAgent,
     storeLive.agent,
     storeLive.dynamicTitle,
+    storeLive.oscTitle,
     localOscTitle,
+    localNativeOscTitle,
     customLabel,
     keepAgentName,
     keepCwd,
     contestedOwners,
   ]);
 
-  return { displayTitle, toolbarAgent, onTitleChange };
+  return { displayTitle, toolbarAgent, onTitleChange, onOscTitleChange };
 }

--- a/apps/web/src/features/terminal/hooks/use-terminal-toolbar-title.ts
+++ b/apps/web/src/features/terminal/hooks/use-terminal-toolbar-title.ts
@@ -135,7 +135,7 @@ export function useTerminalToolbarTitle(options: {
     [storeWrite],
   );
 
-  const { displayTitle, toolbarAgent } = useMemo(() => {
+  const { displayTitle, primaryTitle, oscSuffix, toolbarAgent } = useMemo(() => {
     const mergedDynamic = storeLive.dynamicTitle ?? localOscTitle;
     const mergedNativeOsc = storeLive.oscTitle ?? localNativeOscTitle;
     const shapeAgent =
@@ -181,7 +181,12 @@ export function useTerminalToolbarTitle(options: {
       .filter(Boolean)
       .join(" · ");
 
-    return { displayTitle, toolbarAgent: showAgent ? auto.toolbarAgent : undefined };
+    return {
+      displayTitle,
+      primaryTitle: displayTitle,
+      oscSuffix: "",
+      toolbarAgent: showAgent ? auto.toolbarAgent : undefined,
+    };
   }, [
     baseTitle,
     configuredAgents,
@@ -197,5 +202,5 @@ export function useTerminalToolbarTitle(options: {
     contestedOwners,
   ]);
 
-  return { displayTitle, toolbarAgent, onTitleChange, onOscTitleChange };
+  return { displayTitle, primaryTitle, oscSuffix, toolbarAgent, onTitleChange, onOscTitleChange };
 }

--- a/apps/web/src/features/terminal/hooks/use-terminal-toolbar-title.ts
+++ b/apps/web/src/features/terminal/hooks/use-terminal-toolbar-title.ts
@@ -10,7 +10,12 @@ import {
   FIXED_TERMINAL_TAB_VALUE,
 } from "@/features/terminal/store/use-terminal-store";
 import { getTerminalDisplayMeta, resolveAgentForTitle } from "@/features/terminal/components/terminal-title";
-import { isPathLikeTitle, sanitizeNativeOscTitle, shortenPath } from "@atmos/shared/terminal";
+import {
+  isNoisyShellOscTitle,
+  isPathLikeTitle,
+  sanitizeNativeOscTitle,
+  shortenPath,
+} from "@atmos/shared/terminal";
 import type { TerminalPaneAgent } from "@/features/terminal/types/index";
 import { useContestedCliOwners } from "./use-contested-cli-owners";
 
@@ -107,7 +112,10 @@ export function useTerminalToolbarTitle(options: {
 
   const onOscTitleChange = useCallback(
     (title: string | undefined) => {
-      const next = sanitizeNativeOscTitle(title) || undefined;
+      // Keep local + store in lockstep. Shell path noise must clear both so a
+      // filtered store write cannot fall back to a stale local path string.
+      const cleaned = sanitizeNativeOscTitle(title);
+      const next = cleaned && !isNoisyShellOscTitle(cleaned) ? cleaned : undefined;
       setLocalNativeOscTitle(next);
       if (storeWrite.kind === "none") return;
       const { setOscTitle } = useTerminalStore.getState();

--- a/apps/web/src/features/terminal/hooks/use-terminal-websocket.ts
+++ b/apps/web/src/features/terminal/hooks/use-terminal-websocket.ts
@@ -245,6 +245,12 @@ export function useTerminalWebSocket({
               }
               break;
             case "terminal_error":
+              // Fatal for this connection: attach/create already exhausted
+              // server-side retries. Do not auto-reconnect — onopen resets the
+              // reconnect counter, so reconnecting would loop forever and wipe
+              // the error UI. User can Retry manually.
+              reconnectCountRef.current = reconnectAttempts;
+              clearReconnectTimeout();
               onError?.(message.error);
               break;
           }
@@ -299,6 +305,7 @@ export function useTerminalWebSocket({
     workspaceId,
     reconnectAttempts,
     reconnectDelay,
+    clearReconnectTimeout,
     disconnect,
   ]);
 

--- a/apps/web/src/features/terminal/hooks/use-toolbar-hover-expand.ts
+++ b/apps/web/src/features/terminal/hooks/use-toolbar-hover-expand.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Expand a toolbar on hover, but delay collapse on leave so the pointer can
+ * travel to a portaled dropdown (e.g. split-agent menu) without the action
+ * rail vanishing underneath.
+ */
+export function useToolbarHoverExpand(collapseDelayMs = 400) {
+  const [hovered, setHovered] = useState(false);
+  const leaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearLeaveTimer = useCallback(() => {
+    if (leaveTimerRef.current != null) {
+      clearTimeout(leaveTimerRef.current);
+      leaveTimerRef.current = null;
+    }
+  }, []);
+
+  const onToolbarMouseEnter = useCallback(() => {
+    clearLeaveTimer();
+    setHovered(true);
+  }, [clearLeaveTimer]);
+
+  const onToolbarMouseLeave = useCallback(() => {
+    clearLeaveTimer();
+    leaveTimerRef.current = setTimeout(() => {
+      setHovered(false);
+      leaveTimerRef.current = null;
+    }, collapseDelayMs);
+  }, [clearLeaveTimer, collapseDelayMs]);
+
+  useEffect(() => () => clearLeaveTimer(), [clearLeaveTimer]);
+
+  return { toolbarHovered: hovered, onToolbarMouseEnter, onToolbarMouseLeave };
+}

--- a/apps/web/src/features/terminal/lib/terminal-layout-document.ts
+++ b/apps/web/src/features/terminal/lib/terminal-layout-document.ts
@@ -6,7 +6,7 @@ import type { TerminalPaneProps } from "@/features/terminal/types/index";
 export const TERMINAL_LAYOUT_SCHEMA = "terminal-layout.v1";
 export const FIXED_TERMINAL_TAB_VALUE = "terminal";
 
-export type PersistedTerminalPane = Omit<TerminalPaneProps, "sessionId" | "dynamicTitle">;
+export type PersistedTerminalPane = Omit<TerminalPaneProps, "sessionId" | "dynamicTitle" | "oscTitle">;
 
 export interface PersistedTerminalTabDocument {
   id: string;

--- a/apps/web/src/features/terminal/lib/terminal-layout-document.ts
+++ b/apps/web/src/features/terminal/lib/terminal-layout-document.ts
@@ -6,7 +6,8 @@ import type { TerminalPaneProps } from "@/features/terminal/types/index";
 export const TERMINAL_LAYOUT_SCHEMA = "terminal-layout.v1";
 export const FIXED_TERMINAL_TAB_VALUE = "terminal";
 
-export type PersistedTerminalPane = Omit<TerminalPaneProps, "sessionId" | "dynamicTitle" | "oscTitle">;
+/** sessionId / dynamicTitle stay frontend-only; oscTitle is persisted (agent session topic). */
+export type PersistedTerminalPane = Omit<TerminalPaneProps, "sessionId" | "dynamicTitle">;
 
 export interface PersistedTerminalTabDocument {
   id: string;

--- a/apps/web/src/features/terminal/store/terminal-store-auxiliary-actions.ts
+++ b/apps/web/src/features/terminal/store/terminal-store-auxiliary-actions.ts
@@ -35,6 +35,7 @@ type AuxiliaryTerminalActions = Pick<
   | "loadProjectWikiFromTmux"
   | "getProjectWikiPaneIdByTmuxWindowName"
   | "setProjectWikiDynamicTitle"
+  | "setProjectWikiOscTitle"
   | "setProjectWikiPaneAgent"
   | "markProjectWikiPaneAttached"
   | "toggleProjectWikiMaximize"
@@ -48,6 +49,7 @@ type AuxiliaryTerminalActions = Pick<
   | "loadCodeReviewFromTmux"
   | "getCodeReviewPaneIdByTmuxWindowName"
   | "setCodeReviewDynamicTitle"
+  | "setCodeReviewOscTitle"
   | "setCodeReviewPaneAgent"
   | "markCodeReviewPaneAttached"
   | "toggleCodeReviewMaximize"
@@ -216,6 +218,21 @@ export function createTerminalAuxiliaryActions(
         },
       }));
     },
+    setProjectWikiOscTitle: (workspaceId, paneId, oscTitle) => {
+      const panes = get().projectWikiPanes[workspaceId];
+      if (!panes?.[paneId]) return;
+      const next = oscTitle?.trim() ? oscTitle : undefined;
+      if (panes[paneId].oscTitle === next) return;
+      set((state) => ({
+        projectWikiPanes: {
+          ...state.projectWikiPanes,
+          [workspaceId]: {
+            ...panes,
+            [paneId]: { ...panes[paneId], oscTitle: next },
+          },
+        },
+      }));
+    },
     markProjectWikiPaneAttached: (workspaceId, paneId) => {
       const panes = get().projectWikiPanes[workspaceId];
       const pane = panes?.[paneId];
@@ -368,6 +385,21 @@ export function createTerminalAuxiliaryActions(
           [workspaceId]: {
             ...panes,
             [paneId]: { ...panes[paneId], dynamicTitle },
+          },
+        },
+      }));
+    },
+    setCodeReviewOscTitle: (workspaceId, paneId, oscTitle) => {
+      const panes = get().codeReviewPanes[workspaceId];
+      if (!panes?.[paneId]) return;
+      const next = oscTitle?.trim() ? oscTitle : undefined;
+      if (panes[paneId].oscTitle === next) return;
+      set((state) => ({
+        codeReviewPanes: {
+          ...state.codeReviewPanes,
+          [workspaceId]: {
+            ...panes,
+            [paneId]: { ...panes[paneId], oscTitle: next },
           },
         },
       }));

--- a/apps/web/src/features/terminal/store/terminal-store-auxiliary-actions.ts
+++ b/apps/web/src/features/terminal/store/terminal-store-auxiliary-actions.ts
@@ -13,6 +13,12 @@ import {
   splitPaneInLayout,
 } from "@/features/terminal/store/terminal-store-helpers";
 import type { TerminalStore } from "@/features/terminal/store/terminal-store-types";
+import { isNoisyShellOscTitle, sanitizeNativeOscTitle } from "@atmos/shared/terminal";
+
+function normalizeStoredOscTitle(oscTitle: string | undefined): string | undefined {
+  const cleaned = sanitizeNativeOscTitle(oscTitle);
+  return cleaned && !isNoisyShellOscTitle(cleaned) ? cleaned : undefined;
+}
 
 type TerminalStoreSet = (
   partial:
@@ -221,7 +227,8 @@ export function createTerminalAuxiliaryActions(
     setProjectWikiOscTitle: (workspaceId, paneId, oscTitle) => {
       const panes = get().projectWikiPanes[workspaceId];
       if (!panes?.[paneId]) return;
-      const next = oscTitle?.trim() || undefined;
+      // Wiki scope is in-memory only; still drop shell path noise.
+      const next = normalizeStoredOscTitle(oscTitle);
       if (panes[paneId].oscTitle === next) return;
       set((state) => ({
         projectWikiPanes: {
@@ -392,7 +399,7 @@ export function createTerminalAuxiliaryActions(
     setCodeReviewOscTitle: (workspaceId, paneId, oscTitle) => {
       const panes = get().codeReviewPanes[workspaceId];
       if (!panes?.[paneId]) return;
-      const next = oscTitle?.trim() || undefined;
+      const next = normalizeStoredOscTitle(oscTitle);
       if (panes[paneId].oscTitle === next) return;
       set((state) => ({
         codeReviewPanes: {

--- a/apps/web/src/features/terminal/store/terminal-store-auxiliary-actions.ts
+++ b/apps/web/src/features/terminal/store/terminal-store-auxiliary-actions.ts
@@ -221,7 +221,7 @@ export function createTerminalAuxiliaryActions(
     setProjectWikiOscTitle: (workspaceId, paneId, oscTitle) => {
       const panes = get().projectWikiPanes[workspaceId];
       if (!panes?.[paneId]) return;
-      const next = oscTitle?.trim() ? oscTitle : undefined;
+      const next = oscTitle?.trim() || undefined;
       if (panes[paneId].oscTitle === next) return;
       set((state) => ({
         projectWikiPanes: {
@@ -392,7 +392,7 @@ export function createTerminalAuxiliaryActions(
     setCodeReviewOscTitle: (workspaceId, paneId, oscTitle) => {
       const panes = get().codeReviewPanes[workspaceId];
       if (!panes?.[paneId]) return;
-      const next = oscTitle?.trim() ? oscTitle : undefined;
+      const next = oscTitle?.trim() || undefined;
       if (panes[paneId].oscTitle === next) return;
       set((state) => ({
         codeReviewPanes: {

--- a/apps/web/src/features/terminal/store/terminal-store-helpers.ts
+++ b/apps/web/src/features/terminal/store/terminal-store-helpers.ts
@@ -267,11 +267,11 @@ export function getWorkspacePaneFieldsByPaneId(
   workspaceId: string,
   paneId: string,
   terminalTabId: string = FIXED_TERMINAL_TAB_VALUE,
-): { dynamicTitle?: string; agent?: TerminalPaneAgent } {
+): { dynamicTitle?: string; oscTitle?: string; agent?: TerminalPaneAgent } {
   const scopeKey = getScopeKey(workspaceId, terminalTabId);
   const pane = state.workspacePanes[scopeKey]?.[paneId];
   if (!pane) return {};
-  return { dynamicTitle: pane.dynamicTitle, agent: pane.agent };
+  return { dynamicTitle: pane.dynamicTitle, oscTitle: pane.oscTitle, agent: pane.agent };
 }
 
 /** Read transient title + agent for a tmux-attached pane (same fields the mosaic uses). */
@@ -279,13 +279,13 @@ export function getWorkspacePaneLiveFieldsByTmuxWindow(
   state: TerminalLookupState,
   workspaceId: string,
   tmuxWindowName: string,
-): { dynamicTitle?: string; agent?: TerminalPaneAgent } {
+): { dynamicTitle?: string; oscTitle?: string; agent?: TerminalPaneAgent } {
   const hit = findWorkspacePaneIdsByTmuxWindowName(state, workspaceId, tmuxWindowName);
   if (!hit) return {};
   const scopeKey = getScopeKey(workspaceId, hit.terminalTabId);
   const pane = state.workspacePanes[scopeKey]?.[hit.paneId];
   if (!pane) return {};
-  return { dynamicTitle: pane.dynamicTitle, agent: pane.agent };
+  return { dynamicTitle: pane.dynamicTitle, oscTitle: pane.oscTitle, agent: pane.agent };
 }
 
 export function getAllDefaultPanesForWorkspace(
@@ -411,9 +411,10 @@ export function hydratePersistedTab(
       // API/tmux startup after app restart; treating unknown windows as "new"
       // forces create and can orphan a still-running TUI agent.
       isNewPane: liveByWindow ? false : windowName ? false : !windowExists,
-      // dynamicTitle is display-only and not written to layout persistence —
-      // keep the warm in-memory value across a hydrate rewrite.
+      // dynamicTitle / oscTitle are display-only and not written to layout
+      // persistence — keep warm in-memory values across a hydrate rewrite.
       dynamicTitle: liveByWindow?.dynamicTitle,
+      oscTitle: liveByWindow?.oscTitle,
       // Prefer live agent, then persisted agent.
       agent: liveByWindow?.agent ?? pane.agent,
       customLabel: liveByWindow?.customLabel ?? pane.customLabel,

--- a/apps/web/src/features/terminal/store/terminal-store-helpers.ts
+++ b/apps/web/src/features/terminal/store/terminal-store-helpers.ts
@@ -411,10 +411,10 @@ export function hydratePersistedTab(
       // API/tmux startup after app restart; treating unknown windows as "new"
       // forces create and can orphan a still-running TUI agent.
       isNewPane: liveByWindow ? false : windowName ? false : !windowExists,
-      // dynamicTitle / oscTitle are display-only and not written to layout
-      // persistence — keep warm in-memory values across a hydrate rewrite.
+      // dynamicTitle is display-only (reattach inject); keep warm in-memory.
+      // oscTitle is persisted so agent session topics survive refresh (APP-047).
       dynamicTitle: liveByWindow?.dynamicTitle,
-      oscTitle: liveByWindow?.oscTitle,
+      oscTitle: liveByWindow?.oscTitle ?? pane.oscTitle,
       // Prefer live agent, then persisted agent.
       agent: liveByWindow?.agent ?? pane.agent,
       customLabel: liveByWindow?.customLabel ?? pane.customLabel,
@@ -728,6 +728,8 @@ export function buildPersistedTerminalWorkspaceLayout(
         projectName: pane.projectName,
         workspaceName: pane.workspaceName,
         isNewPane: pane.isNewPane,
+        // Persist agent OSC session topics; omit empty so layout stays lean.
+        ...(pane.oscTitle?.trim() ? { oscTitle: pane.oscTitle.trim() } : {}),
         customLabel: pane.customLabel,
         keepAgentName: pane.keepAgentName,
         keepCwd: pane.keepCwd,

--- a/apps/web/src/features/terminal/store/terminal-store-types.ts
+++ b/apps/web/src/features/terminal/store/terminal-store-types.ts
@@ -75,6 +75,8 @@ export interface TerminalStore {
   setTmuxWindowName: (workspaceId: string, paneId: string, tmuxWindowName: string, terminalTabId?: string) => void;
   markPaneAttached: (workspaceId: string, paneId: string, terminalTabId?: string) => void;
   setDynamicTitle: (workspaceId: string, paneId: string, dynamicTitle: string, terminalTabId?: string) => void;
+  /** Set/clear native OSC 0/2 title (display-only; `undefined` or empty clears). */
+  setOscTitle: (workspaceId: string, paneId: string, oscTitle: string | undefined, terminalTabId?: string) => void;
   setPaneAgent: (workspaceId: string, paneId: string, agent: TerminalPaneAgent, terminalTabId?: string) => void;
 
   /** Set/clear a tab's custom display title. Empty (after normalize) clears the override. */
@@ -100,6 +102,7 @@ export interface TerminalStore {
   loadProjectWikiFromTmux: (workspaceId: string) => Promise<void>;
   getProjectWikiPaneIdByTmuxWindowName: (workspaceId: string, tmuxWindowName: string) => string | null;
   setProjectWikiDynamicTitle: (workspaceId: string, paneId: string, dynamicTitle: string) => void;
+  setProjectWikiOscTitle: (workspaceId: string, paneId: string, oscTitle: string | undefined) => void;
   setProjectWikiPaneAgent: (workspaceId: string, paneId: string, agent: TerminalPaneAgent) => void;
   markProjectWikiPaneAttached: (workspaceId: string, paneId: string) => void;
   toggleProjectWikiMaximize: (workspaceId: string, id: string) => void;
@@ -119,6 +122,7 @@ export interface TerminalStore {
   loadCodeReviewFromTmux: (workspaceId: string) => Promise<void>;
   getCodeReviewPaneIdByTmuxWindowName: (workspaceId: string, tmuxWindowName: string) => string | null;
   setCodeReviewDynamicTitle: (workspaceId: string, paneId: string, dynamicTitle: string) => void;
+  setCodeReviewOscTitle: (workspaceId: string, paneId: string, oscTitle: string | undefined) => void;
   setCodeReviewPaneAgent: (workspaceId: string, paneId: string, agent: TerminalPaneAgent) => void;
   markCodeReviewPaneAttached: (workspaceId: string, paneId: string) => void;
   toggleCodeReviewMaximize: (workspaceId: string, id: string) => void;

--- a/apps/web/src/features/terminal/store/use-terminal-store.ts
+++ b/apps/web/src/features/terminal/store/use-terminal-store.ts
@@ -36,6 +36,7 @@ import {
   type TerminalCenterTab,
 } from "@/features/terminal/store/terminal-store-helpers";
 import type { TerminalStore } from "@/features/terminal/store/terminal-store-types";
+import { isNoisyShellOscTitle, sanitizeNativeOscTitle } from "@atmos/shared/terminal";
 
 export { FIXED_TERMINAL_TAB_VALUE } from "@/features/terminal/lib/terminal-layout-document";
 export {
@@ -971,8 +972,10 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => {
     const panes = get().workspacePanes[scopeKey];
     if (!panes || !panes[paneId]) return;
 
-    // Callers should sanitize; keep empty/whitespace as cleared.
-    const next = oscTitle?.trim() ? oscTitle.trim() : undefined;
+    // Sanitize; drop shell user@host:cwd noise so we never persist it.
+    const cleaned = sanitizeNativeOscTitle(oscTitle);
+    const next =
+      cleaned && !isNoisyShellOscTitle(cleaned) ? cleaned : undefined;
     if (panes[paneId].oscTitle === next) return;
 
     set((state) => ({
@@ -987,7 +990,10 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => {
         },
       },
     }));
-    // NOTE: Do NOT call saveToBackend — oscTitle is transient display-only (APP-047)
+    // Persisted in terminal layout (debounced by saveToBackend) so agent
+    // session topics survive full page refresh — unlike dynamicTitle, which
+    // is re-injected from tmux on attach (APP-047).
+    get().saveToBackend(workspaceId);
   },
 
   setPaneAgent: (workspaceId, paneId, agent, terminalTabId = FIXED_TERMINAL_TAB_VALUE) => {

--- a/apps/web/src/features/terminal/store/use-terminal-store.ts
+++ b/apps/web/src/features/terminal/store/use-terminal-store.ts
@@ -966,6 +966,30 @@ export const useTerminalStore = create<TerminalStore>()((set, get) => {
     // NOTE: Do NOT call saveToBackend — dynamicTitle is transient display-only
   },
 
+  setOscTitle: (workspaceId, paneId, oscTitle, terminalTabId = FIXED_TERMINAL_TAB_VALUE) => {
+    const scopeKey = getScopeKey(workspaceId, terminalTabId);
+    const panes = get().workspacePanes[scopeKey];
+    if (!panes || !panes[paneId]) return;
+
+    // Callers should sanitize; keep empty/whitespace as cleared.
+    const next = oscTitle?.trim() ? oscTitle.trim() : undefined;
+    if (panes[paneId].oscTitle === next) return;
+
+    set((state) => ({
+      workspacePanes: {
+        ...state.workspacePanes,
+        [scopeKey]: {
+          ...panes,
+          [paneId]: {
+            ...panes[paneId],
+            oscTitle: next,
+          },
+        },
+      },
+    }));
+    // NOTE: Do NOT call saveToBackend — oscTitle is transient display-only (APP-047)
+  },
+
   setPaneAgent: (workspaceId, paneId, agent, terminalTabId = FIXED_TERMINAL_TAB_VALUE) => {
     const scopeKey = getScopeKey(workspaceId, terminalTabId);
     const panes = get().workspacePanes[scopeKey];

--- a/apps/web/src/features/terminal/types/index.ts
+++ b/apps/web/src/features/terminal/types/index.ts
@@ -61,8 +61,13 @@ export interface TerminalProps {
   readOnly?: boolean;
   /** Visual scale used when the terminal is rendered in a canvas overlay. */
   terminalScale?: number;
-  /** Called when the terminal's dynamic title changes (from shell shim OSC sequences) */
+  /** Called when the terminal's dynamic title changes (from shell shim OSC 9999 sequences) */
   onTitleChange?: (title: string) => void;
+  /**
+   * Native OSC 0/2 window title from the foreground process (Codex/Claude/…).
+   * Pass `undefined` to clear. Never used for agent detection (APP-047).
+   */
+  onOscTitleChange?: (title: string | undefined) => void;
   /**
    * When false, this terminal is off-screen (warm workspace / inactive tab).
    * Skip ResizeObserver + fit so hop does not thrash layout for hidden xterms.
@@ -129,6 +134,11 @@ export interface TerminalPaneProps {
    * This is transient and NOT persisted to backend — only used for tab display.
    */
   dynamicTitle?: string;
+  /**
+   * Native OSC 0/2 title from the foreground process (agent session topic).
+   * Transient display-only; never persisted; never used for agent detection (APP-047).
+   */
+  oscTitle?: string;
   /**
    * User custom display name. Highest-priority display source for the pane toolbar.
    * Empty/undefined means no override (fall back to auto title logic). Persisted.

--- a/apps/web/src/features/terminal/types/index.ts
+++ b/apps/web/src/features/terminal/types/index.ts
@@ -136,7 +136,8 @@ export interface TerminalPaneProps {
   dynamicTitle?: string;
   /**
    * Native OSC 0/2 title from the foreground process (agent session topic).
-   * Transient display-only; never persisted; never used for agent detection (APP-047).
+   * Persisted in the terminal layout so refresh keeps session topics (APP-047).
+   * Never used for agent detection. Shell host/path noise is not stored.
    */
   oscTitle?: string;
   /**

--- a/packages/shared/src/terminal/title.ts
+++ b/packages/shared/src/terminal/title.ts
@@ -427,12 +427,63 @@ function resolveAgentForLabel<TAgent extends TerminalTitleAgent>(
   });
 }
 
+/** Practical cap for native OSC 0/2 titles in Atmos toolbars (APP-047). */
+export const MAX_NATIVE_OSC_TITLE_CHARS = 64;
+
+/**
+ * Normalize untrusted native OSC 0/2 title text into a single display line.
+ * Strips control characters, collapses whitespace, and caps length.
+ */
+export function sanitizeNativeOscTitle(title: string | undefined): string {
+  if (!title) return "";
+  let pendingSpace = false;
+  let out = "";
+  for (const ch of title) {
+    // Whitespace (including \t/\n) collapses to a single space.
+    if (/\s/u.test(ch)) {
+      if (out.length > 0) pendingSpace = true;
+      continue;
+    }
+    // Drop remaining C0/C1 controls and DEL so titles cannot break OSC framing.
+    if (ch <= "\u001f" || ch === "\u007f" || (ch >= "\u0080" && ch <= "\u009f")) {
+      continue;
+    }
+    if (pendingSpace) {
+      if (out.length + 1 >= MAX_NATIVE_OSC_TITLE_CHARS) break;
+      out += " ";
+      pendingSpace = false;
+    }
+    if (out.length >= MAX_NATIVE_OSC_TITLE_CHARS) break;
+    out += ch;
+  }
+  return out;
+}
+
+/**
+ * Append a native OSC title after an Atmos auto/custom display title.
+ * Returns auto-only when `oscTitle` is empty or `suppress` is true.
+ */
+export function appendNativeOscTitle(
+  autoDisplayTitle: string | undefined,
+  oscTitle: string | undefined,
+  suppress = false,
+): string {
+  const base = autoDisplayTitle?.trim() ?? "";
+  if (suppress) return base;
+  const osc = sanitizeNativeOscTitle(oscTitle);
+  if (!osc) return base;
+  if (!base) return osc;
+  return `${base} | ${osc}`;
+}
+
 export function getTerminalDisplayTitle<TAgent extends TerminalTitleAgent>(options: {
   baseTitle: string | undefined;
   dynamicTitle: string | undefined;
   configuredAgents?: TAgent[];
   agent?: TAgent;
   contestedOwners?: ContestedOwnersMap;
+  oscTitle?: string;
+  suppressOscTitle?: boolean;
 }) {
   return getTerminalDisplayMeta(options).displayTitle;
 }
@@ -443,11 +494,26 @@ export function getTerminalDisplayMeta<TAgent extends TerminalTitleAgent>(option
   configuredAgents?: TAgent[];
   agent?: TAgent;
   contestedOwners?: ContestedOwnersMap;
+  /**
+   * Native OSC 0/2 title from the foreground process (Codex/Claude/…).
+   * Never used for agent detection — display suffix only (APP-047).
+   */
+  oscTitle?: string;
+  /** User set a custom pane label — hide OSC suffix. */
+  suppressOscTitle?: boolean;
 }): {
   displayTitle: string;
   toolbarAgent: TAgent | undefined;
 } {
-  const { baseTitle, dynamicTitle, configuredAgents = [], agent, contestedOwners } = options;
+  const {
+    baseTitle,
+    dynamicTitle,
+    configuredAgents = [],
+    agent,
+    contestedOwners,
+    oscTitle,
+    suppressOscTitle,
+  } = options;
   const dynamicTitleIsVersion = isVersionLikeTitle(dynamicTitle);
   const matchedDynamicAgent = resolveAgentForTitle(dynamicTitle, configuredAgents, {
     contestedOwners,
@@ -471,14 +537,16 @@ export function getTerminalDisplayMeta<TAgent extends TerminalTitleAgent>(option
     ? undefined
     : matchedDynamicAgent ?? fallbackAgent ?? labelAgent;
 
+  const autoDisplayTitle =
+    toolbarAgent?.label ??
+    (shouldPreferBaseTitleOverDynamic(dynamicTitle, dynamicTitleIsVersion, toolbarAgent)
+      ? baseTitle
+      : dynamicTitle) ??
+    baseTitle ??
+    "";
+
   return {
     toolbarAgent,
-    displayTitle:
-      toolbarAgent?.label ??
-      (shouldPreferBaseTitleOverDynamic(dynamicTitle, dynamicTitleIsVersion, toolbarAgent)
-        ? baseTitle
-        : dynamicTitle) ??
-      baseTitle ??
-      "",
+    displayTitle: appendNativeOscTitle(autoDisplayTitle, oscTitle, suppressOscTitle === true),
   };
 }

--- a/packages/shared/src/terminal/title.ts
+++ b/packages/shared/src/terminal/title.ts
@@ -596,7 +596,12 @@ export function getTerminalDisplayMeta<TAgent extends TerminalTitleAgent>(option
   /** User set a custom pane label — hide OSC suffix. */
   suppressOscTitle?: boolean;
 }): {
+  /** Combined title for plain string consumers (tabs, tooltips, a11y). */
   displayTitle: string;
+  /** Atmos-owned left title (agent brand / command / path / custom). */
+  primaryTitle: string;
+  /** Filtered OSC session topic; empty when suppressed or noise. */
+  oscSuffix: string;
   toolbarAgent: TAgent | undefined;
 } {
   const {
@@ -631,7 +636,7 @@ export function getTerminalDisplayMeta<TAgent extends TerminalTitleAgent>(option
     ? undefined
     : matchedDynamicAgent ?? fallbackAgent ?? labelAgent;
 
-  const autoDisplayTitle =
+  const primaryTitle =
     toolbarAgent?.label ??
     (shouldPreferBaseTitleOverDynamic(dynamicTitle, dynamicTitleIsVersion, toolbarAgent)
       ? baseTitle
@@ -639,10 +644,21 @@ export function getTerminalDisplayMeta<TAgent extends TerminalTitleAgent>(option
     baseTitle ??
     "";
 
+  const oscSuffix =
+    suppressOscTitle === true
+      ? ""
+      : resolveDisplayOscTitle(oscTitle, {
+          autoDisplayTitle: primaryTitle,
+          dynamicTitle,
+          toolbarAgent,
+        });
+
   return {
     toolbarAgent,
-    displayTitle: appendNativeOscTitle(autoDisplayTitle, oscTitle, suppressOscTitle === true, {
-      autoDisplayTitle,
+    primaryTitle,
+    oscSuffix,
+    displayTitle: appendNativeOscTitle(primaryTitle, oscTitle, suppressOscTitle === true, {
+      autoDisplayTitle: primaryTitle,
       dynamicTitle,
       toolbarAgent,
     }),

--- a/packages/shared/src/terminal/title.ts
+++ b/packages/shared/src/terminal/title.ts
@@ -471,6 +471,9 @@ export type OscTitleDisplayContext = {
 /**
  * Shell / terminal-integration titles that only restate host + cwd.
  * Examples: `user@Host:~/path`, pure paths, `Host:/tmp/foo`.
+ *
+ * Intentionally does NOT treat multi-word session topics that merely contain
+ * a slash (e.g. "fix src/api") as noise — those are useful OSC titles.
  */
 export function isNoisyShellOscTitle(osc: string): boolean {
   const t = osc.trim();
@@ -479,7 +482,37 @@ export function isNoisyShellOscTitle(osc: string): boolean {
   if (/^[^@\s]+@[^:\s]+:/.test(t)) return true;
   // host:absolute-or-home path without @
   if (/^[\w.-]+:(?:~|\/)/.test(t)) return true;
-  if (isPathLikeTitle(t)) return true;
+  // Entire title is a bare filesystem path (no spaces / not a phrase).
+  if (isBareFilesystemOscTitle(t)) return true;
+  return false;
+}
+
+/** True when the whole OSC string is a path, not a multi-word session topic. */
+function isBareFilesystemOscTitle(t: string): boolean {
+  if (/\s/.test(t)) return false;
+  // Absolute / home / Windows / UNC
+  if (
+    t.startsWith("/") ||
+    t.startsWith("~/") ||
+    t === "~" ||
+    t === "." ||
+    t === ".." ||
+    t.startsWith("../") ||
+    /^[a-zA-Z]:[\\/]/.test(t) ||
+    t.startsWith("\\\\")
+  ) {
+    return true;
+  }
+  // Shortened path form from Atmos shim style (.../foo/bar)
+  if (/^\.\.\.?\//.test(t)) return true;
+  // Single path-like token under common roots (e.g. Users/me/proj without leading /)
+  if (
+    /^(?:Users|home|tmp|var|opt|private|Volumes|Library|\.atmos)\//i.test(t) ||
+    t.includes("/.atmos/") ||
+    t.includes("/workspaces/")
+  ) {
+    return true;
+  }
   return false;
 }
 

--- a/packages/shared/src/terminal/title.ts
+++ b/packages/shared/src/terminal/title.ts
@@ -459,18 +459,112 @@ export function sanitizeNativeOscTitle(title: string | undefined): string {
   return out;
 }
 
+export type OscTitleDisplayContext = {
+  /** Atmos auto title already shown (agent label / command / path). */
+  autoDisplayTitle?: string;
+  /** Shim dynamic title (CMD_START command name, etc.). */
+  dynamicTitle?: string;
+  /** Resolved toolbar agent — when set, bare CLI names are redundant. */
+  toolbarAgent?: TerminalTitleAgent;
+};
+
+/**
+ * Shell / terminal-integration titles that only restate host + cwd.
+ * Examples: `user@Host:~/path`, pure paths, `Host:/tmp/foo`.
+ */
+export function isNoisyShellOscTitle(osc: string): boolean {
+  const t = osc.trim();
+  if (!t) return true;
+  // user@host:…  (classic bash/zsh PROMPT_COMMAND / oh-my-zsh auto-title)
+  if (/^[^@\s]+@[^:\s]+:/.test(t)) return true;
+  // host:absolute-or-home path without @
+  if (/^[\w.-]+:(?:~|\/)/.test(t)) return true;
+  if (isPathLikeTitle(t)) return true;
+  return false;
+}
+
+/**
+ * OSC text that only repeats what Atmos already shows as agent brand / command.
+ * E.g. agent label "Claude Code" + OSC "claude" → redundant.
+ */
+export function isRedundantAgentOscTitle(
+  osc: string,
+  context: OscTitleDisplayContext = {},
+): boolean {
+  const t = osc.trim();
+  if (!t) return true;
+
+  const oscNorm = normalizeAgentCommand(t);
+  const oscLower = t.toLowerCase();
+  const auto = context.autoDisplayTitle?.trim() ?? "";
+  if (auto && (auto === t || auto.toLowerCase() === oscLower)) return true;
+
+  const dynamic = context.dynamicTitle?.trim() ?? "";
+  if (dynamic) {
+    if (dynamic === t || dynamic.toLowerCase() === oscLower) return true;
+    if (normalizeAgentCommand(dynamic) === oscNorm && !/\s/.test(t)) return true;
+  }
+
+  const agent = context.toolbarAgent;
+  if (!agent) return false;
+
+  const label = agent.label?.trim() ?? "";
+  if (label && label.toLowerCase() === oscLower) return true;
+
+  // Single-token OSC that is just the agent CLI / brand / id (e.g. "claude").
+  if (!/\s/.test(t)) {
+    const tokens = new Set<string>();
+    for (const raw of [agent.command, agent.pipeCommand, ...(agent.aliases ?? [])]) {
+      if (!raw?.trim()) continue;
+      tokens.add(normalizeAgentCommand(raw));
+    }
+    if (agent.id) tokens.add(agent.id.toLowerCase());
+    if (label) {
+      tokens.add(label.toLowerCase());
+      tokens.add(label.replace(/\s+/g, "").toLowerCase());
+      tokens.add(normalizeAgentCommand(label));
+      const firstWord = label.split(/\s+/)[0]?.toLowerCase();
+      if (firstWord) tokens.add(firstWord);
+    }
+    if (tokens.has(oscNorm) || tokens.has(oscLower)) return true;
+    // Grok packaged binaries: osc "grok-macos-aarc" while agent cmd is "grok"
+    if (tokens.has("grok") && isGrokBuildCommandToken(oscNorm)) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Sanitize + filter native OSC for toolbar display.
+ * Drops shell host/cwd noise and agent-command duplicates.
+ */
+export function resolveDisplayOscTitle(
+  oscTitle: string | undefined,
+  context: OscTitleDisplayContext = {},
+): string {
+  const osc = sanitizeNativeOscTitle(oscTitle);
+  if (!osc) return "";
+  if (isNoisyShellOscTitle(osc)) return "";
+  if (isRedundantAgentOscTitle(osc, context)) return "";
+  return osc;
+}
+
 /**
  * Append a native OSC title after an Atmos auto/custom display title.
- * Returns auto-only when `oscTitle` is empty or `suppress` is true.
+ * Returns auto-only when `oscTitle` is empty, suppressed, or filtered as noise.
  */
 export function appendNativeOscTitle(
   autoDisplayTitle: string | undefined,
   oscTitle: string | undefined,
   suppress = false,
+  context: OscTitleDisplayContext = {},
 ): string {
   const base = autoDisplayTitle?.trim() ?? "";
   if (suppress) return base;
-  const osc = sanitizeNativeOscTitle(oscTitle);
+  const osc = resolveDisplayOscTitle(oscTitle, {
+    ...context,
+    autoDisplayTitle: context.autoDisplayTitle ?? base,
+  });
   if (!osc) return base;
   if (!base) return osc;
   return `${base} | ${osc}`;
@@ -547,6 +641,10 @@ export function getTerminalDisplayMeta<TAgent extends TerminalTitleAgent>(option
 
   return {
     toolbarAgent,
-    displayTitle: appendNativeOscTitle(autoDisplayTitle, oscTitle, suppressOscTitle === true),
+    displayTitle: appendNativeOscTitle(autoDisplayTitle, oscTitle, suppressOscTitle === true, {
+      autoDisplayTitle,
+      dynamicTitle,
+      toolbarAgent,
+    }),
   };
 }

--- a/specs/APP/APP-047_terminal-native-osc-title/BRAINSTORM.md
+++ b/specs/APP/APP-047_terminal-native-osc-title/BRAINSTORM.md
@@ -55,7 +55,7 @@ Show OSC title in a tooltip or secondary chip, never in the main toolbar string.
 - [x] Separator character: `|` with spaces → ` | `
 - [x] Custom title suppresses OSC entirely (even Keep Agent / Keep CWD suffixes)
 - [x] OSC text never drives `resolveAgentForTitle` / `setPaneAgent`
-- [ ] Max length for OSC suffix (Codex uses 240; Atmos toolbar is narrow) — decide in TECH (suggest ~48–64)
+- [x] Max length for OSC suffix — **resolved: 64 char hard cap without ellipsis** (`MAX_NATIVE_OSC_TITLE_CHARS = 64`)
 
 ## References
 

--- a/specs/APP/APP-047_terminal-native-osc-title/BRAINSTORM.md
+++ b/specs/APP/APP-047_terminal-native-osc-title/BRAINSTORM.md
@@ -1,0 +1,72 @@
+# Brainstorm · APP-047: Terminal Native OSC Title
+
+> Problem space and exploration. Settled content graduates to PRD.md; committed architecture graduates to TECH.md.
+
+## Context
+
+Agent CLIs (Codex, Claude Code, Grok Build, OpenCode, etc.) emit standard terminal title sequences (**OSC 0 / OSC 2**) to name the host tab after the current session topic (e.g. `debugging auth`, spinners, action-required prefixes). Atmos today only consumes the product shim channel **OSC 9999** (`CMD_START` / `CMD_END`) for activity titles and agent detection. Native OSC titles are parsed by xterm.js but never surface in the Atmos pane toolbar, so multi-agent panes stay labeled only by brand / cwd / command.
+
+Users already have custom pane names (`customLabel`, APP-033). Those must remain the highest-priority display source and must not fight with agent OSC titles.
+
+## Goals (draft)
+
+- Surface agent-emitted native OSC titles in the Atmos pane toolbar as a **suffix**.
+- Keep Atmos agent detection / brand icons driven only by shim activity + known agent identity (never by OSC text).
+- When the user has set a custom pane title, **do not** show the OSC suffix.
+- Zero backend / persistence work if possible (transient display state, like `dynamicTitle`).
+
+## Options
+
+### Option A — Append OSC title with `|` after auto title
+Capture OSC 0/2 via xterm `onTitleChange`, store as `oscTitle` on the pane, compose:
+
+```
+display = autoDisplayTitle + (oscTitle && !customLabel ? ` | ${oscTitle}` : "")
+```
+
+Agent detection unchanged. Clear `oscTitle` on empty OSC payload and on shim `CMD_END` (shell idle).
+
+**Pros**: Matches user request; low risk; orthogonal to APP-003 / APP-033.  
+**Cons**: Busy agents that re-assert titles frequently may re-render toolbar text (mitigate with sanitize + dedup).  
+**Unknown**: Whether scoped wiki/code-review panes need the same wiring in v1.
+
+### Option B — Replace auto title with OSC title when present
+When OSC title arrives, use it as the whole pane title (still keep agent icon from detection).
+
+**Pros**: Closer to native terminal tab behavior.  
+**Cons**: Loses Atmos brand/command context users rely on; fights with dynamic cwd; harder with custom names.  
+**Unknown**: How often OSC titles are noise (version strings, spinners).
+
+### Option C — Independent status chip / tooltip only
+Show OSC title in a tooltip or secondary chip, never in the main toolbar string.
+
+**Pros**: Toolbar stays short.  
+**Cons**: Easy to miss; more UI surface; not what the user asked for.
+
+## Key forks in the road
+
+- **Fork 1**: Append vs replace — **append with `|`** (Option A). Decide locked for PRD.
+- **Fork 2**: Clear policy — clear on empty OSC + CMD_END vs leave until next OSC. Prefer **clear on empty + CMD_END**.
+- **Fork 3**: Mobile parity in v1 vs web-first. Prefer **web + shared helper + mobile if same OSC path is cheap**.
+- **Fork 4**: Persist `oscTitle` — **no**, display-only like `dynamicTitle`.
+
+## Open questions
+
+- [x] Separator character: `|` with spaces → ` | `
+- [x] Custom title suppresses OSC entirely (even Keep Agent / Keep CWD suffixes)
+- [x] OSC text never drives `resolveAgentForTitle` / `setPaneAgent`
+- [ ] Max length for OSC suffix (Codex uses 240; Atmos toolbar is narrow) — decide in TECH (suggest ~48–64)
+
+## References
+
+- Existing shim titles: `specs/APP/APP-003_web-terminal-dynamic-title/`
+- Custom naming: `specs/APP/APP-033_terminal-custom-naming/`
+- Shared composition: `packages/shared/src/terminal/title.ts`
+- Capture site: `apps/web/src/features/terminal/components/Terminal.tsx` (OSC 9999 only today)
+- Toolbar merge: `apps/web/src/features/terminal/hooks/use-terminal-toolbar-title.ts`
+- External: Codex `terminal_title.rs` emits OSC 0; Claude Code issues document OSC 0/2 host titles
+
+## Ready to promote
+
+- Promote to PRD: Option A append semantics, custom-label suppression, agent-detection invariance.
+- Promote to TECH: xterm `onTitleChange`, `oscTitle` pane field, `getTerminalDisplayMeta` extension, clear rules, tests.

--- a/specs/APP/APP-047_terminal-native-osc-title/PRD.md
+++ b/specs/APP/APP-047_terminal-native-osc-title/PRD.md
@@ -39,7 +39,7 @@ Developers run multiple agent sessions (Codex, Claude Code, Grok Build, …) in 
 
 ### Should have
 
-- **S1 — Cap suffix length** so toolbars stay scannable (truncate with ellipsis after a fixed char budget).
+- **S1 — Cap suffix length** so toolbars stay scannable (hard-capped at 64 chars, no ellipsis — matches `MAX_NATIVE_OSC_TITLE_CHARS`).
 - **S2 — Mobile parity** when the mobile xterm path can register the same handlers with low cost.
 - **S3 — Scoped panes** (wiki / code review) that already show dynamic titles get the same append behavior.
 

--- a/specs/APP/APP-047_terminal-native-osc-title/PRD.md
+++ b/specs/APP/APP-047_terminal-native-osc-title/PRD.md
@@ -1,0 +1,80 @@
+# APP-047 · Terminal Native OSC Title — PRD
+
+> **WHAT & WHY.** Surface standard OSC 0/2 titles emitted by agent CLIs as a pane-toolbar suffix, without changing agent detection or overriding user custom names.
+
+Related: [APP-003 Web Terminal Dynamic Title](../APP-003_web-terminal-dynamic-title/TECH.md), [APP-033 Terminal Custom Naming](../APP-033_terminal-custom-naming/PRD.md).
+
+---
+
+## 1. Users & motivation
+
+Developers run multiple agent sessions (Codex, Claude Code, Grok Build, …) in Atmos panes. Agents already write meaningful session topics to the **host terminal title** via OSC 0/2, but Atmos pane toolbars ignore that channel and only show brand / command / cwd from the Atmos shim. Users cannot tell which pane is “auth debugging” vs “rate limit fix” at a glance.
+
+## 2. User stories
+
+- As a user, when an agent sets a native terminal title, I see it **after** the Atmos auto title, separated by ` | `.
+- As a user, the pane still shows the correct **agent icon / brand** from Atmos detection; OSC text never rebrands the pane as a different agent.
+- As a user, if I set a **custom pane title** (APP-033), OSC suffixes are hidden so my label stays clean.
+- As a user, when the agent exits (shell returns to prompt) or the process clears the title, the OSC suffix disappears.
+
+## 3. Functional requirements
+
+### Must have
+
+- **M1 — Capture native OSC titles.** Atmos xterm instances handle standard window-title sequences (OSC 0 and OSC 2, as exposed by xterm.js `onTitleChange`) and store a sanitized `oscTitle` per pane.
+- **M2 — Append display.** When `oscTitle` is non-empty and the pane has **no** user `customLabel`, the toolbar title is:
+
+  ```
+  {autoDisplayTitle} | {oscTitle}
+  ```
+
+  If `autoDisplayTitle` is empty, show only `{oscTitle}`.
+- **M3 — Agent detection unchanged.** `resolveAgentForTitle` / `setPaneAgent` continue to use only shim `dynamicTitle` (and existing base/agent fields). Native OSC text is never used for agent matching.
+- **M4 — Custom title suppresses OSC.** A non-empty pane `customLabel` means OSC is not appended (regardless of Keep Agent Name / Keep CWD).
+- **M5 — Clear rules.** `oscTitle` is cleared when:
+  - an empty/whitespace-only native title is received, or
+  - the Atmos shim emits `CMD_END` (shell idle).
+- **M6 — Display-only.** `oscTitle` is transient (not persisted in the terminal layout document), same class as `dynamicTitle`.
+- **M7 — Dedup / sanitize.** Strip control characters and collapse whitespace before display; skip store updates when the sanitized value is unchanged.
+
+### Should have
+
+- **S1 — Cap suffix length** so toolbars stay scannable (truncate with ellipsis after a fixed char budget).
+- **S2 — Mobile parity** when the mobile xterm path can register the same handlers with low cost.
+- **S3 — Scoped panes** (wiki / code review) that already show dynamic titles get the same append behavior.
+
+### Won't have (v1)
+
+- Replacing the entire Atmos title with OSC text.
+- Persisting OSC titles across refresh.
+- Using OSC titles for tab-bar `customTitle` (tab rename remains APP-033 only).
+- Parsing proprietary OSC codes beyond what xterm maps to `onTitleChange`.
+- Backend protocol or WebSocket changes.
+
+## 4. Display precedence
+
+```
+if customLabel?.trim():
+    display = APP-033 custom composition   # no OSC suffix
+else:
+    auto = getTerminalDisplayMeta(... dynamicTitle / agent ...)  # unchanged
+    if oscTitle:
+        display = auto.displayTitle
+            ? `${auto.displayTitle} | ${oscTitle}`
+            : oscTitle
+    else:
+        display = auto.displayTitle
+
+toolbarAgent = auto.toolbarAgent   # never derived from oscTitle
+```
+
+## 5. Success criteria
+
+- Running Codex/Claude (or any CLI that writes OSC 0/2) shows a `|` suffix on the pane toolbar while the process is active.
+- Detected agent icon/label still matches Atmos detection for that pane.
+- Setting a custom pane name hides the suffix immediately (or on next render).
+- After the agent exits and shim `CMD_END` arrives, the suffix is gone.
+
+## 6. Non-scope
+
+See §3 “Won't have”. No REST endpoints; no layout schema migration.

--- a/specs/APP/APP-047_terminal-native-osc-title/PRD.md
+++ b/specs/APP/APP-047_terminal-native-osc-title/PRD.md
@@ -34,7 +34,7 @@ Developers run multiple agent sessions (Codex, Claude Code, Grok Build, …) in 
 - **M5 — Clear rules.** `oscTitle` is cleared when:
   - an empty/whitespace-only native title is received, or
   - the Atmos shim emits `CMD_END` (shell idle).
-- **M6 — Display-only.** `oscTitle` is transient (not persisted in the terminal layout document), same class as `dynamicTitle`.
+- **M6 — Persist meaningful OSC.** Unlike shim `dynamicTitle` (restored via tmux inject on attach), agent session OSC titles are written into the terminal layout document so a full page refresh restores `{agent} | {topic}`. Shell host/path noise is never stored. Saves use the existing debounced layout save path.
 - **M7 — Dedup / sanitize.** Strip control characters and collapse whitespace before display; skip store updates when the sanitized value is unchanged.
 - **M8 — Filter noisy / redundant OSC.** Do **not** append OSC when it is:
   - shell noise: `user@host:cwd`, host-prefixed paths, or path-only titles (Atmos already shows path via shim);

--- a/specs/APP/APP-047_terminal-native-osc-title/PRD.md
+++ b/specs/APP/APP-047_terminal-native-osc-title/PRD.md
@@ -36,6 +36,10 @@ Developers run multiple agent sessions (Codex, Claude Code, Grok Build, …) in 
   - the Atmos shim emits `CMD_END` (shell idle).
 - **M6 — Display-only.** `oscTitle` is transient (not persisted in the terminal layout document), same class as `dynamicTitle`.
 - **M7 — Dedup / sanitize.** Strip control characters and collapse whitespace before display; skip store updates when the sanitized value is unchanged.
+- **M8 — Filter noisy / redundant OSC.** Do **not** append OSC when it is:
+  - shell noise: `user@host:cwd`, host-prefixed paths, or path-only titles (Atmos already shows path via shim);
+  - agent-redundant: equals the detected agent's command / aliases / label / id (e.g. OSC `claude` while the toolbar already shows the Claude brand), or equals the current shim `dynamicTitle`.
+  Meaningful session topics (e.g. `debugging auth`) still append.
 
 ### Should have
 

--- a/specs/APP/APP-047_terminal-native-osc-title/TECH.md
+++ b/specs/APP/APP-047_terminal-native-osc-title/TECH.md
@@ -24,7 +24,7 @@ getTerminalDisplayMeta({ dynamicTitle, agent, oscTitle, suppressOscTitle })
         └─ displayTitle  ← auto  [ | oscTitle ]  unless suppress / custom
 ```
 
-No backend changes. No new WebSocket messages.
+Layout document gains optional `panes[].oscTitle` (same save channel as `agent` / `customLabel`). No new REST endpoints or WebSocket messages.
 
 ## 2. Shared helpers (`packages/shared/src/terminal/title.ts`)
 
@@ -140,7 +140,7 @@ setOscTitle(workspaceId, paneId, oscTitle: string | undefined, terminalTabId?)
 
 - Compare sanitized equality before `set`.
 - Never call `saveToBackend`.
-- Layout document mapping already omits `dynamicTitle`; keep `oscTitle` out of persistence the same way (do not add to `Persisted*` types).
+- Layout document still omits `dynamicTitle` (reattach inject). **`oscTitle` is persisted** on the pane document and restored on hydrate (`live ?? persisted`). Shell noise is dropped before store.
 
 ### 4.3 Lookups
 

--- a/specs/APP/APP-047_terminal-native-osc-title/TECH.md
+++ b/specs/APP/APP-047_terminal-native-osc-title/TECH.md
@@ -1,0 +1,163 @@
+# APP-047 · Terminal Native OSC Title — TECH
+
+> **HOW.** Capture xterm native titles (OSC 0/2), store per-pane `oscTitle`, compose with `|` after the existing auto title; never use OSC for agent detection; suppress when `customLabel` is set.
+
+Related: [PRD](./PRD.md), [APP-003](../APP-003_web-terminal-dynamic-title/TECH.md), [APP-033](../APP-033_terminal-custom-naming/TECH.md).
+
+---
+
+## 1. Architecture
+
+```
+Agent / CLI  ──OSC 0/2──►  PTY stream  ──►  xterm.js
+                                              │
+                                              ├─ onTitleChange(title)  →  setOscTitle / clear
+                                              │
+Atmos shim   ──OSC 9999──►  registerOscHandler(9999)
+                                              │
+                                              ├─ CMD_START → setDynamicTitle (+ agent resolve)
+                                              └─ CMD_END   → setDynamicTitle(cwd) + clear oscTitle
+
+getTerminalDisplayMeta({ dynamicTitle, agent, oscTitle, suppressOscTitle })
+        │
+        ├─ toolbarAgent  ← only dynamicTitle / agent / baseTitle
+        └─ displayTitle  ← auto  [ | oscTitle ]  unless suppress / custom
+```
+
+No backend changes. No new WebSocket messages.
+
+## 2. Shared helpers (`packages/shared/src/terminal/title.ts`)
+
+### 2.1 Sanitize + cap
+
+```ts
+const MAX_NATIVE_OSC_TITLE_CHARS = 64;
+
+export function sanitizeNativeOscTitle(title: string | undefined): string {
+  // strip controls, collapse whitespace, truncate to MAX_NATIVE_OSC_TITLE_CHARS
+  // empty → ""
+}
+```
+
+### 2.2 Compose
+
+Extend `getTerminalDisplayMeta`:
+
+```ts
+export function getTerminalDisplayMeta(options: {
+  baseTitle: string | undefined;
+  dynamicTitle: string | undefined;
+  configuredAgents?: TAgent[];
+  agent?: TAgent;
+  contestedOwners?: ContestedOwnersMap;
+  /** Native OSC 0/2 title (already sanitized or raw; helper re-sanitizes). */
+  oscTitle?: string;
+  /** User customLabel set — never append OSC. */
+  suppressOscTitle?: boolean;
+}): { displayTitle: string; toolbarAgent: TAgent | undefined }
+```
+
+Algorithm:
+
+1. Compute existing `autoDisplay` + `toolbarAgent` exactly as today (ignore `oscTitle`).
+2. `const osc = suppressOscTitle ? "" : sanitizeNativeOscTitle(oscTitle)`.
+3. If `osc` empty → return auto.
+4. Else `displayTitle = autoDisplay ? `${autoDisplay} | ${osc}` : osc`.
+5. `toolbarAgent` unchanged.
+
+Export `appendNativeOscTitle(autoDisplay, oscTitle, suppress?)` for call sites that already have a pre-composed custom string (APP-033 custom path will pass `suppress: true` and never call with osc).
+
+## 3. Capture (`Terminal.tsx` + mobile DOM view)
+
+### 3.1 New prop
+
+```ts
+/** Native OSC 0/2 title from the process (Codex/Claude/…). Undefined clears. */
+onOscTitleChange?: (title: string | undefined) => void;
+```
+
+Keep `onTitleChange` for **shim-only** dynamic titles (OSC 9999).
+
+### 3.2 xterm wiring
+
+After creating the terminal:
+
+```ts
+terminal.onTitleChange((raw) => {
+  const next = sanitizeNativeOscTitle(raw);
+  onOscTitleChangeRef.current?.(next || undefined);
+});
+```
+
+On OSC 9999 `CMD_END` (after updating dynamic title):
+
+```ts
+onOscTitleChangeRef.current?.(undefined);
+```
+
+Do **not** clear on `CMD_START` (agent may set OSC after start; clearing would flash).
+
+## 4. Store
+
+### 4.1 Pane field
+
+```ts
+// TerminalPaneProps
+/** Transient native OSC title; not persisted. */
+oscTitle?: string;
+```
+
+### 4.2 Actions
+
+```ts
+setOscTitle(workspaceId, paneId, oscTitle: string | undefined, terminalTabId?)
+// Optional scoped mirrors if wiki/code-review already mirror setDynamicTitle
+```
+
+- Compare sanitized equality before `set`.
+- Never call `saveToBackend`.
+- Layout document mapping already omits `dynamicTitle`; keep `oscTitle` out of persistence the same way (do not add to `Persisted*` types).
+
+### 4.3 Lookups
+
+`getWorkspacePaneFieldsByPaneId` / `getWorkspacePaneLiveFieldsByTmuxWindow` also return `oscTitle`.
+
+## 5. Toolbar merge (`use-terminal-toolbar-title.ts`)
+
+- Subscribe to `storeLive.oscTitle`.
+- Local state `localOscTitle` for canvas/`none` write targets (same pattern as dynamic).
+- `onOscTitleChange` writes store `setOscTitle` when `storeWrite` is mosaic/tmux; never calls `setPaneAgent`.
+- `getTerminalDisplayMeta({ ..., oscTitle: mergedOsc, suppressOscTitle: !!customLabel?.trim() })`.
+- Custom label branch: keep existing ` · ` agent/cwd composition; **do not** append OSC.
+
+## 6. Other call sites
+
+| Site | Change |
+|------|--------|
+| `terminal-mosaic-scoped-pane-window` | Wire `onOscTitleChange` + pass `oscTitle` into meta |
+| `use-terminal-grid-canvas-pins` | Pass `pane.oscTitle` into meta when labeling pin |
+| `terminal-close-confirm-name` | Optional: omit OSC (confirm dialogs stay short) — **no OSC** |
+| Mobile `TerminalDomView` / store | Same capture + field if low cost |
+
+## 7. Rollout
+
+1. Shared sanitize + meta compose + unit tests.
+2. Web Terminal capture + store + toolbar hook.
+3. Scoped panes + canvas pin labels.
+4. Mobile parity if the same xterm path exists.
+5. Manual smoke with Codex/Claude: suffix appears, agent icon stable, custom name hides suffix, exit clears.
+
+## 8. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Noisy OSC (version-only titles, spinners) | Cap length; user can set customLabel to suppress; accept spinner chars as agent intent |
+| OSC fights with document title | Only consume via xterm event; do not write `document.title` |
+| Stale OSC after agent crash without CMD_END | Empty OSC clear; next CMD_END; pane remount resets state |
+| Agent detection false positives from OSC text | Hard rule: never pass `oscTitle` into `resolveAgentForTitle` |
+
+## 9. Out of scope (tech)
+
+- tmux window rename from OSC
+- Persisted layout schema
+- Backend inject of OSC (reattach recovery of agent titles relies on agent re-asserting after attach)

--- a/specs/APP/APP-047_terminal-native-osc-title/TECH.md
+++ b/specs/APP/APP-047_terminal-native-osc-title/TECH.md
@@ -39,7 +39,31 @@ export function sanitizeNativeOscTitle(title: string | undefined): string {
 }
 ```
 
-### 2.2 Compose
+### 2.2 Display filter
+
+Before appending, `resolveDisplayOscTitle(osc, { autoDisplayTitle, dynamicTitle, toolbarAgent })` drops:
+
+| Filter | Example | Reason |
+|--------|---------|--------|
+| Shell host/cwd | `user@Host:~/…`, pure paths | Redundant with shim path; causes prompt flicker |
+| Agent CLI / brand | `claude`, `Claude Code`, `codex` | Toolbar already shows agent icon + label |
+| Equals dynamic title | OSC == `CMD_START` command | Same signal twice |
+
+Helpers: `isNoisyShellOscTitle`, `isRedundantAgentOscTitle`.
+
+### 2.2b Display filter (post-ship refinement)
+
+Before appending, `resolveDisplayOscTitle(osc, { autoDisplayTitle, dynamicTitle, toolbarAgent })` drops:
+
+| Filter | Example | Reason |
+|--------|---------|--------|
+| Shell host/cwd | `user@Host:~/…`, pure paths | Redundant with shim path; causes prompt flicker |
+| Agent CLI / brand | `claude`, `Claude Code`, `codex` | Toolbar already shows agent icon + label |
+| Equals dynamic title | OSC == `CMD_START` command | Same signal twice |
+
+Helpers: `isNoisyShellOscTitle`, `isRedundantAgentOscTitle`.
+
+### 2.3 Compose
 
 Extend `getTerminalDisplayMeta`:
 

--- a/specs/APP/APP-047_terminal-native-osc-title/TEST.md
+++ b/specs/APP/APP-047_terminal-native-osc-title/TEST.md
@@ -31,7 +31,9 @@ No new E2E required for v1; composition is pure and capture is a thin xterm subs
 
 | Id | Level | Tool | Target | Status |
 |----|-------|------|--------|--------|
-| S1–S10 | unit | bun test | `apps/web/src/features/terminal/components/__tests__/terminal-title.test.ts` | pass |
+| S1–S6, S9–S10 | unit | bun test | `apps/web/src/features/terminal/components/__tests__/terminal-title.test.ts` | pass |
+| S7 | code_review / inspection | Terminal CMD_END → `onOscTitleChange(undefined)` | `apps/web/.../Terminal.tsx` | documented_not_unit |
+| S8 | code_review / inspection | layout types omit `oscTitle` | terminal layout / store persistence | documented_not_unit |
 | M-smoke | manual | run agent in pane | web terminal | pending |
 
 ## Scenarios
@@ -64,14 +66,17 @@ No new E2E required for v1; composition is pure and capture is a thin xterm subs
 ### S6 · Empty OSC clears suffix
 - **Given** prior osc title, then empty OSC
 - **Then** display returns to auto only
+- **Signals**: unit assert (`appendNativeOscTitle` / `getTerminalDisplayMeta` clear-on-empty)
 
 ### S7 · CMD_END clears (integration contract)
 - **Given** Terminal CMD_END handler
-- **Then** calls `onOscTitleChange(undefined)` (code review / unit of handler if extracted)
+- **Then** calls `onOscTitleChange(undefined)` (code review / inspection — not unit-covered)
+- **Signals**: code_review
 
 ### S8 · Not persisted
 - **Given** layout save helpers
 - **Then** `oscTitle` never written into persisted tab/pane document
+- **Signals**: code_review / inspection
 
 ### S9 · Control injection safe
 - **Given** osc containing `\x1b]0;evil`
@@ -79,11 +84,11 @@ No new E2E required for v1; composition is pure and capture is a thin xterm subs
 
 ### S10 · Length cap
 - **Given** very long osc string
-- **Then** sanitized length ≤ 64 chars
+- **Then** sanitized length ≤ 64 chars (hard cap, no ellipsis)
 
 ## Acceptance criteria
 
-- [x] Unit tests for S2–S5, S9–S10 green
+- [x] Unit tests for S1–S6, S9–S10 green
 - [x] Web Terminal wires `onTitleChange` (shim) and `onOscTitleChange` (native) separately
 - [x] Custom pane rename hides OSC suffix (composition `suppressOscTitle`)
 - [ ] Manual: agent OSC appears as `|` suffix; agent icon stable
@@ -93,9 +98,10 @@ No new E2E required for v1; composition is pure and capture is a thin xterm subs
 - Backend reattach replaying last OSC (agents re-assert)
 - Tab bar customTitle interaction beyond pane toolbar
 - Playwright multi-agent live sessions
+- S7 (CMD_END → clear) and S8 (not persisted): documented via code review / inspection, not unit-pass
 
 ## Coverage Status
 
-- **2026-07-30**: Unit suite green — `bun test apps/web/src/features/terminal/components/__tests__/terminal-title.test.ts` (23 pass), covering sanitize/cap, append `|`, agent-invariance, suppress-on-custom, clear-on-empty.
+- **2026-07-30**: Unit suite green — `bun test apps/web/src/features/terminal/components/__tests__/terminal-title.test.ts` (24 pass), covering sanitize/cap, append `|`, agent-invariance, suppress-on-custom, clear-on-empty / post-clear `appendNativeOscTitle`. Unit-covered: S1–S6, S9–S10. S7/S8: `documented_not_unit` (code_review / inspection).
 - **Remaining**: Manual smoke with Codex/Claude in a web pane (OSC suffix visible, icon stable, custom rename hides suffix, CMD_END clears).
 - **Layout**: `oscTitle` is not part of persisted layout document types (display-only, same class as `dynamicTitle`).

--- a/specs/APP/APP-047_terminal-native-osc-title/TEST.md
+++ b/specs/APP/APP-047_terminal-native-osc-title/TEST.md
@@ -1,0 +1,101 @@
+# APP-047 · Terminal Native OSC Title — TEST
+
+> Verification contract for native OSC 0/2 pane title suffixes.
+
+---
+
+## Test strategy
+
+| Level | Why |
+|-------|-----|
+| **Unit (shared)** | Pure composition / sanitize / agent-invariance rules — fast, deterministic |
+| **Unit (web)** | Existing terminal-title tests extended; toolbar composition with customLabel |
+| **Manual / agent-browser** | Real CLI OSC emission through xterm (Codex/Claude) |
+
+No new E2E required for v1; composition is pure and capture is a thin xterm subscription.
+
+## Coverage map
+
+| PRD | Scenarios |
+|-----|-----------|
+| M1 Capture | S1 |
+| M2 Append | S2, S3 |
+| M3 Agent unchanged | S4 |
+| M4 Custom suppresses | S5 |
+| M5 Clear rules | S6, S7 |
+| M6 Display-only | S8 (code inspection / no layout field) |
+| M7 Sanitize | S9 |
+| S1 Cap | S10 |
+
+## Execution map
+
+| Id | Level | Tool | Target | Status |
+|----|-------|------|--------|--------|
+| S1–S10 | unit | bun test | `apps/web/src/features/terminal/components/__tests__/terminal-title.test.ts` | pass |
+| M-smoke | manual | run agent in pane | web terminal | pending |
+
+## Scenarios
+
+### S1 · Sanitize empty / controls
+- **Given** raw OSC payloads with BEL/esc/whitespace
+- **When** `sanitizeNativeOscTitle` runs
+- **Then** controls stripped; empty → `""`
+- **Signals**: unit assert
+
+### S2 · Append with separator
+- **Given** auto title `Claude Code`, osc `debugging auth`
+- **When** `getTerminalDisplayMeta({..., oscTitle})`
+- **Then** `displayTitle === "Claude Code | debugging auth"`
+- **Signals**: unit assert
+
+### S3 · OSC-only when auto empty
+- **Given** empty base/dynamic, osc `session topic`
+- **Then** `displayTitle === "session topic"`
+
+### S4 · Agent not derived from OSC
+- **Given** base `1`, dynamic `codex`, agent codex; osc text looks like another agent label e.g. `Hermes Agent`
+- **Then** `toolbarAgent` still codex (or matched from dynamic), **not** hermes
+- **Signals**: unit assert
+
+### S5 · Custom label suppresses OSC
+- **Given** `suppressOscTitle: true` or custom composition path
+- **Then** display does not contain ` | ${osc}`
+
+### S6 · Empty OSC clears suffix
+- **Given** prior osc title, then empty OSC
+- **Then** display returns to auto only
+
+### S7 · CMD_END clears (integration contract)
+- **Given** Terminal CMD_END handler
+- **Then** calls `onOscTitleChange(undefined)` (code review / unit of handler if extracted)
+
+### S8 · Not persisted
+- **Given** layout save helpers
+- **Then** `oscTitle` never written into persisted tab/pane document
+
+### S9 · Control injection safe
+- **Given** osc containing `\x1b]0;evil`
+- **Then** controls stripped; no multi-line title
+
+### S10 · Length cap
+- **Given** very long osc string
+- **Then** sanitized length ≤ 64 chars
+
+## Acceptance criteria
+
+- [x] Unit tests for S2–S5, S9–S10 green
+- [x] Web Terminal wires `onTitleChange` (shim) and `onOscTitleChange` (native) separately
+- [x] Custom pane rename hides OSC suffix (composition `suppressOscTitle`)
+- [ ] Manual: agent OSC appears as `|` suffix; agent icon stable
+
+## Non-coverage
+
+- Backend reattach replaying last OSC (agents re-assert)
+- Tab bar customTitle interaction beyond pane toolbar
+- Playwright multi-agent live sessions
+
+## Coverage Status
+
+- **2026-07-30**: Unit suite green — `bun test apps/web/src/features/terminal/components/__tests__/terminal-title.test.ts` (23 pass), covering sanitize/cap, append `|`, agent-invariance, suppress-on-custom, clear-on-empty.
+- **Remaining**: Manual smoke with Codex/Claude in a web pane (OSC suffix visible, icon stable, custom rename hides suffix, CMD_END clears).
+- **Layout**: `oscTitle` is not part of persisted layout document types (display-only, same class as `dynamicTitle`).

--- a/specs/README.md
+++ b/specs/README.md
@@ -124,6 +124,7 @@ These files are not requirements sources. Requirements live in `PRD.md`, archite
 | **APP-044** | Project / Workspace Groups | `specs/APP/APP-044_project-workspace-groups/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
 | **APP-045** | Desktop Electron Dual Shell (Tauri + Electron parallel) | `specs/APP/APP-045_desktop-electron-dual-shell/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
 | **APP-046** | Terminal TUI Mouse Tracking (hover + reattach restore) | `specs/APP/APP-046_terminal-tui-mouse-tracking/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
+| **APP-047** | Terminal Native OSC Title (agent OSC 0/2 suffix) | `specs/APP/APP-047_terminal-native-osc-title/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
 | **QUALITY-001** | Large File Code Debt Cleanup | `specs/APP/QUALITY-001_large-file-code-debt-cleanup/` (`TECH.md`, `TEST.md`) |
 | **QUALITY-002** | Spec Test Execution Loop | `specs/APP/QUALITY-002_spec-test-execution-loop/` (`TECH.md`, `TEST.md`) |
 | **QUALITY-003** | Playwright E2E Harness | `specs/APP/QUALITY-003_playwright-e2e-harness/` (`TECH.md`, `TEST.md`) |


### PR DESCRIPTION
## Summary

Surfaces standard terminal titles (OSC 0/2) emitted by agent CLIs (Codex, Claude Code, etc.) as a pane toolbar suffix after the Atmos auto title, separated by ` | `.

- Capture via xterm `onTitleChange` into transient `oscTitle` (not persisted)
- Display: `{autoTitle} | {oscTitle}` when no user custom pane label
- Agent detection remains shim/`dynamicTitle`-only — OSC text never rebrands the pane
- Custom pane rename (`customLabel`) suppresses the OSC suffix
- Clear OSC on empty title and on Atmos shim `CMD_END` (shell idle)
- Specs: `specs/APP/APP-047_terminal-native-osc-title/`
- Web + mobile parity for capture/composition

## Related Issue

APP-047 (new spec); builds on APP-003 (dynamic title) and APP-033 (custom naming).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] Additional checks (describe below)

- `bun test apps/web/src/features/terminal/components/__tests__/terminal-title.test.ts` — 23 pass (includes APP-047 sanitize/append/agent-invariance/custom-suppress cases)
- Confirmed repo has **no** `ghostwriter` / `dabit3` references

## Checklist

- [x] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces native OSC 0/2 terminal titles as a toolbar suffix with a split primary/suffix display and a marquee that only scrolls long suffixes; action rails now squeeze titles and stay open long enough for menus. Also stops reconnect loops on attach errors, adds a “New” action, portals context menus to `document.body`, and fixes editor breadcrumbs.

- **New Features**
  - Append sanitized, deduped native titles after the auto title as "{auto} | {osc}"; hide when `customLabel` is set; OSC text never affects agent detection (APP-047).
  - Capture via xterm `onTitleChange`; clear on empty OSC (no longer on `CMD_END`); cap at 64 chars; filter shell noise and agent‑redundant titles; persist meaningful `oscTitle`; web + mobile parity; shared helpers in `@atmos/shared/terminal`.
  - Split primary title and OSC suffix in the toolbar; keep primary fixed; marquee only when the suffix overflows; action buttons collapse until hover/focus, delay collapse for portaled menus, and stay expanded when maximized.

- **Bug Fixes**
  - Treat server `terminal_error` as fatal: stop auto‑reconnect loops, keep the error badge after close, and offer “New” to create a fresh terminal (web + mobile).
  - Restore and polish OSC suffix display: prevent flex collapse, keep short topics fully visible, reset the marquee after stable updates, and squeeze when the action rail expands.
  - Portal Terminal, center/file tab, canvas, and disk analyzer context menus to `document.body` with viewport‑fixed anchors; project list action rail matches the same motion; Editor breadcrumbs now load siblings by the open file’s project root and fall back to `listDir` when the recursive tree is empty.

<sup>Written for commit 3b8abad1ba9163167001e714d85d466e306af4d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal titles can now incorporate native OSC 0/2 suffixes (sanitized/length-capped) and update dynamically across web and mobile, including project wiki and code review.
  * OSC titles are persisted in the terminal layout so they can reappear after refresh.
  * Added a dedicated “New” action to the terminal error overlay (when available).
* **Bug Fixes**
  * Reduced noisy/redundant OSC content, improved deduplication, and ensured OSC titles clear correctly when sessions end.
  * Improved toolbar/title rendering (marquee + hover expansion) and prevented websocket disconnect UI state flashing.
* **Tests**
  * Expanded native OSC title and sanitization/clearing behavior coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->