### PR TITLE
feat(orchestrator): APP-048 Loop/Graph Orchestrator runtime, CLI, skill, UI

### DIFF
--- a/apps/api/src/api/mod.rs
+++ b/apps/api/src/api/mod.rs
@@ -2,6 +2,7 @@ pub mod agent;
 pub mod canvas;
 pub mod dto;
 pub mod hooks;
+pub mod orchestrator;
 pub mod project;
 pub mod review;
 pub mod system;
@@ -18,6 +19,7 @@ pub fn routes() -> Router<AppState> {
         .nest("/api/test", test::routes())
         .nest("/api/project", project::routes())
         .nest("/api/canvas", canvas::routes())
+        .nest("/api/orchestrator", orchestrator::routes())
         .nest("/api/review", review::routes())
         .nest("/api/workspace", workspace::routes())
         .nest("/api/system", system::routes())

--- a/apps/api/src/api/orchestrator/handlers.rs
+++ b/apps/api/src/api/orchestrator/handlers.rs
@@ -1,0 +1,412 @@
+use std::path::PathBuf;
+
+use axum::{
+    extract::{Path, Query, State},
+    Json,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::{
+    api::dto::ApiResponse,
+    app_state::AppState,
+    error::{ApiError, ApiResult},
+};
+use core_service::{
+    Budget, CompiledGraph, CreateRunReq, JudgmentSpecBody, ModeProposal, OrchestratorService,
+};
+
+fn orch(state: &AppState) -> &OrchestratorService {
+    &state.orchestrator_service
+}
+
+fn map_err(e: core_service::ServiceError) -> ApiError {
+    match e {
+        core_service::ServiceError::NotFound(m) => ApiError::NotFound(m),
+        core_service::ServiceError::Validation(m) => ApiError::BadRequest(m),
+        other => ApiError::InternalError(other.to_string()),
+    }
+}
+
+pub async fn status(State(state): State<AppState>) -> ApiResult<Json<ApiResponse<Value>>> {
+    Ok(Json(ApiResponse::success(orch(&state).status())))
+}
+
+pub async fn agents_list(State(_state): State<AppState>) -> ApiResult<Json<ApiResponse<Value>>> {
+    // Minimal catalog — real terminal agents come from shared manifest later
+    Ok(Json(ApiResponse::success(json!({
+        "agents": [
+            {"id": "codex", "label": "Codex"},
+            {"id": "claude-code", "label": "Claude Code"},
+            {"id": "opencode", "label": "OpenCode"},
+        ]
+    }))))
+}
+
+pub async fn skill_dir(State(_state): State<AppState>) -> ApiResult<Json<ApiResponse<Value>>> {
+    Ok(Json(ApiResponse::success(core_service::skill_dir_output())))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateRunBody {
+    pub goal: String,
+    #[serde(default = "default_mode")]
+    pub requested_mode: String,
+    #[serde(default = "default_standalone")]
+    pub target_kind: String,
+    pub project_guid: Option<String>,
+    pub workspace_guid: Option<String>,
+    pub home_cwd: Option<String>,
+    pub budget: Option<Budget>,
+    pub carry_from_run_id: Option<String>,
+    pub maker_agent_id: Option<String>,
+    pub planner_agent_id: Option<String>,
+    pub criteria_agent_id: Option<String>,
+    pub verify_agent_id: Option<String>,
+}
+
+fn default_mode() -> String {
+    "loop".into()
+}
+fn default_standalone() -> String {
+    "standalone".into()
+}
+
+pub async fn create_run(
+    State(state): State<AppState>,
+    Json(body): Json<CreateRunBody>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let home_cwd = body.home_cwd.unwrap_or_else(|| {
+        std::env::current_dir()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| ".".into())
+    });
+    let run = orch(&state)
+        .create_run(CreateRunReq {
+            goal: body.goal,
+            requested_mode: body.requested_mode,
+            target_kind: body.target_kind,
+            project_guid: body.project_guid,
+            workspace_guid: body.workspace_guid,
+            home_cwd,
+            budget: body.budget,
+            carry_from_run_id: body.carry_from_run_id,
+            maker_agent_id: body.maker_agent_id,
+            planner_agent_id: body.planner_agent_id,
+            criteria_agent_id: body.criteria_agent_id,
+            verify_agent_id: body.verify_agent_id,
+        })
+        .map_err(map_err)?;
+    Ok(Json(ApiResponse::success(
+        serde_json::to_value(run).unwrap_or_default(),
+    )))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListQuery {
+    #[serde(default = "default_limit")]
+    pub limit: usize,
+}
+
+fn default_limit() -> usize {
+    50
+}
+
+pub async fn list_runs(
+    State(state): State<AppState>,
+    Query(q): Query<ListQuery>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let runs = orch(&state).list_runs(q.limit).map_err(map_err)?;
+    Ok(Json(ApiResponse::success(json!({ "runs": runs }))))
+}
+
+pub async fn get_run(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let run = orch(&state).load_run(&id).map_err(map_err)?;
+    Ok(Json(ApiResponse::success(
+        serde_json::to_value(run).unwrap_or_default(),
+    )))
+}
+
+pub async fn start_run(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let run = orch(&state).start_run(&id).map_err(map_err)?;
+    Ok(Json(ApiResponse::success(
+        serde_json::to_value(run).unwrap_or_default(),
+    )))
+}
+
+pub async fn cancel_run(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let run = orch(&state).cancel_run(&id).map_err(map_err)?;
+    Ok(Json(ApiResponse::success(
+        serde_json::to_value(run).unwrap_or_default(),
+    )))
+}
+
+pub async fn context_get(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let pack = orch(&state).context_pack(&id).map_err(map_err)?;
+    Ok(Json(ApiResponse::success(pack)))
+}
+
+pub async fn tick_loop(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let run = orch(&state).tick_loop_fixture(&id).map_err(map_err)?;
+    Ok(Json(ApiResponse::success(
+        serde_json::to_value(run).unwrap_or_default(),
+    )))
+}
+
+pub async fn step_graph(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let run = orch(&state).step_graph_fixture(&id).map_err(map_err)?;
+    Ok(Json(ApiResponse::success(
+        serde_json::to_value(run).unwrap_or_default(),
+    )))
+}
+
+pub async fn spec_draft(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<JudgmentSpecBody>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let (run, version) = orch(&state)
+        .draft_spec_from_body(&id, body)
+        .map_err(map_err)?;
+    Ok(Json(ApiResponse::success(json!({
+        "run": run,
+        "version": version,
+    }))))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SpecQuery {
+    pub version: Option<i32>,
+}
+
+pub async fn spec_get(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Query(q): Query<SpecQuery>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let spec = orch(&state)
+        .get_spec(&id, q.version)
+        .map_err(map_err)?;
+    Ok(Json(ApiResponse::success(
+        serde_json::to_value(spec).unwrap_or_default(),
+    )))
+}
+
+pub async fn spec_update(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<JudgmentSpecBody>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    // Pre-lock edit = new draft version
+    let (run, version) = orch(&state)
+        .draft_spec_from_body(&id, body)
+        .map_err(map_err)?;
+    Ok(Json(ApiResponse::success(json!({ "run": run, "version": version }))))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ConfirmBody {
+    pub version: i32,
+}
+
+pub async fn spec_confirm(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<ConfirmBody>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let run = orch(&state)
+        .confirm_spec(&id, body.version)
+        .map_err(map_err)?;
+    Ok(Json(ApiResponse::success(
+        serde_json::to_value(run).unwrap_or_default(),
+    )))
+}
+
+pub async fn write_mode_proposal(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<ModeProposal>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    orch(&state)
+        .write_mode_proposal(&id, &body)
+        .map_err(map_err)?;
+    Ok(Json(ApiResponse::success(json!({ "ok": true }))))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EvidenceBody {
+    pub path: String,
+    #[serde(default = "default_kind")]
+    pub kind: String,
+}
+
+fn default_kind() -> String {
+    "file".into()
+}
+
+pub async fn evidence_attach(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<EvidenceBody>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let meta = orch(&state)
+        .attach_evidence(&id, &body.kind, PathBuf::from(&body.path).as_path())
+        .map_err(map_err)?;
+    Ok(Json(ApiResponse::success(meta)))
+}
+
+pub async fn evidence_list(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let run = orch(&state).load_run(&id).map_err(map_err)?;
+    let dir = PathBuf::from(&run.artifact_dir).join("evidence");
+    let mut items = vec![];
+    if dir.exists() {
+        for e in std::fs::read_dir(&dir).map_err(|e| ApiError::InternalError(e.to_string()))? {
+            let e = e.map_err(|e| ApiError::InternalError(e.to_string()))?;
+            if e.path().extension().and_then(|x| x.to_str()) == Some("json") {
+                if let Ok(v) = std::fs::read_to_string(e.path()) {
+                    if let Ok(j) = serde_json::from_str::<Value>(&v) {
+                        items.push(j);
+                    }
+                }
+            }
+        }
+    }
+    Ok(Json(ApiResponse::success(json!({ "evidence": items }))))
+}
+
+pub async fn graph_compile(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<CompiledGraph>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let g = orch(&state)
+        .compile_run_graph(&id, &body)
+        .map_err(map_err)?;
+    Ok(Json(ApiResponse::success(
+        serde_json::to_value(g).unwrap_or_default(),
+    )))
+}
+
+pub async fn graph_get(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let run = orch(&state).load_run(&id).map_err(map_err)?;
+    Ok(Json(ApiResponse::success(json!({ "graph": run.graph }))))
+}
+
+pub async fn workspace_get(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let run = orch(&state).load_run(&id).map_err(map_err)?;
+    let home = run
+        .workspaces
+        .iter()
+        .find(|w| w.kind == "home")
+        .cloned();
+    Ok(Json(ApiResponse::success(json!({
+        "home": home,
+        "active_bindings": run.role_bindings,
+        "home_cwd": run.home_cwd,
+    }))))
+}
+
+pub async fn workspace_list(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let run = orch(&state).load_run(&id).map_err(map_err)?;
+    Ok(Json(ApiResponse::success(json!({
+        "workspaces": run.workspaces
+    }))))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WorkspaceCreateBody {
+    pub purpose: String,
+    pub path: Option<String>,
+}
+
+pub async fn workspace_create(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<WorkspaceCreateBody>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let ws = orch(&state)
+        .workspace_create(&id, &body.purpose, body.path)
+        .map_err(map_err)?;
+    Ok(Json(ApiResponse::success(
+        serde_json::to_value(ws).unwrap_or_default(),
+    )))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WorkspaceUseBody {
+    pub workspace_guid: String,
+    pub role: Option<String>,
+    pub node_id: Option<String>,
+}
+
+pub async fn workspace_use(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<WorkspaceUseBody>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let run = orch(&state)
+        .workspace_use(
+            &id,
+            &body.workspace_guid,
+            body.role.as_deref(),
+            body.node_id.as_deref(),
+        )
+        .map_err(map_err)?;
+    Ok(Json(ApiResponse::success(
+        serde_json::to_value(run).unwrap_or_default(),
+    )))
+}
+
+pub async fn workspace_merge(
+    State(state): State<AppState>,
+    Path((id, ws)): Path<(String, String)>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let run = orch(&state)
+        .workspace_merge(&id, &ws)
+        .map_err(map_err)?;
+    Ok(Json(ApiResponse::success(
+        serde_json::to_value(run).unwrap_or_default(),
+    )))
+}
+
+pub async fn workspace_abandon(
+    State(state): State<AppState>,
+    Path((id, ws)): Path<(String, String)>,
+) -> ApiResult<Json<ApiResponse<Value>>> {
+    let run = orch(&state)
+        .workspace_abandon(&id, &ws)
+        .map_err(map_err)?;
+    Ok(Json(ApiResponse::success(
+        serde_json::to_value(run).unwrap_or_default(),
+    )))
+}

--- a/apps/api/src/api/orchestrator/handlers.rs
+++ b/apps/api/src/api/orchestrator/handlers.rs
@@ -158,26 +158,6 @@ pub async fn context_get(
     Ok(Json(ApiResponse::success(pack)))
 }
 
-pub async fn tick_loop(
-    State(state): State<AppState>,
-    Path(id): Path<String>,
-) -> ApiResult<Json<ApiResponse<Value>>> {
-    let run = orch(&state).tick_loop_fixture(&id).map_err(map_err)?;
-    Ok(Json(ApiResponse::success(
-        serde_json::to_value(run).unwrap_or_default(),
-    )))
-}
-
-pub async fn step_graph(
-    State(state): State<AppState>,
-    Path(id): Path<String>,
-) -> ApiResult<Json<ApiResponse<Value>>> {
-    let run = orch(&state).step_graph_fixture(&id).map_err(map_err)?;
-    Ok(Json(ApiResponse::success(
-        serde_json::to_value(run).unwrap_or_default(),
-    )))
-}
-
 pub async fn spec_draft(
     State(state): State<AppState>,
     Path(id): Path<String>,

--- a/apps/api/src/api/orchestrator/handlers.rs
+++ b/apps/api/src/api/orchestrator/handlers.rs
@@ -202,9 +202,7 @@ pub async fn spec_get(
     Path(id): Path<String>,
     Query(q): Query<SpecQuery>,
 ) -> ApiResult<Json<ApiResponse<Value>>> {
-    let spec = orch(&state)
-        .get_spec(&id, q.version)
-        .map_err(map_err)?;
+    let spec = orch(&state).get_spec(&id, q.version).map_err(map_err)?;
     Ok(Json(ApiResponse::success(
         serde_json::to_value(spec).unwrap_or_default(),
     )))
@@ -219,7 +217,9 @@ pub async fn spec_update(
     let (run, version) = orch(&state)
         .draft_spec_from_body(&id, body)
         .map_err(map_err)?;
-    Ok(Json(ApiResponse::success(json!({ "run": run, "version": version }))))
+    Ok(Json(ApiResponse::success(
+        json!({ "run": run, "version": version }),
+    )))
 }
 
 #[derive(Debug, Deserialize)]
@@ -321,11 +321,7 @@ pub async fn workspace_get(
     Path(id): Path<String>,
 ) -> ApiResult<Json<ApiResponse<Value>>> {
     let run = orch(&state).load_run(&id).map_err(map_err)?;
-    let home = run
-        .workspaces
-        .iter()
-        .find(|w| w.kind == "home")
-        .cloned();
+    let home = run.workspaces.iter().find(|w| w.kind == "home").cloned();
     Ok(Json(ApiResponse::success(json!({
         "home": home,
         "active_bindings": run.role_bindings,
@@ -391,9 +387,7 @@ pub async fn workspace_merge(
     State(state): State<AppState>,
     Path((id, ws)): Path<(String, String)>,
 ) -> ApiResult<Json<ApiResponse<Value>>> {
-    let run = orch(&state)
-        .workspace_merge(&id, &ws)
-        .map_err(map_err)?;
+    let run = orch(&state).workspace_merge(&id, &ws).map_err(map_err)?;
     Ok(Json(ApiResponse::success(
         serde_json::to_value(run).unwrap_or_default(),
     )))
@@ -403,9 +397,7 @@ pub async fn workspace_abandon(
     State(state): State<AppState>,
     Path((id, ws)): Path<(String, String)>,
 ) -> ApiResult<Json<ApiResponse<Value>>> {
-    let run = orch(&state)
-        .workspace_abandon(&id, &ws)
-        .map_err(map_err)?;
+    let run = orch(&state).workspace_abandon(&id, &ws).map_err(map_err)?;
     Ok(Json(ApiResponse::success(
         serde_json::to_value(run).unwrap_or_default(),
     )))

--- a/apps/api/src/api/orchestrator/mod.rs
+++ b/apps/api/src/api/orchestrator/mod.rs
@@ -1,0 +1,60 @@
+//! APP-048 Orchestrator HTTP API: `/api/orchestrator/v1/*`
+
+mod handlers;
+
+use axum::{
+    routing::{get, post},
+    Router,
+};
+
+use crate::app_state::AppState;
+
+pub fn routes() -> Router<AppState> {
+    Router::new().nest(
+        "/v1",
+        Router::new()
+            .route("/status", get(handlers::status))
+            .route("/agents", get(handlers::agents_list))
+            .route("/runs", get(handlers::list_runs).post(handlers::create_run))
+            .route("/runs/{id}", get(handlers::get_run))
+            .route("/runs/{id}/start", post(handlers::start_run))
+            .route("/runs/{id}/cancel", post(handlers::cancel_run))
+            .route("/runs/{id}/context", get(handlers::context_get))
+            .route("/runs/{id}/tick", post(handlers::tick_loop))
+            .route("/runs/{id}/graph/step", post(handlers::step_graph))
+            .route(
+                "/runs/{id}/spec/draft",
+                post(handlers::spec_draft),
+            )
+            .route("/runs/{id}/spec", get(handlers::spec_get).patch(handlers::spec_update))
+            .route("/runs/{id}/spec/confirm", post(handlers::spec_confirm))
+            .route(
+                "/runs/{id}/mode-proposal",
+                post(handlers::write_mode_proposal),
+            )
+            .route(
+                "/runs/{id}/evidence",
+                get(handlers::evidence_list).post(handlers::evidence_attach),
+            )
+            .route(
+                "/runs/{id}/graph/compile",
+                post(handlers::graph_compile),
+            )
+            .route("/runs/{id}/graph", get(handlers::graph_get))
+            .route("/runs/{id}/workspace", get(handlers::workspace_get))
+            .route(
+                "/runs/{id}/workspaces",
+                get(handlers::workspace_list).post(handlers::workspace_create),
+            )
+            .route("/runs/{id}/workspace/use", post(handlers::workspace_use))
+            .route(
+                "/runs/{id}/workspaces/{ws}/merge",
+                post(handlers::workspace_merge),
+            )
+            .route(
+                "/runs/{id}/workspaces/{ws}/abandon",
+                post(handlers::workspace_abandon),
+            )
+            .route("/skill-dir", get(handlers::skill_dir)),
+    )
+}

--- a/apps/api/src/api/orchestrator/mod.rs
+++ b/apps/api/src/api/orchestrator/mod.rs
@@ -20,8 +20,6 @@ pub fn routes() -> Router<AppState> {
             .route("/runs/{id}/start", post(handlers::start_run))
             .route("/runs/{id}/cancel", post(handlers::cancel_run))
             .route("/runs/{id}/context", get(handlers::context_get))
-            .route("/runs/{id}/tick", post(handlers::tick_loop))
-            .route("/runs/{id}/graph/step", post(handlers::step_graph))
             .route("/runs/{id}/spec/draft", post(handlers::spec_draft))
             .route(
                 "/runs/{id}/spec",

--- a/apps/api/src/api/orchestrator/mod.rs
+++ b/apps/api/src/api/orchestrator/mod.rs
@@ -22,11 +22,11 @@ pub fn routes() -> Router<AppState> {
             .route("/runs/{id}/context", get(handlers::context_get))
             .route("/runs/{id}/tick", post(handlers::tick_loop))
             .route("/runs/{id}/graph/step", post(handlers::step_graph))
+            .route("/runs/{id}/spec/draft", post(handlers::spec_draft))
             .route(
-                "/runs/{id}/spec/draft",
-                post(handlers::spec_draft),
+                "/runs/{id}/spec",
+                get(handlers::spec_get).patch(handlers::spec_update),
             )
-            .route("/runs/{id}/spec", get(handlers::spec_get).patch(handlers::spec_update))
             .route("/runs/{id}/spec/confirm", post(handlers::spec_confirm))
             .route(
                 "/runs/{id}/mode-proposal",
@@ -36,10 +36,7 @@ pub fn routes() -> Router<AppState> {
                 "/runs/{id}/evidence",
                 get(handlers::evidence_list).post(handlers::evidence_attach),
             )
-            .route(
-                "/runs/{id}/graph/compile",
-                post(handlers::graph_compile),
-            )
+            .route("/runs/{id}/graph/compile", post(handlers::graph_compile))
             .route("/runs/{id}/graph", get(handlers::graph_get))
             .route("/runs/{id}/workspace", get(handlers::workspace_get))
             .route(

--- a/apps/api/src/api/system/files.rs
+++ b/apps/api/src/api/system/files.rs
@@ -153,9 +153,8 @@ pub async fn serve_git_blob(Query(query): Query<ServeGitBlobQuery>) -> Result<Re
     let rev = query.rev.trim();
     let (show_spec, display_path) = if rev.starts_with(':') {
         // Index / stage form: `:path` or `:N:path` — validate the path portion.
-        parse_index_show_spec(rev).ok_or_else(|| {
-            (StatusCode::BAD_REQUEST, "Invalid index blob rev").into_response()
-        })?
+        parse_index_show_spec(rev)
+            .ok_or_else(|| (StatusCode::BAD_REQUEST, "Invalid index blob rev").into_response())?
     } else {
         if !is_safe_git_rev(rev) {
             return Err((StatusCode::BAD_REQUEST, "Invalid rev").into_response());

--- a/apps/api/src/api/system/skills.rs
+++ b/apps/api/src/api/system/skills.rs
@@ -437,7 +437,9 @@ bestFor: >-
 
         assert_eq!(
             parse_frontmatter_field(content, "description"),
-            Some("Expert reviewer for multi-line skill descriptions and best practices.".to_string())
+            Some(
+                "Expert reviewer for multi-line skill descriptions and best practices.".to_string()
+            )
         );
         assert_eq!(
             parse_frontmatter_field(content, "bestFor"),

--- a/apps/api/src/api/ws/message/git.rs
+++ b/apps/api/src/api/ws/message/git.rs
@@ -225,10 +225,15 @@ pub enum DiffPreviewKind {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum GitBlobLocator {
-    Worktree { path: String },
+    Worktree {
+        path: String,
+    },
     /// `rev` is a git revision (`HEAD`, `abc123`, `origin/main`) or an index
     /// show-spec (`:path`) when the side is the index.
-    Git { rev: String, path: String },
+    Git {
+        rev: String,
+        path: String,
+    },
 }
 
 /// 获取单个文件 diff 响应

--- a/apps/api/src/api/ws/router/usage.rs
+++ b/apps/api/src/api/ws/router/usage.rs
@@ -4,9 +4,9 @@ use core_service::{Result, ServiceError};
 
 use super::{
     TokenUsageOverviewRequest, UsageAddProviderApiKeyRequest, UsageAllProvidersSwitchRequest,
-    UsageApplyProviderVisibilityRequest, UsageAutoRefreshRequest,
-    UsageDeleteProviderApiKeyRequest, UsageOverviewRequest, UsageProviderFooterCarouselRequest,
-    UsageProviderManualSetupRequest, UsageProviderSwitchRequest, WsMessageService,
+    UsageApplyProviderVisibilityRequest, UsageAutoRefreshRequest, UsageDeleteProviderApiKeyRequest,
+    UsageOverviewRequest, UsageProviderFooterCarouselRequest, UsageProviderManualSetupRequest,
+    UsageProviderSwitchRequest, WsMessageService,
 };
 
 impl WsMessageService {
@@ -69,10 +69,7 @@ impl WsMessageService {
                 )
             })
             .collect();
-        let overview = self
-            .usage_service
-            .apply_provider_visibility(prefs)
-            .await;
+        let overview = self.usage_service.apply_provider_visibility(prefs).await;
         Ok(json!(overview))
     }
 

--- a/apps/api/src/api/ws/terminal_handler.rs
+++ b/apps/api/src/api/ws/terminal_handler.rs
@@ -295,10 +295,8 @@ async fn handle_terminal_socket(socket: WebSocket, config: TerminalSessionConfig
                     );
                     last_error = Some(e);
                     if attempt < ATTACH_MAX_ATTEMPTS {
-                        tokio::time::sleep(std::time::Duration::from_millis(
-                            150 * attempt as u64,
-                        ))
-                        .await;
+                        tokio::time::sleep(std::time::Duration::from_millis(150 * attempt as u64))
+                            .await;
                     }
                 }
             }

--- a/apps/api/src/app_state.rs
+++ b/apps/api/src/app_state.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use crate::api::ws::{WsMessageService, WsService};
 use core_service::{
     AgentHooksService, AgentService, AgentSessionService, AutomationService, CanvasAgentRelay,
-    CanvasDocumentService, MessagePushService, NotificationService, ProjectService, ReviewService,
-    TerminalService, TestService, WorkspaceService,
+    CanvasDocumentService, MessagePushService, NotificationService, OrchestratorService,
+    ProjectService, ReviewService, TerminalService, TestService, WorkspaceService,
 };
 use token_usage::TokenUsageService;
 
@@ -18,6 +18,7 @@ pub struct AppServices {
     pub agent_service: Arc<AgentService>,
     pub agent_session_service: Arc<AgentSessionService>,
     pub automation_service: Arc<AutomationService>,
+    pub orchestrator_service: Arc<OrchestratorService>,
     pub ws_message_service: Arc<WsMessageService>,
     pub message_push_service: Arc<MessagePushService>,
     pub terminal_service: Arc<TerminalService>,
@@ -36,6 +37,7 @@ pub struct AppState {
     pub agent_service: Arc<AgentService>,
     pub agent_session_service: Arc<AgentSessionService>,
     pub automation_service: Arc<AutomationService>,
+    pub orchestrator_service: Arc<OrchestratorService>,
     pub message_push_service: Arc<MessagePushService>,
     pub terminal_service: Arc<TerminalService>,
     pub token_usage_service: Arc<TokenUsageService>,
@@ -58,6 +60,7 @@ impl Clone for AppState {
             agent_service: Arc::clone(&self.agent_service),
             agent_session_service: Arc::clone(&self.agent_session_service),
             automation_service: Arc::clone(&self.automation_service),
+            orchestrator_service: Arc::clone(&self.orchestrator_service),
             message_push_service: Arc::clone(&self.message_push_service),
             terminal_service: Arc::clone(&self.terminal_service),
             token_usage_service: Arc::clone(&self.token_usage_service),
@@ -84,6 +87,7 @@ impl AppState {
             agent_service: services.agent_service,
             agent_session_service: services.agent_session_service,
             automation_service: services.automation_service,
+            orchestrator_service: services.orchestrator_service,
             message_push_service: services.message_push_service,
             terminal_service: services.terminal_service,
             token_usage_service: services.token_usage_service,

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -401,6 +401,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Arc::clone(&terminal_service),
         Arc::clone(&notification_service),
     ));
+    let orchestrator_service = Arc::new(core_service::OrchestratorService::new());
 
     let agent_session_service = Arc::new(AgentSessionService::new(Arc::clone(&agent_service)));
 
@@ -457,6 +458,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             agent_service,
             agent_session_service,
             automation_service: Arc::clone(&automation_service),
+            orchestrator_service: Arc::clone(&orchestrator_service),
             ws_message_service: ws_message_service.clone(),
             message_push_service,
             terminal_service,

--- a/apps/cli/src/commands/mod.rs
+++ b/apps/cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod canvas;
 pub mod computer;
+pub mod orchestrator;
 pub mod review;
 pub mod runtime;
 pub mod update;

--- a/apps/cli/src/commands/orchestrator.rs
+++ b/apps/cli/src/commands/orchestrator.rs
@@ -1,0 +1,481 @@
+//! `atmos orchestrator …` — APP-048 agent-facing surface.
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+use serde_json::{json, Value};
+
+use crate::api_client::{request_json, ApiClientArgs, DEFAULT_TIMEOUT_MS};
+use reqwest::Method;
+#[derive(Debug, Args)]
+pub struct OrchestratorOpts {
+    #[arg(long, default_value_t = DEFAULT_TIMEOUT_MS)]
+    pub timeout_ms: u64,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum OrchestratorCommand {
+    /// Print skill directory + prompt (local, no HTTP).
+    SkillDir,
+    /// Alias of skill-dir.
+    SkillPath,
+    Status,
+    #[command(subcommand)]
+    Run(RunCmd),
+    #[command(subcommand)]
+    Spec(SpecCmd),
+    #[command(subcommand)]
+    Evidence(EvidenceCmd),
+    #[command(subcommand)]
+    Graph(GraphCmd),
+    #[command(subcommand)]
+    Workspace(WorkspaceCmd),
+    Context {
+        #[arg(long)]
+        run: String,
+    },
+    Agents,
+    /// Fixture Loop tick (server-side sensors).
+    Tick {
+        #[arg(long)]
+        run: String,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum RunCmd {
+    Create {
+        #[arg(long)]
+        goal: String,
+        #[arg(long, default_value = "loop")]
+        mode: String,
+        #[arg(long, default_value = "standalone")]
+        target_kind: String,
+        #[arg(long)]
+        project: Option<String>,
+        #[arg(long)]
+        workspace: Option<String>,
+        #[arg(long)]
+        home_cwd: Option<String>,
+    },
+    List {
+        #[arg(long, default_value_t = 50)]
+        limit: usize,
+    },
+    Get {
+        #[arg(long)]
+        run: String,
+    },
+    Start {
+        #[arg(long)]
+        run: String,
+    },
+    Cancel {
+        #[arg(long)]
+        run: String,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SpecCmd {
+    Draft {
+        #[arg(long)]
+        run: String,
+        #[arg(long)]
+        file: PathBuf,
+    },
+    Get {
+        #[arg(long)]
+        run: String,
+        #[arg(long)]
+        version: Option<i32>,
+    },
+    Confirm {
+        #[arg(long)]
+        run: String,
+        #[arg(long)]
+        version: i32,
+    },
+    Update {
+        #[arg(long)]
+        run: String,
+        #[arg(long)]
+        file: PathBuf,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum EvidenceCmd {
+    Attach {
+        #[arg(long)]
+        run: String,
+        #[arg(long)]
+        file: PathBuf,
+        #[arg(long, default_value = "file")]
+        kind: String,
+    },
+    List {
+        #[arg(long)]
+        run: String,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum GraphCmd {
+    Compile {
+        #[arg(long)]
+        run: String,
+        #[arg(long)]
+        file: PathBuf,
+    },
+    Get {
+        #[arg(long)]
+        run: String,
+    },
+    Step {
+        #[arg(long)]
+        run: String,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum WorkspaceCmd {
+    Get {
+        #[arg(long)]
+        run: String,
+    },
+    List {
+        #[arg(long)]
+        run: String,
+    },
+    Create {
+        #[arg(long)]
+        run: String,
+        #[arg(long)]
+        purpose: String,
+        #[arg(long)]
+        path: Option<String>,
+    },
+    Use {
+        #[arg(long)]
+        run: String,
+        #[arg(long)]
+        workspace: String,
+        #[arg(long)]
+        role: Option<String>,
+        #[arg(long)]
+        node: Option<String>,
+    },
+    Merge {
+        #[arg(long)]
+        run: String,
+        #[arg(long)]
+        workspace: String,
+    },
+    Abandon {
+        #[arg(long)]
+        run: String,
+        #[arg(long)]
+        workspace: String,
+    },
+}
+
+pub async fn execute(
+    api: ApiClientArgs,
+    opts: OrchestratorOpts,
+    command: OrchestratorCommand,
+) -> Result<Value, String> {
+    match command {
+        OrchestratorCommand::SkillDir | OrchestratorCommand::SkillPath => Ok(local_skill_dir()),
+        OrchestratorCommand::Status => get(&api, opts.timeout_ms, "/api/orchestrator/v1/status").await,
+        OrchestratorCommand::Agents => get(&api, opts.timeout_ms, "/api/orchestrator/v1/agents").await,
+        OrchestratorCommand::Context { run } => {
+            get(
+                &api,
+                opts.timeout_ms,
+                &format!("/api/orchestrator/v1/runs/{run}/context"),
+            )
+            .await
+        }
+        OrchestratorCommand::Tick { run } => {
+            post(
+                &api,
+                opts.timeout_ms,
+                &format!("/api/orchestrator/v1/runs/{run}/tick"),
+                json!({}),
+            )
+            .await
+        }
+        OrchestratorCommand::Run(cmd) => match cmd {
+            RunCmd::Create {
+                goal,
+                mode,
+                target_kind,
+                project,
+                workspace,
+                home_cwd,
+            } => {
+                post(
+                    &api,
+                    opts.timeout_ms,
+                    "/api/orchestrator/v1/runs",
+                    json!({
+                        "goal": goal,
+                        "requested_mode": mode,
+                        "target_kind": target_kind,
+                        "project_guid": project,
+                        "workspace_guid": workspace,
+                        "home_cwd": home_cwd,
+                    }),
+                )
+                .await
+            }
+            RunCmd::List { limit } => {
+                get(
+                    &api,
+                    opts.timeout_ms,
+                    &format!("/api/orchestrator/v1/runs?limit={limit}"),
+                )
+                .await
+            }
+            RunCmd::Get { run } => {
+                get(
+                    &api,
+                    opts.timeout_ms,
+                    &format!("/api/orchestrator/v1/runs/{run}"),
+                )
+                .await
+            }
+            RunCmd::Start { run } => {
+                post(
+                    &api,
+                    opts.timeout_ms,
+                    &format!("/api/orchestrator/v1/runs/{run}/start"),
+                    json!({}),
+                )
+                .await
+            }
+            RunCmd::Cancel { run } => {
+                post(
+                    &api,
+                    opts.timeout_ms,
+                    &format!("/api/orchestrator/v1/runs/{run}/cancel"),
+                    json!({}),
+                )
+                .await
+            }
+        },
+        OrchestratorCommand::Spec(cmd) => match cmd {
+            SpecCmd::Draft { run, file } => {
+                let body: Value = serde_json::from_str(
+                    &std::fs::read_to_string(&file)
+                        .map_err(|e| format!("read spec file: {e}"))?,
+                )
+                .map_err(|e| format!("parse spec json: {e}"))?;
+                post(
+                    &api,
+                    opts.timeout_ms,
+                    &format!("/api/orchestrator/v1/runs/{run}/spec/draft"),
+                    body,
+                )
+                .await
+            }
+            SpecCmd::Get { run, version } => {
+                let q = version
+                    .map(|v| format!("?version={v}"))
+                    .unwrap_or_default();
+                get(
+                    &api,
+                    opts.timeout_ms,
+                    &format!("/api/orchestrator/v1/runs/{run}/spec{q}"),
+                )
+                .await
+            }
+            SpecCmd::Confirm { run, version } => {
+                post(
+                    &api,
+                    opts.timeout_ms,
+                    &format!("/api/orchestrator/v1/runs/{run}/spec/confirm"),
+                    json!({ "version": version }),
+                )
+                .await
+            }
+            SpecCmd::Update { run, file } => {
+                let body: Value = serde_json::from_str(
+                    &std::fs::read_to_string(&file)
+                        .map_err(|e| format!("read spec file: {e}"))?,
+                )
+                .map_err(|e| format!("parse spec json: {e}"))?;
+                patch(
+                    &api,
+                    opts.timeout_ms,
+                    &format!("/api/orchestrator/v1/runs/{run}/spec"),
+                    body,
+                )
+                .await
+            }
+        },
+        OrchestratorCommand::Evidence(cmd) => match cmd {
+            EvidenceCmd::Attach { run, file, kind } => {
+                post(
+                    &api,
+                    opts.timeout_ms,
+                    &format!("/api/orchestrator/v1/runs/{run}/evidence"),
+                    json!({
+                        "path": file.display().to_string(),
+                        "kind": kind,
+                    }),
+                )
+                .await
+            }
+            EvidenceCmd::List { run } => {
+                get(
+                    &api,
+                    opts.timeout_ms,
+                    &format!("/api/orchestrator/v1/runs/{run}/evidence"),
+                )
+                .await
+            }
+        },
+        OrchestratorCommand::Graph(cmd) => match cmd {
+            GraphCmd::Compile { run, file } => {
+                let body: Value = serde_json::from_str(
+                    &std::fs::read_to_string(&file)
+                        .map_err(|e| format!("read graph file: {e}"))?,
+                )
+                .map_err(|e| format!("parse graph: {e}"))?;
+                post(
+                    &api,
+                    opts.timeout_ms,
+                    &format!("/api/orchestrator/v1/runs/{run}/graph/compile"),
+                    body,
+                )
+                .await
+            }
+            GraphCmd::Get { run } => {
+                get(
+                    &api,
+                    opts.timeout_ms,
+                    &format!("/api/orchestrator/v1/runs/{run}/graph"),
+                )
+                .await
+            }
+            GraphCmd::Step { run } => {
+                post(
+                    &api,
+                    opts.timeout_ms,
+                    &format!("/api/orchestrator/v1/runs/{run}/graph/step"),
+                    json!({}),
+                )
+                .await
+            }
+        },
+        OrchestratorCommand::Workspace(cmd) => match cmd {
+            WorkspaceCmd::Get { run } => {
+                get(
+                    &api,
+                    opts.timeout_ms,
+                    &format!("/api/orchestrator/v1/runs/{run}/workspace"),
+                )
+                .await
+            }
+            WorkspaceCmd::List { run } => {
+                get(
+                    &api,
+                    opts.timeout_ms,
+                    &format!("/api/orchestrator/v1/runs/{run}/workspaces"),
+                )
+                .await
+            }
+            WorkspaceCmd::Create {
+                run,
+                purpose,
+                path,
+            } => {
+                post(
+                    &api,
+                    opts.timeout_ms,
+                    &format!("/api/orchestrator/v1/runs/{run}/workspaces"),
+                    json!({ "purpose": purpose, "path": path }),
+                )
+                .await
+            }
+            WorkspaceCmd::Use {
+                run,
+                workspace,
+                role,
+                node,
+            } => {
+                post(
+                    &api,
+                    opts.timeout_ms,
+                    &format!("/api/orchestrator/v1/runs/{run}/workspace/use"),
+                    json!({
+                        "workspace_guid": workspace,
+                        "role": role,
+                        "node_id": node,
+                    }),
+                )
+                .await
+            }
+            WorkspaceCmd::Merge { run, workspace } => {
+                post(
+                    &api,
+                    opts.timeout_ms,
+                    &format!("/api/orchestrator/v1/runs/{run}/workspaces/{workspace}/merge"),
+                    json!({}),
+                )
+                .await
+            }
+            WorkspaceCmd::Abandon { run, workspace } => {
+                post(
+                    &api,
+                    opts.timeout_ms,
+                    &format!("/api/orchestrator/v1/runs/{run}/workspaces/{workspace}/abandon"),
+                    json!({}),
+                )
+                .await
+            }
+        },
+    }
+}
+
+fn local_skill_dir() -> Value {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    let dir = home
+        .join(".atmos")
+        .join("skills")
+        .join(".system")
+        .join("atmos-orchestrator");
+    let dir_s = dir.display().to_string();
+    let prompt = format!(
+        "Read the Atmos Orchestrator skill in this directory and use `atmos orchestrator` to manage multi-step runs (Loop/Graph), Judgment Specs, and evidence. Do not invent completion without Spec + sensors.\n{dir_s}"
+    );
+    json!({
+        "skill_dir": dir_s,
+        "skill_md": format!("{dir_s}/SKILL.md"),
+        "prompt": prompt,
+    })
+}
+
+async fn get(api: &ApiClientArgs, _timeout_ms: u64, path: &str) -> Result<Value, String> {
+    request_json(api, Method::GET, path, None, None).await
+}
+
+async fn post(
+    api: &ApiClientArgs,
+    _timeout_ms: u64,
+    path: &str,
+    body: Value,
+) -> Result<Value, String> {
+    request_json(api, Method::POST, path, None, Some(body)).await
+}
+
+async fn patch(
+    api: &ApiClientArgs,
+    _timeout_ms: u64,
+    path: &str,
+    body: Value,
+) -> Result<Value, String> {
+    request_json(api, Method::PATCH, path, None, Some(body)).await
+}

--- a/apps/cli/src/commands/orchestrator.rs
+++ b/apps/cli/src/commands/orchestrator.rs
@@ -35,11 +35,6 @@ pub enum OrchestratorCommand {
         run: String,
     },
     Agents,
-    /// Fixture Loop tick (server-side sensors).
-    Tick {
-        #[arg(long)]
-        run: String,
-    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -132,10 +127,6 @@ pub enum GraphCmd {
         #[arg(long)]
         run: String,
     },
-    Step {
-        #[arg(long)]
-        run: String,
-    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -198,15 +189,6 @@ pub async fn execute(
                 &api,
                 opts.timeout_ms,
                 &format!("/api/orchestrator/v1/runs/{run}/context"),
-            )
-            .await
-        }
-        OrchestratorCommand::Tick { run } => {
-            post(
-                &api,
-                opts.timeout_ms,
-                &format!("/api/orchestrator/v1/runs/{run}/tick"),
-                json!({}),
             )
             .await
         }
@@ -356,15 +338,6 @@ pub async fn execute(
                     &api,
                     opts.timeout_ms,
                     &format!("/api/orchestrator/v1/runs/{run}/graph"),
-                )
-                .await
-            }
-            GraphCmd::Step { run } => {
-                post(
-                    &api,
-                    opts.timeout_ms,
-                    &format!("/api/orchestrator/v1/runs/{run}/graph/step"),
-                    json!({}),
                 )
                 .await
             }

--- a/apps/cli/src/commands/orchestrator.rs
+++ b/apps/cli/src/commands/orchestrator.rs
@@ -187,8 +187,12 @@ pub async fn execute(
 ) -> Result<Value, String> {
     match command {
         OrchestratorCommand::SkillDir | OrchestratorCommand::SkillPath => Ok(local_skill_dir()),
-        OrchestratorCommand::Status => get(&api, opts.timeout_ms, "/api/orchestrator/v1/status").await,
-        OrchestratorCommand::Agents => get(&api, opts.timeout_ms, "/api/orchestrator/v1/agents").await,
+        OrchestratorCommand::Status => {
+            get(&api, opts.timeout_ms, "/api/orchestrator/v1/status").await
+        }
+        OrchestratorCommand::Agents => {
+            get(&api, opts.timeout_ms, "/api/orchestrator/v1/agents").await
+        }
         OrchestratorCommand::Context { run } => {
             get(
                 &api,
@@ -268,8 +272,7 @@ pub async fn execute(
         OrchestratorCommand::Spec(cmd) => match cmd {
             SpecCmd::Draft { run, file } => {
                 let body: Value = serde_json::from_str(
-                    &std::fs::read_to_string(&file)
-                        .map_err(|e| format!("read spec file: {e}"))?,
+                    &std::fs::read_to_string(&file).map_err(|e| format!("read spec file: {e}"))?,
                 )
                 .map_err(|e| format!("parse spec json: {e}"))?;
                 post(
@@ -281,9 +284,7 @@ pub async fn execute(
                 .await
             }
             SpecCmd::Get { run, version } => {
-                let q = version
-                    .map(|v| format!("?version={v}"))
-                    .unwrap_or_default();
+                let q = version.map(|v| format!("?version={v}")).unwrap_or_default();
                 get(
                     &api,
                     opts.timeout_ms,
@@ -302,8 +303,7 @@ pub async fn execute(
             }
             SpecCmd::Update { run, file } => {
                 let body: Value = serde_json::from_str(
-                    &std::fs::read_to_string(&file)
-                        .map_err(|e| format!("read spec file: {e}"))?,
+                    &std::fs::read_to_string(&file).map_err(|e| format!("read spec file: {e}"))?,
                 )
                 .map_err(|e| format!("parse spec json: {e}"))?;
                 patch(
@@ -340,8 +340,7 @@ pub async fn execute(
         OrchestratorCommand::Graph(cmd) => match cmd {
             GraphCmd::Compile { run, file } => {
                 let body: Value = serde_json::from_str(
-                    &std::fs::read_to_string(&file)
-                        .map_err(|e| format!("read graph file: {e}"))?,
+                    &std::fs::read_to_string(&file).map_err(|e| format!("read graph file: {e}"))?,
                 )
                 .map_err(|e| format!("parse graph: {e}"))?;
                 post(
@@ -387,11 +386,7 @@ pub async fn execute(
                 )
                 .await
             }
-            WorkspaceCmd::Create {
-                run,
-                purpose,
-                path,
-            } => {
+            WorkspaceCmd::Create { run, purpose, path } => {
                 post(
                     &api,
                     opts.timeout_ms,

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -6,6 +6,9 @@ use api_client::ApiClientArgs;
 use clap::{Parser, Subcommand};
 use commands::canvas::{execute as execute_canvas, CanvasCommand, CanvasOpts};
 use commands::computer::{execute as execute_computer, ComputerCommand};
+use commands::orchestrator::{
+    execute as execute_orchestrator, OrchestratorCommand, OrchestratorOpts,
+};
 use commands::review::{execute as execute_review, ReviewCommand};
 use commands::runtime::{execute as execute_runtime, RuntimeCommand};
 use commands::update::{execute as execute_update, update_hint_if_needed, UpdateArgs};
@@ -46,6 +49,13 @@ enum Commands {
         #[command(subcommand)]
         command: CanvasCommand,
     },
+    /// Multi-step Loop/Graph Orchestrator runs (APP-048).
+    Orchestrator {
+        #[command(flatten)]
+        opts: OrchestratorOpts,
+        #[command(subcommand)]
+        command: OrchestratorCommand,
+    },
     /// Register this machine on the relay and run it as a remote Computer (APP-016).
     Computer {
         #[command(subcommand)]
@@ -73,6 +83,9 @@ async fn run() -> Result<(), String> {
         Commands::Runtime { command } => execute_runtime(command).await,
         Commands::Computer { command } => execute_computer(command).await,
         Commands::Canvas { canvas, command } => execute_canvas(cli.api, canvas, command).await,
+        Commands::Orchestrator { opts, command } => {
+            execute_orchestrator(cli.api, opts, command).await
+        }
         Commands::Update(args) => execute_update(args).await,
     }
     .map_err(|err| err.to_string())?;

--- a/apps/cli/src/output.rs
+++ b/apps/cli/src/output.rs
@@ -53,7 +53,9 @@ impl CommandKind {
             } else {
                 UpdateVerb::Install
             }),
-            Commands::Canvas { .. } | Commands::Review { .. } => Self::Json,
+            Commands::Canvas { .. }
+            | Commands::Review { .. }
+            | Commands::Orchestrator { .. } => Self::Json,
         }
     }
 

--- a/apps/cli/src/output.rs
+++ b/apps/cli/src/output.rs
@@ -53,9 +53,9 @@ impl CommandKind {
             } else {
                 UpdateVerb::Install
             }),
-            Commands::Canvas { .. }
-            | Commands::Review { .. }
-            | Commands::Orchestrator { .. } => Self::Json,
+            Commands::Canvas { .. } | Commands::Review { .. } | Commands::Orchestrator { .. } => {
+                Self::Json
+            }
         }
     }
 

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1190,6 +1190,7 @@
           "terminals": "Terminals",
           "agents": "Agents",
           "automations": "Automations",
+          "orchestrator": "Orchestrator",
           "canvas": "Canvas",
           "kanban": "Kanban",
           "newWorkspace": "New Workspace",
@@ -1416,6 +1417,27 @@
     },
     "globalSearchItems": {
       "management": {}
+    }
+  },
+  "Orchestrator": {
+    "title": "Orchestrator",
+    "subtitle": "Loop & Graph runs with Judgment Specs",
+    "newRun": "New run",
+    "goalPlaceholder": "Describe the goal for this multi-step agent run…",
+    "create": "Create run",
+    "history": "Run history",
+    "loading": "Loading runs…",
+    "emptyTitle": "No orchestrator runs yet",
+    "emptyBody": "This is Orchestrator — multi-step Loop/Graph runs with evidence, not the free-form Canvas board. Open Canvas from Management Center if you need diagrams.",
+    "copyAgentInstructions": "Copy agent instructions",
+    "copiedSkill": "Copied skill path",
+    "cancel": "Cancel run",
+    "roleChromePreview": "Role chrome",
+    "selectedRun": "Selected run",
+    "mode": {
+      "loop": "Loop",
+      "graph": "Graph",
+      "auto": "Auto"
     }
   },
   "automation": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1433,7 +1433,13 @@
     "copiedSkill": "Copied skill path",
     "cancel": "Cancel run",
     "roleChromePreview": "Role chrome",
+    "roleChromeHint": "Managed terminal headers show role + instance + activity even when agent brands match.",
     "selectedRun": "Selected run",
+    "specTitle": "Judgment Spec",
+    "draftSpec": "Draft Spec",
+    "confirmSpec": "Confirm Spec",
+    "startRun": "Start run",
+    "hitlTitle": "Waiting on you",
     "mode": {
       "loop": "Loop",
       "graph": "Graph",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1190,6 +1190,7 @@
           "terminals": "终端",
           "agents": "Agent",
           "automations": "自动化",
+          "orchestrator": "编排器",
           "canvas": "画布",
           "kanban": "看板",
           "newWorkspace": "新建工作区",
@@ -1416,6 +1417,27 @@
     },
     "globalSearchItems": {
       "management": {}
+    }
+  },
+  "Orchestrator": {
+    "title": "编排器",
+    "subtitle": "带判定标准的 Loop / Graph 多步运行",
+    "newRun": "新建运行",
+    "goalPlaceholder": "描述这次多步 Agent 运行的目标…",
+    "create": "创建运行",
+    "history": "运行历史",
+    "loading": "正在加载…",
+    "emptyTitle": "还没有编排运行",
+    "emptyBody": "这里是 Orchestrator（多步 Loop/Graph + 证据），不是自由画布。需要画图请从管理中心打开 Canvas。",
+    "copyAgentInstructions": "复制 Agent 说明",
+    "copiedSkill": "已复制技能路径",
+    "cancel": "取消运行",
+    "roleChromePreview": "角色标识预览",
+    "selectedRun": "当前选中",
+    "mode": {
+      "loop": "循环",
+      "graph": "图",
+      "auto": "自动"
     }
   },
   "automation": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1433,7 +1433,13 @@
     "copiedSkill": "已复制技能路径",
     "cancel": "取消运行",
     "roleChromePreview": "角色标识预览",
+    "roleChromeHint": "托管终端标题会显示角色 + 实例 + 状态，即使 Agent 品牌相同也能区分。",
     "selectedRun": "当前选中",
+    "specTitle": "判定标准 (Judgment Spec)",
+    "draftSpec": "起草 Spec",
+    "confirmSpec": "确认 Spec",
+    "startRun": "开始运行",
+    "hitlTitle": "等待你的确认",
     "mode": {
       "loop": "循环",
       "graph": "图",

--- a/apps/web/src/app-shell/LeftSidebarManagementCenter.tsx
+++ b/apps/web/src/app-shell/LeftSidebarManagementCenter.tsx
@@ -21,6 +21,7 @@ import {
   SquareKanban,
   SquareTerminal,
   Timer,
+  Workflow,
 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 
@@ -108,6 +109,7 @@ export function LeftSidebarManagementCenter({
       { id: "terminals", labelKey: "managementCenter.items.terminals", icon: SquareTerminal, path: "/terminals" },
       { id: "agents", labelKey: "managementCenter.items.agents", icon: Bot, path: "/agents" },
       { id: "automations", labelKey: "managementCenter.items.automations", icon: Timer, path: "/automations" },
+      { id: "orchestrator", labelKey: "managementCenter.items.orchestrator", icon: Workflow, path: "/orchestrator" },
       { id: "disk-analyzer", labelKey: "managementCenter.items.diskAnalyzer", icon: HardDrive, path: "/disk-analyzer" },
       { id: "canvas", labelKey: "managementCenter.items.canvas", icon: Presentation, kind: "canvas" },
       { id: "kanban", labelKey: "managementCenter.items.kanban", icon: SquareKanban, kind: "kanban" },

--- a/apps/web/src/app/(app)/orchestrator/page.tsx
+++ b/apps/web/src/app/(app)/orchestrator/page.tsx
@@ -1,0 +1,5 @@
+import { OrchestratorPage } from "@/features/orchestrator/components/OrchestratorPage";
+
+export default function Page() {
+  return <OrchestratorPage />;
+}

--- a/apps/web/src/features/orchestrator/components/OrchestratorPage.tsx
+++ b/apps/web/src/features/orchestrator/components/OrchestratorPage.tsx
@@ -2,7 +2,14 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
-import { GitBranch, Loader2, Play, Square, Workflow } from "lucide-react";
+import {
+  CheckCircle2,
+  GitBranch,
+  Loader2,
+  Play,
+  Square,
+  Workflow,
+} from "lucide-react";
 import { Button } from "@workspace/ui/components/ui/button";
 import { cn } from "@workspace/ui/lib/utils";
 
@@ -10,6 +17,7 @@ import {
   composeRoleHeader,
   roleAccentClass,
   type OrchRole,
+  type RoleActivity,
 } from "../lib/role-chrome";
 
 type RunRow = {
@@ -18,26 +26,84 @@ type RunRow = {
   status: string;
   mode?: string | null;
   requested_mode?: string;
+  mode_reason?: string | null;
   stop_reason?: string | null;
   home_cwd?: string;
   locked_spec_version?: number | null;
+  iterations_used?: number;
 };
+
+type LayoutIntent = "setup" | "run_loop" | "run_graph" | "hitl" | "review";
+
+function intentFor(run: RunRow | null): LayoutIntent {
+  if (!run) return "setup";
+  if (run.status === "blocked_human" || run.status === "awaiting_spec_confirm") {
+    return "hitl";
+  }
+  if (
+    run.status === "completed" ||
+    run.status === "failed" ||
+    run.status === "cancelled" ||
+    run.status === "interrupted"
+  ) {
+    return "review";
+  }
+  if (run.status === "running" && run.mode === "graph") return "run_graph";
+  if (run.status === "running" || run.status === "spec_ready") return "run_loop";
+  return "setup";
+}
 
 /**
  * Orchestrator management surface (APP-048).
- * Emil craft: restrained motion (transform/opacity, ease-out, reduced-motion safe),
- * clear hierarchy, no decorative ease-in bounce.
+ * Emil craft: short ease-out transitions, hierarchy, reduced-motion friendly.
  */
 export function OrchestratorPage() {
   const t = useTranslations("Orchestrator");
   const [runs, setRuns] = useState<RunRow[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Stringish>(null);
+  const [error, setError] = useState<string | null>(null);
   const [goal, setGoal] = useState("");
   const [mode, setMode] = useState<"auto" | "loop" | "graph">("loop");
   const [busy, setBusy] = useState(false);
   const [selected, setSelected] = useState<RunRow | null>(null);
   const [skillHint, setSkillHint] = useState<string | null>(null);
+  const [specJson, setSpecJson] = useState(() =>
+    JSON.stringify(
+      {
+        goal_summary: "",
+        risk_tier: "low",
+        acceptance: [
+          {
+            id: "c1",
+            description: "true sensor",
+            kind: "sensor",
+            required: true,
+            sensor: {
+              argv: ["true"],
+              pass_exit_codes: [0],
+              timeout_ms: 5000,
+            },
+            immutable_paths: [],
+            sole_source: "sensor",
+          },
+        ],
+        rejection: [],
+        judgment_order: ["sensor", "llm_judge", "human"],
+      },
+      null,
+      2,
+    ),
+  );
+  const [rolesLive, setRolesLive] = useState<
+    Array<{ role: OrchRole; instance?: string; activity: RoleActivity }>
+  >([
+    { role: "orchestrator", activity: "queued" },
+    { role: "criteria", activity: "queued" },
+    { role: "maker", instance: "iter 0", activity: "queued" },
+    { role: "verify", activity: "queued" },
+  ]);
+
+  const intent = intentFor(selected);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -50,27 +116,64 @@ export function OrchestratorPage() {
       const body = await res.json();
       const list = (body?.data?.runs ?? body?.runs ?? []) as RunRow[];
       setRuns(Array.isArray(list) ? list : []);
+      if (selected) {
+        const fresh = list.find((r) => r.id === selected.id);
+        if (fresh) setSelected(fresh);
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [selected]);
 
   useEffect(() => {
     void load();
-  }, [load]);
+  }, []);
+
+  useEffect(() => {
+    if (!selected) return;
+    if (selected.status === "running") {
+      setRolesLive([
+        { role: "maker", instance: `iter ${selected.iterations_used ?? 0}`, activity: "active" },
+        { role: "verify", activity: "active" },
+      ]);
+    } else if (selected.status === "blocked_human" || selected.status === "awaiting_spec_confirm") {
+      setRolesLive([{ role: "criteria", activity: "waiting_user" }]);
+    } else if (selected.status === "completed") {
+      setRolesLive([
+        { role: "maker", activity: "succeeded" },
+        { role: "verify", activity: "succeeded" },
+      ]);
+    }
+  }, [selected]);
+
+  const api = async (path: string, init?: RequestInit) => {
+    const res = await fetch(path, {
+      credentials: "include",
+      headers: { "Content-Type": "application/json", ...(init?.headers ?? {}) },
+      ...init,
+    });
+    const text = await res.text();
+    let body: unknown = null;
+    try {
+      body = text ? JSON.parse(text) : null;
+    } catch {
+      body = text;
+    }
+    if (!res.ok) {
+      throw new Error(typeof body === "string" ? body : JSON.stringify(body));
+    }
+    return body as { data?: unknown };
+  };
 
   const copyAgentInstructions = async () => {
     try {
-      const res = await fetch("/api/orchestrator/v1/skill-dir", {
-        credentials: "include",
-      });
-      const body = await res.json();
-      const data = body?.data ?? body;
+      const body = await api("/api/orchestrator/v1/skill-dir");
+      const data = (body?.data ?? body) as { prompt?: string; skill_dir?: string };
       const text =
         data?.prompt ??
-        `Read the Atmos Orchestrator skill and use atmos orchestrator CLI.\n${data?.skill_dir ?? ""}`;
+        `Read the Atmos Orchestrator skill.\n${data?.skill_dir ?? ""}`;
       await navigator.clipboard.writeText(text);
       setSkillHint(t("copiedSkill"));
       window.setTimeout(() => setSkillHint(null), 2000);
@@ -84,22 +187,76 @@ export function OrchestratorPage() {
     setBusy(true);
     setError(null);
     try {
-      const res = await fetch("/api/orchestrator/v1/runs", {
+      const body = await api("/api/orchestrator/v1/runs", {
         method: "POST",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           goal: goal.trim(),
           requested_mode: mode,
           target_kind: "standalone",
-          home_cwd: undefined,
         }),
       });
-      if (!res.ok) {
-        const text = await res.text();
-        throw new Error(text || `HTTP ${res.status}`);
-      }
+      const run = (body?.data ?? body) as RunRow;
       setGoal("");
+      setSelected(run);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const draftSpec = async () => {
+    if (!selected) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const parsed = JSON.parse(specJson) as Record<string, unknown>;
+      if (!parsed.goal_summary) parsed.goal_summary = selected.goal;
+      await api(`/api/orchestrator/v1/runs/${selected.id}/spec/draft`, {
+        method: "POST",
+        body: JSON.stringify(parsed),
+      });
+      await load();
+      setRolesLive([{ role: "criteria", activity: "succeeded" }]);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const confirmSpec = async () => {
+    if (!selected?.locked_spec_version && selected?.locked_spec_version !== 0) {
+      // after draft, version is 1 typically — fetch run
+    }
+    if (!selected) return;
+    setBusy(true);
+    try {
+      const version = selected.locked_spec_version ?? 1;
+      await api(`/api/orchestrator/v1/runs/${selected.id}/spec/confirm`, {
+        method: "POST",
+        body: JSON.stringify({ version }),
+      });
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const startRun = async () => {
+    if (!selected) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const body = await api(`/api/orchestrator/v1/runs/${selected.id}/start`, {
+        method: "POST",
+        body: "{}",
+      });
+      const run = (body?.data ?? body) as RunRow;
+      setSelected(run);
       await load();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -111,9 +268,9 @@ export function OrchestratorPage() {
   const cancelRun = async (id: string) => {
     setBusy(true);
     try {
-      await fetch(`/api/orchestrator/v1/runs/${id}/cancel`, {
+      await api(`/api/orchestrator/v1/runs/${id}/cancel`, {
         method: "POST",
-        credentials: "include",
+        body: "{}",
       });
       await load();
     } catch (e) {
@@ -123,26 +280,29 @@ export function OrchestratorPage() {
     }
   };
 
-  const demoRoles = useMemo(
-    () =>
-      (
-        [
-          ["orchestrator", "Codex", null],
-          ["criteria", "Codex", null],
-          ["maker", "Codex", "iter 1"],
-          ["verify", "Codex", null],
-        ] as const
-      ).map(([role, agent, instance]) => ({
-        role: role as OrchRole,
-        header: composeRoleHeader({
-          role: role as OrchRole,
-          agentDisplay: agent,
-          instance,
-          activity: role === "criteria" ? "waiting_user" : "active",
-        }),
-      })),
-    [],
-  );
+  const runStrip = useMemo(() => {
+    if (!selected) return [] as Array<{ id: string; label: string; state: string }>;
+    if (selected.mode === "graph") {
+      return [
+        { id: "1", label: "Maker A", state: selected.status === "completed" ? "done" : "pending" },
+        { id: "2", label: "Join", state: selected.status === "failed" ? "failed" : "pending" },
+        { id: "3", label: "Verify", state: selected.status === "completed" ? "done" : "pending" },
+        { id: "4", label: "Spec", state: selected.stop_reason === "spec_met" ? "done" : "pending" },
+      ];
+    }
+    return [
+      {
+        id: "i",
+        label: `Loop iter ${selected.iterations_used ?? 0}`,
+        state: selected.status === "running" ? "active" : selected.status,
+      },
+      {
+        id: "s",
+        label: `Spec v${selected.locked_spec_version ?? "—"}`,
+        state: selected.locked_spec_version ? "done" : "pending",
+      },
+    ];
+  }, [selected]);
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-background">
@@ -152,9 +312,7 @@ export function OrchestratorPage() {
             <Workflow className="size-4" />
           </div>
           <div>
-            <h1 className="text-base font-semibold tracking-tight">
-              {t("title")}
-            </h1>
+            <h1 className="text-base font-semibold tracking-tight">{t("title")}</h1>
             <p className="text-xs text-muted-foreground">{t("subtitle")}</p>
           </div>
         </div>
@@ -164,23 +322,64 @@ export function OrchestratorPage() {
               {skillHint}
             </span>
           ) : null}
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => void copyAgentInstructions()}
-          >
+          <Button type="button" variant="outline" size="sm" onClick={() => void copyAgentInstructions()}>
             {t("copyAgentInstructions")}
           </Button>
         </div>
       </header>
 
-      <div className="grid min-h-0 flex-1 grid-cols-1 gap-0 lg:grid-cols-[minmax(0,1fr)_320px]">
-        <main className="min-h-0 overflow-y-auto p-6">
-          <section className="mb-8 rounded-xl border border-border bg-card p-4 shadow-sm">
+      {/* HITL strip (M22) */}
+      {intent === "hitl" && selected ? (
+        <div
+          className="flex items-center justify-between border-b border-amber-500/40 bg-amber-500/10 px-6 py-3 transition-colors duration-200 ease-out"
+          role="status"
+        >
+          <p className="text-sm font-medium text-amber-900 dark:text-amber-100">
+            {t("hitlTitle")} · {selected.status}
+          </p>
+          <div className="flex gap-2">
+            <Button type="button" size="sm" variant="secondary" disabled={busy} onClick={() => void confirmSpec()}>
+              {t("confirmSpec")}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {/* Run strip */}
+      {selected && (intent === "run_loop" || intent === "run_graph" || intent === "review") ? (
+        <div className="flex flex-wrap items-center gap-2 border-b border-border px-6 py-2">
+          {runStrip.map((step) => (
+            <span
+              key={step.id}
+              className={cn(
+                "rounded-full border px-2.5 py-0.5 text-[11px] font-medium transition-colors duration-150 ease-out",
+                step.state === "done" || step.state === "completed"
+                  ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-800 dark:text-emerald-200"
+                  : step.state === "failed"
+                    ? "border-destructive/40 bg-destructive/10 text-destructive"
+                    : step.state === "active" || step.state === "running"
+                      ? "border-primary/40 bg-primary/10 text-primary"
+                      : "border-border text-muted-foreground",
+              )}
+            >
+              {step.label}
+            </span>
+          ))}
+          {selected.mode_reason ? (
+            <span className="text-[11px] text-muted-foreground truncate max-w-[40%]">
+              {selected.mode_reason}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="grid min-h-0 flex-1 grid-cols-1 gap-0 lg:grid-cols-[minmax(0,1fr)_300px]">
+        <main className="min-h-0 overflow-y-auto p-6 space-y-6">
+          {/* Setup */}
+          <section className="rounded-xl border border-border bg-card p-4 shadow-sm">
             <h2 className="mb-3 text-sm font-medium">{t("newRun")}</h2>
             <textarea
-              className="mb-3 min-h-[88px] w-full resize-y rounded-lg border border-input bg-background px-3 py-2 text-sm outline-none ring-offset-background transition-[box-shadow] duration-200 ease-out focus-visible:ring-2 focus-visible:ring-ring"
+              className="mb-3 min-h-[72px] w-full resize-y rounded-lg border border-input bg-background px-3 py-2 text-sm outline-none transition-[box-shadow] duration-200 ease-out focus-visible:ring-2 focus-visible:ring-ring"
               placeholder={t("goalPlaceholder")}
               value={goal}
               onChange={(e) => setGoal(e.target.value)}
@@ -202,25 +401,55 @@ export function OrchestratorPage() {
                 </button>
               ))}
             </div>
-            <Button
-              type="button"
-              size="sm"
-              disabled={busy || !goal.trim()}
-              onClick={() => void createRun()}
-            >
-              {busy ? (
-                <Loader2 className="size-3.5 animate-spin" />
-              ) : (
-                <Play className="size-3.5" />
-              )}
+            <Button type="button" size="sm" disabled={busy || !goal.trim()} onClick={() => void createRun()}>
+              {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Play className="size-3.5" />}
               <span className="ml-1.5">{t("create")}</span>
             </Button>
-            {error ? (
-              <p className="mt-3 text-xs text-destructive" role="alert">
-                {String(error)}
-              </p>
-            ) : null}
           </section>
+
+          {/* Spec editor for selected run */}
+          {selected ? (
+            <section className="rounded-xl border border-border bg-card p-4 shadow-sm">
+              <h2 className="mb-2 text-sm font-medium">{t("specTitle")}</h2>
+              <p className="mb-2 font-mono text-[10px] text-muted-foreground">{selected.id}</p>
+              <textarea
+                className="mb-3 min-h-[140px] w-full resize-y rounded-lg border border-input bg-background px-3 py-2 font-mono text-xs outline-none transition-[box-shadow] duration-200 ease-out focus-visible:ring-2 focus-visible:ring-ring"
+                value={specJson}
+                onChange={(e) => setSpecJson(e.target.value)}
+                spellCheck={false}
+              />
+              <div className="flex flex-wrap gap-2">
+                <Button type="button" size="sm" variant="secondary" disabled={busy} onClick={() => void draftSpec()}>
+                  {t("draftSpec")}
+                </Button>
+                <Button type="button" size="sm" variant="outline" disabled={busy} onClick={() => void confirmSpec()}>
+                  {t("confirmSpec")}
+                </Button>
+                <Button type="button" size="sm" disabled={busy} onClick={() => void startRun()}>
+                  <Play className="size-3.5" />
+                  <span className="ml-1.5">{t("startRun")}</span>
+                </Button>
+                {selected.status === "running" ? (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="destructive"
+                    disabled={busy}
+                    onClick={() => void cancelRun(selected.id)}
+                  >
+                    <Square className="size-3.5" />
+                    <span className="ml-1.5">{t("cancel")}</span>
+                  </Button>
+                ) : null}
+              </div>
+              {selected.stop_reason ? (
+                <p className="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <CheckCircle2 className="size-3.5" />
+                  {selected.status} · {selected.stop_reason}
+                </p>
+              ) : null}
+            </section>
+          ) : null}
 
           <section>
             <h2 className="mb-3 text-sm font-medium">{t("history")}</h2>
@@ -233,9 +462,7 @@ export function OrchestratorPage() {
               <div className="rounded-xl border border-dashed border-border px-6 py-10 text-center">
                 <GitBranch className="mx-auto mb-3 size-8 text-muted-foreground/60" />
                 <p className="text-sm font-medium">{t("emptyTitle")}</p>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  {t("emptyBody")}
-                </p>
+                <p className="mt-1 text-xs text-muted-foreground">{t("emptyBody")}</p>
               </div>
             ) : (
               <ul className="space-y-2">
@@ -261,27 +488,18 @@ export function OrchestratorPage() {
                           </p>
                         ) : null}
                       </div>
-                      {run.status === "running" ? (
-                        <Button
-                          type="button"
-                          size="icon"
-                          variant="ghost"
-                          className="size-8 shrink-0"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            void cancelRun(run.id);
-                          }}
-                          aria-label={t("cancel")}
-                        >
-                          <Square className="size-3.5" />
-                        </Button>
-                      ) : null}
                     </button>
                   </li>
                 ))}
               </ul>
             )}
           </section>
+
+          {error ? (
+            <p className="text-xs text-destructive" role="alert">
+              {error}
+            </p>
+          ) : null}
         </main>
 
         <aside className="hidden min-h-0 border-l border-border bg-muted/20 p-4 lg:block">
@@ -289,31 +507,30 @@ export function OrchestratorPage() {
             {t("roleChromePreview")}
           </h2>
           <ul className="space-y-2">
-            {demoRoles.map((r) => (
+            {rolesLive.map((r) => (
               <li
-                key={r.role}
+                key={`${r.role}-${r.instance ?? ""}`}
                 className={cn(
                   "rounded-lg border border-border border-l-4 px-3 py-2 text-xs transition-opacity duration-200 ease-out",
                   roleAccentClass(r.role),
                 )}
+                data-orch-role={r.role}
+                data-orch-activity={r.activity}
               >
-                <span className="font-medium">{r.header}</span>
+                <span className="font-medium">
+                  {composeRoleHeader({
+                    role: r.role,
+                    agentDisplay: "Codex",
+                    instance: r.instance,
+                    activity: r.activity,
+                  })}
+                </span>
               </li>
             ))}
           </ul>
-          {selected ? (
-            <div className="mt-6 rounded-lg border border-border bg-card p-3 text-xs">
-              <p className="font-medium">{t("selectedRun")}</p>
-              <p className="mt-1 break-all text-muted-foreground">{selected.id}</p>
-              <p className="mt-2 text-muted-foreground">
-                Spec v{selected.locked_spec_version ?? "—"}
-              </p>
-            </div>
-          ) : null}
+          <p className="mt-4 text-[10px] leading-relaxed text-muted-foreground">{t("roleChromeHint")}</p>
         </aside>
       </div>
     </div>
   );
 }
-
-type Stringish = string | null;

--- a/apps/web/src/features/orchestrator/components/OrchestratorPage.tsx
+++ b/apps/web/src/features/orchestrator/components/OrchestratorPage.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { GitBranch, Loader2, Play, Square, Workflow } from "lucide-react";
+import { Button } from "@workspace/ui/components/ui/button";
+import { cn } from "@workspace/ui/lib/utils";
+
+import {
+  composeRoleHeader,
+  roleAccentClass,
+  type OrchRole,
+} from "../lib/role-chrome";
+
+type RunRow = {
+  id: string;
+  goal: string;
+  status: string;
+  mode?: string | null;
+  requested_mode?: string;
+  stop_reason?: string | null;
+  home_cwd?: string;
+  locked_spec_version?: number | null;
+};
+
+/**
+ * Orchestrator management surface (APP-048).
+ * Emil craft: restrained motion (transform/opacity, ease-out, reduced-motion safe),
+ * clear hierarchy, no decorative ease-in bounce.
+ */
+export function OrchestratorPage() {
+  const t = useTranslations("Orchestrator");
+  const [runs, setRuns] = useState<RunRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Stringish>(null);
+  const [goal, setGoal] = useState("");
+  const [mode, setMode] = useState<"auto" | "loop" | "graph">("loop");
+  const [busy, setBusy] = useState(false);
+  const [selected, setSelected] = useState<RunRow | null>(null);
+  const [skillHint, setSkillHint] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/orchestrator/v1/runs?limit=30", {
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = await res.json();
+      const list = (body?.data?.runs ?? body?.runs ?? []) as RunRow[];
+      setRuns(Array.isArray(list) ? list : []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const copyAgentInstructions = async () => {
+    try {
+      const res = await fetch("/api/orchestrator/v1/skill-dir", {
+        credentials: "include",
+      });
+      const body = await res.json();
+      const data = body?.data ?? body;
+      const text =
+        data?.prompt ??
+        `Read the Atmos Orchestrator skill and use atmos orchestrator CLI.\n${data?.skill_dir ?? ""}`;
+      await navigator.clipboard.writeText(text);
+      setSkillHint(t("copiedSkill"));
+      window.setTimeout(() => setSkillHint(null), 2000);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const createRun = async () => {
+    if (!goal.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/orchestrator/v1/runs", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          goal: goal.trim(),
+          requested_mode: mode,
+          target_kind: "standalone",
+          home_cwd: undefined,
+        }),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || `HTTP ${res.status}`);
+      }
+      setGoal("");
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const cancelRun = async (id: string) => {
+    setBusy(true);
+    try {
+      await fetch(`/api/orchestrator/v1/runs/${id}/cancel`, {
+        method: "POST",
+        credentials: "include",
+      });
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const demoRoles = useMemo(
+    () =>
+      (
+        [
+          ["orchestrator", "Codex", null],
+          ["criteria", "Codex", null],
+          ["maker", "Codex", "iter 1"],
+          ["verify", "Codex", null],
+        ] as const
+      ).map(([role, agent, instance]) => ({
+        role: role as OrchRole,
+        header: composeRoleHeader({
+          role: role as OrchRole,
+          agentDisplay: agent,
+          instance,
+          activity: role === "criteria" ? "waiting_user" : "active",
+        }),
+      })),
+    [],
+  );
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <header className="flex shrink-0 items-center justify-between border-b border-border px-6 py-4">
+        <div className="flex items-center gap-3">
+          <div className="flex size-9 items-center justify-center rounded-lg bg-primary/10 text-primary transition-opacity duration-200 ease-out">
+            <Workflow className="size-4" />
+          </div>
+          <div>
+            <h1 className="text-base font-semibold tracking-tight">
+              {t("title")}
+            </h1>
+            <p className="text-xs text-muted-foreground">{t("subtitle")}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {skillHint ? (
+            <span className="text-xs text-muted-foreground transition-opacity duration-200 ease-out">
+              {skillHint}
+            </span>
+          ) : null}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void copyAgentInstructions()}
+          >
+            {t("copyAgentInstructions")}
+          </Button>
+        </div>
+      </header>
+
+      <div className="grid min-h-0 flex-1 grid-cols-1 gap-0 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <main className="min-h-0 overflow-y-auto p-6">
+          <section className="mb-8 rounded-xl border border-border bg-card p-4 shadow-sm">
+            <h2 className="mb-3 text-sm font-medium">{t("newRun")}</h2>
+            <textarea
+              className="mb-3 min-h-[88px] w-full resize-y rounded-lg border border-input bg-background px-3 py-2 text-sm outline-none ring-offset-background transition-[box-shadow] duration-200 ease-out focus-visible:ring-2 focus-visible:ring-ring"
+              placeholder={t("goalPlaceholder")}
+              value={goal}
+              onChange={(e) => setGoal(e.target.value)}
+            />
+            <div className="mb-3 flex flex-wrap gap-2">
+              {(["loop", "graph", "auto"] as const).map((m) => (
+                <button
+                  key={m}
+                  type="button"
+                  onClick={() => setMode(m)}
+                  className={cn(
+                    "rounded-full border px-3 py-1 text-xs font-medium transition-colors duration-150 ease-out",
+                    mode === m
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-border bg-background text-muted-foreground hover:bg-muted",
+                  )}
+                >
+                  {t(`mode.${m}`)}
+                </button>
+              ))}
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              disabled={busy || !goal.trim()}
+              onClick={() => void createRun()}
+            >
+              {busy ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <Play className="size-3.5" />
+              )}
+              <span className="ml-1.5">{t("create")}</span>
+            </Button>
+            {error ? (
+              <p className="mt-3 text-xs text-destructive" role="alert">
+                {String(error)}
+              </p>
+            ) : null}
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-sm font-medium">{t("history")}</h2>
+            {loading ? (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="size-4 animate-spin" />
+                {t("loading")}
+              </div>
+            ) : runs.length === 0 ? (
+              <div className="rounded-xl border border-dashed border-border px-6 py-10 text-center">
+                <GitBranch className="mx-auto mb-3 size-8 text-muted-foreground/60" />
+                <p className="text-sm font-medium">{t("emptyTitle")}</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {t("emptyBody")}
+                </p>
+              </div>
+            ) : (
+              <ul className="space-y-2">
+                {runs.map((run) => (
+                  <li key={run.id}>
+                    <button
+                      type="button"
+                      onClick={() => setSelected(run)}
+                      className={cn(
+                        "flex w-full items-start justify-between rounded-xl border border-border bg-card px-4 py-3 text-left transition-[background-color,border-color] duration-150 ease-out hover:bg-muted/40",
+                        selected?.id === run.id && "border-primary/40 bg-muted/30",
+                      )}
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium">{run.goal}</p>
+                        <p className="mt-0.5 text-xs text-muted-foreground">
+                          {run.mode ?? run.requested_mode} · {run.status}
+                          {run.stop_reason ? ` · ${run.stop_reason}` : ""}
+                        </p>
+                        {run.home_cwd ? (
+                          <p className="mt-0.5 truncate font-mono text-[10px] text-muted-foreground/80">
+                            {run.home_cwd}
+                          </p>
+                        ) : null}
+                      </div>
+                      {run.status === "running" ? (
+                        <Button
+                          type="button"
+                          size="icon"
+                          variant="ghost"
+                          className="size-8 shrink-0"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            void cancelRun(run.id);
+                          }}
+                          aria-label={t("cancel")}
+                        >
+                          <Square className="size-3.5" />
+                        </Button>
+                      ) : null}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </main>
+
+        <aside className="hidden min-h-0 border-l border-border bg-muted/20 p-4 lg:block">
+          <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {t("roleChromePreview")}
+          </h2>
+          <ul className="space-y-2">
+            {demoRoles.map((r) => (
+              <li
+                key={r.role}
+                className={cn(
+                  "rounded-lg border border-border border-l-4 px-3 py-2 text-xs transition-opacity duration-200 ease-out",
+                  roleAccentClass(r.role),
+                )}
+              >
+                <span className="font-medium">{r.header}</span>
+              </li>
+            ))}
+          </ul>
+          {selected ? (
+            <div className="mt-6 rounded-lg border border-border bg-card p-3 text-xs">
+              <p className="font-medium">{t("selectedRun")}</p>
+              <p className="mt-1 break-all text-muted-foreground">{selected.id}</p>
+              <p className="mt-2 text-muted-foreground">
+                Spec v{selected.locked_spec_version ?? "—"}
+              </p>
+            </div>
+          ) : null}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+type Stringish = string | null;

--- a/apps/web/src/features/orchestrator/lib/role-chrome.test.ts
+++ b/apps/web/src/features/orchestrator/lib/role-chrome.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  composeAccessibleName,
+  composeRoleHeader,
+  roleGlyph,
+  roleLabel,
+} from "./role-chrome";
+
+describe("orchestrator role chrome (M18b)", () => {
+  test("same agent brand differs by role", () => {
+    const maker = composeRoleHeader({
+      role: "maker",
+      agentDisplay: "Codex",
+      instance: "iter 1",
+    });
+    const verify = composeRoleHeader({
+      role: "verify",
+      agentDisplay: "Codex",
+    });
+    expect(maker).not.toBe(verify);
+    expect(maker).toContain("Maker");
+    expect(verify).toContain("Verify");
+    expect(maker).toContain("Codex");
+    expect(verify).toContain("Codex");
+  });
+
+  test("multi-maker instance labels required in composition", () => {
+    const a = composeRoleHeader({
+      role: "maker",
+      agentDisplay: "Codex",
+      instance: "unit-api",
+    });
+    const b = composeRoleHeader({
+      role: "maker",
+      agentDisplay: "Codex",
+      instance: "unit-ui",
+    });
+    expect(a).not.toBe(b);
+    expect(a).toContain("unit-api");
+    expect(b).toContain("unit-ui");
+  });
+
+  test("activity appears when not active", () => {
+    const h = composeRoleHeader({
+      role: "criteria",
+      agentDisplay: "Claude Code",
+      activity: "waiting_user",
+    });
+    expect(h).toContain("waiting_user");
+  });
+
+  test("accessible name includes glyph and role", () => {
+    const name = composeAccessibleName({
+      role: "orchestrator",
+      agentDisplay: "Codex",
+      activity: "active",
+    });
+    expect(name).toContain(roleGlyph("orchestrator"));
+    expect(name).toContain(roleLabel("orchestrator"));
+  });
+});

--- a/apps/web/src/features/orchestrator/lib/role-chrome.ts
+++ b/apps/web/src/features/orchestrator/lib/role-chrome.ts
@@ -1,0 +1,106 @@
+/**
+ * APP-048 M18b — terminal / card header composition for Orchestrator roles.
+ * Pure helper for unit tests and UI.
+ */
+
+export type OrchRole = "orchestrator" | "criteria" | "maker" | "verify";
+
+export type RoleActivity =
+  | "queued"
+  | "active"
+  | "waiting_user"
+  | "succeeded"
+  | "failed"
+  | "cancelled";
+
+const ROLE_LABEL_EN: Record<OrchRole, string> = {
+  orchestrator: "Planner",
+  criteria: "Criteria",
+  maker: "Maker",
+  verify: "Verify",
+};
+
+const ROLE_SHORT_EN: Record<OrchRole, string> = {
+  orchestrator: "Pln",
+  criteria: "Crit",
+  maker: "Mk",
+  verify: "Vf",
+};
+
+const ROLE_GLYPH: Record<OrchRole, string> = {
+  orchestrator: "O",
+  criteria: "C",
+  maker: "M",
+  verify: "V",
+};
+
+export function roleLabel(role: OrchRole, locale: "en" | "zh" = "en"): string {
+  if (locale === "zh") {
+    const zh: Record<OrchRole, string> = {
+      orchestrator: "规划",
+      criteria: "判定",
+      maker: "执行",
+      verify: "验收",
+    };
+    return zh[role];
+  }
+  return ROLE_LABEL_EN[role];
+}
+
+export function roleShort(role: OrchRole): string {
+  return ROLE_SHORT_EN[role];
+}
+
+export function roleGlyph(role: OrchRole): string {
+  return ROLE_GLYPH[role];
+}
+
+/** Full scan-line header (role + instance + activity when useful). */
+export function composeRoleHeader(input: {
+  role: OrchRole;
+  agentDisplay: string;
+  instance?: string | null;
+  activity?: RoleActivity | string | null;
+}): string {
+  const label = ROLE_LABEL_EN[input.role];
+  const parts = [`[${label}]`, input.agentDisplay.trim() || "Agent"];
+  if (input.instance?.trim()) {
+    parts.push(input.instance.trim());
+  }
+  const activity = input.activity?.trim();
+  if (activity && activity !== "active") {
+    parts.push(`(${activity})`);
+  }
+  return parts.join(" ");
+}
+
+/** Accessible name prioritizes role even when truncated UI drops goal text. */
+export function composeAccessibleName(input: {
+  role: OrchRole;
+  agentDisplay: string;
+  instance?: string | null;
+  activity?: string | null;
+}): string {
+  return [
+    roleGlyph(input.role),
+    roleLabel(input.role),
+    input.agentDisplay,
+    input.instance,
+    input.activity,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+export function roleAccentClass(role: OrchRole): string {
+  switch (role) {
+    case "orchestrator":
+      return "border-l-violet-500 bg-violet-500/10 text-violet-700 dark:text-violet-300";
+    case "criteria":
+      return "border-l-amber-500 bg-amber-500/10 text-amber-800 dark:text-amber-300";
+    case "maker":
+      return "border-l-blue-500 bg-blue-500/10 text-blue-700 dark:text-blue-300";
+    case "verify":
+      return "border-l-emerald-500 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+  }
+}

--- a/crates/ai-usage/src/refresh.rs
+++ b/crates/ai-usage/src/refresh.rs
@@ -187,9 +187,7 @@ pub(crate) fn persist_all_provider_switch(provider_ids: &[String], switch_enable
 }
 
 /// Batch-write switch + footer carousel flags without refreshing provider data.
-pub(crate) fn persist_provider_visibility_batch(
-    prefs: &[(String, bool, bool)],
-) {
+pub(crate) fn persist_provider_visibility_batch(prefs: &[(String, bool, bool)]) {
     if prefs.is_empty() {
         return;
     }

--- a/crates/ai-usage/src/service.rs
+++ b/crates/ai-usage/src/service.rs
@@ -233,9 +233,8 @@ impl UsageService {
         };
 
         for provider in &mut overview.providers {
-            if let Some((_, switch_enabled, footer_carousel_show)) = full_prefs
-                .iter()
-                .find(|(id, _, _)| id == &provider.id)
+            if let Some((_, switch_enabled, footer_carousel_show)) =
+                full_prefs.iter().find(|(id, _, _)| id == &provider.id)
             {
                 provider.switch_enabled = *switch_enabled;
                 provider.footer_carousel_show = *footer_carousel_show;

--- a/crates/browser-cookies/src/keychain.rs
+++ b/crates/browser-cookies/src/keychain.rs
@@ -135,6 +135,7 @@ mod tests {
         assert_eq!(account_for("Brave"), "Brave");
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn process_cache_returns_stored_value_without_reentry() {
         let service = "__atmos_test_keychain_cache__";
@@ -142,11 +143,8 @@ mod tests {
             let mut guard = passphrase_cache().lock().expect("cache lock");
             guard.insert(service.to_string(), "cached-pass".to_string());
         }
-        #[cfg(target_os = "macos")]
-        {
-            let got = safe_storage_passphrase(service).expect("cached hit");
-            assert_eq!(got, "cached-pass");
-        }
+        let got = safe_storage_passphrase(service).expect("cached hit");
+        assert_eq!(got, "cached-pass");
         if let Ok(mut guard) = passphrase_cache().lock() {
             guard.remove(service);
         }

--- a/crates/browser-cookies/src/keychain.rs
+++ b/crates/browser-cookies/src/keychain.rs
@@ -14,13 +14,17 @@
 //! stick across rebuilds/restarts. Fixing that requires a stable Developer ID
 //! signature — not a local secret file.
 
-use std::collections::HashMap;
-use std::sync::{Mutex, OnceLock};
-
 use crate::types::ExtractError;
 
+#[cfg(target_os = "macos")]
+use std::collections::HashMap;
+#[cfg(target_os = "macos")]
+use std::sync::{Mutex, OnceLock};
+
+#[cfg(target_os = "macos")]
 static PASSPHRASE_CACHE: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
 
+#[cfg(target_os = "macos")]
 fn passphrase_cache() -> &'static Mutex<HashMap<String, String>> {
     PASSPHRASE_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }

--- a/crates/core-engine/src/git/changes.rs
+++ b/crates/core-engine/src/git/changes.rs
@@ -273,14 +273,15 @@ impl GitEngine {
                 }
 
                 if y != ' ' {
-                    let counts = unstaged_numstat
-                        .get(&file_path)
-                        .copied()
-                        .unwrap_or(NumstatCounts {
-                            additions: 0,
-                            deletions: 0,
-                            is_binary: false,
-                        });
+                    let counts =
+                        unstaged_numstat
+                            .get(&file_path)
+                            .copied()
+                            .unwrap_or(NumstatCounts {
+                                additions: 0,
+                                deletions: 0,
+                                is_binary: false,
+                            });
                     if !counts.is_binary {
                         total_additions += counts.additions;
                         total_deletions += counts.deletions;
@@ -923,13 +924,9 @@ impl GitEngine {
         let old_classified = old_side.as_ref().map(Self::classify_side);
         let new_classified = new_side.as_ref().map(Self::classify_side);
 
-        let any_binary = old_classified
-            .as_ref()
-            .is_some_and(|s| s.is_binary)
+        let any_binary = old_classified.as_ref().is_some_and(|s| s.is_binary)
             || new_classified.as_ref().is_some_and(|s| s.is_binary);
-        let any_too_large = old_classified
-            .as_ref()
-            .is_some_and(|s| s.too_large)
+        let any_too_large = old_classified.as_ref().is_some_and(|s| s.too_large)
             || new_classified.as_ref().is_some_and(|s| s.too_large);
 
         let kind = if any_binary {
@@ -1026,5 +1023,4 @@ impl GitEngine {
             path.to_string()
         }
     }
-
 }

--- a/crates/core-engine/src/git/mod.rs
+++ b/crates/core-engine/src/git/mod.rs
@@ -52,9 +52,10 @@ fn run_git_bytes(repo_path: &Path, args: &[&str]) -> Result<Vec<u8>> {
 
 /// Like `run_git` but returns Ok(None) instead of Err on non-zero exit.
 fn try_run_git(repo_path: &Path, args: &[&str]) -> Result<Option<String>> {
-    Ok(try_run_git_bytes(repo_path, args)?.map(|bytes| {
-        String::from_utf8_lossy(&bytes).to_string()
-    }))
+    Ok(
+        try_run_git_bytes(repo_path, args)?
+            .map(|bytes| String::from_utf8_lossy(&bytes).to_string()),
+    )
 }
 
 /// Like `run_git_bytes` but returns Ok(None) instead of Err on non-zero exit.
@@ -84,14 +85,9 @@ fn try_run_git_bytes(repo_path: &Path, args: &[&str]) -> Result<Option<Vec<u8>>>
 pub fn show_git_blob_bytes(repo_path: &Path, rev_path_spec: &str) -> Result<Vec<u8>> {
     let spec = rev_path_spec.trim();
     if !is_safe_blob_show_spec(spec) {
-        return Err(EngineError::Git(
-            "Invalid git blob show-spec".to_string(),
-        ));
+        return Err(EngineError::Git("Invalid git blob show-spec".to_string()));
     }
-    let oid = run_git(
-        repo_path,
-        &["rev-parse", "--verify", "--quiet", spec],
-    )?;
+    let oid = run_git(repo_path, &["rev-parse", "--verify", "--quiet", spec])?;
     let oid = oid.trim();
     if oid.is_empty() {
         return Err(EngineError::Git("Blob object not found".to_string()));

--- a/crates/core-engine/src/lib.rs
+++ b/crates/core-engine/src/lib.rs
@@ -36,6 +36,6 @@ pub use tmux::{
     is_inline_mouse_tui_command, is_shell_command, pane_command_basename,
     resolve_mouse_tracking_restore, should_restore_tui_mouse_tracking, MouseEventMode, MouseFormat,
     MouseModeState, TmuxEngine, TmuxInstallPlan, TmuxPaneCapturePage, TmuxPaneSnapshot,
-    TmuxSessionInfo, TmuxVersion, TmuxWindowAtmosMetadata, TmuxWindowInfo, ATMOS_MOUSE_TRACKING_OPTION,
-    DEFAULT_TUI_MOUSE_RESTORE,
+    TmuxSessionInfo, TmuxVersion, TmuxWindowAtmosMetadata, TmuxWindowInfo,
+    ATMOS_MOUSE_TRACKING_OPTION, DEFAULT_TUI_MOUSE_RESTORE,
 };

--- a/crates/core-engine/src/tmux/capture.rs
+++ b/crates/core-engine/src/tmux/capture.rs
@@ -233,11 +233,8 @@ impl TmuxEngine {
             .get_pane_mouse_tracking(session_name, window_index)
             .ok()
             .flatten();
-        let (restore_mouse_tracking, mouse_tracking_sequence) = resolve_mouse_tracking_restore(
-            observed,
-            metadata.alternate,
-            &current_command,
-        );
+        let (restore_mouse_tracking, mouse_tracking_sequence) =
+            resolve_mouse_tracking_restore(observed, metadata.alternate, &current_command);
 
         Ok(TmuxPaneCapturePage {
             snapshot: TmuxPaneSnapshot {
@@ -291,11 +288,8 @@ impl TmuxEngine {
             .get_pane_mouse_tracking(session_name, window_index)
             .ok()
             .flatten();
-        let (restore_mouse_tracking, mouse_tracking_sequence) = resolve_mouse_tracking_restore(
-            observed,
-            metadata.alternate,
-            &current_command,
-        );
+        let (restore_mouse_tracking, mouse_tracking_sequence) =
+            resolve_mouse_tracking_restore(observed, metadata.alternate, &current_command);
 
         Ok(TmuxPaneSnapshot {
             data,

--- a/crates/core-engine/src/tmux/mouse_modes.rs
+++ b/crates/core-engine/src/tmux/mouse_modes.rs
@@ -380,7 +380,10 @@ mod tests {
         let encoded = state.encode_persist();
         assert_eq!(encoded, "any+sgr+focus");
         assert_eq!(MouseModeState::decode_persist(&encoded), Some(state));
-        assert_eq!(MouseModeState::decode_persist("none"), Some(MouseModeState::default()));
+        assert_eq!(
+            MouseModeState::decode_persist("none"),
+            Some(MouseModeState::default())
+        );
         assert_eq!(MouseModeState::decode_persist(""), None);
         assert_eq!(MouseModeState::decode_persist("bogus"), None);
     }

--- a/crates/core-service/src/lib.rs
+++ b/crates/core-service/src/lib.rs
@@ -46,8 +46,8 @@ pub use service::message_push::MessagePushService;
 pub use service::notification::NotificationService;
 pub use service::orchestrator::{
     compose_role_header, skill_dir_output, Budget, CompiledGraph, CreateRunReq, Criterion,
-    JudgmentSpecBody, ModeProposal, OrchMode, OrchRole, OrchestratorService, RunRecord,
-    SensorSpec, SharedOrchestratorService,
+    JudgmentSpecBody, ModeProposal, OrchMode, OrchRole, OrchestratorService, RunRecord, SensorSpec,
+    SharedOrchestratorService,
 };
 pub use service::project::ProjectService;
 pub use service::review::ReviewService;

--- a/crates/core-service/src/lib.rs
+++ b/crates/core-service/src/lib.rs
@@ -44,6 +44,11 @@ pub use service::local_services::{
 };
 pub use service::message_push::MessagePushService;
 pub use service::notification::NotificationService;
+pub use service::orchestrator::{
+    compose_role_header, skill_dir_output, Budget, CompiledGraph, CreateRunReq, Criterion,
+    JudgmentSpecBody, ModeProposal, OrchMode, OrchRole, OrchestratorService, RunRecord,
+    SensorSpec, SharedOrchestratorService,
+};
 pub use service::project::ProjectService;
 pub use service::review::ReviewService;
 pub use service::terminal::{

--- a/crates/core-service/src/service/automation/agents.rs
+++ b/crates/core-service/src/service/automation/agents.rs
@@ -480,9 +480,7 @@ fn agent_yolo_mode_enabled() -> bool {
 }
 
 fn definition_launch_flags(definition: &TerminalAgentDefinition, yolo: bool) -> (String, String) {
-    if yolo
-        && (definition.yolo_params.is_some() || definition.yolo_interactive_params.is_some())
-    {
+    if yolo && (definition.yolo_params.is_some() || definition.yolo_interactive_params.is_some()) {
         let params = definition
             .yolo_params
             .clone()
@@ -1500,7 +1498,10 @@ mod tests {
             && agent.stdout_parser == StdoutParser::CodexJsonl));
         assert!(agents.iter().any(|agent| agent.id == "cursor"
             && agent.cmd == "cursor-agent"
-            && agent.yolo_params.as_deref().is_some_and(|p| p.contains("--force --print"))
+            && agent
+                .yolo_params
+                .as_deref()
+                .is_some_and(|p| p.contains("--force --print"))
             && agent.yolo_interactive_params.as_deref() == Some("--yolo")));
         assert!(agents.iter().any(|agent| {
             agent.id == "antigravity"

--- a/crates/core-service/src/service/automation/agents.rs
+++ b/crates/core-service/src/service/automation/agents.rs
@@ -1626,12 +1626,14 @@ mod tests {
 
     #[test]
     fn s11_supported_builtin_agent_commands_use_declared_prompt_strategies() {
+        // Expectations follow non-YOLO `params` from builtin_agents.json.
+        // YOLO permission flags live in `yoloParams` and are selected via
+        // definition_launch_flags when agent_cli.yolo_mode is enabled.
         let cases = [
             (
                 "claude",
                 PromptStrategy::Arg,
                 vec![
-                    "--dangerously-skip-permissions",
                     "--print",
                     "--output-format",
                     "stream-json",
@@ -1644,58 +1646,49 @@ mod tests {
             (
                 "codex",
                 PromptStrategy::Arg,
-                vec![
-                    "exec",
-                    "--json",
-                    "--dangerously-bypass-approvals-and-sandbox",
-                ],
+                vec!["exec", "--json"],
                 PromptDelivery::Arg,
                 StdoutParser::CodexJsonl,
             ),
             (
                 "gemini",
                 PromptStrategy::PromptFlag,
-                vec!["--yolo", "--output-format", "stream-json", "--prompt"],
+                vec!["--output-format", "stream-json", "--prompt"],
                 PromptDelivery::Arg,
                 StdoutParser::CursorStreamJson,
             ),
             (
                 "antigravity",
                 PromptStrategy::PromptFlag,
-                vec![
-                    "--dangerously-skip-permissions",
-                    "--output-format",
-                    "stream-json",
-                    "-p",
-                ],
+                vec!["--output-format", "stream-json", "-p"],
                 PromptDelivery::Arg,
                 StdoutParser::CursorStreamJson,
             ),
             (
                 "devin",
                 PromptStrategy::Arg,
-                vec!["--permission-mode", "dangerous", "--print"],
+                vec!["--print"],
                 PromptDelivery::Arg,
                 StdoutParser::Plain,
             ),
             (
                 "amp",
                 PromptStrategy::Stdin,
-                vec!["--dangerously-allow-all", "--execute"],
+                vec!["--execute"],
                 PromptDelivery::Stdin,
                 StdoutParser::Plain,
             ),
             (
                 "droid",
                 PromptStrategy::Arg,
-                vec!["exec", "--skip-permissions-unsafe"],
+                vec!["exec"],
                 PromptDelivery::Arg,
                 StdoutParser::Plain,
             ),
             (
                 "opencode",
                 PromptStrategy::Arg,
-                vec!["run", "--format", "json", "--dangerously-skip-permissions"],
+                vec!["run", "--format", "json"],
                 PromptDelivery::Arg,
                 StdoutParser::OpencodeJson,
             ),
@@ -1710,9 +1703,7 @@ mod tests {
                 "cursor",
                 PromptStrategy::Arg,
                 vec![
-                    "--force",
                     "--print",
-                    "--trust",
                     "--output-format",
                     "stream-json",
                     "--stream-partial-output",
@@ -1723,21 +1714,21 @@ mod tests {
             (
                 "kilocode",
                 PromptStrategy::Arg,
-                vec!["run", "--auto", "--format", "json"],
+                vec!["run", "--format", "json"],
                 PromptDelivery::Arg,
                 StdoutParser::OpencodeJson,
             ),
             (
                 "kiro",
                 PromptStrategy::Arg,
-                vec!["chat", "--agent", "atmos", "--trust-all-tools"],
+                vec!["chat", "--agent", "atmos"],
                 PromptDelivery::Arg,
                 StdoutParser::Plain,
             ),
             (
                 "commandcode",
                 PromptStrategy::Arg,
-                vec!["--trust", "--yolo", "--skip-onboarding", "--print"],
+                vec!["--skip-onboarding", "--print"],
                 PromptDelivery::Arg,
                 StdoutParser::Plain,
             ),
@@ -1758,19 +1749,14 @@ mod tests {
             (
                 "hermes",
                 PromptStrategy::PromptFlag,
-                vec!["chat", "--yolo", "-q"],
+                vec!["chat", "-q"],
                 PromptDelivery::Arg,
                 StdoutParser::Plain,
             ),
             (
                 "grok-build",
                 PromptStrategy::PromptFlag,
-                vec![
-                    "--always-approve",
-                    "--output-format",
-                    "streaming-json",
-                    "-p",
-                ],
+                vec!["--output-format", "streaming-json", "-p"],
                 PromptDelivery::Arg,
                 StdoutParser::GrokStreamingJson,
             ),

--- a/crates/core-service/src/service/automation/builtin_agent_upgrade.rs
+++ b/crates/core-service/src/service/automation/builtin_agent_upgrade.rs
@@ -84,10 +84,7 @@ fn trim_str(value: Option<&str>) -> Option<String> {
 }
 
 /// True when the user entry is a real customization (not just YOLO on/off defaults).
-fn is_user_customized_command(
-    entry: &Value,
-    definition: &TerminalAgentDefinitionPublic,
-) -> bool {
+fn is_user_customized_command(entry: &Value, definition: &TerminalAgentDefinitionPublic) -> bool {
     let (yolo_params, yolo_interactive) = definition_launch_flags_for_upgrade(definition, true);
     let (safe_params, safe_interactive) = definition_launch_flags_for_upgrade(definition, false);
 
@@ -103,9 +100,7 @@ fn is_user_customized_command(
         }
     }
 
-    if let Some(interactive) =
-        trim_str(entry.get("interactiveFlags").and_then(|v| v.as_str()))
-    {
+    if let Some(interactive) = trim_str(entry.get("interactiveFlags").and_then(|v| v.as_str())) {
         if interactive != yolo_interactive && interactive != safe_interactive {
             return true;
         }
@@ -149,10 +144,7 @@ fn strip_non_custom_overrides(
             }
         }
         // If nothing meaningful remains besides id (+ optional enabled:true), drop later.
-        let enabled_false = obj
-            .get("enabled")
-            .and_then(|v| v.as_bool())
-            == Some(false);
+        let enabled_false = obj.get("enabled").and_then(|v| v.as_bool()) == Some(false);
         let has_cmd = trim_str(obj.get("cmd").and_then(|v| v.as_str())).is_some();
         if !enabled_false && !has_cmd {
             // Mark for removal by clearing id-only shell — caller filters.
@@ -246,8 +238,8 @@ pub fn ensure_builtin_terminal_agents_upgraded() -> Result<bool> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::agents::definition_launch_flags_for_upgrade;
+    use super::*;
 
     #[test]
     fn yolo_matching_flags_are_not_customized() {

--- a/crates/core-service/src/service/automation/mod.rs
+++ b/crates/core-service/src/service/automation/mod.rs
@@ -37,7 +37,6 @@ use super::workspace::WorkspaceService;
 use agents::automation_agent_capabilities;
 pub use agents::AutomationAgentCapability;
 pub mod builtin_agent_upgrade;
-pub use builtin_agent_upgrade::ensure_builtin_terminal_agents_upgraded;
 pub(crate) use agents::{
     resolve_automation_agent, AutomationAgentInvocation, AutomationCommandInput, PromptDelivery,
     StdoutParser,
@@ -47,6 +46,7 @@ pub use agents::{
     AutomationAgentRunConfig, TerminalAgentCliStatus, TerminalAgentModelCatalog,
     TerminalAgentModelCatalogSource, TerminalAgentModelCatalogStatus, TerminalAgentModelOption,
 };
+pub use builtin_agent_upgrade::ensure_builtin_terminal_agents_upgraded;
 pub use events::{AutomationDefinitionChange, AutomationEvent};
 pub use external_trigger::{
     ExternalTriggerOutcome, ExternalTriggerRejectReason, ExternalTriggerRejection,

--- a/crates/core-service/src/service/git_commit_message.rs
+++ b/crates/core-service/src/service/git_commit_message.rs
@@ -506,6 +506,7 @@ mod tests {
                 additions: 1,
                 deletions: 0,
                 staged: false,
+                is_binary: false,
             })
             .collect::<Vec<_>>();
 
@@ -524,6 +525,7 @@ mod tests {
                 additions: 5,
                 deletions: 2,
                 staged: false,
+                is_binary: false,
             })
             .collect::<Vec<_>>();
 

--- a/crates/core-service/src/service/mod.rs
+++ b/crates/core-service/src/service/mod.rs
@@ -12,6 +12,7 @@ pub mod llm_text_generation;
 pub mod local_services;
 pub mod message_push;
 pub mod notification;
+pub mod orchestrator;
 pub mod project;
 pub mod review;
 pub mod skill;

--- a/crates/core-service/src/service/orchestrator/artifacts.rs
+++ b/crates/core-service/src/service/orchestrator/artifacts.rs
@@ -1,0 +1,126 @@
+//! Artifact paths + atomic JSON publish under run dir.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::error::{Result, ServiceError};
+
+pub fn ensure_run_layout(artifact_dir: &Path) -> Result<()> {
+    for sub in [
+        "specs",
+        "evidence",
+        "verdicts",
+        "prompts",
+        "attempts",
+        "nodes",
+        "workspaces",
+    ] {
+        fs::create_dir_all(artifact_dir.join(sub)).map_err(|e| {
+            ServiceError::Processing(format!("create artifact dir {sub}: {e}"))
+        })?;
+    }
+    Ok(())
+}
+
+pub fn write_json_atomic(path: &Path, value: &impl Serialize) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| ServiceError::Processing(format!("mkdir parent: {e}")))?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    let data = serde_json::to_vec_pretty(value)
+        .map_err(|e| ServiceError::Processing(format!("serialize json: {e}")))?;
+    fs::write(&tmp, &data).map_err(|e| ServiceError::Processing(format!("write tmp: {e}")))?;
+    // Validate re-parse before rename
+    let _: serde_json::Value = serde_json::from_slice(&data)
+        .map_err(|e| ServiceError::Processing(format!("invalid json before rename: {e}")))?;
+    fs::rename(&tmp, path).map_err(|e| ServiceError::Processing(format!("rename atomic: {e}")))?;
+    Ok(())
+}
+
+pub fn read_json_file<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T> {
+    let data =
+        fs::read(path).map_err(|e| ServiceError::Processing(format!("read {}: {e}", path.display())))?;
+    serde_json::from_slice(&data)
+        .map_err(|e| ServiceError::Processing(format!("parse {}: {e}", path.display())))
+}
+
+/// Reject partial/truncated JSON (must parse fully as T).
+pub fn accept_artifact<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T> {
+    if !path.exists() {
+        return Err(ServiceError::Validation(format!(
+            "artifact missing: {}",
+            path.display()
+        )));
+    }
+    // Refuse .tmp
+    if path
+        .extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| e == "tmp" || e.ends_with("tmp"))
+    {
+        return Err(ServiceError::Validation(
+            "refusing temporary artifact path".into(),
+        ));
+    }
+    read_json_file(path)
+}
+
+pub fn orchestrator_root() -> PathBuf {
+    if let Ok(dir) = std::env::var("ATMOS_ORCHESTRATOR_DIR") {
+        return PathBuf::from(dir);
+    }
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    home.join(".atmos").join("orchestrator")
+}
+
+pub fn board_dir() -> PathBuf {
+    orchestrator_root().join("boards")
+}
+
+pub fn runs_dir() -> PathBuf {
+    orchestrator_root().join("runs")
+}
+
+pub fn assert_not_canvas_path(path: &Path) -> Result<()> {
+    let s = path.to_string_lossy();
+    if s.contains("/.atmos/canvas/") || s.contains("\\.atmos\\canvas\\") {
+        return Err(ServiceError::Validation(
+            "orchestrator must not write under ordinary canvas directory".into(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    #[test]
+    fn atomic_write_and_accept() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("mode_proposal.json");
+        write_json_atomic(&path, &json!({"mode": "loop", "reason": "x"})).unwrap();
+        let v: serde_json::Value = accept_artifact(&path).unwrap();
+        assert_eq!(v["mode"], "loop");
+    }
+
+    #[test]
+    fn reject_missing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nope.json");
+        assert!(accept_artifact::<serde_json::Value>(&path).is_err());
+    }
+
+    #[test]
+    fn canvas_path_forbidden() {
+        let p = PathBuf::from("/Users/x/.atmos/canvas/Default.atmos.tldr");
+        assert!(assert_not_canvas_path(&p).is_err());
+        let p2 = PathBuf::from("/Users/x/.atmos/orchestrator/boards/x.atmos.tldr");
+        assert!(assert_not_canvas_path(&p2).is_ok());
+    }
+}

--- a/crates/core-service/src/service/orchestrator/artifacts.rs
+++ b/crates/core-service/src/service/orchestrator/artifacts.rs
@@ -75,14 +75,6 @@ pub fn orchestrator_root() -> PathBuf {
     home.join(".atmos").join("orchestrator")
 }
 
-pub fn board_dir() -> PathBuf {
-    orchestrator_root().join("boards")
-}
-
-pub fn runs_dir() -> PathBuf {
-    orchestrator_root().join("runs")
-}
-
 pub fn assert_not_canvas_path(path: &Path) -> Result<()> {
     let s = path.to_string_lossy();
     if s.contains("/.atmos/canvas/") || s.contains("\\.atmos\\canvas\\") {

--- a/crates/core-service/src/service/orchestrator/artifacts.rs
+++ b/crates/core-service/src/service/orchestrator/artifacts.rs
@@ -17,9 +17,8 @@ pub fn ensure_run_layout(artifact_dir: &Path) -> Result<()> {
         "nodes",
         "workspaces",
     ] {
-        fs::create_dir_all(artifact_dir.join(sub)).map_err(|e| {
-            ServiceError::Processing(format!("create artifact dir {sub}: {e}"))
-        })?;
+        fs::create_dir_all(artifact_dir.join(sub))
+            .map_err(|e| ServiceError::Processing(format!("create artifact dir {sub}: {e}")))?;
     }
     Ok(())
 }
@@ -41,8 +40,8 @@ pub fn write_json_atomic(path: &Path, value: &impl Serialize) -> Result<()> {
 }
 
 pub fn read_json_file<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T> {
-    let data =
-        fs::read(path).map_err(|e| ServiceError::Processing(format!("read {}: {e}", path.display())))?;
+    let data = fs::read(path)
+        .map_err(|e| ServiceError::Processing(format!("read {}: {e}", path.display())))?;
     serde_json::from_slice(&data)
         .map_err(|e| ServiceError::Processing(format!("parse {}: {e}", path.display())))
 }

--- a/crates/core-service/src/service/orchestrator/graph_compile.rs
+++ b/crates/core-service/src/service/orchestrator/graph_compile.rs
@@ -1,0 +1,334 @@
+//! Graph compile + join readiness (APP-048).
+
+use std::collections::{HashMap, HashSet};
+
+use super::schemas::{CompiledGraph, GraphEdge, GraphNode};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompileError(pub String);
+
+impl std::fmt::Display for CompileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+const MAX_NODES: usize = 32;
+const MAX_FANOUT: usize = 4;
+
+pub fn compile_graph(graph: &CompiledGraph) -> Result<CompiledGraph, CompileError> {
+    if graph.nodes.is_empty() {
+        return Err(CompileError("graph has no nodes".into()));
+    }
+    if graph.nodes.len() > MAX_NODES {
+        return Err(CompileError(format!(
+            "too many nodes (max {MAX_NODES})"
+        )));
+    }
+
+    let ids: HashSet<_> = graph.nodes.iter().map(|n| n.id.as_str()).collect();
+    if ids.len() != graph.nodes.len() {
+        return Err(CompileError("duplicate node ids".into()));
+    }
+
+    for e in &graph.edges {
+        if e.kind != "control" && e.kind != "data" {
+            return Err(CompileError(format!("edge {} invalid kind", e.id)));
+        }
+        if !ids.contains(e.from.as_str()) || !ids.contains(e.to.as_str()) {
+            return Err(CompileError(format!(
+                "edge {} unbound endpoints",
+                e.id
+            )));
+        }
+    }
+
+    // Detect cycles without max_cycles on back-edges
+    if has_cycle_without_max(&graph.nodes, &graph.edges) {
+        return Err(CompileError(
+            "cycle detected without max_cycles on edge".into(),
+        ));
+    }
+
+    // Multi-writer on home without isolation
+    let writers: Vec<_> = graph
+        .nodes
+        .iter()
+        .filter(|n| n.kind == "maker" && n.writes && n.isolation != "worktree")
+        .collect();
+    if writers.len() > 1 {
+        // concurrent writers without worktree isolation
+        return Err(CompileError(
+            "multiple writing makers without isolation=worktree on home tree".into(),
+        ));
+    }
+
+    // Fan-out width
+    let mut out_deg: HashMap<&str, usize> = HashMap::new();
+    for e in &graph.edges {
+        if e.kind == "control" {
+            *out_deg.entry(e.from.as_str()).or_default() += 1;
+        }
+    }
+    for (from, deg) in out_deg {
+        if deg > MAX_FANOUT {
+            return Err(CompileError(format!(
+                "fan-out from {from} exceeds {MAX_FANOUT}"
+            )));
+        }
+    }
+
+    let mut entry = graph.entry.clone();
+    if entry.is_empty() {
+        // nodes with no inbound control edges
+        let mut inbound = HashSet::new();
+        for e in &graph.edges {
+            if e.kind == "control" {
+                inbound.insert(e.to.as_str());
+            }
+        }
+        entry = graph
+            .nodes
+            .iter()
+            .filter(|n| !inbound.contains(n.id.as_str()))
+            .map(|n| n.id.clone())
+            .collect();
+    }
+    if entry.is_empty() {
+        return Err(CompileError("no entry nodes".into()));
+    }
+    for e in &entry {
+        if !ids.contains(e.as_str()) {
+            return Err(CompileError(format!("entry {e} unknown")));
+        }
+    }
+
+    // Reachability from entry via control edges
+    let mut adj: HashMap<&str, Vec<&str>> = HashMap::new();
+    for e in &graph.edges {
+        if e.kind == "control" {
+            adj.entry(e.from.as_str()).or_default().push(e.to.as_str());
+        }
+    }
+    let mut seen = HashSet::new();
+    let mut stack: Vec<&str> = entry.iter().map(|s| s.as_str()).collect();
+    while let Some(n) = stack.pop() {
+        if !seen.insert(n) {
+            continue;
+        }
+        if let Some(next) = adj.get(n) {
+            stack.extend(next.iter().copied());
+        }
+    }
+    for n in &graph.nodes {
+        if !seen.contains(n.id.as_str()) {
+            return Err(CompileError(format!(
+                "unreachable node {}",
+                n.id
+            )));
+        }
+    }
+
+    Ok(CompiledGraph {
+        nodes: graph.nodes.clone(),
+        edges: graph.edges.clone(),
+        entry,
+    })
+}
+
+fn has_cycle_without_max(nodes: &[GraphNode], edges: &[GraphEdge]) -> bool {
+    let ids: HashSet<_> = nodes.iter().map(|n| n.id.as_str()).collect();
+    let mut adj: HashMap<&str, Vec<(&str, bool)>> = HashMap::new();
+    for e in edges {
+        if e.kind != "control" {
+            continue;
+        }
+        if !ids.contains(e.from.as_str()) {
+            continue;
+        }
+        let allows_cycle = e.max_cycles.unwrap_or(0) >= 1;
+        adj.entry(e.from.as_str())
+            .or_default()
+            .push((e.to.as_str(), allows_cycle));
+    }
+
+    #[derive(Clone, Copy)]
+    enum Color {
+        White,
+        Gray,
+        Black,
+    }
+    let mut color: HashMap<&str, Color> = ids.iter().map(|id| (*id, Color::White)).collect();
+
+    fn dfs<'a>(
+        u: &'a str,
+        color: &mut HashMap<&'a str, Color>,
+        adj: &HashMap<&'a str, Vec<(&'a str, bool)>>,
+    ) -> bool {
+        color.insert(u, Color::Gray);
+        if let Some(nexts) = adj.get(u) {
+            for (v, allows_cycle) in nexts {
+                match color.get(v).copied().unwrap_or(Color::White) {
+                    Color::Gray if !*allows_cycle => return true,
+                    Color::White => {
+                        if dfs(v, color, adj) {
+                            return true;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        color.insert(u, Color::Black);
+        false
+    }
+
+    let id_list: Vec<&str> = ids.iter().copied().collect();
+    for id in id_list {
+        if matches!(color.get(id), Some(Color::White)) {
+            if dfs(id, &mut color, &adj) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeTerminal {
+    Succeeded,
+    Failed,
+    Cancelled,
+    TimedOut,
+    Skipped,
+    Running,
+}
+
+/// Join readiness: all required inbound must be terminal; fail-closed on fail/hang/missing.
+pub fn join_ready(
+    node_id: &str,
+    edges: &[GraphEdge],
+    states: &HashMap<String, NodeTerminal>,
+) -> Result<(), String> {
+    let required_preds: Vec<&str> = edges
+        .iter()
+        .filter(|e| e.to == node_id && e.kind == "control" && e.required)
+        .map(|e| e.from.as_str())
+        .collect();
+
+    if required_preds.is_empty() {
+        return Ok(());
+    }
+
+    let expected = required_preds.len();
+    let mut observed = 0usize;
+    for p in &required_preds {
+        let st = states.get(*p).copied().unwrap_or(NodeTerminal::Running);
+        match st {
+            NodeTerminal::Running => {
+                return Err(format!("join incomplete: predecessor {p} still running"));
+            }
+            NodeTerminal::Failed | NodeTerminal::Cancelled | NodeTerminal::TimedOut => {
+                return Err(format!(
+                    "join fail-closed: predecessor {p} ended {:?}",
+                    st
+                ));
+            }
+            NodeTerminal::Succeeded | NodeTerminal::Skipped => {
+                observed += 1;
+            }
+        }
+    }
+    if observed != expected {
+        return Err(format!(
+            "join incomplete: expected {expected} got {observed}"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(id: &str, kind: &str) -> GraphNode {
+        GraphNode {
+            id: id.into(),
+            kind: kind.into(),
+            label: id.into(),
+            agent_id: None,
+            fresh_context: None,
+            writes: kind == "maker",
+            isolation: "none".into(),
+            node_timeout_ms: None,
+            workspace_guid: None,
+        }
+    }
+
+    fn edge(id: &str, from: &str, to: &str) -> GraphEdge {
+        GraphEdge {
+            id: id.into(),
+            from: from.into(),
+            to: to.into(),
+            kind: "control".into(),
+            required: true,
+            max_cycles: None,
+        }
+    }
+
+    #[test]
+    fn sequence_compiles() {
+        let g = CompiledGraph {
+            nodes: vec![node("a", "maker"), node("b", "verify")],
+            edges: vec![edge("e1", "a", "b")],
+            entry: vec!["a".into()],
+        };
+        assert!(compile_graph(&g).is_ok());
+    }
+
+    #[test]
+    fn empty_fails() {
+        assert!(compile_graph(&CompiledGraph::default()).is_err());
+    }
+
+    #[test]
+    fn multi_writer_without_isolation_fails() {
+        let mut a = node("a", "maker");
+        a.writes = true;
+        let mut b = node("b", "maker");
+        b.writes = true;
+        let g = CompiledGraph {
+            nodes: vec![a, b, node("j", "join")],
+            edges: vec![edge("e1", "a", "j"), edge("e2", "b", "j")],
+            entry: vec!["a".into(), "b".into()],
+        };
+        let err = compile_graph(&g).unwrap_err();
+        assert!(err.0.contains("isolation"));
+    }
+
+    #[test]
+    fn join_fail_closed_on_failed_pred() {
+        let edges = vec![edge("e1", "a", "j"), edge("e2", "b", "j")];
+        let mut states = HashMap::new();
+        states.insert("a".into(), NodeTerminal::Succeeded);
+        states.insert("b".into(), NodeTerminal::Failed);
+        assert!(join_ready("j", &edges, &states).is_err());
+    }
+
+    #[test]
+    fn join_incomplete_when_running() {
+        let edges = vec![edge("e1", "a", "j")];
+        let mut states = HashMap::new();
+        states.insert("a".into(), NodeTerminal::Running);
+        assert!(join_ready("j", &edges, &states).is_err());
+    }
+
+    #[test]
+    fn join_ok_when_all_succeeded() {
+        let edges = vec![edge("e1", "a", "j"), edge("e2", "b", "j")];
+        let mut states = HashMap::new();
+        states.insert("a".into(), NodeTerminal::Succeeded);
+        states.insert("b".into(), NodeTerminal::Succeeded);
+        assert!(join_ready("j", &edges, &states).is_ok());
+    }
+}

--- a/crates/core-service/src/service/orchestrator/graph_compile.rs
+++ b/crates/core-service/src/service/orchestrator/graph_compile.rs
@@ -162,11 +162,7 @@ fn has_cycle_without_max(nodes: &[GraphNode], edges: &[GraphEdge]) -> bool {
             for (v, allows_cycle) in nexts {
                 match color.get(v).copied().unwrap_or(Color::White) {
                     Color::Gray if !*allows_cycle => return true,
-                    Color::White => {
-                        if dfs(v, color, adj) {
-                            return true;
-                        }
-                    }
+                    Color::White if dfs(v, color, adj) => return true,
                     _ => {}
                 }
             }
@@ -177,10 +173,8 @@ fn has_cycle_without_max(nodes: &[GraphNode], edges: &[GraphEdge]) -> bool {
 
     let id_list: Vec<&str> = ids.iter().copied().collect();
     for id in id_list {
-        if matches!(color.get(id), Some(Color::White)) {
-            if dfs(id, &mut color, &adj) {
-                return true;
-            }
+        if matches!(color.get(id), Some(Color::White)) && dfs(id, &mut color, &adj) {
+            return true;
         }
     }
     false

--- a/crates/core-service/src/service/orchestrator/graph_compile.rs
+++ b/crates/core-service/src/service/orchestrator/graph_compile.rs
@@ -21,9 +21,7 @@ pub fn compile_graph(graph: &CompiledGraph) -> Result<CompiledGraph, CompileErro
         return Err(CompileError("graph has no nodes".into()));
     }
     if graph.nodes.len() > MAX_NODES {
-        return Err(CompileError(format!(
-            "too many nodes (max {MAX_NODES})"
-        )));
+        return Err(CompileError(format!("too many nodes (max {MAX_NODES})")));
     }
 
     let ids: HashSet<_> = graph.nodes.iter().map(|n| n.id.as_str()).collect();
@@ -36,10 +34,7 @@ pub fn compile_graph(graph: &CompiledGraph) -> Result<CompiledGraph, CompileErro
             return Err(CompileError(format!("edge {} invalid kind", e.id)));
         }
         if !ids.contains(e.from.as_str()) || !ids.contains(e.to.as_str()) {
-            return Err(CompileError(format!(
-                "edge {} unbound endpoints",
-                e.id
-            )));
+            return Err(CompileError(format!("edge {} unbound endpoints", e.id)));
         }
     }
 
@@ -122,10 +117,7 @@ pub fn compile_graph(graph: &CompiledGraph) -> Result<CompiledGraph, CompileErro
     }
     for n in &graph.nodes {
         if !seen.contains(n.id.as_str()) {
-            return Err(CompileError(format!(
-                "unreachable node {}",
-                n.id
-            )));
+            return Err(CompileError(format!("unreachable node {}", n.id)));
         }
     }
 
@@ -229,10 +221,7 @@ pub fn join_ready(
                 return Err(format!("join incomplete: predecessor {p} still running"));
             }
             NodeTerminal::Failed | NodeTerminal::Cancelled | NodeTerminal::TimedOut => {
-                return Err(format!(
-                    "join fail-closed: predecessor {p} ended {:?}",
-                    st
-                ));
+                return Err(format!("join fail-closed: predecessor {p} ended {:?}", st));
             }
             NodeTerminal::Succeeded | NodeTerminal::Skipped => {
                 observed += 1;

--- a/crates/core-service/src/service/orchestrator/mod.rs
+++ b/crates/core-service/src/service/orchestrator/mod.rs
@@ -584,13 +584,8 @@ impl OrchestratorService {
         node_id: Option<&str>,
     ) -> Result<PathBuf> {
         let run = self.load_run(run_id)?;
-        let cwd = PathBuf::from(self.resolve_cwd(
-            &run,
-            Some(role.as_str()),
-            node_id,
-        ));
-        fs::create_dir_all(&cwd)
-            .map_err(|e| ServiceError::Processing(format!("role cwd: {e}")))?;
+        let cwd = PathBuf::from(self.resolve_cwd(&run, Some(role.as_str()), node_id));
+        fs::create_dir_all(&cwd).map_err(|e| ServiceError::Processing(format!("role cwd: {e}")))?;
 
         let inv_id = Uuid::new_v4().to_string();
         let role_dir = PathBuf::from(&run.artifact_dir)
@@ -884,17 +879,20 @@ impl OrchestratorService {
                         ready = false;
                         break;
                     }
-                    Some(NodeTerminal::Failed | NodeTerminal::Cancelled | NodeTerminal::TimedOut) => {
+                    Some(
+                        NodeTerminal::Failed | NodeTerminal::Cancelled | NodeTerminal::TimedOut,
+                    ) if n.kind == "join" || n.kind == "verify" || n.kind == "reduce" => {
                         // fail-closed at join or when processing node with failed required pred
-                        if n.kind == "join" || n.kind == "verify" || n.kind == "reduce" {
-                            run.status = RunStatus::Failed.as_str().into();
-                            run.stop_reason = Some(StopReason::JoinIncomplete.as_str().into());
-                            run.finished_at = Some(Utc::now().to_rfc3339());
-                            run.updated_at = Utc::now().to_rfc3339();
-                            self.save_run(&run)?;
-                            return Ok(run);
-                        }
+                        run.status = RunStatus::Failed.as_str().into();
+                        run.stop_reason = Some(StopReason::JoinIncomplete.as_str().into());
+                        run.finished_at = Some(Utc::now().to_rfc3339());
+                        run.updated_at = Utc::now().to_rfc3339();
+                        self.save_run(&run)?;
+                        return Ok(run);
                     }
+                    Some(
+                        NodeTerminal::Failed | NodeTerminal::Cancelled | NodeTerminal::TimedOut,
+                    ) => {}
                     _ => {}
                 }
             }
@@ -933,9 +931,8 @@ impl OrchestratorService {
                 let _ = verify_cwd;
                 let _ = self.role_invoke(run_id, OrchRole::Verify, Some(&n.id));
                 Self::node_fixture_outcome(n)
-            } else if n.kind == "sensor" {
-                Self::node_fixture_outcome(n)
             } else {
+                // sensor and other node kinds use fixture outcomes in this runtime path
                 Self::node_fixture_outcome(n)
             };
 
@@ -1019,12 +1016,7 @@ impl OrchestratorService {
         Ok(run)
     }
 
-    fn fail_run_msg(
-        &self,
-        mut run: RunRecord,
-        reason: StopReason,
-        msg: &str,
-    ) -> Result<RunRecord> {
+    fn fail_run_msg(&self, mut run: RunRecord, reason: StopReason, msg: &str) -> Result<RunRecord> {
         let _ = fs::write(
             PathBuf::from(&run.artifact_dir).join("fail_detail.txt"),
             msg,
@@ -1440,11 +1432,9 @@ mod integration_tests {
         assert_eq!(done.status, "completed");
         assert_eq!(done.stop_reason.as_deref(), Some("spec_met"));
         // role_invoke wrote maker/verify artifacts
-        assert!(
-            PathBuf::from(&done.artifact_dir)
-                .join("work_state.json")
-                .exists()
-        );
+        assert!(PathBuf::from(&done.artifact_dir)
+            .join("work_state.json")
+            .exists());
     }
 
     #[test]
@@ -1518,12 +1508,9 @@ mod integration_tests {
         let before = snapshot_immutable_mtimes(&["tests/guard.rs".into()], &home_cwd);
         std::thread::sleep(std::time::Duration::from_millis(1100));
         fs::write(&protected, b"// tampered\n").unwrap();
-        assert!(check_immutable_not_modified(
-            &["tests/guard.rs".into()],
-            &home_cwd,
-            &before
-        )
-        .is_err());
+        assert!(
+            check_immutable_not_modified(&["tests/guard.rs".into()], &home_cwd, &before).is_err()
+        );
 
         // Also ensure start with integrity path can fail when file changes during maker:
         // Pre-mutate won't trigger because snapshot is after create; instead monkey by
@@ -1812,24 +1799,17 @@ mod integration_tests {
         let ctx = svc.context_pack(&run.id).unwrap();
         assert_eq!(ctx["home"]["cwd"], home_cwd.display().to_string());
 
-        let child = svc
-            .workspace_create(&run.id, "iso", None)
-            .unwrap();
+        let child = svc.workspace_create(&run.id, "iso", None).unwrap();
         svc.workspace_use(&run.id, &child.workspace_guid, Some("maker"), None)
             .unwrap();
         let run2 = svc.load_run(&run.id).unwrap();
-        assert_eq!(
-            svc.resolve_cwd(&run2, Some("maker"), None),
-            child.path
-        );
+        assert_eq!(svc.resolve_cwd(&run2, Some("maker"), None), child.path);
         fs::write(PathBuf::from(&child.path).join("ORCH_RESULT.txt"), "x").unwrap();
         let merged = svc.workspace_merge(&run.id, &child.workspace_guid).unwrap();
-        assert!(
-            merged
-                .workspaces
-                .iter()
-                .any(|w| w.workspace_guid == child.workspace_guid && w.status == "merged")
-        );
+        assert!(merged
+            .workspaces
+            .iter()
+            .any(|w| w.workspace_guid == child.workspace_guid && w.status == "merged"));
 
         let finished = svc.start_run(&run.id).unwrap();
         assert_eq!(finished.status, "completed");

--- a/crates/core-service/src/service/orchestrator/mod.rs
+++ b/crates/core-service/src/service/orchestrator/mod.rs
@@ -1,0 +1,1332 @@
+//! APP-048 Orchestrator service — file-backed runs under `~/.atmos/orchestrator/`.
+
+mod artifacts;
+mod graph_compile;
+mod runtime;
+mod schemas;
+mod sensors;
+
+pub use graph_compile::{compile_graph, join_ready, CompileError, NodeTerminal};
+pub use runtime::*;
+pub use schemas::*;
+pub use sensors::{evaluate_acceptance, immutable_paths_from_spec, run_sensor};
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+use crate::error::{Result, ServiceError};
+
+use artifacts::{
+    accept_artifact, assert_not_canvas_path, ensure_run_layout, orchestrator_root, read_json_file,
+    write_json_atomic,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunRecord {
+    pub id: String,
+    pub goal: String,
+    pub requested_mode: String,
+    pub mode: Option<String>,
+    pub mode_reason: Option<String>,
+    pub status: String,
+    pub stop_reason: Option<String>,
+    pub target_kind: String,
+    pub project_guid: Option<String>,
+    pub workspace_guid: Option<String>,
+    pub home_cwd: String,
+    pub board_id: Option<String>,
+    pub locked_spec_version: Option<i32>,
+    pub budget: Budget,
+    pub graph: Option<CompiledGraph>,
+    pub carry_from_run_id: Option<String>,
+    pub artifact_dir: String,
+    pub maker_agent_id: Option<String>,
+    pub planner_agent_id: Option<String>,
+    pub criteria_agent_id: Option<String>,
+    pub verify_agent_id: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub started_at: Option<String>,
+    pub finished_at: Option<String>,
+    pub iterations_used: u32,
+    pub maker_invocations: u32,
+    pub progress_key: Option<String>,
+    pub progress_streak: u32,
+    pub workspaces: Vec<RunWorkspaceRecord>,
+    pub role_bindings: Vec<RoleBindingRecord>,
+    /// Wall clock start unix ms when running.
+    pub wall_started_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunWorkspaceRecord {
+    pub id: String,
+    pub workspace_guid: String,
+    pub kind: String,
+    pub purpose: Option<String>,
+    pub status: String,
+    pub path: String,
+    pub base_ref: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoleBindingRecord {
+    pub role: Option<String>,
+    pub node_id: Option<String>,
+    pub workspace_guid: String,
+    pub cwd: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateRunReq {
+    pub goal: String,
+    pub requested_mode: String,
+    pub target_kind: String,
+    pub project_guid: Option<String>,
+    pub workspace_guid: Option<String>,
+    pub home_cwd: String,
+    pub budget: Option<Budget>,
+    pub carry_from_run_id: Option<String>,
+    pub maker_agent_id: Option<String>,
+    pub planner_agent_id: Option<String>,
+    pub criteria_agent_id: Option<String>,
+    pub verify_agent_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct OrchestratorEvent {
+    pub run_id: String,
+    pub kind: String,
+    pub payload: serde_json::Value,
+}
+
+pub struct OrchestratorService {
+    root: PathBuf,
+    event_tx: broadcast::Sender<OrchestratorEvent>,
+}
+
+impl Default for OrchestratorService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OrchestratorService {
+    pub fn new() -> Self {
+        let (event_tx, _) = broadcast::channel(256);
+        Self {
+            root: orchestrator_root(),
+            event_tx,
+        }
+    }
+
+    pub fn with_root(root: PathBuf) -> Self {
+        let (event_tx, _) = broadcast::channel(256);
+        Self { root, event_tx }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<OrchestratorEvent> {
+        self.event_tx.subscribe()
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn runs_path(&self) -> PathBuf {
+        self.root.join("runs")
+    }
+
+    fn boards_path(&self) -> PathBuf {
+        self.root.join("boards")
+    }
+
+    fn run_dir(&self, id: &str) -> PathBuf {
+        self.runs_path().join(id)
+    }
+
+    fn run_json_path(&self, id: &str) -> PathBuf {
+        self.run_dir(id).join("run.json")
+    }
+
+    pub fn load_run(&self, id: &str) -> Result<RunRecord> {
+        let path = self.run_json_path(id);
+        if !path.exists() {
+            return Err(ServiceError::NotFound(format!("run {id}")));
+        }
+        read_json_file(&path)
+    }
+
+    fn save_run(&self, run: &RunRecord) -> Result<()> {
+        let path = self.run_json_path(&run.id);
+        assert_not_canvas_path(&path)?;
+        write_json_atomic(&path, run)
+    }
+
+    fn emit(&self, run_id: &str, kind: &str, payload: serde_json::Value) {
+        let _ = self.event_tx.send(OrchestratorEvent {
+            run_id: run_id.into(),
+            kind: kind.into(),
+            payload,
+        });
+    }
+
+    pub fn status(&self) -> serde_json::Value {
+        serde_json::json!({
+            "ok": true,
+            "orchestrator_root": self.root.display().to_string(),
+            "feature": "orchestrator",
+            "version": "0.1.0",
+        })
+    }
+
+    pub fn create_run(&self, req: CreateRunReq) -> Result<RunRecord> {
+        let mode = OrchMode::parse(&req.requested_mode).ok_or_else(|| {
+            ServiceError::Validation(format!("invalid mode {}", req.requested_mode))
+        })?;
+        let target = TargetKind::parse(&req.target_kind).ok_or_else(|| {
+            ServiceError::Validation(format!("invalid target_kind {}", req.target_kind))
+        })?;
+        if req.goal.trim().is_empty() {
+            return Err(ServiceError::Validation("goal required".into()));
+        }
+        if req.home_cwd.trim().is_empty() {
+            return Err(ServiceError::Validation("home_cwd required".into()));
+        }
+        match target {
+            TargetKind::Workspace if req.workspace_guid.is_none() => {
+                return Err(ServiceError::Validation(
+                    "workspace_guid required for workspace target".into(),
+                ));
+            }
+            TargetKind::Project if req.project_guid.is_none() => {
+                return Err(ServiceError::Validation(
+                    "project_guid required for project target".into(),
+                ));
+            }
+            _ => {}
+        }
+
+        let id = Uuid::new_v4().to_string();
+        let artifact_dir = self.run_dir(&id);
+        fs::create_dir_all(&artifact_dir)
+            .map_err(|e| ServiceError::Processing(format!("mkdir run: {e}")))?;
+        ensure_run_layout(&artifact_dir)?;
+        assert_not_canvas_path(&artifact_dir)?;
+
+        // Ensure boards dir exists and is under orchestrator (not canvas)
+        let boards = self.boards_path();
+        fs::create_dir_all(&boards)
+            .map_err(|e| ServiceError::Processing(format!("mkdir boards: {e}")))?;
+        assert_not_canvas_path(&boards)?;
+
+        let now = Utc::now().to_rfc3339();
+        let home_ws = RunWorkspaceRecord {
+            id: Uuid::new_v4().to_string(),
+            workspace_guid: req
+                .workspace_guid
+                .clone()
+                .unwrap_or_else(|| format!("home-{id}")),
+            kind: "home".into(),
+            purpose: Some("run home".into()),
+            status: "active".into(),
+            path: req.home_cwd.clone(),
+            base_ref: None,
+            created_at: now.clone(),
+        };
+
+        let run = RunRecord {
+            id: id.clone(),
+            goal: req.goal,
+            requested_mode: mode.as_str().into(),
+            mode: None,
+            mode_reason: None,
+            status: RunStatus::DraftingSpec.as_str().into(),
+            stop_reason: None,
+            target_kind: target.as_str().into(),
+            project_guid: req.project_guid,
+            workspace_guid: req.workspace_guid,
+            home_cwd: req.home_cwd.clone(),
+            board_id: Some(format!("board-{id}")),
+            locked_spec_version: None,
+            budget: req.budget.unwrap_or_default(),
+            graph: None,
+            carry_from_run_id: req.carry_from_run_id,
+            artifact_dir: artifact_dir.display().to_string(),
+            maker_agent_id: req.maker_agent_id,
+            planner_agent_id: req.planner_agent_id,
+            criteria_agent_id: req.criteria_agent_id,
+            verify_agent_id: req.verify_agent_id,
+            created_at: now.clone(),
+            updated_at: now,
+            started_at: None,
+            finished_at: None,
+            iterations_used: 0,
+            maker_invocations: 0,
+            progress_key: None,
+            progress_streak: 0,
+            workspaces: vec![home_ws],
+            role_bindings: vec![],
+            wall_started_ms: None,
+        };
+        self.save_run(&run)?;
+        self.emit(
+            &id,
+            "run_updated",
+            serde_json::to_value(&run).unwrap_or_default(),
+        );
+        let _ = mode; // silence if unused in some builds
+        Ok(run)
+    }
+
+    pub fn list_runs(&self, limit: usize) -> Result<Vec<RunRecord>> {
+        let dir = self.runs_path();
+        if !dir.exists() {
+            return Ok(vec![]);
+        }
+        let mut runs = Vec::new();
+        for entry in fs::read_dir(&dir)
+            .map_err(|e| ServiceError::Processing(format!("read runs: {e}")))?
+        {
+            let entry = entry.map_err(|e| ServiceError::Processing(e.to_string()))?;
+            let run_json = entry.path().join("run.json");
+            if run_json.exists() {
+                if let Ok(r) = read_json_file::<RunRecord>(&run_json) {
+                    runs.push(r);
+                }
+            }
+        }
+        runs.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        runs.truncate(limit.max(1));
+        Ok(runs)
+    }
+
+    pub fn resolve_cwd(&self, run: &RunRecord, role: Option<&str>, node_id: Option<&str>) -> String {
+        for b in &run.role_bindings {
+            if role.is_some() && b.role.as_deref() == role {
+                return b.cwd.clone();
+            }
+            if node_id.is_some() && b.node_id.as_deref() == node_id {
+                return b.cwd.clone();
+            }
+        }
+        run.home_cwd.clone()
+    }
+
+    pub fn draft_spec_from_body(
+        &self,
+        run_id: &str,
+        body: JudgmentSpecBody,
+    ) -> Result<(RunRecord, i32)> {
+        if body.acceptance.is_empty() {
+            return Err(ServiceError::Validation(
+                "acceptance criteria required".into(),
+            ));
+        }
+        let mut run = self.load_run(run_id)?;
+        if RunStatus::parse(&run.status).is_some_and(|s| s.is_terminal()) {
+            return Err(ServiceError::Validation("run already finished".into()));
+        }
+
+        let version = run.locked_spec_version.unwrap_or(0) + 1;
+        if version as u32 > run.budget.max_spec_versions {
+            run.status = RunStatus::Failed.as_str().into();
+            run.stop_reason = Some(StopReason::CriteriaUnsatisfiable.as_str().into());
+            run.finished_at = Some(Utc::now().to_rfc3339());
+            self.save_run(&run)?;
+            return Err(ServiceError::Validation(
+                "max_spec_versions exceeded".into(),
+            ));
+        }
+
+        // weaken check against previous
+        if let Some(prev_v) = run.locked_spec_version {
+            let prev_path = PathBuf::from(&run.artifact_dir)
+                .join("specs")
+                .join(format!("v{prev_v}.json"));
+            if prev_path.exists() {
+                let prev: JudgmentSpecBody = read_json_file(&prev_path)?;
+                if spec_weakens(&prev, &body) && !requires_user_confirm(&body) {
+                    // force confirm on weaken
+                }
+            }
+        }
+
+        let path = PathBuf::from(&run.artifact_dir)
+            .join("specs")
+            .join(format!("v{version}.json"));
+        write_json_atomic(&path, &body)?;
+
+        let need_confirm = requires_user_confirm(&body) || {
+            // if weaken vs previous, need confirm
+            if let Some(prev_v) = run.locked_spec_version {
+                let prev_path = PathBuf::from(&run.artifact_dir)
+                    .join("specs")
+                    .join(format!("v{prev_v}.json"));
+                if prev_path.exists() {
+                    let prev: JudgmentSpecBody = read_json_file(&prev_path)?;
+                    spec_weakens(&prev, &body)
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        };
+
+        run.locked_spec_version = Some(version);
+        run.status = if need_confirm {
+            RunStatus::AwaitingSpecConfirm.as_str().into()
+        } else {
+            // auto-confirm sensor-only low risk
+            RunStatus::AwaitingSpecConfirm.as_str().into()
+        };
+        // Store confirm flag in a sidecar
+        let meta = serde_json::json!({
+            "version": version,
+            "requires_user_confirm": need_confirm,
+            "confirmed": !need_confirm,
+            "confirmed_by": if need_confirm { serde_json::Value::Null } else { serde_json::json!("auto") },
+        });
+        write_json_atomic(
+            &PathBuf::from(&run.artifact_dir).join("specs").join(format!("v{version}.meta.json")),
+            &meta,
+        )?;
+
+        if !need_confirm {
+            // auto-confirm path: leave status as awaiting then auto flip
+            run.status = RunStatus::DraftingSpec.as_str().into(); // ready to start after confirm helper
+            // mark ready
+            run.status = "spec_ready".into(); // intermediate — start will accept
+        }
+
+        run.updated_at = Utc::now().to_rfc3339();
+        self.save_run(&run)?;
+        Ok((run, version))
+    }
+
+    pub fn confirm_spec(&self, run_id: &str, version: i32) -> Result<RunRecord> {
+        let mut run = self.load_run(run_id)?;
+        if run.locked_spec_version != Some(version) {
+            return Err(ServiceError::Validation("spec version mismatch".into()));
+        }
+        let meta_path = PathBuf::from(&run.artifact_dir)
+            .join("specs")
+            .join(format!("v{version}.meta.json"));
+        let mut meta: serde_json::Value = if meta_path.exists() {
+            read_json_file(&meta_path)?
+        } else {
+            serde_json::json!({})
+        };
+        meta["confirmed"] = serde_json::json!(true);
+        meta["confirmed_by"] = serde_json::json!("user");
+        write_json_atomic(&meta_path, &meta)?;
+        run.status = "spec_ready".into();
+        run.updated_at = Utc::now().to_rfc3339();
+        self.save_run(&run)?;
+        Ok(run)
+    }
+
+    pub fn get_spec(&self, run_id: &str, version: Option<i32>) -> Result<JudgmentSpecBody> {
+        let run = self.load_run(run_id)?;
+        let v = version.or(run.locked_spec_version).ok_or_else(|| {
+            ServiceError::NotFound("no spec".into())
+        })?;
+        let path = PathBuf::from(&run.artifact_dir)
+            .join("specs")
+            .join(format!("v{v}.json"));
+        read_json_file(&path)
+    }
+
+    fn spec_confirmed(&self, run: &RunRecord) -> Result<bool> {
+        let Some(v) = run.locked_spec_version else {
+            return Ok(false);
+        };
+        let meta_path = PathBuf::from(&run.artifact_dir)
+            .join("specs")
+            .join(format!("v{v}.meta.json"));
+        if !meta_path.exists() {
+            return Ok(false);
+        }
+        let meta: serde_json::Value = read_json_file(&meta_path)?;
+        Ok(meta.get("confirmed").and_then(|c| c.as_bool()) == Some(true))
+    }
+
+    pub fn start_run(&self, run_id: &str) -> Result<RunRecord> {
+        let mut run = self.load_run(run_id)?;
+        if run.locked_spec_version.is_none() {
+            return Err(ServiceError::Validation("ORCH_SPEC_REQUIRED".into()));
+        }
+        if !self.spec_confirmed(&run)? {
+            // auto-confirm if meta says no require
+            let v = run.locked_spec_version.unwrap();
+            let meta_path = PathBuf::from(&run.artifact_dir)
+                .join("specs")
+                .join(format!("v{v}.meta.json"));
+            if meta_path.exists() {
+                let meta: serde_json::Value = read_json_file(&meta_path)?;
+                if meta.get("requires_user_confirm").and_then(|c| c.as_bool()) == Some(true)
+                    && meta.get("confirmed").and_then(|c| c.as_bool()) != Some(true)
+                {
+                    return Err(ServiceError::Validation(
+                        "ORCH_SPEC_CONFIRM_REQUIRED".into(),
+                    ));
+                }
+                if meta.get("confirmed").and_then(|c| c.as_bool()) != Some(true) {
+                    // treat as confirmed for sensor-only
+                    let mut m = meta;
+                    m["confirmed"] = serde_json::json!(true);
+                    m["confirmed_by"] = serde_json::json!("auto");
+                    write_json_atomic(&meta_path, &m)?;
+                }
+            }
+        }
+
+        let requested = OrchMode::parse(&run.requested_mode)
+            .ok_or_else(|| ServiceError::Validation("bad mode".into()))?;
+
+        // Load proposal if auto or graph
+        let proposal_path = PathBuf::from(&run.artifact_dir).join("mode_proposal.json");
+        let proposal = if proposal_path.exists() {
+            Some(accept_artifact::<ModeProposal>(&proposal_path)?)
+        } else {
+            None
+        };
+
+        if requested == OrchMode::Auto && proposal.is_none() {
+            return Err(ServiceError::Validation(
+                "auto mode requires mode_proposal.json from planner".into(),
+            ));
+        }
+
+        // Forced loop/graph: skip planner (M17b)
+        let (effective, reason) = resolve_effective_mode(requested, proposal.as_ref())
+            .map_err(ServiceError::Validation)?;
+
+        if effective == EffectiveMode::Graph {
+            if let Some(p) = &proposal {
+                if let Some(g) = &p.graph {
+                    let compiled = compile_graph(g).map_err(|e| {
+                        ServiceError::Validation(format!("ORCH_GRAPH_COMPILE_FAILED: {}", e.0))
+                    })?;
+                    run.graph = Some(compiled);
+                } else if p.topology_hint.as_deref() == Some("diamond") && p.named_units.len() >= 2 {
+                    run.graph = Some(diamond_from_units(&p.named_units));
+                    compile_graph(run.graph.as_ref().unwrap()).map_err(|e| {
+                        ServiceError::Validation(format!("ORCH_GRAPH_COMPILE_FAILED: {}", e.0))
+                    })?;
+                }
+            }
+            if run.graph.is_none() {
+                // demote already handled in resolve for auto; for forced graph without topology fail
+                if requested == OrchMode::Graph {
+                    return Err(ServiceError::Validation(
+                        "ORCH_GRAPH_COMPILE_FAILED: missing graph".into(),
+                    ));
+                }
+            }
+        }
+
+        run.mode = Some(effective.as_str().into());
+        run.mode_reason = Some(reason);
+        run.status = RunStatus::Running.as_str().into();
+        run.started_at = Some(Utc::now().to_rfc3339());
+        run.wall_started_ms = Some(now_ms());
+        run.updated_at = Utc::now().to_rfc3339();
+        self.save_run(&run)?;
+        self.emit(
+            run_id,
+            "run_updated",
+            serde_json::to_value(&run).unwrap_or_default(),
+        );
+        Ok(run)
+    }
+
+    /// Fixture-friendly Loop tick: runs sensors in home (or bound) cwd; no real terminal agent.
+    pub fn tick_loop_fixture(&self, run_id: &str) -> Result<RunRecord> {
+        let mut run = self.load_run(run_id)?;
+        if run.status != RunStatus::Running.as_str() {
+            return Err(ServiceError::Validation("run not running".into()));
+        }
+        if run.mode.as_deref() != Some("loop") {
+            return Err(ServiceError::Validation("not a loop run".into()));
+        }
+
+        let elapsed = run
+            .wall_started_ms
+            .map(|s| now_ms().saturating_sub(s))
+            .unwrap_or(0);
+        match check_budget(
+            &run.budget,
+            run.iterations_used,
+            run.maker_invocations,
+            elapsed,
+        ) {
+            BudgetCheck::Iterations => {
+                return self.fail_run(run, StopReason::BudgetIterations);
+            }
+            BudgetCheck::Wall => return self.fail_run(run, StopReason::BudgetWall),
+            BudgetCheck::Makers => return self.fail_run(run, StopReason::BudgetMakers),
+            BudgetCheck::Ok => {}
+        }
+
+        run.iterations_used += 1;
+        run.maker_invocations += 1;
+
+        let spec = self.get_spec(run_id, run.locked_spec_version)?;
+        let cwd = PathBuf::from(self.resolve_cwd(&run, Some("maker"), None));
+
+        // Sensor integrity snapshot would be here; fixture skips file mtime unless paths exist
+
+        let results = evaluate_acceptance(&spec.acceptance, &cwd)?;
+        let verdict_id = Uuid::new_v4().to_string();
+        let failing: Vec<String> = results
+            .iter()
+            .filter(|r| !r.pass || r.unverified)
+            .map(|r| r.criterion_id.clone())
+            .collect();
+        let key = progress_key(&failing, &[]);
+        run.progress_streak =
+            update_progress_streak(run.progress_key.as_deref(), run.progress_streak, &key);
+        run.progress_key = Some(key);
+
+        let complete = can_complete(&spec, &results, false);
+        let (result, summary) = match &complete {
+            Ok(()) => (VerdictResult::Pass, "spec met".to_string()),
+            Err(CompleteGateError::Unverified { id }) => {
+                (VerdictResult::Unverified, format!("unverified {id}"))
+            }
+            Err(CompleteGateError::HumanBlocked { id }) => {
+                (VerdictResult::BlockedHuman, format!("human {id}"))
+            }
+            Err(e) => (VerdictResult::Fail, format!("{e:?}")),
+        };
+
+        let verdict = serde_json::json!({
+            "id": verdict_id,
+            "run_id": run_id,
+            "spec_version": run.locked_spec_version,
+            "iteration": run.iterations_used,
+            "result": result.as_str(),
+            "summary": summary,
+            "criterion_results": results,
+        });
+        write_json_atomic(
+            &PathBuf::from(&run.artifact_dir)
+                .join("verdicts")
+                .join(format!("{verdict_id}.json")),
+            &verdict,
+        )?;
+
+        if complete.is_ok() {
+            run.status = RunStatus::Completed.as_str().into();
+            run.stop_reason = Some(StopReason::SpecMet.as_str().into());
+            run.finished_at = Some(Utc::now().to_rfc3339());
+        } else if matches!(result, VerdictResult::BlockedHuman) {
+            run.status = RunStatus::BlockedHuman.as_str().into();
+        } else if matches!(result, VerdictResult::Unverified) {
+            run.status = RunStatus::Failed.as_str().into();
+            run.stop_reason = Some(StopReason::WorkerFailed.as_str().into());
+            run.finished_at = Some(Utc::now().to_rfc3339());
+        } else if run.progress_streak >= NO_PROGRESS_THRESHOLD {
+            run.status = RunStatus::Failed.as_str().into();
+            run.stop_reason = Some(StopReason::NoProgress.as_str().into());
+            run.finished_at = Some(Utc::now().to_rfc3339());
+        } else {
+            // continue loop — re-check budget after tick
+            let elapsed = run
+                .wall_started_ms
+                .map(|s| now_ms().saturating_sub(s))
+                .unwrap_or(0);
+            if check_budget(
+                &run.budget,
+                run.iterations_used,
+                run.maker_invocations,
+                elapsed,
+            ) != BudgetCheck::Ok
+            {
+                let reason = match check_budget(
+                    &run.budget,
+                    run.iterations_used,
+                    run.maker_invocations,
+                    elapsed,
+                ) {
+                    BudgetCheck::Iterations => StopReason::BudgetIterations,
+                    BudgetCheck::Wall => StopReason::BudgetWall,
+                    BudgetCheck::Makers => StopReason::BudgetMakers,
+                    BudgetCheck::Ok => StopReason::WorkerFailed,
+                };
+                return self.fail_run(run, reason);
+            }
+        }
+
+        run.updated_at = Utc::now().to_rfc3339();
+        self.save_run(&run)?;
+        Ok(run)
+    }
+
+    /// Execute a simple graph sequence once (fixture): walk entry, verify join.
+    pub fn step_graph_fixture(&self, run_id: &str) -> Result<RunRecord> {
+        let mut run = self.load_run(run_id)?;
+        if run.mode.as_deref() != Some("graph") {
+            return Err(ServiceError::Validation("not graph mode".into()));
+        }
+        let graph = run
+            .graph
+            .clone()
+            .ok_or_else(|| ServiceError::Validation("no graph".into()))?;
+        compile_graph(&graph).map_err(|e| ServiceError::Validation(e.0))?;
+
+        let mut states: HashMap<String, NodeTerminal> = HashMap::new();
+        for n in &graph.nodes {
+            if n.kind == "maker" {
+                run.maker_invocations += 1;
+                // isolation check already at compile
+                states.insert(n.id.clone(), NodeTerminal::Succeeded);
+            } else if n.kind == "verify" {
+                // fresh context simulated by different binding key
+                let _cwd = self.resolve_cwd(&run, Some("verify"), Some(&n.id));
+                states.insert(n.id.clone(), NodeTerminal::Succeeded);
+            } else if n.kind == "join" {
+                match join_ready(&n.id, &graph.edges, &states) {
+                    Ok(()) => {
+                        states.insert(n.id.clone(), NodeTerminal::Succeeded);
+                    }
+                    Err(e) => {
+                        run.status = RunStatus::Failed.as_str().into();
+                        run.stop_reason = Some(StopReason::JoinIncomplete.as_str().into());
+                        run.finished_at = Some(Utc::now().to_rfc3339());
+                        run.updated_at = Utc::now().to_rfc3339();
+                        self.save_run(&run)?;
+                        return Err(ServiceError::Validation(e));
+                    }
+                }
+            } else {
+                states.insert(n.id.clone(), NodeTerminal::Succeeded);
+            }
+        }
+
+        // final complete via sensors if present
+        if let Ok(spec) = self.get_spec(run_id, run.locked_spec_version) {
+            let results = evaluate_acceptance(&spec.acceptance, Path::new(&run.home_cwd))?;
+            if can_complete(&spec, &results, false).is_ok() {
+                run.status = RunStatus::Completed.as_str().into();
+                run.stop_reason = Some(StopReason::SpecMet.as_str().into());
+                run.finished_at = Some(Utc::now().to_rfc3339());
+            }
+        } else {
+            run.status = RunStatus::Completed.as_str().into();
+            run.stop_reason = Some(StopReason::SpecMet.as_str().into());
+            run.finished_at = Some(Utc::now().to_rfc3339());
+        }
+        run.updated_at = Utc::now().to_rfc3339();
+        self.save_run(&run)?;
+        Ok(run)
+    }
+
+    fn fail_run(&self, mut run: RunRecord, reason: StopReason) -> Result<RunRecord> {
+        run.status = RunStatus::Failed.as_str().into();
+        run.stop_reason = Some(reason.as_str().into());
+        run.finished_at = Some(Utc::now().to_rfc3339());
+        run.updated_at = Utc::now().to_rfc3339();
+        self.save_run(&run)?;
+        Ok(run)
+    }
+
+    pub fn cancel_run(&self, run_id: &str) -> Result<RunRecord> {
+        let mut run = self.load_run(run_id)?;
+        if RunStatus::parse(&run.status).is_some_and(|s| s.is_terminal()) {
+            return Ok(run);
+        }
+        run.status = RunStatus::Cancelled.as_str().into();
+        run.stop_reason = Some(StopReason::UserCancel.as_str().into());
+        run.finished_at = Some(Utc::now().to_rfc3339());
+        run.updated_at = Utc::now().to_rfc3339();
+        self.save_run(&run)?;
+        Ok(run)
+    }
+
+    pub fn write_mode_proposal(&self, run_id: &str, proposal: &ModeProposal) -> Result<()> {
+        let run = self.load_run(run_id)?;
+        let path = PathBuf::from(&run.artifact_dir).join("mode_proposal.json");
+        write_json_atomic(&path, proposal)
+    }
+
+    pub fn context_pack(&self, run_id: &str) -> Result<serde_json::Value> {
+        let run = self.load_run(run_id)?;
+        Ok(serde_json::json!({
+            "run_id": run.id,
+            "status": run.status,
+            "requested_mode": run.requested_mode,
+            "mode": run.mode,
+            "mode_reason": run.mode_reason,
+            "stop_reason": run.stop_reason,
+            "goal": run.goal,
+            "home": {
+                "target_kind": run.target_kind,
+                "project_guid": run.project_guid,
+                "workspace_guid": run.workspace_guid,
+                "cwd": run.home_cwd,
+            },
+            "workspaces": run.workspaces,
+            "active_bindings": run.role_bindings,
+            "budget": run.budget,
+            "artifacts": {
+                "root": run.artifact_dir,
+            },
+            "locked_spec_version": run.locked_spec_version,
+            "skill_dir_hint": skill_dir_hint(),
+        }))
+    }
+
+    pub fn workspace_create(
+        &self,
+        run_id: &str,
+        purpose: &str,
+        path: Option<String>,
+    ) -> Result<RunWorkspaceRecord> {
+        let mut run = self.load_run(run_id)?;
+        if run.target_kind == TargetKind::Standalone.as_str() {
+            // limited: dir under artifact
+            let child_path = path.unwrap_or_else(|| {
+                PathBuf::from(&run.artifact_dir)
+                    .join("workspaces")
+                    .join(Uuid::new_v4().to_string())
+                    .display()
+                    .to_string()
+            });
+            fs::create_dir_all(&child_path)
+                .map_err(|e| ServiceError::Processing(e.to_string()))?;
+            let rec = RunWorkspaceRecord {
+                id: Uuid::new_v4().to_string(),
+                workspace_guid: format!("child-{}", Uuid::new_v4()),
+                kind: "child".into(),
+                purpose: Some(purpose.into()),
+                status: "active".into(),
+                path: child_path,
+                base_ref: None,
+                created_at: Utc::now().to_rfc3339(),
+            };
+            run.workspaces.push(rec.clone());
+            run.updated_at = Utc::now().to_rfc3339();
+            self.save_run(&run)?;
+            return Ok(rec);
+        }
+
+        let child_path = path.unwrap_or_else(|| {
+            // sibling dir next to home for fixture isolation
+            let home = PathBuf::from(&run.home_cwd);
+            home.parent()
+                .unwrap_or(home.as_path())
+                .join(format!("orch-child-{}", &run.id[..8.min(run.id.len())]))
+                .join(Uuid::new_v4().to_string())
+                .display()
+                .to_string()
+        });
+        fs::create_dir_all(&child_path).map_err(|e| ServiceError::Processing(e.to_string()))?;
+        // mark create_source for discovery
+        let _ = fs::write(
+            PathBuf::from(&child_path).join(".atmos-orch-workspace"),
+            format!("run_id={}\ncreate_source=orchestrator\n", run.id),
+        );
+
+        let rec = RunWorkspaceRecord {
+            id: Uuid::new_v4().to_string(),
+            workspace_guid: format!("child-{}", Uuid::new_v4()),
+            kind: "child".into(),
+            purpose: Some(purpose.into()),
+            status: "active".into(),
+            path: child_path,
+            base_ref: run.workspace_guid.clone(),
+            created_at: Utc::now().to_rfc3339(),
+        };
+        run.workspaces.push(rec.clone());
+        run.updated_at = Utc::now().to_rfc3339();
+        self.save_run(&run)?;
+        Ok(rec)
+    }
+
+    pub fn workspace_use(
+        &self,
+        run_id: &str,
+        workspace_guid: &str,
+        role: Option<&str>,
+        node_id: Option<&str>,
+    ) -> Result<RunRecord> {
+        let mut run = self.load_run(run_id)?;
+        let ws = run
+            .workspaces
+            .iter()
+            .find(|w| w.workspace_guid == workspace_guid)
+            .ok_or_else(|| ServiceError::Validation("ORCH_WORKSPACE_NOT_CHILD".into()))?
+            .clone();
+        if ws.status != "active" && ws.kind != "home" {
+            return Err(ServiceError::Validation("workspace not active".into()));
+        }
+        run.role_bindings.retain(|b| {
+            !(role.is_some() && b.role.as_deref() == role
+                || node_id.is_some() && b.node_id.as_deref() == node_id)
+        });
+        run.role_bindings.push(RoleBindingRecord {
+            role: role.map(|s| s.into()),
+            node_id: node_id.map(|s| s.into()),
+            workspace_guid: ws.workspace_guid,
+            cwd: ws.path,
+        });
+        run.updated_at = Utc::now().to_rfc3339();
+        self.save_run(&run)?;
+        Ok(run)
+    }
+
+    pub fn workspace_merge(&self, run_id: &str, workspace_guid: &str) -> Result<RunRecord> {
+        let mut run = self.load_run(run_id)?;
+        let home = run.home_cwd.clone();
+        let mut found = false;
+        for w in &mut run.workspaces {
+            if w.workspace_guid == workspace_guid && w.kind == "child" {
+                // fixture merge: copy a marker file if present
+                let marker = PathBuf::from(&w.path).join("ORCH_RESULT.txt");
+                if marker.exists() {
+                    let dest = PathBuf::from(&home).join("ORCH_RESULT.txt");
+                    let _ = fs::create_dir_all(&home);
+                    let _ = fs::copy(&marker, &dest);
+                }
+                w.status = "merged".into();
+                found = true;
+            }
+        }
+        if !found {
+            return Err(ServiceError::Validation("ORCH_WORKSPACE_NOT_CHILD".into()));
+        }
+        run.updated_at = Utc::now().to_rfc3339();
+        self.save_run(&run)?;
+        Ok(run)
+    }
+
+    pub fn workspace_abandon(&self, run_id: &str, workspace_guid: &str) -> Result<RunRecord> {
+        let mut run = self.load_run(run_id)?;
+        let mut found = false;
+        for w in &mut run.workspaces {
+            if w.workspace_guid == workspace_guid && w.kind == "child" {
+                w.status = "abandoned".into();
+                found = true;
+            }
+        }
+        if !found {
+            return Err(ServiceError::Validation("ORCH_WORKSPACE_NOT_CHILD".into()));
+        }
+        run.role_bindings
+            .retain(|b| b.workspace_guid != workspace_guid);
+        run.updated_at = Utc::now().to_rfc3339();
+        self.save_run(&run)?;
+        Ok(run)
+    }
+
+    pub fn attach_evidence(
+        &self,
+        run_id: &str,
+        kind: &str,
+        src_path: &Path,
+    ) -> Result<serde_json::Value> {
+        let run = self.load_run(run_id)?;
+        let id = Uuid::new_v4().to_string();
+        let dest = PathBuf::from(&run.artifact_dir)
+            .join("evidence")
+            .join(format!("{id}.bin"));
+        fs::copy(src_path, &dest)
+            .map_err(|e| ServiceError::Processing(format!("copy evidence: {e}")))?;
+        let meta = serde_json::json!({
+            "id": id,
+            "run_id": run_id,
+            "kind": kind,
+            "path": dest.display().to_string(),
+        });
+        write_json_atomic(
+            &PathBuf::from(&run.artifact_dir)
+                .join("evidence")
+                .join(format!("{id}.json")),
+            &meta,
+        )?;
+        Ok(meta)
+    }
+
+    pub fn compile_run_graph(&self, run_id: &str, graph: &CompiledGraph) -> Result<CompiledGraph> {
+        let compiled = compile_graph(graph).map_err(|e| {
+            ServiceError::Validation(format!("ORCH_GRAPH_COMPILE_FAILED: {}", e.0))
+        })?;
+        let mut run = self.load_run(run_id)?;
+        run.graph = Some(compiled.clone());
+        write_json_atomic(
+            &PathBuf::from(&run.artifact_dir).join("graph.compiled.json"),
+            &compiled,
+        )?;
+        run.updated_at = Utc::now().to_rfc3339();
+        self.save_run(&run)?;
+        Ok(compiled)
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn diamond_from_units(units: &[String]) -> CompiledGraph {
+    let mut nodes = Vec::new();
+    let mut edges = Vec::new();
+    for (i, u) in units.iter().enumerate() {
+        nodes.push(GraphNode {
+            id: format!("maker-{i}"),
+            kind: "maker".into(),
+            label: u.clone(),
+            agent_id: None,
+            fresh_context: None,
+            writes: true,
+            isolation: "worktree".into(),
+            node_timeout_ms: None,
+            workspace_guid: None,
+        });
+    }
+    nodes.push(GraphNode {
+        id: "join".into(),
+        kind: "join".into(),
+        label: "join".into(),
+        agent_id: None,
+        fresh_context: None,
+        writes: false,
+        isolation: "none".into(),
+        node_timeout_ms: None,
+        workspace_guid: None,
+    });
+    nodes.push(GraphNode {
+        id: "verify".into(),
+        kind: "verify".into(),
+        label: "verify".into(),
+        agent_id: None,
+        fresh_context: Some(true),
+        writes: false,
+        isolation: "none".into(),
+        node_timeout_ms: None,
+        workspace_guid: None,
+    });
+    for (i, _) in units.iter().enumerate() {
+        edges.push(GraphEdge {
+            id: format!("e-m{i}-j"),
+            from: format!("maker-{i}"),
+            to: "join".into(),
+            kind: "control".into(),
+            required: true,
+            max_cycles: None,
+        });
+    }
+    edges.push(GraphEdge {
+        id: "e-j-v".into(),
+        from: "join".into(),
+        to: "verify".into(),
+        kind: "control".into(),
+        required: true,
+        max_cycles: None,
+    });
+    let entry = (0..units.len()).map(|i| format!("maker-{i}")).collect();
+    CompiledGraph {
+        nodes,
+        edges,
+        entry,
+    }
+}
+
+pub fn skill_dir_hint() -> String {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    home.join(".atmos")
+        .join("skills")
+        .join(".system")
+        .join("atmos-orchestrator")
+        .display()
+        .to_string()
+}
+
+pub fn skill_dir_output() -> serde_json::Value {
+    let dir = skill_dir_hint();
+    let prompt = format!(
+        "Read the Atmos Orchestrator skill in this directory and use `atmos orchestrator` to manage multi-step runs (Loop/Graph), Judgment Specs, and evidence. Do not invent completion without Spec + sensors.\n{dir}"
+    );
+    serde_json::json!({
+        "skill_dir": dir,
+        "skill_md": format!("{dir}/SKILL.md"),
+        "prompt": prompt,
+    })
+}
+
+// Re-export Arc helper for AppState
+pub type SharedOrchestratorService = Arc<OrchestratorService>;
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn svc() -> (OrchestratorService, PathBuf) {
+        let dir = tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        // leak tempdir for test duration via into_path
+        std::mem::forget(dir);
+        (OrchestratorService::with_root(root.clone()), root)
+    }
+
+    #[test]
+    fn loop_completes_when_sensor_passes() {
+        let (svc, home) = svc();
+        let home_cwd = home.join("project");
+        fs::create_dir_all(&home_cwd).unwrap();
+        let run = svc
+            .create_run(CreateRunReq {
+                goal: "pass typecheck".into(),
+                requested_mode: "loop".into(),
+                target_kind: "standalone".into(),
+                project_guid: None,
+                workspace_guid: None,
+                home_cwd: home_cwd.display().to_string(),
+                budget: Some(Budget {
+                    max_iterations: 3,
+                    max_wall_ms: 60_000,
+                    max_maker_invocations: 5,
+                    max_spec_versions: 3,
+                }),
+                carry_from_run_id: None,
+                maker_agent_id: None,
+                planner_agent_id: None,
+                criteria_agent_id: None,
+                verify_agent_id: None,
+            })
+            .unwrap();
+
+        let body = JudgmentSpecBody {
+            goal_summary: "g".into(),
+            risk_tier: "low".into(),
+            acceptance: vec![Criterion {
+                id: "c1".into(),
+                description: "true".into(),
+                kind: "sensor".into(),
+                required: true,
+                sensor: Some(SensorSpec {
+                    argv: vec!["true".into()],
+                    cwd: None,
+                    pass_exit_codes: vec![0],
+                    timeout_ms: 5000,
+                }),
+                falsify: None,
+                evidence_required: vec![],
+                immutable_paths: vec![],
+                sole_source: Some("sensor".into()),
+            }],
+            rejection: vec![],
+            judgment_order: vec!["sensor".into()],
+        };
+        svc.draft_spec_from_body(&run.id, body).unwrap();
+        // auto confirm for low risk
+        let meta_path = PathBuf::from(&run.artifact_dir)
+            .join("specs")
+            .join("v1.meta.json");
+        let mut meta: serde_json::Value = read_json_file(&meta_path).unwrap();
+        meta["confirmed"] = serde_json::json!(true);
+        write_json_atomic(&meta_path, &meta).unwrap();
+
+        let started = svc.start_run(&run.id).unwrap();
+        assert_eq!(started.mode.as_deref(), Some("loop"));
+        let done = svc.tick_loop_fixture(&run.id).unwrap();
+        assert_eq!(done.status, "completed");
+        assert_eq!(done.stop_reason.as_deref(), Some("spec_met"));
+    }
+
+    #[test]
+    fn start_without_spec_fails() {
+        let (svc, home) = svc();
+        let home_cwd = home.join("p");
+        fs::create_dir_all(&home_cwd).unwrap();
+        let run = svc
+            .create_run(CreateRunReq {
+                goal: "x".into(),
+                requested_mode: "loop".into(),
+                target_kind: "standalone".into(),
+                project_guid: None,
+                workspace_guid: None,
+                home_cwd: home_cwd.display().to_string(),
+                budget: None,
+                carry_from_run_id: None,
+                maker_agent_id: None,
+                planner_agent_id: None,
+                criteria_agent_id: None,
+                verify_agent_id: None,
+            })
+            .unwrap();
+        let err = svc.start_run(&run.id).unwrap_err();
+        assert!(err.to_string().contains("SPEC"));
+    }
+
+    #[test]
+    fn workspace_create_use_merge() {
+        let (svc, home) = svc();
+        let home_cwd = home.join("proj");
+        fs::create_dir_all(&home_cwd).unwrap();
+        let run = svc
+            .create_run(CreateRunReq {
+                goal: "iso".into(),
+                requested_mode: "loop".into(),
+                target_kind: "project".into(),
+                project_guid: Some("pj".into()),
+                workspace_guid: None,
+                home_cwd: home_cwd.display().to_string(),
+                budget: None,
+                carry_from_run_id: None,
+                maker_agent_id: None,
+                planner_agent_id: None,
+                criteria_agent_id: None,
+                verify_agent_id: None,
+            })
+            .unwrap();
+        let child = svc.workspace_create(&run.id, "experiment", None).unwrap();
+        assert_eq!(child.kind, "child");
+        assert!(child.path.contains("orch-child") || Path::new(&child.path).exists());
+        let run = svc
+            .workspace_use(&run.id, &child.workspace_guid, Some("maker"), None)
+            .unwrap();
+        let cwd = svc.resolve_cwd(&run, Some("maker"), None);
+        assert_eq!(cwd, child.path);
+        fs::write(PathBuf::from(&child.path).join("ORCH_RESULT.txt"), "ok").unwrap();
+        let run = svc.workspace_merge(&run.id, &child.workspace_guid).unwrap();
+        let child = run
+            .workspaces
+            .iter()
+            .find(|w| w.workspace_guid == child.workspace_guid)
+            .unwrap();
+        assert_eq!(child.status, "merged");
+        assert!(home_cwd.join("ORCH_RESULT.txt").exists());
+    }
+
+    #[test]
+    fn multi_writer_graph_compile_fails() {
+        let (svc, home) = svc();
+        let home_cwd = home.join("p");
+        fs::create_dir_all(&home_cwd).unwrap();
+        let run = svc
+            .create_run(CreateRunReq {
+                goal: "g".into(),
+                requested_mode: "graph".into(),
+                target_kind: "standalone".into(),
+                project_guid: None,
+                workspace_guid: None,
+                home_cwd: home_cwd.display().to_string(),
+                budget: None,
+                carry_from_run_id: None,
+                maker_agent_id: None,
+                planner_agent_id: None,
+                criteria_agent_id: None,
+                verify_agent_id: None,
+            })
+            .unwrap();
+        let g = CompiledGraph {
+            nodes: vec![
+                GraphNode {
+                    id: "a".into(),
+                    kind: "maker".into(),
+                    label: "a".into(),
+                    agent_id: None,
+                    fresh_context: None,
+                    writes: true,
+                    isolation: "none".into(),
+                    node_timeout_ms: None,
+                    workspace_guid: None,
+                },
+                GraphNode {
+                    id: "b".into(),
+                    kind: "maker".into(),
+                    label: "b".into(),
+                    agent_id: None,
+                    fresh_context: None,
+                    writes: true,
+                    isolation: "none".into(),
+                    node_timeout_ms: None,
+                    workspace_guid: None,
+                },
+            ],
+            edges: vec![],
+            entry: vec!["a".into(), "b".into()],
+        };
+        assert!(svc.compile_run_graph(&run.id, &g).is_err());
+    }
+
+    #[test]
+    fn never_writes_canvas_dir() {
+        let (svc, _) = svc();
+        assert!(svc.root().join("boards").to_string_lossy().contains("orchestrator")
+            || !svc.root().to_string_lossy().contains("canvas"));
+        // boards created under orchestrator root
+        let _ = fs::create_dir_all(svc.boards_path());
+        assert!(!svc.boards_path().to_string_lossy().contains("/canvas/"));
+    }
+
+    #[test]
+    fn cancel_run() {
+        let (svc, home) = svc();
+        let home_cwd = home.join("p");
+        fs::create_dir_all(&home_cwd).unwrap();
+        let run = svc
+            .create_run(CreateRunReq {
+                goal: "c".into(),
+                requested_mode: "loop".into(),
+                target_kind: "standalone".into(),
+                project_guid: None,
+                workspace_guid: None,
+                home_cwd: home_cwd.display().to_string(),
+                budget: None,
+                carry_from_run_id: None,
+                maker_agent_id: None,
+                planner_agent_id: None,
+                criteria_agent_id: None,
+                verify_agent_id: None,
+            })
+            .unwrap();
+        let body = JudgmentSpecBody {
+            goal_summary: "g".into(),
+            risk_tier: "low".into(),
+            acceptance: vec![Criterion {
+                id: "c1".into(),
+                description: "t".into(),
+                kind: "sensor".into(),
+                required: true,
+                sensor: Some(SensorSpec {
+                    argv: vec!["false".into()],
+                    cwd: None,
+                    pass_exit_codes: vec![0],
+                    timeout_ms: 2000,
+                }),
+                falsify: None,
+                evidence_required: vec![],
+                immutable_paths: vec![],
+                sole_source: None,
+            }],
+            rejection: vec![],
+            judgment_order: vec!["sensor".into()],
+        };
+        svc.draft_spec_from_body(&run.id, body).unwrap();
+        let meta_path = PathBuf::from(&run.artifact_dir).join("specs/v1.meta.json");
+        let mut meta: serde_json::Value = read_json_file(&meta_path).unwrap();
+        meta["confirmed"] = serde_json::json!(true);
+        write_json_atomic(&meta_path, &meta).unwrap();
+        svc.start_run(&run.id).unwrap();
+        let cancelled = svc.cancel_run(&run.id).unwrap();
+        assert_eq!(cancelled.status, "cancelled");
+        assert_eq!(cancelled.stop_reason.as_deref(), Some("user_cancel"));
+    }
+}

--- a/crates/core-service/src/service/orchestrator/mod.rs
+++ b/crates/core-service/src/service/orchestrator/mod.rs
@@ -9,7 +9,10 @@ mod sensors;
 pub use graph_compile::{compile_graph, join_ready, CompileError, NodeTerminal};
 pub use runtime::*;
 pub use schemas::*;
-pub use sensors::{evaluate_acceptance, immutable_paths_from_spec, run_sensor};
+pub use sensors::{
+    check_immutable_not_modified, evaluate_acceptance, immutable_paths_from_spec, run_sensor,
+    snapshot_immutable_mtimes,
+};
 
 use std::collections::HashMap;
 use std::fs;
@@ -469,6 +472,11 @@ impl OrchestratorService {
     }
 
     pub fn start_run(&self, run_id: &str) -> Result<RunRecord> {
+        self.start_run_with_options(run_id, true)
+    }
+
+    /// `sync_advance`: Runtime runs fixture Loop/Graph to terminal (default true for tests/CLI).
+    pub fn start_run_with_options(&self, run_id: &str, sync_advance: bool) -> Result<RunRecord> {
         let mut run = self.load_run(run_id)?;
         if run.locked_spec_version.is_none() {
             return Err(ServiceError::Validation("ORCH_SPEC_REQUIRED".into()));
@@ -556,11 +564,124 @@ impl OrchestratorService {
             "run_updated",
             serde_json::to_value(&run).unwrap_or_default(),
         );
+
+        if !sync_advance {
+            return Ok(run);
+        }
+        // Runtime owns advancement (M26): fixture agents run to terminal state.
+        let run = match effective {
+            EffectiveMode::Loop => self.advance_loop_until_terminal(run_id)?,
+            EffectiveMode::Graph => self.advance_graph_until_terminal(run_id)?,
+        };
         Ok(run)
     }
 
-    /// Fixture-friendly Loop tick: runs sensors in home (or bound) cwd; no real terminal agent.
-    pub fn tick_loop_fixture(&self, run_id: &str) -> Result<RunRecord> {
+    /// Fixture Terminal Agent role invoke: writes contracted artifacts under run dir with bound cwd.
+    pub fn role_invoke(
+        &self,
+        run_id: &str,
+        role: OrchRole,
+        node_id: Option<&str>,
+    ) -> Result<PathBuf> {
+        let run = self.load_run(run_id)?;
+        let cwd = PathBuf::from(self.resolve_cwd(
+            &run,
+            Some(role.as_str()),
+            node_id,
+        ));
+        fs::create_dir_all(&cwd)
+            .map_err(|e| ServiceError::Processing(format!("role cwd: {e}")))?;
+
+        let inv_id = Uuid::new_v4().to_string();
+        let role_dir = PathBuf::from(&run.artifact_dir)
+            .join("roles")
+            .join(role.as_str())
+            .join(&inv_id);
+        fs::create_dir_all(&role_dir)
+            .map_err(|e| ServiceError::Processing(format!("role dir: {e}")))?;
+
+        let prompt = format!(
+            "role={}\nrun_id={}\ncwd={}\ngoal={}\nnode={}\n",
+            role.as_str(),
+            run_id,
+            cwd.display(),
+            run.goal,
+            node_id.unwrap_or("-")
+        );
+        fs::write(role_dir.join("prompt.md"), &prompt)
+            .map_err(|e| ServiceError::Processing(format!("write prompt: {e}")))?;
+
+        let artifact = match role {
+            OrchRole::Orchestrator => {
+                let path = PathBuf::from(&run.artifact_dir).join("mode_proposal.json");
+                let proposal = ModeProposal {
+                    mode: EffectiveMode::Loop,
+                    reason: "fixture planner defaults to loop".into(),
+                    plan_complexity: "low".into(),
+                    topology_hint: Some("linear".into()),
+                    graph: None,
+                    named_units: vec![],
+                };
+                write_json_atomic(&path, &proposal)?;
+                path
+            }
+            OrchRole::Criteria => {
+                let path = PathBuf::from(&run.artifact_dir)
+                    .join("specs")
+                    .join("role_criteria_hint.json");
+                write_json_atomic(
+                    &path,
+                    &serde_json::json!({"ok": true, "role": "criteria", "cwd": cwd.display().to_string()}),
+                )?;
+                path
+            }
+            OrchRole::Maker => {
+                let path = PathBuf::from(&run.artifact_dir).join("work_state.json");
+                write_json_atomic(
+                    &path,
+                    &serde_json::json!({
+                        "role": "maker",
+                        "cwd": cwd.display().to_string(),
+                        "files_touched": [],
+                        "iteration": run.iterations_used + 1,
+                    }),
+                )?;
+                // marker in working cwd
+                let _ = fs::write(cwd.join(".orch_maker_ran"), inv_id.as_bytes());
+                path
+            }
+            OrchRole::Verify => {
+                let path = PathBuf::from(&run.artifact_dir)
+                    .join("verdicts")
+                    .join(format!("verify-{inv_id}.json"));
+                // Fresh context: verify must not share maker role dir
+                write_json_atomic(
+                    &path,
+                    &serde_json::json!({
+                        "role": "verify",
+                        "cwd": cwd.display().to_string(),
+                        "fresh_context": true,
+                        "node_id": node_id,
+                    }),
+                )?;
+                let _ = fs::write(cwd.join(".orch_verify_ran"), inv_id.as_bytes());
+                path
+            }
+        };
+
+        // Atomic done sentinel after artifact
+        write_json_atomic(
+            &role_dir.join("role.done"),
+            &serde_json::json!({
+                "ok": true,
+                "artifact": artifact.display().to_string(),
+            }),
+        )?;
+        Ok(artifact)
+    }
+
+    /// Runtime-owned Loop advance (not agent CLI). Runs maker role + sensors + integrity.
+    pub fn advance_loop_once(&self, run_id: &str) -> Result<RunRecord> {
         let mut run = self.load_run(run_id)?;
         if run.status != RunStatus::Running.as_str() {
             return Err(ServiceError::Validation("run not running".into()));
@@ -579,21 +700,28 @@ impl OrchestratorService {
             run.maker_invocations,
             elapsed,
         ) {
-            BudgetCheck::Iterations => {
-                return self.fail_run(run, StopReason::BudgetIterations);
-            }
+            BudgetCheck::Iterations => return self.fail_run(run, StopReason::BudgetIterations),
             BudgetCheck::Wall => return self.fail_run(run, StopReason::BudgetWall),
             BudgetCheck::Makers => return self.fail_run(run, StopReason::BudgetMakers),
             BudgetCheck::Ok => {}
         }
 
+        let spec = self.get_spec(run_id, run.locked_spec_version)?;
+        let cwd = PathBuf::from(self.resolve_cwd(&run, Some("maker"), None));
+        let protected = immutable_paths_from_spec(&spec.acceptance);
+        let before = snapshot_immutable_mtimes(&protected, &cwd);
+
+        // Maker Terminal Agent (fixture)
+        self.role_invoke(run_id, OrchRole::Maker, None)?;
         run.iterations_used += 1;
         run.maker_invocations += 1;
 
-        let spec = self.get_spec(run_id, run.locked_spec_version)?;
-        let cwd = PathBuf::from(self.resolve_cwd(&run, Some("maker"), None));
+        if let Err(msg) = check_immutable_not_modified(&protected, &cwd, &before) {
+            return self.fail_run_msg(run, StopReason::WorkerFailed, &msg);
+        }
 
-        // Sensor integrity snapshot would be here; fixture skips file mtime unless paths exist
+        // Verify role on fresh binding (same home unless isolated)
+        let _ = self.role_invoke(run_id, OrchRole::Verify, Some("loop-verify"));
 
         let results = evaluate_acceptance(&spec.acceptance, &cwd)?;
         let verdict_id = Uuid::new_v4().to_string();
@@ -619,20 +747,19 @@ impl OrchestratorService {
             Err(e) => (VerdictResult::Fail, format!("{e:?}")),
         };
 
-        let verdict = serde_json::json!({
-            "id": verdict_id,
-            "run_id": run_id,
-            "spec_version": run.locked_spec_version,
-            "iteration": run.iterations_used,
-            "result": result.as_str(),
-            "summary": summary,
-            "criterion_results": results,
-        });
         write_json_atomic(
             &PathBuf::from(&run.artifact_dir)
                 .join("verdicts")
                 .join(format!("{verdict_id}.json")),
-            &verdict,
+            &serde_json::json!({
+                "id": verdict_id,
+                "run_id": run_id,
+                "spec_version": run.locked_spec_version,
+                "iteration": run.iterations_used,
+                "result": result.as_str(),
+                "summary": summary,
+                "criterion_results": results,
+            }),
         )?;
 
         if complete.is_ok() {
@@ -650,30 +777,22 @@ impl OrchestratorService {
             run.stop_reason = Some(StopReason::NoProgress.as_str().into());
             run.finished_at = Some(Utc::now().to_rfc3339());
         } else {
-            // continue loop — re-check budget after tick
             let elapsed = run
                 .wall_started_ms
                 .map(|s| now_ms().saturating_sub(s))
                 .unwrap_or(0);
-            if check_budget(
+            match check_budget(
                 &run.budget,
                 run.iterations_used,
                 run.maker_invocations,
                 elapsed,
-            ) != BudgetCheck::Ok
-            {
-                let reason = match check_budget(
-                    &run.budget,
-                    run.iterations_used,
-                    run.maker_invocations,
-                    elapsed,
-                ) {
-                    BudgetCheck::Iterations => StopReason::BudgetIterations,
-                    BudgetCheck::Wall => StopReason::BudgetWall,
-                    BudgetCheck::Makers => StopReason::BudgetMakers,
-                    BudgetCheck::Ok => StopReason::WorkerFailed,
-                };
-                return self.fail_run(run, reason);
+            ) {
+                BudgetCheck::Ok => {}
+                BudgetCheck::Iterations => {
+                    return self.fail_run(run, StopReason::BudgetIterations);
+                }
+                BudgetCheck::Wall => return self.fail_run(run, StopReason::BudgetWall),
+                BudgetCheck::Makers => return self.fail_run(run, StopReason::BudgetMakers),
             }
         }
 
@@ -682,8 +801,41 @@ impl OrchestratorService {
         Ok(run)
     }
 
-    /// Execute a simple graph sequence once (fixture): walk entry, verify join.
-    pub fn step_graph_fixture(&self, run_id: &str) -> Result<RunRecord> {
+    pub fn advance_loop_until_terminal(&self, run_id: &str) -> Result<RunRecord> {
+        loop {
+            let run = self.load_run(run_id)?;
+            if RunStatus::parse(&run.status).is_some_and(|s| s.is_terminal())
+                || run.status == RunStatus::BlockedHuman.as_str()
+            {
+                return Ok(run);
+            }
+            let run = self.advance_loop_once(run_id)?;
+            if RunStatus::parse(&run.status).is_some_and(|s| s.is_terminal())
+                || run.status == RunStatus::BlockedHuman.as_str()
+            {
+                return Ok(run);
+            }
+            if run.iterations_used >= run.budget.max_iterations {
+                return self.fail_run(run, StopReason::BudgetIterations);
+            }
+        }
+    }
+
+    /// Graph node fixture outcome from id/label suffix: -fail, -hang, else success.
+    fn node_fixture_outcome(n: &GraphNode) -> NodeTerminal {
+        let key = format!("{} {}", n.id, n.label).to_ascii_lowercase();
+        if key.contains("-hang") || key.contains("hang") && key.contains("timeout") {
+            return NodeTerminal::TimedOut;
+        }
+        if key.contains("-fail") || key.ends_with("_fail") {
+            return NodeTerminal::Failed;
+        }
+        // Optional outcome file under nodes/{id}/outcome.json
+        NodeTerminal::Succeeded
+    }
+
+    /// Runtime-owned Graph advance with join fail-closed and Spec completion gate.
+    pub fn advance_graph_until_terminal(&self, run_id: &str) -> Result<RunRecord> {
         let mut run = self.load_run(run_id)?;
         if run.mode.as_deref() != Some("graph") {
             return Err(ServiceError::Validation("not graph mode".into()));
@@ -694,54 +846,189 @@ impl OrchestratorService {
             .ok_or_else(|| ServiceError::Validation("no graph".into()))?;
         compile_graph(&graph).map_err(|e| ServiceError::Validation(e.0))?;
 
+        // Require Spec for completion (M12)
+        let spec = self
+            .get_spec(run_id, run.locked_spec_version)
+            .map_err(|_| ServiceError::Validation("ORCH_SPEC_REQUIRED".into()))?;
+
+        // Topological-ish: process in order entry → edges; simple multi-pass
         let mut states: HashMap<String, NodeTerminal> = HashMap::new();
-        for n in &graph.nodes {
-            if n.kind == "maker" {
-                run.maker_invocations += 1;
-                // isolation check already at compile
-                states.insert(n.id.clone(), NodeTerminal::Succeeded);
-            } else if n.kind == "verify" {
-                // fresh context simulated by different binding key
-                let _cwd = self.resolve_cwd(&run, Some("verify"), Some(&n.id));
-                states.insert(n.id.clone(), NodeTerminal::Succeeded);
-            } else if n.kind == "join" {
-                match join_ready(&n.id, &graph.edges, &states) {
-                    Ok(()) => {
-                        states.insert(n.id.clone(), NodeTerminal::Succeeded);
+        let mut pending: Vec<String> = graph.entry.clone();
+        let mut safety = 0usize;
+
+        while !pending.is_empty() && safety < 64 {
+            safety += 1;
+            let id = pending.remove(0);
+            if states.contains_key(&id) {
+                continue;
+            }
+            let Some(n) = graph.nodes.iter().find(|n| n.id == id) else {
+                continue;
+            };
+
+            // Wait for required predecessors
+            let preds: Vec<_> = graph
+                .edges
+                .iter()
+                .filter(|e| e.to == id && e.kind == "control" && e.required)
+                .map(|e| e.from.clone())
+                .collect();
+            let mut ready = true;
+            for p in &preds {
+                match states.get(p) {
+                    None => {
+                        ready = false;
+                        break;
                     }
-                    Err(e) => {
+                    Some(NodeTerminal::Running) => {
+                        ready = false;
+                        break;
+                    }
+                    Some(NodeTerminal::Failed | NodeTerminal::Cancelled | NodeTerminal::TimedOut) => {
+                        // fail-closed at join or when processing node with failed required pred
+                        if n.kind == "join" || n.kind == "verify" || n.kind == "reduce" {
+                            run.status = RunStatus::Failed.as_str().into();
+                            run.stop_reason = Some(StopReason::JoinIncomplete.as_str().into());
+                            run.finished_at = Some(Utc::now().to_rfc3339());
+                            run.updated_at = Utc::now().to_rfc3339();
+                            self.save_run(&run)?;
+                            return Ok(run);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            if !ready {
+                pending.push(id);
+                continue;
+            }
+
+            let outcome = if n.kind == "join" {
+                match join_ready(&n.id, &graph.edges, &states) {
+                    Ok(()) => NodeTerminal::Succeeded,
+                    Err(_) => {
                         run.status = RunStatus::Failed.as_str().into();
                         run.stop_reason = Some(StopReason::JoinIncomplete.as_str().into());
                         run.finished_at = Some(Utc::now().to_rfc3339());
                         run.updated_at = Utc::now().to_rfc3339();
                         self.save_run(&run)?;
-                        return Err(ServiceError::Validation(e));
+                        return Ok(run);
                     }
                 }
+            } else if n.kind == "maker" {
+                run.maker_invocations += 1;
+                // Bind cwd for this node if isolated
+                if n.isolation == "worktree" {
+                    // ensure child workspace binding for node
+                    if let Some(ws) = &n.workspace_guid {
+                        let _ = self.workspace_use(run_id, ws, Some("maker"), Some(&n.id));
+                    }
+                }
+                let _ = self.role_invoke(run_id, OrchRole::Maker, Some(&n.id));
+                Self::node_fixture_outcome(n)
+            } else if n.kind == "verify" {
+                // Fresh verify context: bind verify role separately from maker
+                let verify_cwd = self.resolve_cwd(&run, Some("verify"), Some(&n.id));
+                // Ensure verify does not use maker node binding only
+                let _ = verify_cwd;
+                let _ = self.role_invoke(run_id, OrchRole::Verify, Some(&n.id));
+                Self::node_fixture_outcome(n)
+            } else if n.kind == "sensor" {
+                Self::node_fixture_outcome(n)
             } else {
-                states.insert(n.id.clone(), NodeTerminal::Succeeded);
+                Self::node_fixture_outcome(n)
+            };
+
+            if matches!(outcome, NodeTerminal::TimedOut | NodeTerminal::Failed)
+                && (n.kind == "maker" || n.kind == "verify")
+            {
+                states.insert(n.id.clone(), outcome);
+                // enqueue successors so join can observe failure
+            } else {
+                states.insert(n.id.clone(), outcome);
+            }
+
+            for e in &graph.edges {
+                if e.from == id && e.kind == "control" && !states.contains_key(&e.to) {
+                    pending.push(e.to.clone());
+                }
             }
         }
 
-        // final complete via sensors if present
-        if let Ok(spec) = self.get_spec(run_id, run.locked_spec_version) {
-            let results = evaluate_acceptance(&spec.acceptance, Path::new(&run.home_cwd))?;
-            if can_complete(&spec, &results, false).is_ok() {
+        // Any hang left as Running?
+        for n in &graph.nodes {
+            if matches!(states.get(&n.id), Some(NodeTerminal::TimedOut)) {
+                run.status = RunStatus::Failed.as_str().into();
+                run.stop_reason = Some(StopReason::JoinIncomplete.as_str().into());
+                run.finished_at = Some(Utc::now().to_rfc3339());
+                run.updated_at = Utc::now().to_rfc3339();
+                self.save_run(&run)?;
+                return Ok(run);
+            }
+            if matches!(states.get(&n.id), Some(NodeTerminal::Failed)) {
+                // If any required terminal node failed without successful join path
+                if n.kind == "maker" || n.kind == "verify" {
+                    run.status = RunStatus::Failed.as_str().into();
+                    run.stop_reason = Some(StopReason::WorkerFailed.as_str().into());
+                    run.finished_at = Some(Utc::now().to_rfc3339());
+                    run.updated_at = Utc::now().to_rfc3339();
+                    self.save_run(&run)?;
+                    return Ok(run);
+                }
+            }
+        }
+
+        // Spec gate — never complete without Spec + evidence
+        let results = evaluate_acceptance(&spec.acceptance, Path::new(&run.home_cwd))?;
+        match can_complete(&spec, &results, false) {
+            Ok(()) => {
                 run.status = RunStatus::Completed.as_str().into();
                 run.stop_reason = Some(StopReason::SpecMet.as_str().into());
                 run.finished_at = Some(Utc::now().to_rfc3339());
             }
-        } else {
-            run.status = RunStatus::Completed.as_str().into();
-            run.stop_reason = Some(StopReason::SpecMet.as_str().into());
-            run.finished_at = Some(Utc::now().to_rfc3339());
+            Err(CompleteGateError::HumanBlocked { .. }) => {
+                run.status = RunStatus::BlockedHuman.as_str().into();
+            }
+            Err(_) => {
+                run.status = RunStatus::Failed.as_str().into();
+                run.stop_reason = Some(StopReason::WorkerFailed.as_str().into());
+                run.finished_at = Some(Utc::now().to_rfc3339());
+            }
         }
         run.updated_at = Utc::now().to_rfc3339();
         self.save_run(&run)?;
         Ok(run)
     }
 
+    /// @deprecated use advance_loop_once — kept as alias for internal tests
+    pub fn tick_loop_fixture(&self, run_id: &str) -> Result<RunRecord> {
+        self.advance_loop_once(run_id)
+    }
+
+    /// @deprecated use advance_graph_until_terminal
+    pub fn step_graph_fixture(&self, run_id: &str) -> Result<RunRecord> {
+        self.advance_graph_until_terminal(run_id)
+    }
+
     fn fail_run(&self, mut run: RunRecord, reason: StopReason) -> Result<RunRecord> {
+        run.status = RunStatus::Failed.as_str().into();
+        run.stop_reason = Some(reason.as_str().into());
+        run.finished_at = Some(Utc::now().to_rfc3339());
+        run.updated_at = Utc::now().to_rfc3339();
+        self.save_run(&run)?;
+        Ok(run)
+    }
+
+    fn fail_run_msg(
+        &self,
+        mut run: RunRecord,
+        reason: StopReason,
+        msg: &str,
+    ) -> Result<RunRecord> {
+        let _ = fs::write(
+            PathBuf::from(&run.artifact_dir).join("fail_detail.txt"),
+            msg,
+        );
         run.status = RunStatus::Failed.as_str().into();
         run.stop_reason = Some(reason.as_str().into());
         run.finished_at = Some(Utc::now().to_rfc3339());
@@ -1148,11 +1435,479 @@ mod integration_tests {
         meta["confirmed"] = serde_json::json!(true);
         write_json_atomic(&meta_path, &meta).unwrap();
 
-        let started = svc.start_run(&run.id).unwrap();
-        assert_eq!(started.mode.as_deref(), Some("loop"));
-        let done = svc.tick_loop_fixture(&run.id).unwrap();
+        let done = svc.start_run(&run.id).unwrap();
+        assert_eq!(done.mode.as_deref(), Some("loop"));
         assert_eq!(done.status, "completed");
         assert_eq!(done.stop_reason.as_deref(), Some("spec_met"));
+        // role_invoke wrote maker/verify artifacts
+        assert!(
+            PathBuf::from(&done.artifact_dir)
+                .join("work_state.json")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn sensor_integrity_fails_when_protected_file_mutated() {
+        let (svc, home) = svc();
+        let home_cwd = home.join("proj");
+        fs::create_dir_all(&home_cwd).unwrap();
+        let protected = home_cwd.join("tests/guard.rs");
+        fs::create_dir_all(protected.parent().unwrap()).unwrap();
+        fs::write(&protected, b"// original\n").unwrap();
+
+        let run = svc
+            .create_run(CreateRunReq {
+                goal: "integrity".into(),
+                requested_mode: "loop".into(),
+                target_kind: "standalone".into(),
+                project_guid: None,
+                workspace_guid: None,
+                home_cwd: home_cwd.display().to_string(),
+                budget: Some(Budget {
+                    max_iterations: 2,
+                    max_wall_ms: 60_000,
+                    max_maker_invocations: 3,
+                    max_spec_versions: 3,
+                }),
+                carry_from_run_id: None,
+                maker_agent_id: None,
+                planner_agent_id: None,
+                criteria_agent_id: None,
+                verify_agent_id: None,
+            })
+            .unwrap();
+
+        let body = JudgmentSpecBody {
+            goal_summary: "g".into(),
+            risk_tier: "low".into(),
+            acceptance: vec![Criterion {
+                id: "c1".into(),
+                description: "true".into(),
+                kind: "sensor".into(),
+                required: true,
+                sensor: Some(SensorSpec {
+                    argv: vec!["true".into()],
+                    cwd: None,
+                    pass_exit_codes: vec![0],
+                    timeout_ms: 5000,
+                }),
+                falsify: None,
+                evidence_required: vec![],
+                immutable_paths: vec!["tests/guard.rs".into()],
+                sole_source: Some("sensor".into()),
+            }],
+            rejection: vec![],
+            judgment_order: vec!["sensor".into()],
+        };
+        svc.draft_spec_from_body(&run.id, body).unwrap();
+        let meta_path = PathBuf::from(&run.artifact_dir).join("specs/v1.meta.json");
+        let mut meta: serde_json::Value = read_json_file(&meta_path).unwrap();
+        meta["confirmed"] = serde_json::json!(true);
+        write_json_atomic(&meta_path, &meta).unwrap();
+
+        // After start, maker runs — but we mutate protected file mid-flight by racing:
+        // Call advance after mutating between snapshot and check by temporarily
+        // wrapping: mutate file after snapshot inside maker by pre-mutating with
+        // newer mtime during role_invoke — simulate by calling advance after
+        // changing file with sleep for mtime granularity.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        // Manually run one advance path with mutation: use start which auto-runs;
+        // Instead invoke advance after setting running and mutating during maker.
+        // Simpler: unit-level check that mutating after snapshot fails:
+        let before = snapshot_immutable_mtimes(&["tests/guard.rs".into()], &home_cwd);
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        fs::write(&protected, b"// tampered\n").unwrap();
+        assert!(check_immutable_not_modified(
+            &["tests/guard.rs".into()],
+            &home_cwd,
+            &before
+        )
+        .is_err());
+
+        // Also ensure start with integrity path can fail when file changes during maker:
+        // Pre-mutate won't trigger because snapshot is after create; instead monkey by
+        // running advance_loop_once after setting status running with confirmed spec.
+        let mut run = svc.load_run(&run.id).unwrap();
+        run.status = "running".into();
+        run.mode = Some("loop".into());
+        run.wall_started_ms = Some(now_ms());
+        svc.save_run(&run).unwrap();
+
+        // Snapshot happens at start of advance; change file by making maker write to it:
+        // role_invoke maker doesn't touch tests/guard.rs — so inject tamper via custom:
+        // Call snapshot, then write, then check is unit-tested above.
+        // Integration: replace immutable path with a file maker touches:
+        let marker = home_cwd.join(".orch_maker_ran");
+        // re-draft with immutable_paths on maker marker that role_invoke writes
+        let body2 = JudgmentSpecBody {
+            goal_summary: "g".into(),
+            risk_tier: "low".into(),
+            acceptance: vec![Criterion {
+                id: "c1".into(),
+                description: "true".into(),
+                kind: "sensor".into(),
+                required: true,
+                sensor: Some(SensorSpec {
+                    argv: vec!["true".into()],
+                    cwd: None,
+                    pass_exit_codes: vec![0],
+                    timeout_ms: 5000,
+                }),
+                falsify: None,
+                evidence_required: vec![],
+                immutable_paths: vec![".orch_maker_ran".into()],
+                sole_source: Some("sensor".into()),
+            }],
+            rejection: vec![],
+            judgment_order: vec!["sensor".into()],
+        };
+        // Pre-create protected empty file so snapshot has mtime
+        fs::write(&marker, b"seed").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        svc.draft_spec_from_body(&run.id, body2).unwrap();
+        let meta_path = PathBuf::from(&run.artifact_dir).join("specs/v2.meta.json");
+        let mut meta: serde_json::Value = read_json_file(&meta_path).unwrap();
+        meta["confirmed"] = serde_json::json!(true);
+        write_json_atomic(&meta_path, &meta).unwrap();
+        let mut run = svc.load_run(&run.id).unwrap();
+        run.locked_spec_version = Some(2);
+        run.status = "running".into();
+        run.mode = Some("loop".into());
+        run.wall_started_ms = Some(now_ms());
+        svc.save_run(&run).unwrap();
+
+        let after = svc.advance_loop_once(&run.id).unwrap();
+        // maker role_invoke overwrites .orch_maker_ran → integrity fail
+        assert_eq!(after.status, "failed");
+        assert_eq!(after.stop_reason.as_deref(), Some("worker_failed"));
+    }
+
+    #[test]
+    fn graph_fail_closed_on_failed_branch() {
+        let (svc, home) = svc();
+        let home_cwd = home.join("g");
+        fs::create_dir_all(&home_cwd).unwrap();
+        let run = svc
+            .create_run(CreateRunReq {
+                goal: "graph fail".into(),
+                requested_mode: "graph".into(),
+                target_kind: "standalone".into(),
+                project_guid: None,
+                workspace_guid: None,
+                home_cwd: home_cwd.display().to_string(),
+                budget: None,
+                carry_from_run_id: None,
+                maker_agent_id: None,
+                planner_agent_id: None,
+                criteria_agent_id: None,
+                verify_agent_id: None,
+            })
+            .unwrap();
+        let body = JudgmentSpecBody {
+            goal_summary: "g".into(),
+            risk_tier: "low".into(),
+            acceptance: vec![Criterion {
+                id: "c1".into(),
+                description: "true".into(),
+                kind: "sensor".into(),
+                required: true,
+                sensor: Some(SensorSpec {
+                    argv: vec!["true".into()],
+                    cwd: None,
+                    pass_exit_codes: vec![0],
+                    timeout_ms: 5000,
+                }),
+                falsify: None,
+                evidence_required: vec![],
+                immutable_paths: vec![],
+                sole_source: Some("sensor".into()),
+            }],
+            rejection: vec![],
+            judgment_order: vec!["sensor".into()],
+        };
+        svc.draft_spec_from_body(&run.id, body).unwrap();
+        let meta_path = PathBuf::from(&run.artifact_dir).join("specs/v1.meta.json");
+        let mut meta: serde_json::Value = read_json_file(&meta_path).unwrap();
+        meta["confirmed"] = serde_json::json!(true);
+        write_json_atomic(&meta_path, &meta).unwrap();
+
+        let g = CompiledGraph {
+            nodes: vec![
+                GraphNode {
+                    id: "a".into(),
+                    kind: "maker".into(),
+                    label: "a".into(),
+                    agent_id: None,
+                    fresh_context: None,
+                    writes: true,
+                    isolation: "worktree".into(),
+                    node_timeout_ms: None,
+                    workspace_guid: None,
+                },
+                GraphNode {
+                    id: "b-fail".into(),
+                    kind: "maker".into(),
+                    label: "b-fail".into(),
+                    agent_id: None,
+                    fresh_context: None,
+                    writes: true,
+                    isolation: "worktree".into(),
+                    node_timeout_ms: None,
+                    workspace_guid: None,
+                },
+                GraphNode {
+                    id: "join".into(),
+                    kind: "join".into(),
+                    label: "join".into(),
+                    agent_id: None,
+                    fresh_context: None,
+                    writes: false,
+                    isolation: "none".into(),
+                    node_timeout_ms: None,
+                    workspace_guid: None,
+                },
+            ],
+            edges: vec![
+                GraphEdge {
+                    id: "e1".into(),
+                    from: "a".into(),
+                    to: "join".into(),
+                    kind: "control".into(),
+                    required: true,
+                    max_cycles: None,
+                },
+                GraphEdge {
+                    id: "e2".into(),
+                    from: "b-fail".into(),
+                    to: "join".into(),
+                    kind: "control".into(),
+                    required: true,
+                    max_cycles: None,
+                },
+            ],
+            entry: vec!["a".into(), "b-fail".into()],
+        };
+        svc.compile_run_graph(&run.id, &g).unwrap();
+        // write mode proposal with graph for start
+        svc.write_mode_proposal(
+            &run.id,
+            &ModeProposal {
+                mode: EffectiveMode::Graph,
+                reason: "parallel".into(),
+                plan_complexity: "high".into(),
+                topology_hint: None,
+                graph: Some(g),
+                named_units: vec![],
+            },
+        )
+        .unwrap();
+
+        let done = svc.start_run(&run.id).unwrap();
+        assert_eq!(done.status, "failed");
+        assert!(
+            done.stop_reason.as_deref() == Some("join_incomplete")
+                || done.stop_reason.as_deref() == Some("worker_failed")
+        );
+    }
+
+    #[test]
+    fn graph_never_completes_without_spec() {
+        let (svc, home) = svc();
+        let home_cwd = home.join("gs");
+        fs::create_dir_all(&home_cwd).unwrap();
+        let run = svc
+            .create_run(CreateRunReq {
+                goal: "no spec".into(),
+                requested_mode: "loop".into(),
+                target_kind: "standalone".into(),
+                project_guid: None,
+                workspace_guid: None,
+                home_cwd: home_cwd.display().to_string(),
+                budget: None,
+                carry_from_run_id: None,
+                maker_agent_id: None,
+                planner_agent_id: None,
+                criteria_agent_id: None,
+                verify_agent_id: None,
+            })
+            .unwrap();
+        // Force graph mode without going through start_run's full path
+        let mut run = svc.load_run(&run.id).unwrap();
+        run.mode = Some("graph".into());
+        run.status = "running".into();
+        run.graph = Some(CompiledGraph {
+            nodes: vec![GraphNode {
+                id: "a".into(),
+                kind: "maker".into(),
+                label: "a".into(),
+                agent_id: None,
+                fresh_context: None,
+                writes: false,
+                isolation: "none".into(),
+                node_timeout_ms: None,
+                workspace_guid: None,
+            }],
+            edges: vec![],
+            entry: vec!["a".into()],
+        });
+        svc.save_run(&run).unwrap();
+        let err = svc.advance_graph_until_terminal(&run.id).unwrap_err();
+        assert!(err.to_string().contains("SPEC"));
+    }
+
+    #[test]
+    fn cli_workflow_create_spec_start_context_workspace() {
+        // Mirrors agent CLI sequence without HTTP: create → draft → confirm → start → context → workspace.
+        let (svc, home) = svc();
+        let home_cwd = home.join("cli-home");
+        fs::create_dir_all(&home_cwd).unwrap();
+        let run = svc
+            .create_run(CreateRunReq {
+                goal: "cli path".into(),
+                requested_mode: "loop".into(),
+                target_kind: "project".into(),
+                project_guid: Some("pj-1".into()),
+                workspace_guid: None,
+                home_cwd: home_cwd.display().to_string(),
+                budget: Some(Budget::default()),
+                carry_from_run_id: None,
+                maker_agent_id: Some("codex".into()),
+                planner_agent_id: None,
+                criteria_agent_id: None,
+                verify_agent_id: None,
+            })
+            .unwrap();
+        assert!(!run.id.is_empty());
+
+        // start without spec → ORCH_SPEC_REQUIRED
+        let err = svc.start_run(&run.id).unwrap_err().to_string();
+        assert!(err.contains("SPEC"), "{err}");
+
+        let body = JudgmentSpecBody {
+            goal_summary: "cli".into(),
+            risk_tier: "low".into(),
+            acceptance: vec![Criterion {
+                id: "c1".into(),
+                description: "ok".into(),
+                kind: "sensor".into(),
+                required: true,
+                sensor: Some(SensorSpec {
+                    argv: vec!["true".into()],
+                    cwd: None,
+                    pass_exit_codes: vec![0],
+                    timeout_ms: 3000,
+                }),
+                falsify: None,
+                evidence_required: vec![],
+                immutable_paths: vec![],
+                sole_source: Some("sensor".into()),
+            }],
+            rejection: vec![],
+            judgment_order: vec!["sensor".into()],
+        };
+        let (_, ver) = svc.draft_spec_from_body(&run.id, body).unwrap();
+        svc.confirm_spec(&run.id, ver).unwrap();
+
+        let ctx = svc.context_pack(&run.id).unwrap();
+        assert_eq!(ctx["home"]["cwd"], home_cwd.display().to_string());
+
+        let child = svc
+            .workspace_create(&run.id, "iso", None)
+            .unwrap();
+        svc.workspace_use(&run.id, &child.workspace_guid, Some("maker"), None)
+            .unwrap();
+        let run2 = svc.load_run(&run.id).unwrap();
+        assert_eq!(
+            svc.resolve_cwd(&run2, Some("maker"), None),
+            child.path
+        );
+        fs::write(PathBuf::from(&child.path).join("ORCH_RESULT.txt"), "x").unwrap();
+        let merged = svc.workspace_merge(&run.id, &child.workspace_guid).unwrap();
+        assert!(
+            merged
+                .workspaces
+                .iter()
+                .any(|w| w.workspace_guid == child.workspace_guid && w.status == "merged")
+        );
+
+        let finished = svc.start_run(&run.id).unwrap();
+        assert_eq!(finished.status, "completed");
+        assert_eq!(finished.stop_reason.as_deref(), Some("spec_met"));
+
+        let cancelled_base = svc
+            .create_run(CreateRunReq {
+                goal: "cancel me".into(),
+                requested_mode: "loop".into(),
+                target_kind: "standalone".into(),
+                project_guid: None,
+                workspace_guid: None,
+                home_cwd: home_cwd.display().to_string(),
+                budget: None,
+                carry_from_run_id: None,
+                maker_agent_id: None,
+                planner_agent_id: None,
+                criteria_agent_id: None,
+                verify_agent_id: None,
+            })
+            .unwrap();
+        let body = JudgmentSpecBody {
+            goal_summary: "c".into(),
+            risk_tier: "low".into(),
+            acceptance: vec![Criterion {
+                id: "c1".into(),
+                description: "f".into(),
+                kind: "sensor".into(),
+                required: true,
+                sensor: Some(SensorSpec {
+                    argv: vec!["false".into()],
+                    cwd: None,
+                    pass_exit_codes: vec![0],
+                    timeout_ms: 2000,
+                }),
+                falsify: None,
+                evidence_required: vec![],
+                immutable_paths: vec![],
+                sole_source: None,
+            }],
+            rejection: vec![],
+            judgment_order: vec!["sensor".into()],
+        };
+        let (_, v) = svc.draft_spec_from_body(&cancelled_base.id, body).unwrap();
+        svc.confirm_spec(&cancelled_base.id, v).unwrap();
+        svc.start_run_with_options(&cancelled_base.id, false)
+            .unwrap();
+        let c = svc.cancel_run(&cancelled_base.id).unwrap();
+        assert_eq!(c.status, "cancelled");
+    }
+
+    #[test]
+    fn role_invoke_uses_home_cwd() {
+        let (svc, home) = svc();
+        let home_cwd = home.join("cwdproj");
+        fs::create_dir_all(&home_cwd).unwrap();
+        let run = svc
+            .create_run(CreateRunReq {
+                goal: "cwd".into(),
+                requested_mode: "loop".into(),
+                target_kind: "standalone".into(),
+                project_guid: None,
+                workspace_guid: None,
+                home_cwd: home_cwd.display().to_string(),
+                budget: None,
+                carry_from_run_id: None,
+                maker_agent_id: None,
+                planner_agent_id: None,
+                criteria_agent_id: None,
+                verify_agent_id: None,
+            })
+            .unwrap();
+        let art = svc.role_invoke(&run.id, OrchRole::Maker, None).unwrap();
+        assert!(art.exists());
+        assert!(home_cwd.join(".orch_maker_ran").exists());
+        let ws: serde_json::Value =
+            read_json_file(&PathBuf::from(&run.artifact_dir).join("work_state.json")).unwrap();
+        assert_eq!(ws["cwd"], home_cwd.display().to_string());
     }
 
     #[test]
@@ -1335,7 +2090,7 @@ mod integration_tests {
         let mut meta: serde_json::Value = read_json_file(&meta_path).unwrap();
         meta["confirmed"] = serde_json::json!(true);
         write_json_atomic(&meta_path, &meta).unwrap();
-        svc.start_run(&run.id).unwrap();
+        svc.start_run_with_options(&run.id, false).unwrap();
         let cancelled = svc.cancel_run(&run.id).unwrap();
         assert_eq!(cancelled.status, "cancelled");
         assert_eq!(cancelled.stop_reason.as_deref(), Some("user_cancel"));

--- a/crates/core-service/src/service/orchestrator/mod.rs
+++ b/crates/core-service/src/service/orchestrator/mod.rs
@@ -294,8 +294,8 @@ impl OrchestratorService {
             return Ok(vec![]);
         }
         let mut runs = Vec::new();
-        for entry in fs::read_dir(&dir)
-            .map_err(|e| ServiceError::Processing(format!("read runs: {e}")))?
+        for entry in
+            fs::read_dir(&dir).map_err(|e| ServiceError::Processing(format!("read runs: {e}")))?
         {
             let entry = entry.map_err(|e| ServiceError::Processing(e.to_string()))?;
             let run_json = entry.path().join("run.json");
@@ -310,7 +310,12 @@ impl OrchestratorService {
         Ok(runs)
     }
 
-    pub fn resolve_cwd(&self, run: &RunRecord, role: Option<&str>, node_id: Option<&str>) -> String {
+    pub fn resolve_cwd(
+        &self,
+        run: &RunRecord,
+        role: Option<&str>,
+        node_id: Option<&str>,
+    ) -> String {
         for b in &run.role_bindings {
             if role.is_some() && b.role.as_deref() == role {
                 return b.cwd.clone();
@@ -398,14 +403,16 @@ impl OrchestratorService {
             "confirmed_by": if need_confirm { serde_json::Value::Null } else { serde_json::json!("auto") },
         });
         write_json_atomic(
-            &PathBuf::from(&run.artifact_dir).join("specs").join(format!("v{version}.meta.json")),
+            &PathBuf::from(&run.artifact_dir)
+                .join("specs")
+                .join(format!("v{version}.meta.json")),
             &meta,
         )?;
 
         if !need_confirm {
             // auto-confirm path: leave status as awaiting then auto flip
             run.status = RunStatus::DraftingSpec.as_str().into(); // ready to start after confirm helper
-            // mark ready
+                                                                  // mark ready
             run.status = "spec_ready".into(); // intermediate — start will accept
         }
 
@@ -438,9 +445,9 @@ impl OrchestratorService {
 
     pub fn get_spec(&self, run_id: &str, version: Option<i32>) -> Result<JudgmentSpecBody> {
         let run = self.load_run(run_id)?;
-        let v = version.or(run.locked_spec_version).ok_or_else(|| {
-            ServiceError::NotFound("no spec".into())
-        })?;
+        let v = version
+            .or(run.locked_spec_version)
+            .ok_or_else(|| ServiceError::NotFound("no spec".into()))?;
         let path = PathBuf::from(&run.artifact_dir)
             .join("specs")
             .join(format!("v{v}.json"));
@@ -519,7 +526,8 @@ impl OrchestratorService {
                         ServiceError::Validation(format!("ORCH_GRAPH_COMPILE_FAILED: {}", e.0))
                     })?;
                     run.graph = Some(compiled);
-                } else if p.topology_hint.as_deref() == Some("diamond") && p.named_units.len() >= 2 {
+                } else if p.topology_hint.as_deref() == Some("diamond") && p.named_units.len() >= 2
+                {
                     run.graph = Some(diamond_from_units(&p.named_units));
                     compile_graph(run.graph.as_ref().unwrap()).map_err(|e| {
                         ServiceError::Validation(format!("ORCH_GRAPH_COMPILE_FAILED: {}", e.0))
@@ -804,8 +812,7 @@ impl OrchestratorService {
                     .display()
                     .to_string()
             });
-            fs::create_dir_all(&child_path)
-                .map_err(|e| ServiceError::Processing(e.to_string()))?;
+            fs::create_dir_all(&child_path).map_err(|e| ServiceError::Processing(e.to_string()))?;
             let rec = RunWorkspaceRecord {
                 id: Uuid::new_v4().to_string(),
                 workspace_guid: format!("child-{}", Uuid::new_v4()),
@@ -960,9 +967,8 @@ impl OrchestratorService {
     }
 
     pub fn compile_run_graph(&self, run_id: &str, graph: &CompiledGraph) -> Result<CompiledGraph> {
-        let compiled = compile_graph(graph).map_err(|e| {
-            ServiceError::Validation(format!("ORCH_GRAPH_COMPILE_FAILED: {}", e.0))
-        })?;
+        let compiled = compile_graph(graph)
+            .map_err(|e| ServiceError::Validation(format!("ORCH_GRAPH_COMPILE_FAILED: {}", e.0)))?;
         let mut run = self.load_run(run_id)?;
         run.graph = Some(compiled.clone());
         write_json_atomic(
@@ -1269,8 +1275,13 @@ mod integration_tests {
     #[test]
     fn never_writes_canvas_dir() {
         let (svc, _) = svc();
-        assert!(svc.root().join("boards").to_string_lossy().contains("orchestrator")
-            || !svc.root().to_string_lossy().contains("canvas"));
+        assert!(
+            svc.root()
+                .join("boards")
+                .to_string_lossy()
+                .contains("orchestrator")
+                || !svc.root().to_string_lossy().contains("canvas")
+        );
         // boards created under orchestrator root
         let _ = fs::create_dir_all(svc.boards_path());
         assert!(!svc.boards_path().to_string_lossy().contains("/canvas/"));

--- a/crates/core-service/src/service/orchestrator/runtime.rs
+++ b/crates/core-service/src/service/orchestrator/runtime.rs
@@ -1,0 +1,409 @@
+//! Pure Runtime gates (APP-048). No I/O.
+
+use super::schemas::*;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompleteGateError {
+    NoSpec,
+    AcceptanceFailed { id: String },
+    RejectionFired { id: String },
+    HumanBlocked { id: String },
+    Unverified { id: String },
+    MakerSelfDeclare,
+}
+
+/// Completion gate: all required acceptance pass, no rejection, no human block, no unverified.
+pub fn can_complete(
+    spec: &JudgmentSpecBody,
+    criterion_results: &[CriterionResult],
+    allow_maker_self_declare: bool,
+) -> Result<(), CompleteGateError> {
+    if allow_maker_self_declare {
+        return Err(CompleteGateError::MakerSelfDeclare);
+    }
+    if spec.acceptance.is_empty() {
+        return Err(CompleteGateError::NoSpec);
+    }
+
+    for c in &spec.acceptance {
+        if !c.required {
+            continue;
+        }
+        let Some(r) = criterion_results.iter().find(|r| r.criterion_id == c.id) else {
+            return Err(CompleteGateError::Unverified { id: c.id.clone() });
+        };
+        if r.unverified {
+            return Err(CompleteGateError::Unverified { id: c.id.clone() });
+        }
+        if c.kind == "human" && !r.pass {
+            return Err(CompleteGateError::HumanBlocked { id: c.id.clone() });
+        }
+        if !r.pass {
+            return Err(CompleteGateError::AcceptanceFailed { id: c.id.clone() });
+        }
+    }
+
+    for c in &spec.rejection {
+        if let Some(r) = criterion_results.iter().find(|r| r.criterion_id == c.id) {
+            if r.pass {
+                // rejection criterion "pass" means the bad condition was detected
+                return Err(CompleteGateError::RejectionFired { id: c.id.clone() });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn requires_user_confirm(spec: &JudgmentSpecBody) -> bool {
+    if matches!(spec.risk_tier.as_str(), "high" | "critical") {
+        return true;
+    }
+    let has_sensor = spec
+        .acceptance
+        .iter()
+        .any(|c| c.required && c.kind == "sensor");
+    for c in &spec.acceptance {
+        if !c.required {
+            continue;
+        }
+        if c.kind == "human" {
+            return true;
+        }
+        if c.kind == "llm_judge" {
+            // confirm if any required llm_judge exists (M13 tightened)
+            return true;
+        }
+        if c.kind == "llm_judge" && !has_sensor {
+            return true;
+        }
+    }
+    false
+}
+
+/// True when `next` weakens `prev` (drops required acceptance or softens risk).
+pub fn spec_weakens(prev: &JudgmentSpecBody, next: &JudgmentSpecBody) -> bool {
+    let risk_rank = |t: &str| match t {
+        "critical" => 3,
+        "high" => 2,
+        "medium" => 1,
+        _ => 0,
+    };
+    if risk_rank(&next.risk_tier) < risk_rank(&prev.risk_tier) {
+        return true;
+    }
+    for c in &prev.acceptance {
+        if !c.required {
+            continue;
+        }
+        let still = next.acceptance.iter().any(|n| n.id == c.id && n.required);
+        if !still {
+            return true;
+        }
+    }
+    false
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BudgetCheck {
+    Ok,
+    Iterations,
+    Wall,
+    Makers,
+}
+
+pub fn check_budget(
+    budget: &Budget,
+    iterations_used: u32,
+    maker_invocations: u32,
+    elapsed_ms: u64,
+) -> BudgetCheck {
+    if iterations_used >= budget.max_iterations {
+        return BudgetCheck::Iterations;
+    }
+    if maker_invocations >= budget.max_maker_invocations {
+        return BudgetCheck::Makers;
+    }
+    if elapsed_ms >= budget.max_wall_ms {
+        return BudgetCheck::Wall;
+    }
+    BudgetCheck::Ok
+}
+
+pub fn progress_key(failing_criterion_ids: &[String], sensor_signatures: &[String]) -> String {
+    let mut ids = failing_criterion_ids.to_vec();
+    ids.sort();
+    let mut sigs = sensor_signatures.to_vec();
+    sigs.sort();
+    format!("{}|{}", ids.join(","), sigs.join(","))
+}
+
+pub fn update_progress_streak(prev_key: Option<&str>, prev_streak: u32, new_key: &str) -> u32 {
+    match prev_key {
+        Some(p) if p == new_key && !new_key.is_empty() => prev_streak.saturating_add(1),
+        _ => 1,
+    }
+}
+
+pub const NO_PROGRESS_THRESHOLD: u32 = 3;
+
+/// Resolve effective mode from request + optional proposal (M6b demote).
+pub fn resolve_effective_mode(
+    requested: OrchMode,
+    proposal: Option<&ModeProposal>,
+) -> Result<(EffectiveMode, String), String> {
+    match requested {
+        OrchMode::Loop => Ok((EffectiveMode::Loop, "user override".into())),
+        OrchMode::Graph => {
+            if let Some(p) = proposal {
+                if let Some(g) = &p.graph {
+                    if let Err(e) = super::graph_compile::compile_graph(g) {
+                        return Ok((
+                            EffectiveMode::Loop,
+                            format!("graph compile failed, demoted to loop: {e}"),
+                        ));
+                    }
+                } else if p.named_units.len() < 2 && p.topology_hint.as_deref() != Some("diamond") {
+                    return Ok((
+                        EffectiveMode::Loop,
+                        "graph requested without compilable topology; demoted to loop".into(),
+                    ));
+                }
+            }
+            Ok((
+                EffectiveMode::Graph,
+                proposal
+                    .map(|p| p.reason.clone())
+                    .unwrap_or_else(|| "user forced graph".into()),
+            ))
+        }
+        OrchMode::Auto => {
+            let Some(p) = proposal else {
+                return Err("auto mode requires mode_proposal.json".into());
+            };
+            match p.mode {
+                EffectiveMode::Loop => Ok((EffectiveMode::Loop, p.reason.clone())),
+                EffectiveMode::Graph => {
+                    if let Some(g) = &p.graph {
+                        if let Err(e) = super::graph_compile::compile_graph(g) {
+                            return Ok((
+                                EffectiveMode::Loop,
+                                format!("auto graph demoted: {e}"),
+                            ));
+                        }
+                        Ok((EffectiveMode::Graph, p.reason.clone()))
+                    } else if p.topology_hint.as_deref() == Some("diamond")
+                        && p.named_units.len() >= 2
+                    {
+                        Ok((EffectiveMode::Graph, p.reason.clone()))
+                    } else {
+                        Ok((
+                            EffectiveMode::Loop,
+                            format!(
+                                "auto preferred loop (no valid graph): {}",
+                                p.reason
+                            ),
+                        ))
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sensor_crit(id: &str) -> Criterion {
+        Criterion {
+            id: id.into(),
+            description: "d".into(),
+            kind: "sensor".into(),
+            required: true,
+            sensor: Some(SensorSpec {
+                argv: vec!["true".into()],
+                cwd: None,
+                pass_exit_codes: vec![0],
+                timeout_ms: 1000,
+            }),
+            falsify: None,
+            evidence_required: vec![],
+            immutable_paths: vec!["tests/foo.rs".into()],
+            sole_source: Some("sensor".into()),
+        }
+    }
+
+    fn base_spec() -> JudgmentSpecBody {
+        JudgmentSpecBody {
+            goal_summary: "g".into(),
+            risk_tier: "low".into(),
+            acceptance: vec![sensor_crit("c1")],
+            rejection: vec![],
+            judgment_order: vec![
+                "sensor".into(),
+                "llm_judge".into(),
+                "human".into(),
+            ],
+        }
+    }
+
+    #[test]
+    fn complete_requires_all_acceptance() {
+        let spec = base_spec();
+        assert!(can_complete(&spec, &[], false).is_err());
+        assert!(can_complete(
+            &spec,
+            &[CriterionResult {
+                criterion_id: "c1".into(),
+                pass: true,
+                evidence_ids: vec!["e1".into()],
+                detail: "ok".into(),
+                unverified: false,
+            }],
+            false
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn unverified_blocks_complete() {
+        let spec = base_spec();
+        let err = can_complete(
+            &spec,
+            &[CriterionResult {
+                criterion_id: "c1".into(),
+                pass: false,
+                evidence_ids: vec![],
+                detail: "timeout".into(),
+                unverified: true,
+            }],
+            false,
+        )
+        .unwrap_err();
+        assert!(matches!(err, CompleteGateError::Unverified { .. }));
+    }
+
+    #[test]
+    fn maker_self_declare_banned() {
+        let spec = base_spec();
+        assert!(matches!(
+            can_complete(&spec, &[], true),
+            Err(CompleteGateError::MakerSelfDeclare)
+        ));
+    }
+
+    #[test]
+    fn rejection_blocks_complete() {
+        let mut spec = base_spec();
+        spec.rejection.push(Criterion {
+            id: "bad".into(),
+            description: "no".into(),
+            kind: "sensor".into(),
+            required: true,
+            sensor: None,
+            falsify: None,
+            evidence_required: vec![],
+            immutable_paths: vec![],
+            sole_source: None,
+        });
+        let err = can_complete(
+            &spec,
+            &[
+                CriterionResult {
+                    criterion_id: "c1".into(),
+                    pass: true,
+                    evidence_ids: vec![],
+                    detail: String::new(),
+                    unverified: false,
+                },
+                CriterionResult {
+                    criterion_id: "bad".into(),
+                    pass: true, // rejection detected
+                    evidence_ids: vec![],
+                    detail: String::new(),
+                    unverified: false,
+                },
+            ],
+            false,
+        )
+        .unwrap_err();
+        assert!(matches!(err, CompleteGateError::RejectionFired { .. }));
+    }
+
+    #[test]
+    fn human_confirm_for_llm_judge() {
+        let mut spec = base_spec();
+        spec.acceptance.push(Criterion {
+            id: "h".into(),
+            description: "human".into(),
+            kind: "llm_judge".into(),
+            required: true,
+            sensor: None,
+            falsify: None,
+            evidence_required: vec![],
+            immutable_paths: vec![],
+            sole_source: Some("llm_judge".into()),
+        });
+        assert!(requires_user_confirm(&spec));
+    }
+
+    #[test]
+    fn weaken_detects_dropped_criterion() {
+        let prev = base_spec();
+        let mut next = base_spec();
+        next.acceptance.clear();
+        assert!(spec_weakens(&prev, &next));
+    }
+
+    #[test]
+    fn budget_wall() {
+        let b = Budget {
+            max_iterations: 8,
+            max_wall_ms: 100,
+            max_maker_invocations: 12,
+            max_spec_versions: 3,
+        };
+        assert_eq!(check_budget(&b, 0, 0, 100), BudgetCheck::Wall);
+    }
+
+    #[test]
+    fn no_progress_streak() {
+        assert_eq!(update_progress_streak(Some("a"), 2, "a"), 3);
+        assert_eq!(update_progress_streak(Some("a"), 2, "b"), 1);
+    }
+
+    #[test]
+    fn auto_demotes_bad_graph() {
+        let proposal = ModeProposal {
+            mode: EffectiveMode::Graph,
+            reason: "try graph".into(),
+            plan_complexity: "low".into(),
+            topology_hint: None,
+            graph: Some(CompiledGraph {
+                nodes: vec![],
+                edges: vec![],
+                entry: vec![],
+            }),
+            named_units: vec![],
+        };
+        let (mode, reason) = resolve_effective_mode(OrchMode::Auto, Some(&proposal)).unwrap();
+        assert_eq!(mode, EffectiveMode::Loop);
+        assert!(reason.contains("demot") || reason.contains("loop") || reason.contains("compile"));
+    }
+
+    #[test]
+    fn user_loop_skips_proposal() {
+        let (mode, _) = resolve_effective_mode(OrchMode::Loop, None).unwrap();
+        assert_eq!(mode, EffectiveMode::Loop);
+    }
+
+    #[test]
+    fn role_header_distinguishes_same_brand() {
+        let a = compose_role_header(OrchRole::Maker, "Codex", Some("iter 1"), "active");
+        let b = compose_role_header(OrchRole::Verify, "Codex", None, "active");
+        assert_ne!(a, b);
+        assert!(a.contains("Maker"));
+        assert!(b.contains("Verify"));
+    }
+}

--- a/crates/core-service/src/service/orchestrator/runtime.rs
+++ b/crates/core-service/src/service/orchestrator/runtime.rs
@@ -186,10 +186,7 @@ pub fn resolve_effective_mode(
                 EffectiveMode::Graph => {
                     if let Some(g) = &p.graph {
                         if let Err(e) = super::graph_compile::compile_graph(g) {
-                            return Ok((
-                                EffectiveMode::Loop,
-                                format!("auto graph demoted: {e}"),
-                            ));
+                            return Ok((EffectiveMode::Loop, format!("auto graph demoted: {e}")));
                         }
                         Ok((EffectiveMode::Graph, p.reason.clone()))
                     } else if p.topology_hint.as_deref() == Some("diamond")
@@ -199,10 +196,7 @@ pub fn resolve_effective_mode(
                     } else {
                         Ok((
                             EffectiveMode::Loop,
-                            format!(
-                                "auto preferred loop (no valid graph): {}",
-                                p.reason
-                            ),
+                            format!("auto preferred loop (no valid graph): {}", p.reason),
                         ))
                     }
                 }
@@ -240,11 +234,7 @@ mod tests {
             risk_tier: "low".into(),
             acceptance: vec![sensor_crit("c1")],
             rejection: vec![],
-            judgment_order: vec![
-                "sensor".into(),
-                "llm_judge".into(),
-                "human".into(),
-            ],
+            judgment_order: vec!["sensor".into(), "llm_judge".into(), "human".into()],
         }
     }
 

--- a/crates/core-service/src/service/orchestrator/schemas.rs
+++ b/crates/core-service/src/service/orchestrator/schemas.rs
@@ -1,0 +1,389 @@
+//! Shared Orchestrator types (APP-048). Pure data — no I/O.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OrchMode {
+    Auto,
+    Loop,
+    Graph,
+}
+
+impl OrchMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Loop => "loop",
+            Self::Graph => "graph",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "auto" => Some(Self::Auto),
+            "loop" => Some(Self::Loop),
+            "graph" => Some(Self::Graph),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EffectiveMode {
+    Loop,
+    Graph,
+}
+
+impl EffectiveMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Loop => "loop",
+            Self::Graph => "graph",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunStatus {
+    DraftingSpec,
+    AwaitingSpecConfirm,
+    Running,
+    BlockedHuman,
+    RefiningSpec,
+    Completed,
+    Failed,
+    Cancelled,
+    Interrupted,
+}
+
+impl RunStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::DraftingSpec => "drafting_spec",
+            Self::AwaitingSpecConfirm => "awaiting_spec_confirm",
+            Self::Running => "running",
+            Self::BlockedHuman => "blocked_human",
+            Self::RefiningSpec => "refining_spec",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::Interrupted => "interrupted",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "drafting_spec" => Some(Self::DraftingSpec),
+            "awaiting_spec_confirm" => Some(Self::AwaitingSpecConfirm),
+            "running" => Some(Self::Running),
+            "blocked_human" => Some(Self::BlockedHuman),
+            "refining_spec" => Some(Self::RefiningSpec),
+            "completed" => Some(Self::Completed),
+            "failed" => Some(Self::Failed),
+            "cancelled" => Some(Self::Cancelled),
+            "interrupted" => Some(Self::Interrupted),
+            _ => None,
+        }
+    }
+
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Completed | Self::Failed | Self::Cancelled | Self::Interrupted
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StopReason {
+    SpecMet,
+    BudgetIterations,
+    BudgetWall,
+    BudgetMakers,
+    NoProgress,
+    UserCancel,
+    CriteriaUnsatisfiable,
+    GraphCompileFailed,
+    WorkerFailed,
+    ArtifactInvalid,
+    JoinIncomplete,
+    InterruptedEnvironment,
+}
+
+impl StopReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SpecMet => "spec_met",
+            Self::BudgetIterations => "budget_iterations",
+            Self::BudgetWall => "budget_wall",
+            Self::BudgetMakers => "budget_makers",
+            Self::NoProgress => "no_progress",
+            Self::UserCancel => "user_cancel",
+            Self::CriteriaUnsatisfiable => "criteria_unsatisfiable",
+            Self::GraphCompileFailed => "graph_compile_failed",
+            Self::WorkerFailed => "worker_failed",
+            Self::ArtifactInvalid => "artifact_invalid",
+            Self::JoinIncomplete => "join_incomplete",
+            Self::InterruptedEnvironment => "interrupted_environment",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TargetKind {
+    Project,
+    Workspace,
+    Standalone,
+}
+
+impl TargetKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Project => "project",
+            Self::Workspace => "workspace",
+            Self::Standalone => "standalone",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "project" => Some(Self::Project),
+            "workspace" => Some(Self::Workspace),
+            "standalone" => Some(Self::Standalone),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OrchRole {
+    Orchestrator,
+    Criteria,
+    Maker,
+    Verify,
+}
+
+impl OrchRole {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Orchestrator => "orchestrator",
+            Self::Criteria => "criteria",
+            Self::Maker => "maker",
+            Self::Verify => "verify",
+        }
+    }
+
+    pub fn ui_label_en(self) -> &'static str {
+        match self {
+            Self::Orchestrator => "Planner",
+            Self::Criteria => "Criteria",
+            Self::Maker => "Maker",
+            Self::Verify => "Verify",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Budget {
+    pub max_iterations: u32,
+    pub max_wall_ms: u64,
+    pub max_maker_invocations: u32,
+    pub max_spec_versions: u32,
+}
+
+impl Default for Budget {
+    fn default() -> Self {
+        Self {
+            max_iterations: 8,
+            max_wall_ms: 2_700_000,
+            max_maker_invocations: 12,
+            max_spec_versions: 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ModeProposal {
+    pub mode: EffectiveMode,
+    pub reason: String,
+    #[serde(default = "default_plan_complexity")]
+    pub plan_complexity: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topology_hint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub graph: Option<CompiledGraph>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub named_units: Vec<String>,
+}
+
+fn default_plan_complexity() -> String {
+    "low".into()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SensorSpec {
+    pub argv: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default = "default_pass_codes")]
+    pub pass_exit_codes: Vec<i32>,
+    #[serde(default = "default_sensor_timeout")]
+    pub timeout_ms: u64,
+}
+
+fn default_pass_codes() -> Vec<i32> {
+    vec![0]
+}
+
+fn default_sensor_timeout() -> u64 {
+    120_000
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Criterion {
+    pub id: String,
+    pub description: String,
+    pub kind: String, // sensor | llm_judge | human
+    #[serde(default = "default_true")]
+    pub required: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sensor: Option<SensorSpec>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub falsify: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence_required: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub immutable_paths: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sole_source: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JudgmentSpecBody {
+    pub goal_summary: String,
+    pub risk_tier: String,
+    pub acceptance: Vec<Criterion>,
+    #[serde(default)]
+    pub rejection: Vec<Criterion>,
+    #[serde(default = "default_judgment_order")]
+    pub judgment_order: Vec<String>,
+}
+
+fn default_judgment_order() -> Vec<String> {
+    vec![
+        "sensor".into(),
+        "llm_judge".into(),
+        "human".into(),
+    ]
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CriterionResult {
+    pub criterion_id: String,
+    pub pass: bool,
+    #[serde(default)]
+    pub evidence_ids: Vec<String>,
+    #[serde(default)]
+    pub detail: String,
+    /// When true, criterion could not be evaluated (timeout/error) — not a pass.
+    #[serde(default)]
+    pub unverified: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VerdictResult {
+    Pass,
+    Fail,
+    CriteriaGap,
+    BlockedHuman,
+    Unverified,
+}
+
+impl VerdictResult {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pass => "pass",
+            Self::Fail => "fail",
+            Self::CriteriaGap => "criteria_gap",
+            Self::BlockedHuman => "blocked_human",
+            Self::Unverified => "unverified",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GraphNode {
+    pub id: String,
+    pub kind: String,
+    pub label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fresh_context: Option<bool>,
+    #[serde(default = "default_true")]
+    pub writes: bool,
+    #[serde(default = "default_isolation_none")]
+    pub isolation: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_timeout_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_guid: Option<String>,
+}
+
+fn default_isolation_none() -> String {
+    "none".into()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GraphEdge {
+    pub id: String,
+    pub from: String,
+    pub to: String,
+    #[serde(default = "default_control")]
+    pub kind: String,
+    #[serde(default = "default_true")]
+    pub required: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_cycles: Option<u32>,
+}
+
+fn default_control() -> String {
+    "control".into()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct CompiledGraph {
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<GraphEdge>,
+    #[serde(default)]
+    pub entry: Vec<String>,
+}
+
+/// Role chrome composition (M18b) — pure helper for UI/tests.
+pub fn compose_role_header(
+    role: OrchRole,
+    agent_display: &str,
+    instance: Option<&str>,
+    activity: &str,
+) -> String {
+    let role_label = role.ui_label_en();
+    let mut parts = vec![format!("[{role_label}]"), agent_display.to_string()];
+    if let Some(inst) = instance.filter(|s| !s.is_empty()) {
+        parts.push(inst.to_string());
+    }
+    if !activity.is_empty() && activity != "active" {
+        parts.push(format!("({activity})"));
+    }
+    parts.join(" ")
+}

--- a/crates/core-service/src/service/orchestrator/schemas.rs
+++ b/crates/core-service/src/service/orchestrator/schemas.rs
@@ -280,11 +280,7 @@ pub struct JudgmentSpecBody {
 }
 
 fn default_judgment_order() -> Vec<String> {
-    vec![
-        "sensor".into(),
-        "llm_judge".into(),
-        "human".into(),
-    ]
+    vec!["sensor".into(), "llm_judge".into(), "human".into()]
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/core-service/src/service/orchestrator/sensors.rs
+++ b/crates/core-service/src/service/orchestrator/sensors.rs
@@ -1,0 +1,217 @@
+//! Deterministic sensors for Judgment Spec.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use super::schemas::{Criterion, CriterionResult, SensorSpec};
+use crate::error::{Result, ServiceError};
+
+pub fn run_sensor(spec: &SensorSpec, default_cwd: &Path) -> Result<(bool, String, i32)> {
+    if spec.argv.is_empty() {
+        return Err(ServiceError::Validation("sensor argv empty".into()));
+    }
+    let cwd = spec
+        .cwd
+        .as_ref()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| default_cwd.to_path_buf());
+
+    let mut cmd = Command::new(&spec.argv[0]);
+    if spec.argv.len() > 1 {
+        cmd.args(&spec.argv[1..]);
+    }
+    cmd.current_dir(&cwd);
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    // timeout via wait_timeout pattern — use std with kill on timeout
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| ServiceError::Processing(format!("spawn sensor: {e}")))?;
+
+    let timeout = Duration::from_millis(spec.timeout_ms.max(1));
+    let start = std::time::Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let code = status.code().unwrap_or(-1);
+                let pass = spec.pass_exit_codes.contains(&code);
+                let detail = format!("exit={code} cwd={}", cwd.display());
+                return Ok((pass, detail, code));
+            }
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Ok((false, format!("sensor timeout after {}ms", spec.timeout_ms), -1));
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            Err(e) => {
+                return Err(ServiceError::Processing(format!("wait sensor: {e}")));
+            }
+        }
+    }
+}
+
+pub fn evaluate_acceptance(
+    criteria: &[Criterion],
+    default_cwd: &Path,
+) -> Result<Vec<CriterionResult>> {
+    let mut out = Vec::new();
+    for c in criteria {
+        if !c.required {
+            continue;
+        }
+        match c.kind.as_str() {
+            "sensor" => {
+                let Some(sensor) = &c.sensor else {
+                    out.push(CriterionResult {
+                        criterion_id: c.id.clone(),
+                        pass: false,
+                        evidence_ids: vec![],
+                        detail: "missing sensor spec".into(),
+                        unverified: true,
+                    });
+                    continue;
+                };
+                match run_sensor(sensor, default_cwd) {
+                    Ok((pass, detail, code)) => {
+                        let unverified = code == -1 && detail.contains("timeout");
+                        out.push(CriterionResult {
+                            criterion_id: c.id.clone(),
+                            pass: pass && !unverified,
+                            evidence_ids: vec![],
+                            detail,
+                            unverified,
+                        });
+                    }
+                    Err(e) => {
+                        out.push(CriterionResult {
+                            criterion_id: c.id.clone(),
+                            pass: false,
+                            evidence_ids: vec![],
+                            detail: e.to_string(),
+                            unverified: true,
+                        });
+                    }
+                }
+            }
+            "human" => {
+                out.push(CriterionResult {
+                    criterion_id: c.id.clone(),
+                    pass: false,
+                    evidence_ids: vec![],
+                    detail: "awaiting human".into(),
+                    unverified: false,
+                });
+            }
+            "llm_judge" => {
+                // M1: without verify role output, treat as unverified (not pass)
+                out.push(CriterionResult {
+                    criterion_id: c.id.clone(),
+                    pass: false,
+                    evidence_ids: vec![],
+                    detail: "llm_judge pending verify artifact".into(),
+                    unverified: true,
+                });
+            }
+            other => {
+                out.push(CriterionResult {
+                    criterion_id: c.id.clone(),
+                    pass: false,
+                    evidence_ids: vec![],
+                    detail: format!("unknown kind {other}"),
+                    unverified: true,
+                });
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Paths that makers must not mutate (sensor integrity).
+pub fn immutable_paths_from_spec(criteria: &[Criterion]) -> Vec<String> {
+    let mut paths = Vec::new();
+    for c in criteria {
+        paths.extend(c.immutable_paths.iter().cloned());
+        if let Some(s) = &c.sensor {
+            // treat script paths in argv as protected when they look like files
+            for a in &s.argv {
+                if a.contains('/') || a.ends_with(".rs") || a.ends_with(".sh") || a.ends_with(".ts")
+                {
+                    paths.push(a.clone());
+                }
+            }
+        }
+    }
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+pub fn check_immutable_not_modified(
+    protected: &[String],
+    home: &Path,
+    before: &std::collections::HashMap<String, u64>,
+) -> std::result::Result<(), String> {
+    for rel in protected {
+        let p = if Path::new(rel).is_absolute() {
+            PathBuf::from(rel)
+        } else {
+            home.join(rel)
+        };
+        let meta = match std::fs::metadata(&p) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        let mtime = meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        if let Some(prev) = before.get(rel) {
+            if mtime > *prev {
+                return Err(format!(
+                    "sensor integrity: protected path modified: {rel}"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn true_sensor_passes() {
+        let dir = tempdir().unwrap();
+        let spec = SensorSpec {
+            argv: vec!["true".into()],
+            cwd: None,
+            pass_exit_codes: vec![0],
+            timeout_ms: 5_000,
+        };
+        let (pass, _, code) = run_sensor(&spec, dir.path()).unwrap();
+        assert!(pass);
+        assert_eq!(code, 0);
+    }
+
+    #[test]
+    fn false_sensor_fails() {
+        let dir = tempdir().unwrap();
+        let spec = SensorSpec {
+            argv: vec!["false".into()],
+            cwd: None,
+            pass_exit_codes: vec![0],
+            timeout_ms: 5_000,
+        };
+        let (pass, _, _) = run_sensor(&spec, dir.path()).unwrap();
+        assert!(!pass);
+    }
+}

--- a/crates/core-service/src/service/orchestrator/sensors.rs
+++ b/crates/core-service/src/service/orchestrator/sensors.rs
@@ -155,9 +155,32 @@ pub fn immutable_paths_from_spec(criteria: &[Criterion]) -> Vec<String> {
     paths
 }
 
-/// Compare protected path mtimes against a pre-maker snapshot.
-/// Kept for sensor-integrity wiring on the maker/verify path (call sites TBD).
-#[allow(dead_code)]
+/// Snapshot mtimes for protected paths (pre-maker).
+pub fn snapshot_immutable_mtimes(
+    protected: &[String],
+    home: &Path,
+) -> std::collections::HashMap<String, u64> {
+    let mut map = std::collections::HashMap::new();
+    for rel in protected {
+        let p = if Path::new(rel).is_absolute() {
+            PathBuf::from(rel)
+        } else {
+            home.join(rel)
+        };
+        if let Ok(meta) = std::fs::metadata(&p) {
+            let mtime = meta
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            map.insert(rel.clone(), mtime);
+        }
+    }
+    map
+}
+
+/// Compare protected path mtimes against a pre-maker snapshot (M11b).
 pub fn check_immutable_not_modified(
     protected: &[String],
     home: &Path,

--- a/crates/core-service/src/service/orchestrator/sensors.rs
+++ b/crates/core-service/src/service/orchestrator/sensors.rs
@@ -44,7 +44,11 @@ pub fn run_sensor(spec: &SensorSpec, default_cwd: &Path) -> Result<(bool, String
                 if start.elapsed() >= timeout {
                     let _ = child.kill();
                     let _ = child.wait();
-                    return Ok((false, format!("sensor timeout after {}ms", spec.timeout_ms), -1));
+                    return Ok((
+                        false,
+                        format!("sensor timeout after {}ms", spec.timeout_ms),
+                        -1,
+                    ));
                 }
                 std::thread::sleep(Duration::from_millis(20));
             }
@@ -174,9 +178,7 @@ pub fn check_immutable_not_modified(
             .unwrap_or(0);
         if let Some(prev) = before.get(rel) {
             if mtime > *prev {
-                return Err(format!(
-                    "sensor integrity: protected path modified: {rel}"
-                ));
+                return Err(format!("sensor integrity: protected path modified: {rel}"));
             }
         }
     }

--- a/crates/core-service/src/service/orchestrator/sensors.rs
+++ b/crates/core-service/src/service/orchestrator/sensors.rs
@@ -155,6 +155,9 @@ pub fn immutable_paths_from_spec(criteria: &[Criterion]) -> Vec<String> {
     paths
 }
 
+/// Compare protected path mtimes against a pre-maker snapshot.
+/// Kept for sensor-integrity wiring on the maker/verify path (call sites TBD).
+#[allow(dead_code)]
 pub fn check_immutable_not_modified(
     protected: &[String],
     home: &Path,
@@ -215,5 +218,25 @@ mod tests {
         };
         let (pass, _, _) = run_sensor(&spec, dir.path()).unwrap();
         assert!(!pass);
+    }
+
+    #[test]
+    fn immutable_check_detects_mtime_increase() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("protected.txt");
+        std::fs::write(&file, b"v1").unwrap();
+        let mtime = std::fs::metadata(&file)
+            .unwrap()
+            .modified()
+            .unwrap()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        // Seed with a strictly older baseline so the current mtime fails.
+        let before =
+            std::collections::HashMap::from([("protected.txt".into(), mtime.saturating_sub(2))]);
+        let err = check_immutable_not_modified(&["protected.txt".into()], dir.path(), &before)
+            .expect_err("current mtime should exceed baseline");
+        assert!(err.contains("protected path modified"));
     }
 }

--- a/crates/core-service/src/service/terminal.rs
+++ b/crates/core-service/src/service/terminal.rs
@@ -236,7 +236,8 @@ impl TerminalService {
             let workspace_repo = WorkspaceRepo::new(db);
             if let Ok(Some(workspace)) = workspace_repo.find_by_guid(workspace_id).await {
                 let project_repo = ProjectRepo::new(db);
-                if let Ok(Some(project)) = project_repo.find_by_guid(&workspace.project_guid).await {
+                if let Ok(Some(project)) = project_repo.find_by_guid(&workspace.project_guid).await
+                {
                     candidates.push(
                         self.tmux_engine
                             .get_session_name_from_names(&project.name, &workspace.name),
@@ -284,7 +285,6 @@ impl TerminalService {
             .next()
             .unwrap_or_else(|| self.tmux_engine.get_session_name(workspace_id))
     }
-
 
     /// Detect the best available tmux installation plan for the current API host.
     pub fn get_tmux_install_plan(&self) -> core_engine::TmuxInstallPlan {
@@ -1147,7 +1147,12 @@ mod tests {
         let resolved = service
             .resolve_tmux_session_name("ws-guid", Some("Atmos"), Some("Main"))
             .await;
-        assert_eq!(resolved, service.tmux_engine.get_session_name_from_names("Atmos", "Main"));
+        assert_eq!(
+            resolved,
+            service
+                .tmux_engine
+                .get_session_name_from_names("Atmos", "Main")
+        );
     }
 
     #[tokio::test]

--- a/crates/core-service/src/service/terminal/runtime.rs
+++ b/crates/core-service/src/service/terminal/runtime.rs
@@ -11,7 +11,7 @@ use core_engine::tmux::control::{
     encode_refresh_client_report_command, encode_send_keys_hex_commands, parse_control_line_bytes,
     ControlModeEvent, TmuxPassthroughUnwrapper,
 };
-use core_engine::{MouseModeState, TmuxEngine};
+use core_engine::TmuxEngine;
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, info, warn};
@@ -223,7 +223,7 @@ pub(super) fn run_control_mode_tmux_session(
             .get_pane_mouse_tracking_by_id(&reader_pane_id)
             .ok()
             .flatten()
-            .unwrap_or_else(MouseModeState::default);
+            .unwrap_or_default();
 
         // Suppress %output bytes that flow during the tmux control client's
         // initial attach/resize/refresh cycle. Those bytes are tmux replaying

--- a/crates/infra/src/db/migration/m20260731_000034_create_orchestrator_tables.rs
+++ b/crates/infra/src/db/migration/m20260731_000034_create_orchestrator_tables.rs
@@ -1,0 +1,318 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(OrchestratorRun::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(OrchestratorRun::Id)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(OrchestratorRun::CreatedAt).date_time().not_null())
+                    .col(ColumnDef::new(OrchestratorRun::UpdatedAt).date_time().not_null())
+                    .col(ColumnDef::new(OrchestratorRun::Goal).text().not_null())
+                    .col(ColumnDef::new(OrchestratorRun::RequestedMode).string().not_null())
+                    .col(ColumnDef::new(OrchestratorRun::Mode).string().null())
+                    .col(ColumnDef::new(OrchestratorRun::ModeReason).text().null())
+                    .col(ColumnDef::new(OrchestratorRun::Status).string().not_null())
+                    .col(ColumnDef::new(OrchestratorRun::StopReason).string().null())
+                    .col(ColumnDef::new(OrchestratorRun::TargetKind).string().not_null())
+                    .col(ColumnDef::new(OrchestratorRun::ProjectGuid).string().null())
+                    .col(ColumnDef::new(OrchestratorRun::WorkspaceGuid).string().null())
+                    .col(ColumnDef::new(OrchestratorRun::HomeCwd).string().not_null())
+                    .col(ColumnDef::new(OrchestratorRun::BoardId).string().null())
+                    .col(ColumnDef::new(OrchestratorRun::LockedSpecVersion).integer().null())
+                    .col(ColumnDef::new(OrchestratorRun::BudgetJson).text().not_null())
+                    .col(ColumnDef::new(OrchestratorRun::GraphJson).text().null())
+                    .col(ColumnDef::new(OrchestratorRun::CarryFromRunId).string().null())
+                    .col(ColumnDef::new(OrchestratorRun::ArtifactDir).string().not_null())
+                    .col(ColumnDef::new(OrchestratorRun::MakerAgentId).string().null())
+                    .col(ColumnDef::new(OrchestratorRun::PlannerAgentId).string().null())
+                    .col(ColumnDef::new(OrchestratorRun::CriteriaAgentId).string().null())
+                    .col(ColumnDef::new(OrchestratorRun::VerifyAgentId).string().null())
+                    .col(ColumnDef::new(OrchestratorRun::StartedAt).date_time().null())
+                    .col(ColumnDef::new(OrchestratorRun::FinishedAt).date_time().null())
+                    .col(ColumnDef::new(OrchestratorRun::IterationsUsed).integer().not_null().default(0))
+                    .col(ColumnDef::new(OrchestratorRun::MakerInvocations).integer().not_null().default(0))
+                    .col(ColumnDef::new(OrchestratorRun::ProgressKey).string().null())
+                    .col(ColumnDef::new(OrchestratorRun::ProgressStreak).integer().not_null().default(0))
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_orchestrator_run_status")
+                    .table(OrchestratorRun::Table)
+                    .col(OrchestratorRun::Status)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(OrchestratorJudgmentSpec::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(OrchestratorJudgmentSpec::Id)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(OrchestratorJudgmentSpec::RunId).string().not_null())
+                    .col(ColumnDef::new(OrchestratorJudgmentSpec::Version).integer().not_null())
+                    .col(ColumnDef::new(OrchestratorJudgmentSpec::RiskTier).string().not_null())
+                    .col(
+                        ColumnDef::new(OrchestratorJudgmentSpec::RequiresUserConfirm)
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
+                    .col(ColumnDef::new(OrchestratorJudgmentSpec::ConfirmedAt).date_time().null())
+                    .col(ColumnDef::new(OrchestratorJudgmentSpec::ConfirmedBy).string().null())
+                    .col(ColumnDef::new(OrchestratorJudgmentSpec::BodyPath).string().not_null())
+                    .col(ColumnDef::new(OrchestratorJudgmentSpec::BodyJson).text().not_null())
+                    .col(ColumnDef::new(OrchestratorJudgmentSpec::CreatedAt).date_time().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_orchestrator_spec_run_version")
+                    .table(OrchestratorJudgmentSpec::Table)
+                    .col(OrchestratorJudgmentSpec::RunId)
+                    .col(OrchestratorJudgmentSpec::Version)
+                    .unique()
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(OrchestratorVerdict::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(OrchestratorVerdict::Id)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(OrchestratorVerdict::RunId).string().not_null())
+                    .col(ColumnDef::new(OrchestratorVerdict::SpecVersion).integer().not_null())
+                    .col(ColumnDef::new(OrchestratorVerdict::Iteration).integer().null())
+                    .col(ColumnDef::new(OrchestratorVerdict::NodeId).string().null())
+                    .col(ColumnDef::new(OrchestratorVerdict::Result).string().not_null())
+                    .col(ColumnDef::new(OrchestratorVerdict::Summary).text().not_null())
+                    .col(ColumnDef::new(OrchestratorVerdict::CriterionResultsJson).text().not_null())
+                    .col(ColumnDef::new(OrchestratorVerdict::CreatedAt).date_time().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(OrchestratorEvidence::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(OrchestratorEvidence::Id)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(OrchestratorEvidence::RunId).string().not_null())
+                    .col(ColumnDef::new(OrchestratorEvidence::VerdictId).string().null())
+                    .col(ColumnDef::new(OrchestratorEvidence::Kind).string().not_null())
+                    .col(ColumnDef::new(OrchestratorEvidence::Path).string().not_null())
+                    .col(ColumnDef::new(OrchestratorEvidence::MetaJson).text().null())
+                    .col(ColumnDef::new(OrchestratorEvidence::CreatedAt).date_time().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(OrchestratorRunWorkspace::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(OrchestratorRunWorkspace::Id)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(OrchestratorRunWorkspace::RunId).string().not_null())
+                    .col(ColumnDef::new(OrchestratorRunWorkspace::WorkspaceGuid).string().not_null())
+                    .col(ColumnDef::new(OrchestratorRunWorkspace::Kind).string().not_null())
+                    .col(ColumnDef::new(OrchestratorRunWorkspace::Purpose).string().null())
+                    .col(ColumnDef::new(OrchestratorRunWorkspace::Status).string().not_null())
+                    .col(ColumnDef::new(OrchestratorRunWorkspace::Path).string().not_null())
+                    .col(ColumnDef::new(OrchestratorRunWorkspace::BaseRef).string().null())
+                    .col(ColumnDef::new(OrchestratorRunWorkspace::CreatedAt).date_time().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(OrchestratorRoleBinding::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(OrchestratorRoleBinding::Id)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(OrchestratorRoleBinding::RunId).string().not_null())
+                    .col(ColumnDef::new(OrchestratorRoleBinding::Role).string().null())
+                    .col(ColumnDef::new(OrchestratorRoleBinding::NodeId).string().null())
+                    .col(ColumnDef::new(OrchestratorRoleBinding::WorkspaceGuid).string().not_null())
+                    .col(ColumnDef::new(OrchestratorRoleBinding::Cwd).string().not_null())
+                    .col(ColumnDef::new(OrchestratorRoleBinding::UpdatedAt).date_time().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(OrchestratorRoleBinding::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(OrchestratorRunWorkspace::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(OrchestratorEvidence::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(OrchestratorVerdict::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(OrchestratorJudgmentSpec::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(OrchestratorRun::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Iden)]
+enum OrchestratorRun {
+    Table,
+    Id,
+    CreatedAt,
+    UpdatedAt,
+    Goal,
+    RequestedMode,
+    Mode,
+    ModeReason,
+    Status,
+    StopReason,
+    TargetKind,
+    ProjectGuid,
+    WorkspaceGuid,
+    HomeCwd,
+    BoardId,
+    LockedSpecVersion,
+    BudgetJson,
+    GraphJson,
+    CarryFromRunId,
+    ArtifactDir,
+    MakerAgentId,
+    PlannerAgentId,
+    CriteriaAgentId,
+    VerifyAgentId,
+    StartedAt,
+    FinishedAt,
+    IterationsUsed,
+    MakerInvocations,
+    ProgressKey,
+    ProgressStreak,
+}
+
+#[derive(Iden)]
+enum OrchestratorJudgmentSpec {
+    Table,
+    Id,
+    RunId,
+    Version,
+    RiskTier,
+    RequiresUserConfirm,
+    ConfirmedAt,
+    ConfirmedBy,
+    BodyPath,
+    BodyJson,
+    CreatedAt,
+}
+
+#[derive(Iden)]
+enum OrchestratorVerdict {
+    Table,
+    Id,
+    RunId,
+    SpecVersion,
+    Iteration,
+    NodeId,
+    Result,
+    Summary,
+    CriterionResultsJson,
+    CreatedAt,
+}
+
+#[derive(Iden)]
+enum OrchestratorEvidence {
+    Table,
+    Id,
+    RunId,
+    VerdictId,
+    Kind,
+    Path,
+    MetaJson,
+    CreatedAt,
+}
+
+#[derive(Iden)]
+enum OrchestratorRunWorkspace {
+    Table,
+    Id,
+    RunId,
+    WorkspaceGuid,
+    Kind,
+    Purpose,
+    Status,
+    Path,
+    BaseRef,
+    CreatedAt,
+}
+
+#[derive(Iden)]
+enum OrchestratorRoleBinding {
+    Table,
+    Id,
+    RunId,
+    Role,
+    NodeId,
+    WorkspaceGuid,
+    Cwd,
+    UpdatedAt,
+}

--- a/crates/infra/src/db/migration/m20260731_000034_create_orchestrator_tables.rs
+++ b/crates/infra/src/db/migration/m20260731_000034_create_orchestrator_tables.rs
@@ -17,34 +17,109 @@ impl MigrationTrait for Migration {
                             .not_null()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(OrchestratorRun::CreatedAt).date_time().not_null())
-                    .col(ColumnDef::new(OrchestratorRun::UpdatedAt).date_time().not_null())
+                    .col(
+                        ColumnDef::new(OrchestratorRun::CreatedAt)
+                            .date_time()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRun::UpdatedAt)
+                            .date_time()
+                            .not_null(),
+                    )
                     .col(ColumnDef::new(OrchestratorRun::Goal).text().not_null())
-                    .col(ColumnDef::new(OrchestratorRun::RequestedMode).string().not_null())
+                    .col(
+                        ColumnDef::new(OrchestratorRun::RequestedMode)
+                            .string()
+                            .not_null(),
+                    )
                     .col(ColumnDef::new(OrchestratorRun::Mode).string().null())
                     .col(ColumnDef::new(OrchestratorRun::ModeReason).text().null())
                     .col(ColumnDef::new(OrchestratorRun::Status).string().not_null())
                     .col(ColumnDef::new(OrchestratorRun::StopReason).string().null())
-                    .col(ColumnDef::new(OrchestratorRun::TargetKind).string().not_null())
+                    .col(
+                        ColumnDef::new(OrchestratorRun::TargetKind)
+                            .string()
+                            .not_null(),
+                    )
                     .col(ColumnDef::new(OrchestratorRun::ProjectGuid).string().null())
-                    .col(ColumnDef::new(OrchestratorRun::WorkspaceGuid).string().null())
+                    .col(
+                        ColumnDef::new(OrchestratorRun::WorkspaceGuid)
+                            .string()
+                            .null(),
+                    )
                     .col(ColumnDef::new(OrchestratorRun::HomeCwd).string().not_null())
                     .col(ColumnDef::new(OrchestratorRun::BoardId).string().null())
-                    .col(ColumnDef::new(OrchestratorRun::LockedSpecVersion).integer().null())
-                    .col(ColumnDef::new(OrchestratorRun::BudgetJson).text().not_null())
+                    .col(
+                        ColumnDef::new(OrchestratorRun::LockedSpecVersion)
+                            .integer()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRun::BudgetJson)
+                            .text()
+                            .not_null(),
+                    )
                     .col(ColumnDef::new(OrchestratorRun::GraphJson).text().null())
-                    .col(ColumnDef::new(OrchestratorRun::CarryFromRunId).string().null())
-                    .col(ColumnDef::new(OrchestratorRun::ArtifactDir).string().not_null())
-                    .col(ColumnDef::new(OrchestratorRun::MakerAgentId).string().null())
-                    .col(ColumnDef::new(OrchestratorRun::PlannerAgentId).string().null())
-                    .col(ColumnDef::new(OrchestratorRun::CriteriaAgentId).string().null())
-                    .col(ColumnDef::new(OrchestratorRun::VerifyAgentId).string().null())
-                    .col(ColumnDef::new(OrchestratorRun::StartedAt).date_time().null())
-                    .col(ColumnDef::new(OrchestratorRun::FinishedAt).date_time().null())
-                    .col(ColumnDef::new(OrchestratorRun::IterationsUsed).integer().not_null().default(0))
-                    .col(ColumnDef::new(OrchestratorRun::MakerInvocations).integer().not_null().default(0))
+                    .col(
+                        ColumnDef::new(OrchestratorRun::CarryFromRunId)
+                            .string()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRun::ArtifactDir)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRun::MakerAgentId)
+                            .string()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRun::PlannerAgentId)
+                            .string()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRun::CriteriaAgentId)
+                            .string()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRun::VerifyAgentId)
+                            .string()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRun::StartedAt)
+                            .date_time()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRun::FinishedAt)
+                            .date_time()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRun::IterationsUsed)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRun::MakerInvocations)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
                     .col(ColumnDef::new(OrchestratorRun::ProgressKey).string().null())
-                    .col(ColumnDef::new(OrchestratorRun::ProgressStreak).integer().not_null().default(0))
+                    .col(
+                        ColumnDef::new(OrchestratorRun::ProgressStreak)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
                     .to_owned(),
             )
             .await?;
@@ -71,20 +146,52 @@ impl MigrationTrait for Migration {
                             .not_null()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(OrchestratorJudgmentSpec::RunId).string().not_null())
-                    .col(ColumnDef::new(OrchestratorJudgmentSpec::Version).integer().not_null())
-                    .col(ColumnDef::new(OrchestratorJudgmentSpec::RiskTier).string().not_null())
+                    .col(
+                        ColumnDef::new(OrchestratorJudgmentSpec::RunId)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorJudgmentSpec::Version)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorJudgmentSpec::RiskTier)
+                            .string()
+                            .not_null(),
+                    )
                     .col(
                         ColumnDef::new(OrchestratorJudgmentSpec::RequiresUserConfirm)
                             .boolean()
                             .not_null()
                             .default(false),
                     )
-                    .col(ColumnDef::new(OrchestratorJudgmentSpec::ConfirmedAt).date_time().null())
-                    .col(ColumnDef::new(OrchestratorJudgmentSpec::ConfirmedBy).string().null())
-                    .col(ColumnDef::new(OrchestratorJudgmentSpec::BodyPath).string().not_null())
-                    .col(ColumnDef::new(OrchestratorJudgmentSpec::BodyJson).text().not_null())
-                    .col(ColumnDef::new(OrchestratorJudgmentSpec::CreatedAt).date_time().not_null())
+                    .col(
+                        ColumnDef::new(OrchestratorJudgmentSpec::ConfirmedAt)
+                            .date_time()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorJudgmentSpec::ConfirmedBy)
+                            .string()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorJudgmentSpec::BodyPath)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorJudgmentSpec::BodyJson)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorJudgmentSpec::CreatedAt)
+                            .date_time()
+                            .not_null(),
+                    )
                     .to_owned(),
             )
             .await?;
@@ -113,14 +220,42 @@ impl MigrationTrait for Migration {
                             .not_null()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(OrchestratorVerdict::RunId).string().not_null())
-                    .col(ColumnDef::new(OrchestratorVerdict::SpecVersion).integer().not_null())
-                    .col(ColumnDef::new(OrchestratorVerdict::Iteration).integer().null())
+                    .col(
+                        ColumnDef::new(OrchestratorVerdict::RunId)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorVerdict::SpecVersion)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorVerdict::Iteration)
+                            .integer()
+                            .null(),
+                    )
                     .col(ColumnDef::new(OrchestratorVerdict::NodeId).string().null())
-                    .col(ColumnDef::new(OrchestratorVerdict::Result).string().not_null())
-                    .col(ColumnDef::new(OrchestratorVerdict::Summary).text().not_null())
-                    .col(ColumnDef::new(OrchestratorVerdict::CriterionResultsJson).text().not_null())
-                    .col(ColumnDef::new(OrchestratorVerdict::CreatedAt).date_time().not_null())
+                    .col(
+                        ColumnDef::new(OrchestratorVerdict::Result)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorVerdict::Summary)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorVerdict::CriterionResultsJson)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorVerdict::CreatedAt)
+                            .date_time()
+                            .not_null(),
+                    )
                     .to_owned(),
             )
             .await?;
@@ -136,12 +271,32 @@ impl MigrationTrait for Migration {
                             .not_null()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(OrchestratorEvidence::RunId).string().not_null())
-                    .col(ColumnDef::new(OrchestratorEvidence::VerdictId).string().null())
-                    .col(ColumnDef::new(OrchestratorEvidence::Kind).string().not_null())
-                    .col(ColumnDef::new(OrchestratorEvidence::Path).string().not_null())
+                    .col(
+                        ColumnDef::new(OrchestratorEvidence::RunId)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorEvidence::VerdictId)
+                            .string()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorEvidence::Kind)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorEvidence::Path)
+                            .string()
+                            .not_null(),
+                    )
                     .col(ColumnDef::new(OrchestratorEvidence::MetaJson).text().null())
-                    .col(ColumnDef::new(OrchestratorEvidence::CreatedAt).date_time().not_null())
+                    .col(
+                        ColumnDef::new(OrchestratorEvidence::CreatedAt)
+                            .date_time()
+                            .not_null(),
+                    )
                     .to_owned(),
             )
             .await?;
@@ -157,14 +312,46 @@ impl MigrationTrait for Migration {
                             .not_null()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(OrchestratorRunWorkspace::RunId).string().not_null())
-                    .col(ColumnDef::new(OrchestratorRunWorkspace::WorkspaceGuid).string().not_null())
-                    .col(ColumnDef::new(OrchestratorRunWorkspace::Kind).string().not_null())
-                    .col(ColumnDef::new(OrchestratorRunWorkspace::Purpose).string().null())
-                    .col(ColumnDef::new(OrchestratorRunWorkspace::Status).string().not_null())
-                    .col(ColumnDef::new(OrchestratorRunWorkspace::Path).string().not_null())
-                    .col(ColumnDef::new(OrchestratorRunWorkspace::BaseRef).string().null())
-                    .col(ColumnDef::new(OrchestratorRunWorkspace::CreatedAt).date_time().not_null())
+                    .col(
+                        ColumnDef::new(OrchestratorRunWorkspace::RunId)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRunWorkspace::WorkspaceGuid)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRunWorkspace::Kind)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRunWorkspace::Purpose)
+                            .string()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRunWorkspace::Status)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRunWorkspace::Path)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRunWorkspace::BaseRef)
+                            .string()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRunWorkspace::CreatedAt)
+                            .date_time()
+                            .not_null(),
+                    )
                     .to_owned(),
             )
             .await?;
@@ -180,12 +367,36 @@ impl MigrationTrait for Migration {
                             .not_null()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(OrchestratorRoleBinding::RunId).string().not_null())
-                    .col(ColumnDef::new(OrchestratorRoleBinding::Role).string().null())
-                    .col(ColumnDef::new(OrchestratorRoleBinding::NodeId).string().null())
-                    .col(ColumnDef::new(OrchestratorRoleBinding::WorkspaceGuid).string().not_null())
-                    .col(ColumnDef::new(OrchestratorRoleBinding::Cwd).string().not_null())
-                    .col(ColumnDef::new(OrchestratorRoleBinding::UpdatedAt).date_time().not_null())
+                    .col(
+                        ColumnDef::new(OrchestratorRoleBinding::RunId)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRoleBinding::Role)
+                            .string()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRoleBinding::NodeId)
+                            .string()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRoleBinding::WorkspaceGuid)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRoleBinding::Cwd)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OrchestratorRoleBinding::UpdatedAt)
+                            .date_time()
+                            .not_null(),
+                    )
                     .to_owned(),
             )
             .await?;
@@ -195,10 +406,18 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(OrchestratorRoleBinding::Table).to_owned())
+            .drop_table(
+                Table::drop()
+                    .table(OrchestratorRoleBinding::Table)
+                    .to_owned(),
+            )
             .await?;
         manager
-            .drop_table(Table::drop().table(OrchestratorRunWorkspace::Table).to_owned())
+            .drop_table(
+                Table::drop()
+                    .table(OrchestratorRunWorkspace::Table)
+                    .to_owned(),
+            )
             .await?;
         manager
             .drop_table(Table::drop().table(OrchestratorEvidence::Table).to_owned())
@@ -207,7 +426,11 @@ impl MigrationTrait for Migration {
             .drop_table(Table::drop().table(OrchestratorVerdict::Table).to_owned())
             .await?;
         manager
-            .drop_table(Table::drop().table(OrchestratorJudgmentSpec::Table).to_owned())
+            .drop_table(
+                Table::drop()
+                    .table(OrchestratorJudgmentSpec::Table)
+                    .to_owned(),
+            )
             .await?;
         manager
             .drop_table(Table::drop().table(OrchestratorRun::Table).to_owned())

--- a/crates/infra/src/db/migration/mod.rs
+++ b/crates/infra/src/db/migration/mod.rs
@@ -37,6 +37,7 @@ mod m20260609_000030_add_automation_agent_config;
 mod m20260702_000031_create_terminal_side_chat;
 mod m20260718_000032_drop_canvas_board;
 mod m20260725_000033_create_item_group_tables;
+mod m20260731_000034_create_orchestrator_tables;
 
 pub struct Migrator;
 
@@ -76,6 +77,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260702_000031_create_terminal_side_chat::Migration),
             Box::new(m20260718_000032_drop_canvas_board::Migration),
             Box::new(m20260725_000033_create_item_group_tables::Migration),
+            Box::new(m20260731_000034_create_orchestrator_tables::Migration),
         ]
     }
 }

--- a/crates/infra/src/utils/system_skill_sync.rs
+++ b/crates/infra/src/utils/system_skill_sync.rs
@@ -39,6 +39,8 @@ const ALL_SYSTEM_SKILL_NAMES: &[&str] = &[
     "atmos-review-fix",
     // Canvas terminal-agent integration (APP-015)
     "atmos-canvas-agent",
+    // Orchestrator Loop/Graph (APP-048)
+    "atmos-orchestrator",
 ];
 
 #[derive(Clone, Debug, Deserialize)]
@@ -172,6 +174,7 @@ fn repo_skill_root(skill_name: &str) -> Option<&'static str> {
         "git-commit" => Some("skills/git-commit"),
         "atmos-review-fix" => Some("skills/atmos-review-fix"),
         "atmos-canvas-agent" => Some("skills/atmos-canvas-agent"),
+        "atmos-orchestrator" => Some("skills/atmos-orchestrator"),
         _ => None,
     }
 }

--- a/crates/infra/src/utils/user_path.rs
+++ b/crates/infra/src/utils/user_path.rs
@@ -32,8 +32,10 @@ pub fn ensure_user_cli_path_on_startup() -> Result<(), String> {
 /// Cached PATH suitable for child processes (login shell + common bins + env).
 pub fn user_cli_path() -> &'static OsStr {
     static PATH: OnceLock<OsString> = OnceLock::new();
-    PATH.get_or_init(|| build_user_cli_path().unwrap_or_else(|_| env::var_os("PATH").unwrap_or_default()))
-        .as_os_str()
+    PATH.get_or_init(|| {
+        build_user_cli_path().unwrap_or_else(|_| env::var_os("PATH").unwrap_or_default())
+    })
+    .as_os_str()
 }
 
 /// `std::process::Command` that resolves `program` on the user CLI PATH.

--- a/skills/atmos-orchestrator/SKILL.md
+++ b/skills/atmos-orchestrator/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: atmos-orchestrator
+version: "1.0.0"
+description: "Operate Atmos Orchestrator multi-step agent runs (Loop/Graph) via `atmos orchestrator` CLI: create runs, Judgment Specs, evidence, workspace isolation, and context. Use for multi-step coding with explicit completion criteria."
+license: MIT
+---
+
+# Atmos Orchestrator Agent Skill
+
+Drive **multi-step Loop / Graph runs** with `atmos orchestrator`.  
+Do **not** invent “done” without a Judgment Spec + sensors.  
+Do **not** use ordinary Canvas (`atmos canvas`) to simulate orchestration.
+
+```text
+Default:  run create → spec draft → confirm → start → tick/poll → done
+Optional: workspace create/use/merge for isolation
+```
+
+---
+
+## Prerequisites
+
+1. `atmos` on `PATH`.
+2. Local Atmos Server running (`atmos runtime ensure` / dev-api).
+3. CLI auth same as other `atmos` commands.
+4. Run **home** = user Project/Workspace path (or standalone).
+
+`atmos orchestrator skill-dir` prints this directory after system skill sync.
+
+---
+
+## Decision tree
+
+| Intent | Action | Reference |
+|--------|--------|-----------|
+| Multi-step fix with tests | Loop + sensor Spec | this file |
+| Real parallel/branch work | Graph + compile | `references/workspace-isolation.md` |
+| Full flags / errors | — | `references/command-reference.md` |
+| Role artifacts | — | `references/roles-and-artifacts.md` |
+
+---
+
+## Default workflow
+
+1. `atmos orchestrator status`
+2. `atmos orchestrator run create --goal "…" --mode loop --workspace <guid> --home-cwd <path>`  
+   (or `--target-kind project --project <guid>`)
+3. Write Spec JSON (sensors first), then:  
+   `atmos orchestrator spec draft --run <id> --file spec.json`
+4. `atmos orchestrator spec confirm --run <id> --version 1` if required
+5. `atmos orchestrator run start --run <id>`
+6. Loop: `atmos orchestrator tick --run <id>` **or** `run get` until terminal status
+7. On need for isolation: see workspace section below
+8. Report `stop_reason`, Spec version, evidence paths
+
+### Forced mode
+
+`--mode loop|graph` **skips planner**. Auto requires `mode_proposal.json` (planner).
+
+---
+
+## Working directory (critical)
+
+- **Default cwd for every role** = run **home** (user’s Project/Workspace).
+- Use `atmos orchestrator context get --run <id>` — field `home.cwd`.
+- **Never** invent a random home directory.
+
+### When to isolate
+
+Create a **child workspace** only when the task needs it:
+
+- parallel writers
+- speculative / risky changes
+- branch-per-feature before merge
+
+```text
+atmos orchestrator workspace create --run <id> --purpose "parallel experiment"
+atmos orchestrator workspace use --run <id> --workspace <guid> --role maker
+# … work …
+atmos orchestrator workspace merge --run <id> --workspace <guid>
+# or abandon
+```
+
+Do **not** run raw `git worktree` outside this CLI (orphans forbidden).
+
+---
+
+## Compact verbs
+
+| Verb | Purpose |
+|------|---------|
+| `skill-dir` | Local skill path |
+| `status` | API health |
+| `run create\|list\|get\|start\|cancel` | Lifecycle |
+| `spec draft\|get\|confirm\|update` | Judgment Spec |
+| `evidence attach\|list` | Evidence files |
+| `graph compile\|get\|step` | Graph |
+| `workspace get\|list\|create\|use\|merge\|abandon` | Home + children |
+| `context get` | Agent context pack |
+| `tick` | Fixture Loop step (sensors) |
+| `agents` | Agent ids |
+
+Full flags: `references/command-reference.md`.
+
+---
+
+## Anti-patterns
+
+- ❌ Complete because maker said “done”
+- ❌ Maker edits Spec or sensor files to force green
+- ❌ Multi-maker write on home without isolation
+- ❌ Start without Spec
+- ❌ Simulate Loop via `atmos canvas` scripts
+- ❌ Use ACP / random LLM API as Orchestrator brain
+
+---
+
+## Errors (short)
+
+| Code | Recovery |
+|------|----------|
+| `ORCH_SPEC_REQUIRED` | `spec draft` |
+| `ORCH_SPEC_CONFIRM_REQUIRED` | `spec confirm` |
+| `ORCH_GRAPH_COMPILE_FAILED` | fix graph or use `--mode loop` |
+| `ORCH_WORKSPACE_NOT_CHILD` | `workspace list` |
+
+---
+
+## Reporting
+
+- Run id, mode, Spec version, `stop_reason`
+- `home.cwd` + any child workspaces
+- Evidence paths under run artifact dir

--- a/skills/atmos-orchestrator/SKILL.md
+++ b/skills/atmos-orchestrator/SKILL.md
@@ -12,8 +12,9 @@ Do **not** invent “done” without a Judgment Spec + sensors.
 Do **not** use ordinary Canvas (`atmos canvas`) to simulate orchestration.
 
 ```text
-Default:  run create → spec draft → confirm → start → tick/poll → done
+Default:  run create → spec draft → confirm → start → poll run get → done
 Optional: workspace create/use/merge for isolation
+Runtime owns Loop/Graph advancement (no public tick verb).
 ```
 
 ---
@@ -48,8 +49,9 @@ Optional: workspace create/use/merge for isolation
 3. Write Spec JSON (sensors first), then:  
    `atmos orchestrator spec draft --run <id> --file spec.json`
 4. `atmos orchestrator spec confirm --run <id> --version 1` if required
-5. `atmos orchestrator run start --run <id>`
-6. Loop: `atmos orchestrator tick --run <id>` **or** `run get` until terminal status
+5. `atmos orchestrator run start --run <id>`  
+   (Runtime advances Loop/Graph with fixture or worker agents — agents do **not** call tick)
+6. Poll: `atmos orchestrator run get --run <id>` / `context get` until terminal status
 7. On need for isolation: see workspace section below
 8. Report `stop_reason`, Spec version, evidence paths
 
@@ -97,7 +99,6 @@ Do **not** run raw `git worktree` outside this CLI (orphans forbidden).
 | `graph compile\|get\|step` | Graph |
 | `workspace get\|list\|create\|use\|merge\|abandon` | Home + children |
 | `context get` | Agent context pack |
-| `tick` | Fixture Loop step (sensors) |
 | `agents` | Agent ids |
 
 Full flags: `references/command-reference.md`.

--- a/skills/atmos-orchestrator/references/command-reference.md
+++ b/skills/atmos-orchestrator/references/command-reference.md
@@ -13,7 +13,6 @@ Global: `--api-url`, token env, `--json`, `--timeout-ms`.
 | `run get` | `GET /runs/{id}` |
 | `run start` | `POST /runs/{id}/start` |
 | `run cancel` | `POST /runs/{id}/cancel` |
-| `tick` | `POST /runs/{id}/tick` |
 | `spec draft` | `POST /runs/{id}/spec/draft` |
 | `spec get` | `GET /runs/{id}/spec` |
 | `spec confirm` | `POST /runs/{id}/spec/confirm` |
@@ -21,7 +20,6 @@ Global: `--api-url`, token env, `--json`, `--timeout-ms`.
 | `evidence attach` | `POST /runs/{id}/evidence` |
 | `context get` | `GET /runs/{id}/context` |
 | `graph compile` | `POST /runs/{id}/graph/compile` |
-| `graph step` | `POST /runs/{id}/graph/step` |
 | `workspace create` | `POST /runs/{id}/workspaces` |
 | `workspace use` | `POST /runs/{id}/workspace/use` |
 | `workspace merge` | `POST /runs/{id}/workspaces/{ws}/merge` |

--- a/skills/atmos-orchestrator/references/command-reference.md
+++ b/skills/atmos-orchestrator/references/command-reference.md
@@ -1,0 +1,31 @@
+# Orchestrator CLI command reference
+
+Base HTTP: `/api/orchestrator/v1` (authenticated).
+
+Global: `--api-url`, token env, `--json`, `--timeout-ms`.
+
+| CLI | HTTP |
+|-----|------|
+| `status` | `GET /status` |
+| `agents` | `GET /agents` |
+| `run create` | `POST /runs` |
+| `run list` | `GET /runs` |
+| `run get` | `GET /runs/{id}` |
+| `run start` | `POST /runs/{id}/start` |
+| `run cancel` | `POST /runs/{id}/cancel` |
+| `tick` | `POST /runs/{id}/tick` |
+| `spec draft` | `POST /runs/{id}/spec/draft` |
+| `spec get` | `GET /runs/{id}/spec` |
+| `spec confirm` | `POST /runs/{id}/spec/confirm` |
+| `spec update` | `PATCH /runs/{id}/spec` |
+| `evidence attach` | `POST /runs/{id}/evidence` |
+| `context get` | `GET /runs/{id}/context` |
+| `graph compile` | `POST /runs/{id}/graph/compile` |
+| `graph step` | `POST /runs/{id}/graph/step` |
+| `workspace create` | `POST /runs/{id}/workspaces` |
+| `workspace use` | `POST /runs/{id}/workspace/use` |
+| `workspace merge` | `POST /runs/{id}/workspaces/{ws}/merge` |
+| `workspace abandon` | `POST /runs/{id}/workspaces/{ws}/abandon` |
+| `skill-dir` | local only |
+
+Exit non-zero on HTTP 4xx/5xx. Validation messages may include `ORCH_*` codes.

--- a/skills/atmos-orchestrator/references/roles-and-artifacts.md
+++ b/skills/atmos-orchestrator/references/roles-and-artifacts.md
@@ -1,0 +1,12 @@
+# Roles and artifacts
+
+| Role env | UI label | Artifact |
+|----------|----------|----------|
+| orchestrator | Planner | `mode_proposal.json` |
+| criteria | Criteria | `specs/v{n}.json` |
+| maker | Maker | code + `work_state.json` |
+| verify | Verify | verdicts |
+
+Atomic write: `*.json.tmp` → validate → rename.
+
+Maker cannot write `specs/` or `verdicts/`.

--- a/skills/atmos-orchestrator/references/workspace-isolation.md
+++ b/skills/atmos-orchestrator/references/workspace-isolation.md
@@ -1,0 +1,20 @@
+# Workspace isolation
+
+## Run home
+
+User selects Project or Workspace when creating a run. That path is `home.cwd` for Planner, Criteria, Maker, and Verify by default.
+
+## Child workspace
+
+```text
+workspace create → use (bind role) → work → merge | abandon
+```
+
+- `create_source` marker: `.atmos-orch-workspace` with `run_id`
+- Parallel writers require `isolation=worktree` on graph nodes **and** child cwd bind
+- Merge is explicit and user-visible
+
+## Do not
+
+- Create orphan worktrees outside CLI
+- Write outside home/children (`ORCH_CWD_FORBIDDEN`)

--- a/skills/system-skills-manifest.json
+++ b/skills/system-skills-manifest.json
@@ -61,6 +61,12 @@
       "skills/atmos-canvas-agent/references/document-scripts.md",
       "skills/atmos-canvas-agent/references/documents.md",
       "skills/atmos-canvas-agent/references/command-reference.md"
+    ],
+    "atmos-orchestrator": [
+      "skills/atmos-orchestrator/SKILL.md",
+      "skills/atmos-orchestrator/references/command-reference.md",
+      "skills/atmos-orchestrator/references/workspace-isolation.md",
+      "skills/atmos-orchestrator/references/roles-and-artifacts.md"
     ]
   }
 }

--- a/specs/APP/APP-048_loop-graph-agent-orchestration/BRAINSTORM.md
+++ b/specs/APP/APP-048_loop-graph-agent-orchestration/BRAINSTORM.md
@@ -1,0 +1,247 @@
+# Brainstorm · APP-048: Loop / Graph Agent Orchestration
+
+> Problem space and exploration. Settled content graduates to PRD.md; committed architecture graduates to TECH.md.
+>
+> **Note (post multi-agent review):** PRD/TECH/TEST were hardened for auto-topology, Spec integrity, join completeness, mid-flight budgets, role+status chrome, and Phase-1 Graph bar. Prefer those files as source of truth over older option text when conflicted.
+
+## Context
+
+Atmos already has a strong **Harness**: tmux-backed terminals, terminal code agents (Claude Code, Codex, OpenCode, …), canvas as a diagram + widget surface (`canvas-terminal`, product widgets), `atmos canvas` CLI + skills (APP-015), and thin scheduled runs via Automations (APP-017). What is missing is a first-class way to run **evidence-driven multi-step agent work** on that harness—either as a **Loop** (feedback cycle) or a **Graph** (explicit control flow with branch/parallel/HITL)—with a smart **orchestrator** that can choose mode from the task (or accept a user override), and with a separate agent that **writes the completion criteria** before anyone claims “done.”
+
+Trigger: product desire to add Loop Agent / Graph Agent capabilities on Canvas, informed by vault notes on Harness / Loop / Graph / Foundation Engineering (setpoint, sensors, maker/checker). Deep research confirmed industry patterns (ReAct loops, LangGraph-style graphs, routing) and Atmos boundaries (terminal agents preferred over ACP for execution; no general workflow platform yet).
+
+**Who feels it**: Agentic Builders running multi-step coding work in Atmos who today either babysit a single terminal agent, hack multi-agent structure by hand on canvas, or use Automations for single non-interactive shots.
+
+**Current workarounds**: manual multi-pane terminals; side-chat one-shot fork (APP-030); canvas diagrams that are structural only (arrows are not executable); Automations for scheduled single runs; ad-hoc “keep going until it looks good” without durable acceptance criteria.
+
+**Why it’s hard**: Loop without independent judgment becomes a blind self-congratulating cycle; Graph without real dependencies is ceremony; pure keyword routing is dumb; pure freestyle “meta agent” without a deterministic runtime is unsafe; ACP vs terminal agent is an easy product fork that Atmos has already answered for code work.
+
+## Goals (draft)
+
+- Make **Loop** and **Graph** peer, first-class orchestration modes—not a “ship Loop first, Graph later” product story.
+- Provide an **Orchestrator** that is **intelligent** (LLM/agent) for mode selection and planning, with **user override** (`auto | loop | graph`).
+- Make **completion criteria** a first-class artifact: a dedicated **Criteria Agent** authors a **Judgment Spec**; all subsequent verify steps bind to that spec (versioned).
+- Keep **execution** on **Terminal Agents** (product line: native terminal code agents, not ACP chat as the worker).
+- Keep a **deterministic Orchestration Runtime** for budgets, stop rules, edge execution, evidence gates, and maker≠checker—so intelligence cannot silently rewrite the rules of the game.
+- Use **Canvas** as the topology + evidence + run-status surface; extend existing terminal/tmux primitives rather than inventing a second agent bus.
+- Align with Automations philosophy: **thin orchestration over terminal agents**, not a second full agent runtime or generic enterprise workflow platform.
+
+## Settled direction (from conversation)
+
+These are product/architecture anchors for PRD/TECH—not open options unless a later PRD deliberately reopens them.
+
+### Layer model
+
+```
+Orchestrator Agent          → mode, topology, next step, explain "why"
+Criteria Agent              → Judgment Spec (setpoint / "what is correct")
+Orchestration Runtime       → enforce budget, stop, edges, evidence, user override
+Worker Terminal Agent(s)    → maker: write code / run tools in tmux panes
+Checker / Judge             → verdict against Spec only (sensors first, then LLM/human)
+Canvas                      → edit topology, run highlight, evidence, Spec card
+CLI / Skill                 → agent-facing ops (create-run, tick, attach-evidence, compile-graph)
+```
+
+| Role | Intelligent? | Responsibility |
+|------|----------------|----------------|
+| **Orchestrator Agent** | Yes | Choose `loop` / `graph` / ask user; plan topology; schedule steps; explain decisions |
+| **Criteria Agent** | Yes | Author and version **Judgment Spec** from goal + risk; may refine on `criteria_gap` only |
+| **Orchestration Runtime** | No (by design) | Run lifecycle, budgets, max iterations, no-progress, executable edges, force user `mode`, refuse complete without Spec/evidence |
+| **Worker (Maker)** | Yes | Terminal code agent doing the work; **must not** edit Judgment Spec |
+| **Checker / Judge** | Sensors + optional LLM | Evaluate **only** against locked Spec; output pass/fail + criterion ids + evidence paths |
+| **Harness** | Existing | Terminal, tmux identity, canvas shapes, CLI bus |
+
+### Loop vs Graph (both ship as peers)
+
+- **Loop**: reusable feedback primitive—find work → dispatch maker → collect evidence → judge vs Spec → record state → decide next (retry / pass / stop / refine criteria). Evidence-driven, **not** confidence-driven.
+- **Graph**: explicit state machine—nodes (work) + edges (routing) on shared run state; sequence, branch, fan-out/join, bounded cycles, HITL interrupt/resume. Prefer **diamond** when parallel: fan-out → pure-code reduce → **fresh-context** verify → synthesize.
+- **Composition**: a Graph node may embed a Loop; Loop is not “phase 1 product” and Graph “phase 2 product.” Shared contracts (Run, Judgment Spec, Evidence, events) are designed once.
+- **Upgrade heuristic is a router signal, not a roadmap**: use Graph only when ≥2 independently workable units with **nameable** dependencies (pass the fake-edge test). Otherwise Loop. User can force either mode.
+
+### Orchestrator is an Agent—not keyword matching
+
+- Reject pure keyword/rules routing as the product brain.
+- Also reject “one freestyle meta Terminal Agent owns the entire control plane with no runtime.”
+- **Intelligence path**: Terminal Agent roles (`orchestrator`, `criteria`, `verify`) emit **structured JSON artifacts** validated by Runtime. Not `crates/llm` cloud/local API providers.
+- Orchestrator **proposes**; Runtime **accepts/rejects** illegal proposals (e.g. complete without Spec, exceed budget, maker self-pass).
+
+### Criteria / Judgment Spec is first-class (Loop’s scarce part)
+
+Aligned with Foundation Engineering vault notes: the scarce skill is defining **what counts as correct** (setpoint), not writing another outer loop shell.
+
+- **Criteria Agent** runs before (or at start of) a run and produces a versioned **Judgment Spec**.
+- All verify/check steps bind to `spec_id@version`.
+- Spec should prefer **falsification paths** and **evidence paths**, not only positive “looks good” checks.
+- **Granularity**: verification must be fine enough for the blast radius of the change; coarse “it runs” acceptance is a known failure mode (blind loop).
+- **Judgment sink (cost order)**: deterministic sensors (typecheck, tests, lint, policy cmds) → LLM judge with rubric → human. Never start at human or confidence.
+- **Maker ≠ Checker**: independent context for verify (new pane / new session / at least different system role). Fresh context for Graph verify nodes.
+- **Who may change Spec**: Criteria Agent (version bump + audit). Maker never. Judge never invents new law—only returns `criteria_gap` if Spec is wrong/too coarse.
+- **No Spec → Runtime refuses to mark completed** (and ideally refuses to start multi-step run without draft Spec or explicit user skip policy—decide in PRD).
+
+### Execution: Terminal Agent; not ACP as worker
+
+- **Workers** are terminal-resident code agents (same family as Agent Select / APP-015 / APP-017).
+- **Orchestration** is Atmos-owned thin runtime + agent brains above—not ACP session graph execution.
+- **ACP** remains a separate surface (APP-004 / chat protocol). Optional future Graph node type `acp-session` is not M1; do not route canvas control through `/ws/agent` for this feature (APP-015 already out of scoped that).
+- Product quote anchor (PRD-V1.0): prefer running existing code agents in the terminal over ACP-built process UIs for coding work.
+
+### Canvas and edges
+
+- Today: custom shapes `canvas-terminal`, `canvas-widget`; arrows are structural (`fromId`/`toId`), not executable control flow.
+- Product widgets (workspace/files/review/browser/agent-chat) are **not** orchestration nodes—do not overload them.
+- Direction: Canvas shows run frame, Spec card, evidence, mode control; Graph mode adds flow nodes + executable edge metadata on bound arrows; decorative unbound arrows lint-warn and stay out of execution.
+- Map agent edges to proven tmux primitives where possible: observe=`capture-pane`, inject=`send-keys`, fork=side-chat identity, join=orchestrator reduce/verify—not a fictional live A2A bus. Stable identity: `ATMOS_PANE_ID` (not flaky frontend session ids).
+
+### State machines (do not collapse into one table)
+
+| Layer | States (draft) |
+|-------|----------------|
+| Terminal agent hook | `idle` · `running` · `permission_request` (do not casually expand) |
+| Canvas agent presence | `idle` · `active` |
+| **Orchestration run (new)** | `running` → `completed` \| `failed` \| `cancelled` \| `interrupted` |
+| Node-level (graph) | `pending` · `running` · `blocked` · `succeeded` · `failed` (etc.) |
+
+Stop reasons must be explainable: `spec_met`, `budget`, `no_progress`, `user_cancel`, `criteria_unsatisfiable`, …
+
+### Explicit anti-patterns (design must forbid)
+
+**Loop**: unbounded retry; maker self-declare done; soft “Ralph” completion; missing objective gates / state / token budget; blind looping on judgment-heavy work (auth, payments, architecture) without human criteria; not reading diffs (understanding debt); confidence-as-exit.
+
+**Graph**: formalize too early (trace before formalize); “verifier” sharing maker context; fake independence (shared files/API races); silent fan-in merge; fan-in context collapse; graphing small/linear/exploratory work that fails the fake-edge test.
+
+**Product**: second generic workflow platform; ACP as default control plane; keyword-only orchestrator; product widgets as flow nodes.
+
+### Mode selection UX
+
+- User can set `mode: auto | loop | graph` per run (hard override beats Orchestrator).
+- Auto uses Orchestrator Agent structured decision + lowest-complexity-that-works heuristic.
+- Mid-run **full topology swap** (loop run → different graph) is **not** required; prefer HITL interrupt, node-level replan, or **new run** carrying evidence. Decide residual UX in PRD.
+
+## Options
+
+### Option A — Peer Loop + Graph + intelligent Orchestrator + Criteria Agent (leaning)
+
+Ship both modes as peers under one Run contract; Orchestrator Agent chooses or user overrides; Criteria Agent authors Judgment Spec; Runtime enforces; workers are Terminal Agents; Canvas is the ops surface.
+
+**Pros**: matches conversation and vault; smart without blind loops; reuses harness; clear roles.  
+**Cons**: larger design surface than “just a while loop in a skill”; needs careful MVP slice of UI.  
+**Unknown**: exact M1 UI density (frame+status vs full flow shapes on day one)—implementation slice, not product peer-ness.
+
+### Option B — Terminal meta-agent only (skill-driven, no Runtime)
+
+A single Orchestrator Terminal Agent with skills simulates loop/graph via canvas notes and scripts.
+
+**Pros**: fast to demo; no new backend run object.  
+**Cons**: weak enforcement; maker can rewrite criteria; hard to observe budgets/stop; conflicts with Foundation Engineering.  
+**Decision lean**: reject as sole architecture; optional as Planner implementation of Orchestrator Agent only.
+
+### Option C — ACP graph runtime
+
+Drive multi-agent work through ACP sessions and `/ws/agent` as the orchestrated mesh.
+
+**Pros**: structured protocol events; tool permissions.  
+**Cons**: fights terminal-first product line; APP-015/017 explicitly avoid ACP for terminal/canvas/automation workers; poorer native agent UX for coding CLIs.  
+**Decision lean**: out of scope as primary path; optional node type later only.
+
+### Option D — Automations expansion only
+
+Grow APP-017 into multi-step graphs without a canvas-facing Loop/Graph product.
+
+**Pros**: reuses scheduler/artifacts.  
+**Cons**: Automations are thin scheduled terminal runs, not interactive multi-agent topology UX; under-serves canvas “see the graph / loop” goal.  
+**Decision lean**: share Runtime primitives where useful; keep Automations as a **consumer/trigger** of runs, not the only face of Loop/Graph.
+
+### Option E — Phased “Loop MVP then Graph later” as product messaging
+
+**Pros**: smaller first ship story.  
+**Cons**: user explicitly rejected “which first” framing; shared contracts would fork if designed sequentially.  
+**Decision lean**: **peer capabilities + shared contracts**; engineering may still slice UI (e.g. Loop UI denser first) without dropping Graph from product definition or schema design.
+
+## Key forks in the road
+
+- **Fork 1 — Orchestrator brain host**: structured `crates/llm` vs Terminal Agent — **resolved in TECH: always Terminal Agent roles** (not user API/local-model LLM providers).
+- **Fork 2 — Criteria confirm UX**: always human-confirm Spec vs auto-accept when only deterministic sensors — **decide in PRD** (risk-based default likely).
+- **Fork 3 — M1 Canvas density**: run frame + Spec + status only vs full flow ShapeUtils on day one — **decide in PRD** (peer modes ≠ equal UI chrome day one).
+- **Fork 4 — Run storage**: SQLite + `~/.atmos/` artifacts like Automations vs canvas-document-local only — **decide in TECH**; prefer durable run objects.
+- **Fork 5 — Relation to Automations**: shared Runtime module vs separate services — **decide in TECH**; product surfaces stay distinct.
+- **Fork 6 — Skip Spec escape hatch**: power-user “no Spec” mode vs always require Spec — **decide in PRD** (default require Spec).
+- **Fork 7 — Mid-run mode change**: forbid vs new-run-only vs limited replan — **lean new-run or replan inside mode**; decide in PRD.
+
+## Open questions
+
+- [ ] Primary entry surface for M1: Canvas toolbar, Management Center, composer, CLI-only, or all? — **PRD**
+- [ ] Which built-in terminal agents are eligible as workers / criteria / judge (interactive vs non-interactive flags)? — **PRD / TECH**
+- [ ] Judgment Spec schema fields and sensor plugin list for M1 — **TECH**
+- [ ] Event channel: extend existing WS vs new orchestration WS topic — **TECH** (WebSocket-first)
+- [ ] How Orchestrator Agent credentials/model are chosen (user’s terminal agent vs Atmos-managed LLM) — **PRD / TECH**
+- [ ] Multi-workspace / multi-computer runs — likely out of M1; confirm — **PRD**
+- [ ] Whether document scripts (`atmos canvas` exec) host any loop simulation or stay orthogonal — **TECH**
+- [ ] i18n surfaces for Spec card / mode picker copy — **PRD** (follow app i18n rules)
+- [ ] Exact fake-edge linter rules and when compile-graph fails closed — **TECH**
+
+## References
+
+### Related Atmos specs / code
+
+- [APP-014 Canvas](../APP-014_canvas/) — board baseline
+- [APP-015 Canvas Terminal Agent Integration](../APP-015_canvas-terminal-agent-integration/) — CLI → API → browser bus; terminal agents, not ACP
+- [APP-017 Atmos Automations](../APP-017_atmos-automations/) — thin terminal-agent orchestration; non-interactive runs
+- [APP-030 Terminal Side Chat](../APP-030_terminal-side-chat/) — one-shot fork / identity metadata
+- [APP-002 Terminal Multiplexing](../APP-002_terminal-multiplexing/) — tmux session model
+- [APP-004 Local Agent Integration ACP](../APP-004_local-agent-integration-acp/) — orthogonal ACP lane
+- Canvas shapes: `apps/web/src/features/canvas/` (`canvas-terminal`, `canvas-widget`, arrow bindings, agent bus)
+- Terminal identity: `crates/core-service` / `crates/core-engine` tmux (`ATMOS_PANE_ID`, capture/send)
+- Skills: `skills/atmos-canvas-agent/`
+- Terminal agents manifest: `resources/terminal-agents/`
+
+### Vault / methodology (external to repo)
+
+- Harness / Loop / Graph layering (clippings under Obsidian vault `_Clippings/`)
+- Foundation Engineering (Loop): setpoint, sensor, maker/checker, evidence path, granularity, judgment sink
+- Graph Engineering: diamond topology, fake-edge test, formalize after trace
+
+### Industry patterns (background)
+
+- ReAct tool loops; LangGraph nodes/edges/state; Anthropic workflow vs agent; Google ADK LoopAgent; Azure lowest-complexity orchestration ladder
+
+## Ready to promote
+
+### Promote to PRD
+
+- Peer product modes: **Loop** and **Graph**, plus **auto** routing and **user mode override**
+- Role model: Orchestrator Agent, Criteria Agent, Runtime, Worker Terminal Agent, Checker
+- Judgment Spec as must-have object; verify binds to Spec version; maker cannot edit Spec
+- Terminal Agent as default worker; ACP out of scope as primary orchestration path
+- Canvas as primary visualization/ops surface for runs (entry points still open)
+- Explicit anti-patterns list as non-goals / forbidden behaviors
+- Success signals: runs stop with explainable reason; Spec visible; evidence attached; no confidence-only pass
+- Out of scope draft: generic workflow marketplace, ACP mesh, mid-run full topology hot-swap, multi-computer orchestration
+- **Terminal role chrome**: each Orchestrator-managed terminal must show role in **header/UI** (Orchestrator / Criteria / Maker / Verify), even when agent brand is the same — landed as PRD **M18b**
+- **CLI + Skill**: progressive `atmos-orchestrator` skill + HTTP CLI; `context get`; Runtime-owned tick (not public agent verb) — TECH § Agent-facing CLI & Skill
+- **Run home cwd + workspace CLI**: all roles default to user Project/Workspace; opt-in child worktree create/use/merge/abandon — PRD M3a/M3c, TECH workspace lifecycle
+
+### Promote to TECH
+
+- Run object + lifecycle states + events (WS-first)
+- Judgment Spec schema, versioning, audit, criteria_gap flow
+- Orchestrator decision schema (`mode`, `reason`, `topology_hint`, `stop`, …)
+- Loop tick pipeline vs Graph compile/execute (shared evidence attach)
+- Executable edge metadata on tldraw arrows; flow node ShapeUtils (when in slice)
+- tmux edge mapping and `ATMOS_PANE_ID` binding
+- Relationship to AutomationService / process supervision reuse
+- Skill + CLI: full HTTP/verb tables, skill package layout, skill-dir + UI copy instructions (**not** public tick/set-mode)
+- State machine separation (hook / presence / run / node)
+
+### Promote to TEST (later)
+
+- Mode override always wins over Orchestrator
+- Run cannot complete without Spec-met (or explicit allowed skip if PRD allows)
+- Maker cannot mutate Spec; only Criteria Agent version bump
+- Checker fail includes criterion id + evidence path
+- Deterministic sensor failure blocks pass even if LLM judge says ok
+- Graph fake-edge compile failure
+- Budget / max_iter / no_progress stop reasons
+- Fresh-context verify does not share maker conversation state
+- User cancel → `cancelled` / interrupt semantics
+- Canvas shows Spec version and latest verdict
+- Regression: APP-015 canvas CLI path and APP-017 automations still work independently

--- a/specs/APP/APP-048_loop-graph-agent-orchestration/PRD.md
+++ b/specs/APP/APP-048_loop-graph-agent-orchestration/PRD.md
@@ -1,0 +1,312 @@
+# PRD · APP-048: Orchestrator (Loop / Graph Agent Orchestration)
+
+> Product Requirements · WHAT and WHY. Settled direction for a **first-class Orchestrator product surface** that reuses Canvas capabilities for evidence-driven **Loop** and **Graph** multi-step agent work—distinct from the ordinary workspace Canvas.
+>
+> **Post-review revision**: incorporates multi-agent / harness / maker–checker feedback (auto-topology, Spec integrity, join completeness, role+status chrome, Phase-1 Graph bar). See [TECH](./TECH.md) / [TEST](./TEST.md).
+
+Related: [BRAINSTORM](./BRAINSTORM.md), [APP-014 Canvas](../APP-014_canvas/PRD.md), [APP-015 Canvas Terminal Agent](../APP-015_canvas-terminal-agent-integration/PRD.md), [APP-017 Automations](../APP-017_atmos-automations/PRD.md), [APP-030 Terminal Side Chat](../APP-030_terminal-side-chat/PRD.md), [APP-004 ACP](../APP-004_local-agent-integration-acp/TECH.md) (orthogonal).
+
+---
+
+## Context
+
+- **Problem**: Agentic Builders can run terminal code agents and draw structure on the ordinary Canvas, but Atmos has no dedicated place to **orchestrate multi-step agent work** with (1) an intelligent mode choice between feedback **Loop** and explicit **Graph**, (2) a durable **definition of done**, and (3) enforceable stop/evidence rules.
+- **Why now**: Harness (tmux, terminal agents, Canvas, Automations) exists; Foundation Engineering says the scarce work is **setpoints** (what is correct), not another outer prompt shell. Industry consensus: prefer single-agent loops for coherent coding writes; use graphs when routes/dependencies are real; put bugs on edges/verifiers, not on “more agents.”
+- **Product decision**: Ship **Orchestrator** as its **own feature**, reusing Canvas **engine**, not ordinary Canvas identity. Intelligence and workers are **Terminal Agents** (not `crates/llm` user API/local models).
+- **Related**: APP-014/015 (engine reuse), APP-017 (sibling scheduled thin runs), APP-004 (orthogonal ACP).
+
+---
+
+## Goals
+
+1. **Primary**: Users open **Orchestrator**, state a goal, lock a **Judgment Spec**, run **Loop** or **Graph** (or **auto**), and see **why** the run continued or stopped—with **evidence**, never confidence.
+2. **Primary**: Loop and Graph are **peer capabilities** under one Run/Spec/Evidence contract, with a **hard Phase-1 Graph acceptance bar** (not an empty enum).
+3. **Primary**: Criteria path authors **done**; verify binds versioned Spec; makers cannot rewrite or game the grade line (including sensors).
+4. **Secondary**: Native Terminal Agents; deterministic **Runtime**; scannable multi-pane UX (role + instance + activity).
+5. **Secondary**: Prefer **lowest complexity** (Loop by default for linear coding); Graph for real parallel/branch/HITL topology.
+
+### Non-goals
+
+Not a generic workflow studio; not ACP mesh; not keyword-only routing; not ordinary Canvas with extra buttons; not multi-Computer single runs; not token FinOps ledger in M1.
+
+---
+
+## Product surface: Orchestrator vs ordinary Canvas
+
+| | **Ordinary Canvas** | **Orchestrator** |
+|--|---------------------|------------------|
+| Purpose | Free-form board | Multi-step **runs** + Spec + Loop/Graph |
+| Entry | Existing Canvas | Dedicated **Orchestrator** entry |
+| Document | `~/.atmos/canvas/` | `~/.atmos/orchestrator/boards/` (separate schema) |
+| Widgets | Product widgets OK | **No** ordinary product widgets as flow nodes |
+| Mental model | “My board” | “My run(s)” |
+
+Empty state **must** explain multi-step runs + Spec; offer link to ordinary Canvas if needed. Visual chrome should not be confusable with workspace board (header “Orchestrator run”).
+
+---
+
+## Users & Scenarios
+
+- **Primary**: Agentic Builder — multi-step work with clear done-ness.
+- **Secondary**: Reviewer — audit Spec, evidence, stop reason without replaying chat.
+
+### Key scenarios
+
+1. Auto → Loop for linear fix; Spec sensors green → `spec_met`.
+2. Auto proposes Graph with named units → topology emitted or diamond; compile fails → **force Loop** with reason.
+3. Force Graph with two research makers + verify; one branch hangs → join **fails** (not silent partial).
+4. Two makers same Codex brand: headers show **role + instance + activity**.
+5. `criteria_gap` weakens Spec → user must re-confirm; after max Spec versions → stop.
+6. Human criterion open → run **blocked**; sensors green alone cannot complete.
+7. Maker edits test file used by Spec sensor → not silent green (fail closed / Spec violation).
+8. Cancel mid multi-pane run; wall budget kills long maker mid-flight.
+9. User forces `loop` → **skip** planner role (lower multi-agent tax).
+
+---
+
+## User Stories
+
+- As a builder, I want a dedicated Orchestrator surface so runs ≠ free-form diagrams.
+- As a builder, I want Loop and Graph both real, with auto preferring Loop when edges would be fake.
+- As a builder, I want mode override and forced-mode **without** paying for a planner agent.
+- As a builder, I want a Judgment Spec before makers run, and verify that cites clauses + evidence.
+- As a builder, I want makers as Terminal Agents I already use.
+- As a builder, I want each terminal header to show **who (role), which unit (instance), and what state (activity)**.
+- As a reviewer, I want run history with mode reason, Spec version, verdicts, stop reason.
+- As a user, I want cancel + hard budgets so loops cannot run away.
+- As a user, when auto picks Graph, I want either a **valid topology** or an automatic demotion to Loop—not a broken DAG.
+
+---
+
+## Functional Requirements
+
+### Must Have
+
+#### Product identity & entry
+
+- **M1 · Orchestrator product surface**: First-class entry distinct from ordinary Canvas; no requirement to open default canvas document.
+- **M2 · Canvas engine reuse**: Separate Orchestrator board lifecycle/storage; ordinary canvas docs never auto-written by runs.
+- **M3 · Context binding (run home)**: Every run is bound to a **Project**, an existing **Workspace**, or an explicit **standalone** orchestrator working directory (TECH). That binding is the run’s **home context** and is always visible on the run.
+- **M3a · Default working directory for all roles**: Every Orchestrator-managed Terminal Agent role (Planner, Criteria, Maker, Verify) **defaults its cwd / launch path** to the run home:
+  - bound **Workspace** → that workspace worktree path;
+  - bound **Project** only → project root (TECH path resolution);
+  - **standalone** → run standalone workdir under `~/.atmos/orchestrator/…` (TECH).  
+  Agents must **not** invent a random home directory. Sensors, prompts, and `context get` all report this home cwd.
+- **M3b · Empty state & identity**: Empty state and run chrome state “this is Orchestrator runs, not free-form Canvas”; optional link to ordinary Canvas.
+- **M3c · Dynamic isolated Workspace / worktree**: Roles (or the Planner graph) may decide a task needs **isolation** (risky refactor, parallel makers, speculative experiment) and **create a child Workspace** (git worktree / Atmos workspace) under the run’s Project, execute there, then **merge / promote / abandon**.
+  - Isolation is **opt-in and task-driven**, not the default for every role.
+  - Default remains: work **in the user-selected Project/Workspace**.
+  - Parallel **writers** on the home worktree stay forbidden unless isolation + explicit merge/verify (M8).
+  - Child workspaces are Orchestrator-labeled, linked to `run_id`, and user-visible.
+  - Product supports **merge back** or **abandon** with a clear outcome—not silent drift.
+
+#### Modes (Loop / Graph / Auto)
+
+- **M4 · Peer modes**: `loop` | `graph` | `auto` under one Run/Spec/Evidence contract.
+- **M5 · User mode override**: User `loop`/`graph` always wins; UI shows effective mode.
+- **M6 · Auto routing**: Planner Terminal Agent (role chrome label **Planner** in UI; product surface remains “Orchestrator”) proposes mode + reason; prefer Loop when fake edges; never keyword-only.
+- **M6b · Auto topology resolution**: When auto (or user) selects **graph**:
+  1. Prefer **named units** + diamond template when `topology_hint=diamond`, **or**
+  2. Planner emits a **compilable graph proposal** artifact, **or**
+  3. Compile fails / units unnamed → **force Loop** with visible reason.  
+  Never start Graph with empty or decorative-only edges.
+- **M7 · Loop**: maker → evidence → judge vs Spec → retry / complete / stop / criteria refine. Evidence+Spec only.
+- **M8 · Graph**: sequence, branch, fan-out/join, bounded cycle, human block. Prefer diamond when parallel is real.
+  - **Coding domain default**: **serialize writers** on a shared tree; parallelize **read/research** or **independent verifiable units**. Multiple makers writing the **same worktree** without isolation + explicit merge/verify is **forbidden** (see anti-patterns).
+  - Join must not succeed on silent partial fan-in (hang / missing branch = fail).
+  - Verify uses **fresh context** (and independence tier—see M16b).
+- **M8b · Phase-1 Graph acceptance bar** (merge-blocking product bar, not optional UX): Graph mode must **execute** at least **sequence**, **verify (fresh pane)**, and **join fail-closed** (including hang/missing branch), with stop reasons and CLI/skill path. Full board ShapeUtil polish and diamond template may be thinner; **empty Graph enum is not acceptable**. Nested Loop-in-Graph is **out of M1**.
+- **M9 · No mid-run mode teleport**: New run (optional `carry_from`) or within-mode replan only. **Cancel** available; pause is Nice (N3).
+
+#### Criteria & Judgment Spec
+
+- **M10 · Criteria Agent**: Drafts versioned Judgment Spec before makers (unless carry-forward Spec rules apply—TECH).
+- **M11 · Spec content**: User-visible Spec includes:
+  - **acceptance** criteria (required outcomes),
+  - **rejection / forbidden** outcomes where practical,
+  - **evidence expectations** per required clause,
+  - stop/budget hints (or run budget link),
+  - judgment order: **sensors → optional LLM-rubric judge → human** (never confidence-as-pass).
+  - Rule: if a clause is sensor-checkable, a **sensor must own it**; `llm_judge` cannot sole-pass a required sensor-checkable outcome.
+- **M11b · Sensor integrity**: Makers must not “edit the grader.” Files/commands that implement locked Spec sensors (tests, scripts, named paths) are **protected**: mutation fails closed or forces Spec re-version + user confirm. Acceptance surface is **read-only for executors**.
+- **M12 · Completion gate**: `completed` only if:
+  - all **required acceptance** pass,
+  - no **rejection** criterion fires,
+  - no open **human** blocks,
+  - no required criterion is **unverified** (sensor/judge error, timeout, missing evidence).  
+  Missing grader ⇒ **not passed**.
+- **M13 · Confirm policy**:
+  - User confirm if any **human** criterion, **high/critical** risk, any required **llm_judge**, or Spec **weakens** vs prior version.
+  - Auto-confirm only when **all required** criteria are deterministic sensors and risk is low/medium (user may still edit).
+- **M14 · Spec immutability for makers**: Makers cannot edit locked Spec. Only Criteria path version-bumps.
+- **M14b · Spec evolution budget**:
+  - Max Spec versions per run (default **3**, TECH knobs).
+  - **Weakening** (drop/soften failed clause, lower risk controls) always requires user confirm.
+  - **Strengthening** may continue under same risk tier without re-confirm when policy allows.
+  - Exceeding budget → `criteria_unsatisfiable` (or human Spec edit), not infinite legislate loops.
+- **M15 · Verdict binds Spec version**: Every verdict cites `spec_id`, version, criterion ids, evidence refs.
+
+#### Runtime, roles, workers
+
+- **M16 · Runtime guarantees**: lifecycle; **wall + iteration + maker-invocation budgets with mid-flight enforcement**; no-progress; cancel; mode override; confidence ban; maker≠checker; join completeness; artifact I/O discipline (TECH). **M1 budgets are wall/iteration/makers—not token FinOps** (token ledger deferred).
+- **M16b · Independence tiers** (maker≠checker):
+  - **Tier A (minimum)**: fresh verify context + role chrome + Runtime bans maker self-pass.
+  - **Tier B (default when ≥2 agents installed)**: prefer **different agent binary** for `verify` (and ideally `criteria`) vs `maker`; UI shows when same agent is used.
+  - **Tier C (high/critical risk)**: independent verify agent **or** human on any non-sensor required criterion; no sole `llm_judge` pass.
+- **M17 · Terminal Agent workers**: All intelligent roles + makers are terminal-resident code agents.
+- **M17b · Forced-mode fast path**: When user sets `loop` or `graph`, **skip Planner role** entirely (still run Criteria unless carry-forward Spec applies).
+- **M18 · Role separation**: Planner (mode/plan), Criteria, Maker, Verify/Judge, Runtime. Do not collapse copy into “the agent.”
+- **M18b · Terminal chrome (scan-first)**: Every Orchestrator-managed pane, tab, and board terminal card must show:
+  1. **Role** (localized full + short; UI role for planner role: **Planner** to avoid product-name collision),
+  2. **Instance** (required when ≥2 panes share a role—e.g. graph `node.label`, Loop `iter N`),
+  3. **Agent brand**,
+  4. **Activity**: `queued | active | waiting_user | succeeded | failed | cancelled` (at least).
+  - Role must not be tooltip-only; **non-color channel** required (glyph/letter badge + optional accent).
+  - Truncation keeps Role (and Activity icon) before goal text.
+  - Ordinary terminals unchanged.
+- **M19 · ACP not primary**.
+- **M19b · Intelligence host**: Terminal Agents only for planner/criteria/verify intelligence—not `crates/llm` feature providers.
+
+#### Run UX, evidence, controls
+
+- **M20 · Run object**: goal, modes, Spec version, status, stop reason, evidence summary, budgets, binding, mode_reason.
+- **M21 · Run states**: include at least `drafting_spec` | `awaiting_spec_confirm` | `running` | `blocked_human` | `refining_spec` | `completed` | `failed` | `cancelled` | `interrupted`. Terminal statuses always show stop reason when finished.
+- **M22 · Live surface & layout intents**:
+  - **Setup**: Spec + mode + agents primary; board minimal.
+  - **Run · Loop**: active Maker + iteration strip primary; Spec mini; board collapsible.
+  - **Run · Graph**: **linear run strip / node checklist** primary; topology board as minimap (not free editor); click step focuses matching terminal.
+  - **HITL**: full-width human/Spec action strip; terminals dimmed.
+  - **Review**: evidence + Spec + stop reason; terminals collapsed.
+  - **Running graph**: palette off / edit locked; highlight only (draft graph edit only when not running).
+  - When ≥2 Orchestrator panes open, **follow/focus active worker** is Phase-1 Must (not merely Nice).
+- **M22b · Pane density**: Prefer auto-collapse Planner/Criteria after artifacts accepted; cap focused PTYs (e.g. 2) with overflow list of role+status chips (exact caps in TECH).
+- **M23 · Evidence visibility**: open evidence; name failed criterion; show unverified errors.
+- **M24 · Run controls**: **start**, **cancel**, history. **Pause/resume = N3 only** (M1 cancel-only).
+- **M25 · Explainability**: mode_reason; stop_reason enums; which role proposed vs worked vs judged.
+
+#### Agent-facing ops
+
+- **M26 · Skill + CLI (agent-operable Orchestrator)**: Ship system skill **`atmos-orchestrator`** + CLI **`atmos orchestrator`** so Terminal Agents know **when/how** to operate runs without inventing protocols.
+  - **Skill**: progressive disclosure (`SKILL.md` + on-demand `references/` for schemas, roles/artifacts, **workspace/isolation**, workflows, full flags)—mirror APP-015 canvas skill structure; teach prerequisites, Loop vs Graph, role boundaries, **default cwd = run home**, when to spawn isolated workspace, merge/abandon, artifact paths, anti-patterns, error recovery, context acquisition.
+  - **CLI transport**: authenticated **HTTP** to API (APP-015 pattern)—**not** browser WebSocket; **not** ACP.
+  - **Verbs (M1 public)**:
+    - Core: `skill-dir` (local); `status`; `run create|list|get|start|cancel`; `spec draft|get|confirm|update`; `evidence attach|list`; `graph compile|get`; `context get`; `agents list`.
+    - **Workspace (required)**: `workspace get` (home + active cwd for a role/run); `workspace list` (home + child workspaces for the run); `workspace create` (isolated child under Project—worktree/workspace); `workspace use` / bind role or next maker step to a workspace; `workspace merge` (promote child → home / base branch); `workspace abandon` (discard child). Exact flags/HTTP in TECH.
+  - **Not agent-facing**: public `tick` / mid-run `set-mode` (Runtime owns ticks; mode change = new run).
+  - **Discoverability**: `skill-dir` + Orchestrator UI **Copy agent instructions** (prompt + skill directory only, not full skill body)—parity with APP-015 M19.
+  - **Communication model**: CLI for control/inspect **including workspace lifecycle**; role panes speak to Runtime only via **validated run artifacts**; outer user agent keeps conversation ownership (manager/tools, not free handoff chaos).
+
+### Nice to Have
+
+- **N1 · Diamond one-click template** (Phase-1 may still use diamond via auto M6b without fancy UI).
+- **N2 · Spec library** per Project (sensor-first starters encouraged even as lightweight presets in Phase 1 if cheap).
+- **N3 · Pause / resume**.
+- **N4 · Automations trigger**.
+- **N5 · Richer presence follow** beyond M22 minimum.
+- **N6 · Export run report**.
+- **N7 · Multi-run comparison**.
+- **N8 · Optional ACP node**.
+- **N9 · Token / cost ledger**.
+
+---
+
+## Out of Scope
+
+- Merging into ordinary Canvas; product widgets as flow nodes.
+- ACP / `/ws/agent` default mesh; `crates/llm` as Orchestrator brain.
+- Keyword-only auto; generic enterprise workflow marketplace.
+- Mid-run Loop↔Graph hot-swap; multi-Computer single run; mobile-first.
+- Guaranteed unattended overnight without Computer online.
+- Replacing Automations; auto-resume after API process death (M1 marks `interrupted`).
+- Nested Loop-inside-Graph composition (post-M1).
+
+### Forbidden product behaviors
+
+Shipping any of these is a **failed** interpretation:
+
+1. Complete because maker said “done” without Spec + evidence.
+2. Maker edits acceptance Spec mid-run.
+3. Soften Spec after fail without user confirm.
+4. Complete when required sensor did not execute successfully (`unverified`).
+5. Sole `llm_judge` pass for a criterion that has a declared sensor.
+6. Maker mutates sensor implementation files to force green without Spec re-version + policy.
+7. Verify that shares maker conversation as only judgment path.
+8. Graph join success while required branch **failed, cancelled, hung, or missing**.
+9. Fan-out multiple makers **writing the same home worktree** without isolation + explicit merge/verify.
+9b. Launching Orchestrator roles with a **cwd outside** the run home / approved child workspace without an explicit bind.
+9c. Creating orphan worktrees not linked to the run (untracked isolation).
+10. Auto always Graph for any multi-step wording; or start Graph with uncompilable/empty topology.
+11. Route Orchestrator primarily through ACP or `crates/llm` providers.
+12. Role-less terminal headers when multiple Orchestrator panes share an agent brand.
+
+---
+
+## Success Metrics
+
+- Loop **and** Graph dogfood runs from Orchestrator entry (Graph meets M8b bar).
+- Spec version + criterion-linked verdict + stop reason always visible.
+- Auto reason visible; override works; auto-Graph demotes to Loop when topology invalid.
+- Attempted complete without Spec / with unverified sensors blocked.
+- Multi-pane scan: user names role+activity without opening scrollback.
+- Qualitative: “criteria + loop/graph with real terminals,” not “another chat.”
+
+---
+
+## Risks & Open Questions
+
+### Risks
+
+- Canvas confusion → M1–M3b.
+- Spec ceremony → M13 auto-confirm + sensor templates.
+- Graph ceremony / parallel write → M6b, M8 coding defaults, forbidden #9.
+- Terminal Agent JSON flake → TECH role_invoke contract.
+- Multi-agent cost → M17b forced-mode skip planner; collapse planner/criteria panes.
+- Same-agent correlated judgment → M16b tiers.
+
+### Open questions (remaining)
+
+- Default agent when many installed (last-used vs Orchestrator settings) — TECH default OK.
+- Exact PTY focus cap numbers — TECH.
+- Whether verify uses non-interactive flags by default — TECH.
+- Design tokens for role accents — design pass.
+
+### Resolved forks
+
+| Topic | Resolution |
+|-------|------------|
+| Intelligence host | Terminal Agents only |
+| Spec confirm | Risk + weaken + llm_judge/human (M13) |
+| Skip Spec complete | Never (M12) |
+| Mid-run mode | New run only (M9) |
+| Pause M1 | Cancel only (M24); N3 later |
+| Phase-1 Graph | Hard bar M8b |
+| Parallel makers | Serialize shared-tree writes (M8) |
+| Role chrome | Role+instance+activity (M18b) |
+| Planner naming | UI role **Planner**; product **Orchestrator** |
+
+---
+
+## Milestones
+
+- **Phase 1 — Ship bar**: Entry + Run home cwd for all roles + optional child workspace create/merge/abandon + Spec gates + Runtime + Terminal chrome M18b + **Loop full path** + **Graph M8b** + CLI/skill **including workspace verbs** + isolation from ordinary canvas. Board topology chrome may be minimal.
+- **Phase 2 — Graph UX depth**: Diamond template UI (N1), richer topology editing, Spec library (N2), stronger HITL polish.
+- **Phase 3**: Automations trigger, export, optional ACP node, token ledger.
+
+---
+
+## Glossary
+
+| Term | Meaning |
+|------|---------|
+| **Orchestrator** | Product surface / feature |
+| **Planner** | Terminal role that proposes mode/topology (UI label; `ATMOS_ORCH_ROLE=orchestrator`) |
+| **Criteria** | Authors Judgment Spec (setpoint) |
+| **Judgment Spec** | Versioned definition of done + rejection + evidence |
+| **Loop / Graph** | Peer execution modes |
+| **Runtime** | Deterministic controller (budgets, gates, joins) |
+| **Maker** | Actuator / implementer |
+| **Verify** | Independent judgment vs Spec |
+| **Sensor** | Deterministic check implementing Spec clauses |
+| **Ordinary Canvas** | APP-014 free-form board |
+| **Run home** | User-selected Project / Workspace / standalone cwd for the run |
+| **Child workspace** | Orchestrator-created isolated worktree/workspace for a role or branch of work; merge or abandon |

--- a/specs/APP/APP-048_loop-graph-agent-orchestration/TECH.md
+++ b/specs/APP/APP-048_loop-graph-agent-orchestration/TECH.md
@@ -1,0 +1,832 @@
+# TECH · APP-048: Orchestrator (Loop / Graph Agent Orchestration)
+
+> Technical Design · HOW. Implements [PRD APP-048](./PRD.md). Addresses **M1–M26**, **M3b**, **M6b**, **M8b**, **M11b**, **M14b**, **M16b**, **M17b**, **M18b**, **M19b**, **M22b**. Nice-to-haves **N1–N9** deferred unless noted.
+>
+> **Post-review revision**: auto-topology, role_invoke I/O, mid-flight budgets, join completeness, Spec integrity, work state, chrome scan fields, Phase-1 Graph bar.
+
+## Scope summary
+
+First-class **Orchestrator** on the connected Atmos Computer:
+
+- Dedicated UI + board (Canvas **engine** reuse; **separate** document namespace).
+- Durable Run / Judgment Spec / Evidence / Verdict (SQLite + `~/.atmos/orchestrator/`).
+- **Runtime** enforces mode, Spec, budgets (mid-flight), join completeness, maker≠checker tiers, artifact contracts.
+- **Loop** + **Graph** peer executors; Graph Phase-1 bar = sequence + verify + join fail-closed (hang/missing).
+- All intelligent roles = **Terminal Agents** (not `crates/llm` providers).
+- WS-first UI; HTTP for CLI.
+
+Out of scope: APP-017 scheduling, ACP mesh, multi-Computer runs, auto-resume after process death, nested Loop-in-Graph, token FinOps.
+
+---
+
+## Architecture overview
+
+```mermaid
+flowchart TB
+  UI["apps/web · features/orchestrator"]
+  CLI["apps/cli · atmos orchestrator"]
+  API["apps/api · WS + CLI HTTP"]
+  Svc["core-service · OrchestratorService + Runtime"]
+  Term["TerminalService + TmuxEngine"]
+  Agents["Terminal Agents · planner/criteria/maker/verify"]
+  Infra["infra · SQLite"]
+  FS["~/.atmos/orchestrator/**"]
+
+  UI --> API --> Svc
+  CLI --> API
+  Svc --> Infra
+  Svc --> Term --> Agents
+  Svc --> FS
+  UI --> Board["Orchestrator board file"]
+  Svc --> Board
+```
+
+| Layer | Responsibility |
+|-------|----------------|
+| `crates/infra` | run/spec/verdict/evidence tables + repos |
+| `crates/core-engine` | tmux capture/send helpers |
+| `crates/core-service` | OrchestratorService, Runtime, Loop/Graph, role_invoke, sensors, Spec |
+| `apps/api` | WsAction/Event, CLI HTTP |
+| `apps/web` | orchestrator feature, chrome, layout intents |
+| `apps/cli` + `skills/atmos-orchestrator` | agent-facing ops |
+
+**Not used**: ACP `/ws/agent` as worker path; `crates/llm` generate_text for planner/criteria/verify.
+
+---
+
+## Product decisions resolved in TECH
+
+| Topic | Decision |
+|-------|----------|
+| Navigation | Management Center **Orchestrator** + `/orchestrator` (+ project-scoped deep link OK) |
+| Board storage | `~/.atmos/orchestrator/boards/{id}.atmos.tldr`, schema `atmos-orchestrator-board.1` — never ordinary canvas dir |
+| Intelligence | Terminal Agents only; forced `loop\|graph` **skips planner** (M17b) |
+| Auto topology (M6b) | `ModeProposal.graph` or diamond expand; compile fail → effective mode Loop + reason |
+| Run home cwd | All roles default cwd = run binding (workspace path / project root / standalone dir). Never random. |
+| Child workspace | Opt-in via CLI/Runtime: create under Project with `create_source = "orchestrator"`, link `run_id`; merge or abandon APIs |
+| Parallel makers | Default **forbid** multi-maker write on **home** worktree without child isolation + merge/verify node; compile fails |
+| Spec confirm | Human / high-critical / required llm_judge / **weaken** → user confirm; auto only all-required sensors + low/medium |
+| Spec churn | `max_spec_versions=3`; weaken needs confirm |
+| Budgets M1 | `max_iterations=8`, `max_wall_ms=45m`, `max_maker_invocations=12`; **mid-flight wall watchdog**; tokens deferred |
+| No-progress | `progress_key = hash(sorted failing criterion_ids + sensor exit signatures)` × 3 ticks → `failed` + `no_progress` |
+| Pause | N3 only; M1 cancel |
+| Graph Phase-1 | Executor: sequence, verify fresh, join completeness; UI: linear run strip + optional thin topology |
+| Nested Loop-in-Graph | Out of M1 |
+| Join | All required inbound terminal; hang/timeout → fail; expected count |
+| role_invoke | File-only accept (atomic rename); timeouts; one repair; no fence-as-sole-accept |
+| Independence | Tier B prefer distinct verify agent when ≥2 installed |
+| Carry Spec | `carry_from_run_id` may reuse Spec if goal unchanged + user confirm |
+| CLI | HTTP like APP-015 |
+
+---
+
+## PRD coverage map
+
+| PRD | TECH |
+|-----|------|
+| M1–M3c | routes, board, run home cwd, child workspace lifecycle, empty state |
+| M4–M6b | mode lock, ModeProposal + graph, demote Loop |
+| M7–M8b | LoopEngine, GraphEngine, compile, isolation rules |
+| M9 | reject set_mode when running; carry_from |
+| M10–M15, M11b, M14b | criteria, Spec schema, integrity, churn |
+| M16–M16b | Runtime, budgets, tiers |
+| M17–M19b | terminal roles, skip planner, no ACP/llm brain |
+| M18b | chrome composition |
+| M20–M25, M22b | run model, layout intents, cancel |
+| M26 | § Agent-facing CLI & Skill + **workspace** verbs; skill-dir; context get includes home/children |
+
+---
+
+## Module-by-module design
+
+### crates/infra
+
+Migration e.g. `m20260731_000034_create_orchestrator_tables.rs`:
+
+- `orchestrator_run` — goal, requested/effective mode, status, stop_reason, **target_kind, project_guid, workspace_guid (home)**, board_id, locked_spec_*, mode_reason, budget_json, graph_json, carry_from, artifact_dir, agent ids, timestamps
+- `orchestrator_run_workspace` — run_id, workspace_guid, kind home|child, purpose, status active|merged|abandoned, base_ref, path cache, created_at
+- `orchestrator_role_binding` — run_id, role?, node_id?, workspace_guid (active cwd bind)
+- `orchestrator_judgment_spec` — run_id, version, risk_tier, requires_user_confirm, confirmed_*, body_path, created_at
+- `orchestrator_verdict` — run_id, spec version, iteration/node_id, result, criterion_results_json, summary
+- `orchestrator_evidence` — run_id, verdict_id?, kind, path, meta_json
+
+Repo: data-only CRUD + status transitions with optimistic checks.
+
+### crates/core-engine
+
+Reuse tmux send/capture/window env. Env always:
+
+`ATMOS_PANE_ID`, `ATMOS_ORCH_RUN_ID`, `ATMOS_ORCH_ROLE=orchestrator|criteria|maker|verify`, optional `ATMOS_ORCH_NODE_ID`.
+
+### crates/llm
+
+**Out of brain path.** Do not call `llm::generate_text` / feature providers for propose_mode, draft_spec, or judge. AgentCli spawn code in `llm_text_generation.rs` may be **referenced** only as process-launch pattern for Terminal Agents.
+
+### crates/core-service
+
+```
+service/orchestrator/
+  mod.rs runtime.rs loop_engine.rs graph_engine.rs graph_compile.rs
+  criteria.rs role_invoke.rs sensors.rs agents_resolve.rs
+  artifacts.rs work_state.rs board.rs events.rs schemas.rs integrity.rs
+```
+
+```rust
+pub struct OrchestratorService {
+    db: Arc<DatabaseConnection>,
+    terminal_service: Arc<TerminalService>,
+    workspace_service: Arc<WorkspaceService>,
+    tmux: TmuxEngine,
+    event_tx: broadcast::Sender<OrchestratorEvent>,
+}
+```
+
+#### Terminal roles
+
+| Role | env | UI label | Artifact |
+|------|-----|----------|----------|
+| planner | `orchestrator` | **Planner** | `mode_proposal.json` |
+| criteria | `criteria` | Criteria | `specs/v{n}.json` |
+| maker | `maker` | Maker | side effects + work_state |
+| verify | `verify` | Verify | verdicts / judge JSON |
+
+#### role_invoke contract (P0)
+
+1. Resolve agent for role (run override → defaults → maker fallback; verify prefers non-maker if Tier B).
+2. Write prompt under `runs/{id}/prompts/{role}-{invocation_id}.md`.
+3. Launch non-interactive if capable; else visible pane with `orchRole` meta.
+4. **Accept only** final artifact path after **atomic publish**: write `*.json.tmp` → validate schema → `rename` to final.
+5. **Do not** accept JSON fence/stdout as sole success path in M1 (optional: use as repair input only).
+6. Timeouts (defaults): planner/criteria **120s**; maker **idle/wall per budget**; verify **180s** (knobs overridable).
+7. Invalid → one repair re-invoke → then `worker_failed` / `artifact_invalid`.
+8. **Done rule (locked)**: accept when **(a)** final artifact validates **and** **(b)** process has exited with code 0 **or** a sibling `role.done` file exists with `{"ok":true,"artifact":"<relative-path>"}` written **after** the final artifact rename. Prefer file+exit; `role.done` supports long-lived interactive panes that cannot exit.
+
+#### Runtime rules
+
+| Rule | Behavior |
+|------|----------|
+| Mode lock | User loop/graph → skip planner; auto → require valid ModeProposal |
+| Auto graph | mode=graph requires compilable graph in proposal or template expand; else demote Loop |
+| Spec start | start_run needs locked Spec |
+| Complete | all required acceptance pass ∧ no rejection ∧ no blocked_human ∧ no unverified required |
+| Confidence ban | no maker self-pass |
+| Spec write | maker cannot update Spec; FS deny maker write to `specs/`, `verdicts/` |
+| Sensor integrity | `integrity.rs` watches Spec-declared paths; unauthorized mutation → fail closed |
+| Verify | new window, role=verify, adversarial system prompt; Tier B agent pick |
+| criteria_gap | set `refining_spec`; **park/cancel active makers**; Criteria only; weaken → confirm |
+| Human block | `blocked_human`; park makers |
+| Cancel | flag → interrupt all run panes → wait ≤5s → force kill → `cancelled` |
+| Wall budget | pre-dispatch **and** watchdog timer cancels roles mid-flight |
+| Maker budget | each maker start counts; fan-out included |
+| Join | see Graph |
+| Restart | any `running` → `interrupted` + orphan pane reclaim by `ATMOS_ORCH_RUN_ID` |
+| No-progress | progress_key ×3 → `failed`+`no_progress` |
+
+#### LoopEngine
+
+```
+tick:
+  budget/cancel checks
+  dispatch maker (work_state + Spec summary + last feedback)
+  wait (idle timeout / wall)
+  update work_state.json
+  run sensors (required) → optional llm_judge → human gates
+  verdict (pass|fail|criteria_gap|blocked_human|unverified)
+  branch
+```
+
+#### GraphEngine + compile
+
+**Compile fail-closed if:**
+
+- executable edge missing kind or endpoints
+- cycle without `max_cycles ≥ 1`
+- no entry / unreachable required nodes (fail M1)
+- multi-maker **write** nodes same worktree without isolation flag
+- exceeds max_nodes / max_fanout (defaults e.g. 32 nodes / fanout 4)
+- graph empty when mode=graph
+
+**Join readiness:**
+
+```
+required_preds = control inbounds where required=true (default true)
+all terminal ∈ {succeeded, failed, cancelled, timed_out, skipped}
+if any required failed|cancelled|timed_out → join failed
+if any required still running past node_timeout → join failed (not silent partial)
+if expected_count != observed terminal → fail
+reduce/synthesize only after join success
+```
+
+Node kinds: `maker | sensor | verify | reduce | human | join` (join may be implicit multi-inbound—document one approach and stick to it; prefer explicit `join` for clarity).
+
+**Isolation & cwd:**
+
+- Default `cwd` for every role = **run home path** resolved from binding.
+- Graph `maker` with `writes: true` (default) and concurrent peers → require `isolation: "worktree"` and a bound `workspace_guid` (child) **or** compile error.
+- Planner/Criteria/Verify usually stay on **home** unless explicitly bound to a child (e.g. verify child branch before merge).
+- Child create uses `WorkspaceService` with `create_source = "orchestrator"` (mirror APP-017 automation source labeling).
+
+#### Work state
+
+`work_state.json` + `attempts/v{n}.md`: files touched, commands, last fail summary, git head. Loop makers read; parallel makers get **partitioned** slices; verify gets Spec + evidence **not** maker chat transcripts.
+
+#### Sensors
+
+```rust
+enum SensorKind {
+  Command { argv: Vec<String>, cwd: PathBuf, pass_exit_codes: Vec<i32>, timeout_ms: u64 },
+  FileExists { path: PathBuf },
+  FileRegex { path: PathBuf, pattern: String },
+  GitDiffStat { /* optional */ },
+}
+```
+
+Default sensor `timeout_ms=120_000`. No shell string concat. Capture truncated stdout/stderr to evidence.
+
+#### Independence resolver
+
+```
+if risk high/critical → Tier C rules
+else if count_installed_agents >= 2 → prefer verify_agent != maker_agent
+else Tier A only + UI badge "same agent as maker"
+```
+
+### apps/api
+
+**WsAction:** OrchestratorRunCreate/Get/List/Cancel/Start, ProposeMode, DraftSpec, ConfirmSpec, UpdateSpecDraft, HumanVerdict, AttachEvidence, BoardGet, AgentCapabilities.
+
+**WsEvent:** RunUpdated, SpecUpdated, VerdictRecorded, NodeUpdated, EvidenceAttached, RoleActivityUpdated.
+
+**HTTP CLI:** full path table in § Agent-facing CLI & Skill below (not a vague `/*`).
+
+Idempotency: start/confirm should be safe to retry (status checks).
+
+### apps/web
+
+```
+features/orchestrator/
+  components/  Entry, RunView, SpecCard, ModePicker, RunHeader,
+               RunStrip, HitlStrip, Board, TerminalCard, RoleChrome,
+               CopyAgentInstructions  # M26 / APP-015-style clipboard
+  hooks/ store/ lib/ (chrome composition, layout intent)
+```
+
+**Layout intents** implement PRD M22. **Running graph**: lock palette.  
+**Copy agent instructions** (Must): same product duty as APP-015 M19 — clipboard = short prompt + skill dir (not full SKILL body).
+
+**Chrome composition** (pure helper unit-tested):
+
+```
+scan line: [RoleGlyph][RoleShort] [ActivityIcon] [Agent] [Instance]
+tooltip: full role + goal + run id
+```
+
+i18n: `orchestrator.role.planner|criteria|maker|verify` + `*.short` + activity strings (en/zh).
+
+---
+
+## Agent-facing CLI & Skill (M26) — full design
+
+This is how **Terminal Agents and operators** drive Orchestrator without inventing protocols. Pattern mirrors **APP-015** (skill progressive disclosure + intent-level CLI + HTTP to API). UI remains WS-first; agents do **not** open `/ws` for orchestration.
+
+### Mental model for agents
+
+```text
+User / outer agent
+    │  (optional) atmos orchestrator skill-dir → read SKILL.md
+    ▼
+atmos orchestrator <verb>     ──HTTP──►  apps/api /api/orchestrator/v1/*
+    │                                      │
+    │                                      ▼
+    │                               OrchestratorService + Runtime
+    │                                      │
+    │                         spawn role panes (planner/criteria/maker/verify)
+    │                                      │
+    └──── ground truth: run artifacts under
+         ~/.atmos/orchestrator/runs/{run_id}/
+         (mode_proposal, specs, evidence, verdicts, work_state)
+```
+
+| Channel | Who | Purpose |
+|---------|-----|---------|
+| **CLI HTTP** | Any terminal agent / shell | Create/inspect/control runs; draft/confirm Spec; attach evidence; compile graph |
+| **WS** | Browser Orchestrator UI only | Live RunUpdated / NodeUpdated / chrome |
+| **Role artifacts** | Planner/Criteria/Maker/Verify panes | Structured I/O Runtime trusts (not free-form chat) |
+| **ACP / crates/llm** | — | **Not** used for Orchestrator brain/workers |
+
+**Who owns the outer reply loop:** the **user’s Terminal Agent session** (or human) that called CLI remains the conversation owner. Orchestrator roles are **delegated workers** with bounded contracts—not decentralized handoffs that steal the chat (OpenAI manager/tools pattern). Runtime owns lifecycle/stop; agents propose artifacts only.
+
+**Tick is Runtime-owned:** agents do **not** call a public `tick` verb every loop. After `run start`, the server runner drives LoopEngine/GraphEngine. Agents may `run get` / `events` / read artifacts to observe. (Internal test hooks may expose tick; not agent-facing M1.)
+
+### Skill package: `skills/atmos-orchestrator/`
+
+System skill (sync like canvas): `skills/system-skills-manifest.json` + `~/.atmos/skills/.system/atmos-orchestrator/`.
+
+```text
+skills/atmos-orchestrator/
+  SKILL.md                         # progressive: when/how, default workflows, compact verb table, anti-patterns
+  references/
+    command-reference.md           # full flags, HTTP map, error codes, --json shapes
+    schemas.md                     # ModeProposal, JudgmentSpec, Verdict, role.done (link TECH types)
+    roles-and-artifacts.md         # env, pane chrome, who may write what, fresh verify
+    workspace-isolation.md         # home cwd, create/use/merge/abandon, when to isolate
+    workflows.md                   # create→spec→start Loop; Graph path; HITL; criteria_gap; isolate-merge
+    anti-patterns.md               # PRD forbidden list in agent-facing language
+```
+
+**Progressive disclosure (industry + APP-015):**
+
+1. Startup: only skill name/description (~100 tokens).
+2. When user/agent needs Orchestrator: load `SKILL.md` via skill-dir path.
+3. Load `references/*` only when needed (schemas, full flags, Graph).
+
+**SKILL.md must teach (not optional):**
+
+- Prerequisites: `atmos` on PATH; local API up; auth like other CLI; **run home Project/Workspace**.
+- Decision tree: babysit one agent vs create Orchestrator run; Loop vs Graph; never invent Spec.
+- **Cwd rules**: always start from run home; use `workspace create` only when isolation is justified; merge/abandon before treating work as done on home.
+- Default workflow: create run (bound to workspace) → draft Spec → start → poll get → cancel if needed.
+- Isolation workflow: detect need → `workspace create` → `workspace use` for role/step → work → `workspace merge` or `abandon`.
+- Verb table (below) including **workspace** verbs.
+- Role boundaries: maker cannot write Spec; verify fresh context; sensors-first.
+- Context acquisition: `context get` (home + children + active cwd), artifact paths, `work_state.json`.
+- Spawn: Runtime spawns roles into bound cwd; agents should **not** freestyle multi-tmux meshes or orphan worktrees.
+- Errors + recovery.
+- Reporting: run id, mode, Spec version, stop_reason, workspace_guids, evidence paths.
+
+### Discoverability
+
+| Affordance | Behavior |
+|------------|----------|
+| `atmos orchestrator skill-dir` | Local only (no HTTP). Print skill install dir + one-line prompt to read `SKILL.md` (canvas pattern). Alias: `skill-path`. |
+| Orchestrator UI “Copy agent instructions” | Clipboard: brief prompt + skill directory path (APP-015 M19 equivalent). **Must** for M26 product parity. |
+| System skill sync | API startup installs under `~/.atmos/skills/.system/atmos-orchestrator/`. |
+
+Clipboard prompt template (exact string in impl TECH polish; intent):
+
+```text
+Read the Atmos Orchestrator skill in this directory and use `atmos orchestrator` to manage multi-step runs (Loop/Graph), Judgment Specs, and evidence. Do not invent completion without Spec + sensors.
+<absolute skill dir>
+```
+
+### CLI command tree
+
+```text
+atmos orchestrator
+  skill-dir | skill-path          # local
+  status                          # API health + orchestrator capability summary
+  run create | list | get | start | cancel | watch?
+  spec draft | get | confirm | update
+  evidence attach | list
+  graph compile | get
+  context get                     # compact context bundle for agents
+  agents list                     # eligible terminal agents for roles
+  workspace get | list | create | use | merge | abandon
+```
+
+Global flags (align canvas/CLI): `--api-url`, auth token env, `--json` machine output, `--timeout-ms`.
+
+#### Verb contracts (agent-facing)
+
+| Verb | HTTP | Purpose | Key flags / body |
+|------|------|---------|------------------|
+| `skill-dir` | *(none)* | Print skill path + prompt | — |
+| `status` | `GET /api/orchestrator/v1/status` | API up, feature enabled, defaults | — |
+| `run create` | `POST /api/orchestrator/v1/runs` | Create draft run | `--goal`, `--mode auto\|loop\|graph`, **`--project` / `--workspace` / `--standalone` (home)**, `--budget-*`, role agent ids, `--carry-from` |
+| `run list` | `GET /api/orchestrator/v1/runs` | History | `--limit`, `--status` |
+| `run get` | `GET /api/orchestrator/v1/runs/{id}` | Full detail + artifact paths + workspace bindings | `--run` |
+| `run start` | `POST .../runs/{id}/start` | Lock mode+Spec and start runner | `--run` |
+| `run cancel` | `POST .../runs/{id}/cancel` | Cancel | `--run` |
+| `spec draft` | `POST .../runs/{id}/spec/draft` | Invoke Criteria role **in home cwd** | `--run` |
+| `spec get` | `GET .../runs/{id}/spec` | Current Spec body | `--run`, `--version` |
+| `spec confirm` | `POST .../runs/{id}/spec/confirm` | User/agent confirm locked draft | `--run`, `--version` |
+| `spec update` | `PATCH .../runs/{id}/spec` | Human/agent edit **pre-lock** body | `--run`, `--file` JSON |
+| `evidence attach` | `POST .../runs/{id}/evidence` | Attach file/meta | `--run`, `--file`, `--kind`, `--criterion` |
+| `evidence list` | `GET .../runs/{id}/evidence` | List evidence | `--run` |
+| `graph compile` | `POST .../runs/{id}/graph/compile` | Validate/store graph | `--run`, `--file` optional |
+| `graph get` | `GET .../runs/{id}/graph` | Compiled graph | `--run` |
+| `context get` | `GET .../runs/{id}/context` | **Agent context pack** (home + children + active cwd) | `--run`, optional `--role` / `--node` |
+| `agents list` | `GET .../agents` | Role-eligible agents | — |
+| `workspace get` | `GET .../runs/{id}/workspace` | Home + active binding for role/node | `--run`, `--role?`, `--node?` |
+| `workspace list` | `GET .../runs/{id}/workspaces` | Home + all child workspaces for run | `--run` |
+| `workspace create` | `POST .../runs/{id}/workspaces` | Create isolated child under Project | `--run`, `--purpose`, `--base-branch?`, `--name?` |
+| `workspace use` | `POST .../runs/{id}/workspace/use` | Bind role/node/next-step to workspace | `--run`, `--workspace`, `--role?`, `--node?` |
+| `workspace merge` | `POST .../runs/{id}/workspaces/{ws}/merge` | Merge/promote child → home (or base) | `--run`, `--workspace`, `--strategy?` |
+| `workspace abandon` | `POST .../runs/{id}/workspaces/{ws}/abandon` | Discard child isolation | `--run`, `--workspace` |
+
+**Not public M1:** `tick`, `set-mode` after start (mode change = new run). Optional `run watch` streams events via HTTP SSE or poll—if deferred, agents poll `run get` every N seconds (document N=2–5s).
+
+#### Response shape (`--json`)
+
+```ts
+// success
+{ "ok": true, "data": { /* RunDetail | Spec | ... */ } }
+// error
+{ "ok": false, "error": { "code": "ORCH_*", "message": string, "hint"?: string, "run_id"?: string } }
+```
+
+Exit codes: `0` ok; `1` generic; `2` usage; `3` auth; `4` not found; `5` conflict (e.g. start without Spec); `6` validation (graph compile, Spec schema).
+
+#### Error codes (skill table)
+
+| Code | Meaning | Agent recovery |
+|------|---------|----------------|
+| `ORCH_API_OFFLINE` | Cannot reach API | Start local Atmos / check `--api-url` |
+| `ORCH_UNAUTHORIZED` | Auth failed | Fix CLI token |
+| `ORCH_NOT_FOUND` | Bad run id | `run list` |
+| `ORCH_SPEC_REQUIRED` | Start without Spec | `spec draft` / confirm |
+| `ORCH_SPEC_CONFIRM_REQUIRED` | High risk / human / weaken | User confirm or `spec confirm` after review |
+| `ORCH_MODE_LOCKED` | Illegal mode change | `run create --carry-from` |
+| `ORCH_GRAPH_COMPILE_FAILED` | Fake/bad edges | Fix graph or use `--mode loop` |
+| `ORCH_BUDGET` | Wall/iter/makers | `run get` stop_reason; new run |
+| `ORCH_FORBIDDEN_ROLE_WRITE` | Maker tried Spec write | Use criteria path only |
+| `ORCH_ARTIFACT_INVALID` | Role JSON failed | Read skill schemas; re-draft |
+| `ORCH_WORKSPACE_REQUIRED` | Isolation needed but no Project | Bind project or use home-only mode |
+| `ORCH_WORKSPACE_NOT_CHILD` | Merge target not run-linked | `workspace list` |
+| `ORCH_MERGE_CONFLICT` | Merge failed | Report paths; user/agent resolve then retry |
+| `ORCH_CWD_FORBIDDEN` | Role cwd outside home/children | `workspace use` valid id |
+
+### Context acquisition (`context get`)
+
+Agents must not guess. `context get` returns a compact bundle:
+
+```ts
+{
+  run_id, status, requested_mode, mode, mode_reason, stop_reason?,
+  goal,
+  home: {
+    target_kind: "project" | "workspace" | "standalone",
+    project_guid?, workspace_guid?, cwd: string  // absolute path — default for all roles
+  },
+  workspaces: Array<{
+    workspace_guid, path, kind: "home" | "child",
+    create_source?: "orchestrator", purpose?, status: "active" | "merged" | "abandoned"
+  }>,
+  active_bindings: Array<{ role?, node_id?, workspace_guid, cwd }>,
+  spec: { version, path, risk_tier, requires_user_confirm, summary },
+  budget: Budget & { remaining_wall_ms?, iterations_used? },
+  artifacts: { root, mode_proposal?, work_state?, specs_glob, evidence_glob },
+  roles_active: Array<{ role, agent_id, activity, pane_hint?, cwd }>,
+  last_verdict?: { result, summary, criterion_ids },
+  graph?: { entry, node_count, compile_ok },
+  skill_dir_hint: string
+}
+```
+
+Also document: agents can **read files** under `artifacts.root` with ordinary tools; Runtime is source of truth for status.
+
+### Workspace lifecycle (M3c) — service design
+
+```text
+Run home (user-selected Project / Workspace / standalone)
+    │
+    ├─ role default cwd ──────────────────────────► home.cwd
+    │
+    └─ workspace create (task needs isolation)
+           │  WorkspaceService.create(... create_source="orchestrator",
+           │    metadata: { orch_run_id, purpose })
+           ▼
+       child workspace (worktree path)
+           │
+           ├─ workspace use --role maker --node N
+           │     role_invoke launches with cwd=child.path
+           ▼
+       workspace merge  ──► home (or base branch) + child status=merged
+         or abandon     ──► child status=abandoned (no silent leave-behind)
+```
+
+**Rules:**
+
+1. `workspace create` requires run `target_kind` of `project` or `workspace` with resolvable `project_guid`. Standalone runs may only create dirs under the run artifact tree (not full Atmos Workspace)—document as limited isolation.
+2. Child rows stored in SQLite: `orchestrator_run_workspace` (`run_id`, `workspace_guid`, `kind`, `purpose`, `status`, `base_ref`, timestamps).
+3. `role_invoke` resolves cwd: binding for (run, role, node) → else home.cwd.
+4. Sensors default to **active maker cwd** when judging that maker’s work; Spec may pin sensor cwd to `home` for integration tests after merge.
+5. Merge strategy M1: reuse existing git/workspace merge primitives where possible (fast-forward / open PR / apply patch—exact strategy enum in impl; product requires **explicit user-visible success/fail**).
+6. On run `cancel` / `abandon` all open children: do **not** auto-delete worktrees without policy; mark abandoned and surface in UI for cleanup (retention Nice later).
+
+### Spawn & delegation (what agents teach)
+
+Skill text (normative):
+
+1. **Prefer** `run create --workspace …` (or project) so **home cwd** is the user’s place of work.
+2. **Prefer** Runtime-spawned roles over manually opening random terminals; cwd always home or bound child.
+3. When Runtime starts a role, it sets env, prompt file, and **cwd**; worker produces contracted artifact only.
+4. **When to isolate (task judgment):** parallel writers; destructive/experimental changes; branch-per-feature before merge. Then: `workspace create` → `workspace use` → work → `workspace merge` | `abandon`.
+5. **When not to isolate:** simple linear fix, Spec sensors on home tree, Criteria/Planner by default.
+6. **Delegation contract** (planner graph units): objective, output schema, boundaries, `isolation` + optional `workspace_guid`.
+7. **Verify** must not receive maker chat; only Spec + evidence; often on **home** after merge, or on child if verifying branch before merge (explicit bind).
+8. **Maker** reads `context get` / `work_state.json` + Spec path; never edits `specs/`.
+9. Do not `git worktree add` outside Orchestrator CLI—untracked orphans are forbidden.
+
+### Interaction loops (agent playbooks)
+
+**A. Outer agent helps user set up a run**
+
+```text
+skill-dir → read SKILL.md
+run create --goal "…" --mode auto --workspace <user workspace>
+context get   # confirm home.cwd
+spec draft    # Criteria runs in home.cwd
+spec get / confirm as needed
+run start
+loop: run get / context get until terminal status
+if need isolation mid-task:
+  workspace create --purpose "…"
+  workspace use --role maker
+  # Runtime next maker tick uses child cwd
+  … later workspace merge or abandon
+if blocked_human: tell user
+if failed: report stop_reason + evidence + workspace list
+```
+
+**B. Role worker (prompt injected by Runtime)** — not free-form CLI invent:
+
+```text
+Read prompt file + schemas.md
+Write only contracted artifact via atomic rename
+Exit 0 (or write role.done)
+```
+
+**C. HITL**
+
+Human uses UI; agents may `run get` and must not invent `spec_met`.
+
+### HTTP API table (authoritative for CLI)
+
+Base: `/api/orchestrator/v1`  
+Auth: same CLI bearer as `atmos canvas` / existing atmos CLI.
+
+| Method | Path | Notes |
+|--------|------|-------|
+| GET | `/status` | |
+| GET | `/agents` | |
+| POST | `/runs` | create |
+| GET | `/runs` | list query |
+| GET | `/runs/{id}` | |
+| POST | `/runs/{id}/start` | |
+| POST | `/runs/{id}/cancel` | |
+| GET | `/runs/{id}/context` | |
+| POST | `/runs/{id}/spec/draft` | |
+| GET | `/runs/{id}/spec` | |
+| POST | `/runs/{id}/spec/confirm` | |
+| PATCH | `/runs/{id}/spec` | draft only |
+| POST | `/runs/{id}/evidence` | multipart or path ref |
+| GET | `/runs/{id}/evidence` | |
+| POST | `/runs/{id}/graph/compile` | |
+| GET | `/runs/{id}/graph` | |
+| GET | `/runs/{id}/workspace` | home + active |
+| GET | `/runs/{id}/workspaces` | list children |
+| POST | `/runs/{id}/workspaces` | create child |
+| POST | `/runs/{id}/workspace/use` | bind role/node |
+| POST | `/runs/{id}/workspaces/{ws}/merge` | |
+| POST | `/runs/{id}/workspaces/{ws}/abandon` | |
+
+Timeouts: default CLI 120s; `spec draft` / role-heavy / merge ops may use 180–300s (`--timeout-ms`).
+
+### Relation to ordinary Canvas skill
+
+- `atmos canvas` remains for **diagrams / ordinary boards**.
+- Orchestrator agents should **not** simulate Loop/Graph via canvas document scripts.
+- Cross-link in both skills: “multi-step agent runs → Orchestrator; free-form diagrams → Canvas.”
+
+---
+
+## Data model
+
+```ts
+type OrchMode = "auto" | "loop" | "graph";
+type EffectiveMode = "loop" | "graph";
+
+type RunStatus =
+  | "drafting_spec"
+  | "awaiting_spec_confirm"
+  | "running"
+  | "blocked_human"
+  | "refining_spec"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "interrupted";
+
+type StopReason =
+  | "spec_met"
+  | "budget_iterations"
+  | "budget_wall"
+  | "budget_makers"
+  | "no_progress"
+  | "user_cancel"
+  | "criteria_unsatisfiable"
+  | "graph_compile_failed"
+  | "worker_failed"
+  | "artifact_invalid"
+  | "join_incomplete"
+  | "interrupted_environment";
+
+type RoleActivity =
+  | "queued" | "active" | "waiting_user" | "succeeded" | "failed" | "cancelled";
+
+interface Budget {
+  max_iterations: number;        // 8
+  max_wall_ms: number;           // 2_700_000
+  max_maker_invocations: number; // 12
+  max_spec_versions: number;     // 3
+}
+
+interface ModeProposal {
+  mode: EffectiveMode;
+  reason: string;
+  plan_complexity: "low" | "high";
+  topology_hint?: "linear" | "diamond" | "custom";
+  /** Required when mode=graph unless diamond template can expand from named_units */
+  graph?: CompiledGraph;
+  named_units?: string[];
+}
+
+interface Criterion {
+  id: string;
+  description: string;
+  kind: "sensor" | "llm_judge" | "human";
+  required: boolean;
+  sensor?: SensorSpec;
+  falsify?: string;
+  evidence_required?: string[];
+  immutable_paths?: string[];  // sensor integrity
+  sole_source?: "sensor" | "llm_judge" | "human";
+}
+
+interface JudgmentSpecBody {
+  goal_summary: string;
+  risk_tier: "low" | "medium" | "high" | "critical";
+  acceptance: Criterion[];
+  rejection: Criterion[];
+  judgment_order: Array<"sensor" | "llm_judge" | "human">;
+}
+
+type VerdictResult =
+  | "pass" | "fail" | "criteria_gap" | "blocked_human" | "unverified";
+
+interface GraphNode {
+  id: string;
+  kind: "maker" | "sensor" | "verify" | "reduce" | "human" | "join";
+  label: string;
+  shape_id?: string;
+  agent_id?: string;
+  fresh_context?: boolean; // verify default true
+  writes?: boolean;        // maker default true
+  isolation?: "none" | "worktree";
+  node_timeout_ms?: number;
+}
+
+interface GraphEdge {
+  id: string;
+  from: string;
+  to: string;
+  kind: "control" | "data";
+  required?: boolean; // default true for control
+  max_cycles?: number;
+}
+```
+
+**Artifacts**
+
+```text
+~/.atmos/orchestrator/
+  boards/{board_id}.atmos.tldr
+  runs/{run_id}/
+    run.json
+    events.jsonl
+    mode_proposal.json
+    work_state.json
+    attempts/v{n}.md
+    specs/v{n}.json
+    graph.compiled.json
+    prompts/...
+    nodes/{node_id}/...          # per-node isolation
+    roles/{role}/{inv_id}/...    # optional alternate
+    evidence/...
+    verdicts/...
+```
+
+---
+
+## Transport
+
+WS payloads include agent ids:
+
+```ts
+OrchestratorRunCreate: {
+  goal, requested_mode, target_kind, project_guid?, workspace_guid?,
+  budget?, carry_from_run_id?,
+  maker_agent_id?, planner_agent_id?, criteria_agent_id?, verify_agent_id?
+}
+```
+
+Events include `orchRole`, `nodeId?`, `activity` for chrome.
+
+---
+
+## Security & permissions
+
+- Local Computer only.
+- Sensor argv structured; deny dangerous patterns.
+- Maker cannot write Spec/verdict dirs; integrity on sensor paths.
+- Evidence under run dir; path traversal rejected.
+- No secrets in info logs.
+
+---
+
+## Terminal role chrome (M18b)
+
+Pane meta:
+
+```ts
+{ orchRunId, orchRole, orchNodeId?, orchInstanceLabel?, activity: RoleActivity }
+```
+
+Composition rules: Role glyph+short, Activity icon, Agent, Instance (mandatory if duplicate role). Accents optional; glyph required for a11y. Truncation priority: Role → Activity → Agent → Instance → goal.
+
+Ephemeral: after planner/criteria success, UI may collapse panes to Roles rail (M22b).
+
+---
+
+## Board / layout
+
+| Intent | Primary | Secondary |
+|--------|---------|-----------|
+| Setup | Spec + mode + agents | empty board |
+| Run Loop | Maker + iteration | Spec mini |
+| Run Graph | **RunStrip** + active terminal | topology minimap |
+| HITL | HitlStrip | dim PTYs |
+| Review | Evidence + Spec + stop | collapsed PTYs |
+
+Running: graph edit locked. Draft: orch-flow-node + executable edges only; no product widgets.
+
+---
+
+## Background runner
+
+One runner per `run_id`. Wall watchdog task. On cancel/interrupt: multi-pane kill hygiene. Server restart: reclaim orphans, mark interrupted—**no auto-resume**.
+
+---
+
+## Rollout plan
+
+1. Infra + repos  
+2. Runtime pure logic (complete gate, budgets, no-progress, join, compile, demote Loop)  
+3. Artifacts + integrity + atomic role_invoke fixtures  
+4. LoopEngine service tests  
+5. GraphEngine sequence/verify/join tests (M8b bar)  
+6. Terminal spawn + orchRole meta + chrome unit tests  
+7. WS + web entry/RunView/Spec/RunStrip/Hitl  
+8. Layout intents + running lock  
+9. CLI full verb set + HTTP handlers + skill package (`SKILL.md` + references) + skill-dir + UI Copy agent instructions  
+10. Dogfood flag / polish / i18n  
+
+---
+
+## Risks & tradeoffs
+
+| Item | Mitigation |
+|------|------------|
+| Terminal Agent JSON flake | atomic files + timeouts + one repair |
+| Mid-flight cost | wall watchdog |
+| Parallel write | compile forbid shared-tree multi-writer |
+| Ceremony | skip planner on forced mode; sensor auto-confirm |
+| Same-agent judge | Tier B/C |
+| Rollback | flag off; no canvas writes |
+
+**Explicit non-goals M1:** auto-resume, token ledger, arbitrary multi-Computer workspaces.  
+**In M1:** run home cwd for all roles + **child workspace create / use / merge / abandon** via CLI+Runtime (not free-form orphan worktrees).
+
+---
+
+## Dependencies
+
+APP-014/015 patterns, APP-002 tmux, terminal agent manifests, APP-017 agent invocation patterns. Orthogonal: ACP, crates/llm features.
+
+---
+
+## Open questions
+
+- [ ] Exact max focused PTY count (propose 2).  
+- [ ] Default planner/criteria agent = maker vs last-used.  
+- [ ] Merge strategy enum defaults (ff-only vs merge commit vs open PR) — product default propose **merge commit or existing workspace merge path**.
+
+---
+
+## Appendix · Forbidden → enforcement
+
+| Forbidden | Enforcement |
+|-----------|-------------|
+| Maker self-done | Verdict pipeline only |
+| Maker edits Spec | API + FS |
+| Soften Spec w/o confirm | Spec diff weaken detector |
+| Unverified complete | VerdictResult + complete gate |
+| LLM sole-pass sensor clause | schema sole_source + Runtime |
+| Edit grader files | integrity.rs |
+| Shared-context-only verify | new pane + prompt |
+| Silent join / partial | join completeness |
+| Multi-writer same tree | compile |
+| Auto empty graph | M6b demote |
+| ACP / llm brain | architecture tests |
+| Role-less chrome | UI composition tests |

--- a/specs/APP/APP-048_loop-graph-agent-orchestration/TEST.md
+++ b/specs/APP/APP-048_loop-graph-agent-orchestration/TEST.md
@@ -1,0 +1,278 @@
+# TEST · APP-048: Orchestrator (Loop / Graph Agent Orchestration)
+
+> Test Plan · verification contract for Orchestrator after post-review PRD/TECH hardening. References [PRD](./PRD.md) and [TECH](./TECH.md).
+
+## Test strategy
+
+- **Rust unit/service**: Runtime gates (complete, unverified, weaken Spec, budgets mid-flight, join completeness, compile, demote Loop, role_invoke atomic I/O, integrity)—primary merge bar.
+- **Rust integration / WS**: run lifecycle with **fixture Terminal Agents** (scripts writing JSON artifacts), not `crates/llm`.
+- **Bun**: chrome composition, layout intent helpers, i18n keys.
+- **E2E / agent-browser**: entry isolation, multi-role headers, HITL strip, running graph lock.
+- **Manual**: real Codex/Claude Loop + Graph dogfood.
+
+## Coverage map
+
+| PRD | Scenarios |
+|-----|-----------|
+| M1–M3c | S1, S2, S2b, S3, S4, S59–S64 |
+| M4–M6b | S5–S9, S48 |
+| M7 | S10, S11 |
+| M8–M8b | S12–S14, S20, S41–S44 |
+| M9 | S15 |
+| M10–M15, M11b, M14b | S16–S22, S21b–c, S19c, S25b–c, S18b |
+| M16–M16b | S18, S23–S25, S14b, S39–S40 |
+| M17–M19b | S26, S28, S49 |
+| M18b | S27, S27b–g |
+| M20–M25, M22b | S29–S33, S30b, S50 |
+| M26 | S34–S35, S51–S58, S59–S64 |
+| Forbidden / races | S36–S38, S45–S47 |
+| N* | S-deferred |
+
+## Execution map
+
+| Scenario | Level | Tool | Target / method | Fixture | Signals | Status |
+|----------|-------|------|-----------------|---------|---------|--------|
+| S1 | E2E/bun | Playwright/bun | nav Orchestrator | app shell | entry visible | planned |
+| S2 | E2E | Playwright | open without Canvas | — | no default canvas required | planned |
+| S2b | E2E/agent-browser | — | empty state | — | copy distinguishes Canvas | planned |
+| S3 | Service | cargo | board paths | temp home | orchestrator/boards only | planned |
+| S4 | Service | cargo | target validation | guids | reject invalid | planned |
+| S5 | Service | cargo | modes | — | auto/loop/graph stored | planned |
+| S6 | Service | cargo | shared contracts | — | Spec/verdict parity | planned |
+| S7 | Service | cargo | override | fixture planner→graph | effective loop | planned |
+| S8 | Service | cargo | propose_mode | mode_proposal.json | reason set | planned |
+| S9 | Service | cargo | no agent / bad JSON | — | no keyword auto | planned |
+| S10 | Service | cargo | Loop pass | sensors OK | completed/spec_met | planned |
+| S11 | Service | cargo | Loop budget | fail sensors | budget_iterations | planned |
+| S12 | Service | cargo | Graph sequence | 2 nodes | ordered complete | planned |
+| S13 | Service | cargo | join failed branch | fan-out | not completed | planned |
+| S14 | Service | cargo | verify fresh pane | panes | pane B ≠ A | planned |
+| S14b | Service | cargo | Tier B agent pick | 2 agents | verify ≠ maker | planned |
+| S15 | Service | cargo | mode while running | — | rejected | planned |
+| S16 | Service | cargo | draft Spec | fixture criteria | v1 file | planned |
+| S17 | Unit | cargo | empty acceptance | — | reject | planned |
+| S18 | Service | cargo | complete no Spec | — | reject | planned |
+| S18b | Service | cargo | human open + sensors pass | — | not completed | planned |
+| S19 | Unit | cargo | human confirm | — | required | planned |
+| S19b | Unit | cargo | sensor auto-confirm | low risk | confirmed_by=auto | planned |
+| S19c | Unit | cargo | trivial sensor + llm_judge | — | requires confirm | planned |
+| S20 | Service | cargo | graph not stub | — | node transitions | planned |
+| S21 | Service | cargo | maker update Spec | locked | denied | planned |
+| S21b | Service | cargo | weaken Spec | gap | blocked until confirm | planned |
+| S21c | Service | cargo | maker edits sensor file | integrity | fail closed | planned |
+| S22 | Service | cargo | verdict bind | — | version+criteria | planned |
+| S23 | Service | cargo | no_progress | same key×3 | failed+no_progress | planned |
+| S24 | Service | cargo | wall pre-check | max_wall=0 | budget_wall | planned |
+| S25 | Service | cargo | confidence ban | — | not completed | planned |
+| S25b | Service | cargo | sensor timeout | — | unverified / not completed | planned |
+| S25c | Service | cargo | rejection fires | — | not completed | planned |
+| S26 | Integration | cargo/manual | spawn | tmux | role env+meta | planned |
+| S27 | Unit | cargo/bun | events | — | roles distinct | planned |
+| S27b | Bun | bun | chrome compose | same brand | titles differ | planned |
+| S27c | E2E/browser | — | multi-role UI | fixtures | badges visible | planned |
+| S27d | Bun | bun | multi-maker instance | 2 makers | instance labels | planned |
+| S27e | Bun/E2E | — | activity chip | — | waiting_user visible | planned |
+| S27f | Bun | bun | truncation | long goal | role in a11y name | planned |
+| S27g | Bun | bun | grayscale a11y | — | glyph present | planned |
+| S28 | Static | cargo/rg | no ACP/llm brain | — | gate pass | planned |
+| S29 | Service | cargo | cancel | running | cancelled | planned |
+| S30 | E2E | — | board highlight | — | node/iter | planned |
+| S30b | E2E | — | running graph lock | — | no free-draw | planned |
+| S31 | Service | cargo | evidence file | — | path OK | planned |
+| S32 | Service | cargo | run list | 3 runs | fields | planned |
+| S33 | Service | cargo | mode_reason | — | persisted | planned |
+| S34 | CLI | cli | skill-dir | skill synced | path + prompt lines | planned |
+| S35 | CLI | cli | create/get | API | id | planned |
+| S51 | CLI | cli | spec draft/get/confirm | fixture API | Spec version | planned |
+| S52 | CLI | cli | run start without Spec | — | ORCH_SPEC_REQUIRED exit≠0 | planned |
+| S53 | CLI | cli | evidence attach | file | evidence listed | planned |
+| S54 | CLI | cli | graph compile bad | bad edges | ORCH_GRAPH_COMPILE_FAILED | planned |
+| S55 | CLI | cli | context get | running/draft | pack has goal/spec/artifacts | planned |
+| S56 | CLI | cli | run cancel | running | cancelled | planned |
+| S57 | CLI | cli | forced mode no planner | --mode loop | start without mode_proposal | planned |
+| S58 | Bun/E2E | — | Copy agent instructions | UI | clipboard skill dir | planned |
+| S36 | Service | cargo | role timeout | hang agent | worker_failed/artifact_invalid | planned |
+| S37 | Service | cargo | partial JSON | half write | not accepted | planned |
+| S38 | Service | cargo | atomic rename | — | accept final only | planned |
+| S39 | Service | cargo | wall mid-flight | long maker | budget_wall kill | planned |
+| S40 | Service | cargo | max makers fan-out | — | budget_makers | planned |
+| S41 | Service | cargo | join hang branch | timeout | join_incomplete / failed | planned |
+| S42 | Service | cargo | join 1 of 2 | missing | fail | planned |
+| S43 | Service | cargo | compile cycle | no max_cycles | fail | planned |
+| S44 | Service | cargo | max_cycles | — | stop reason | planned |
+| S45 | Service | cargo | gap parks makers | running makers | refining_spec | planned |
+| S46 | Service | cargo | restart reclaim | running row | interrupted | planned |
+| S47 | Service | cargo | cancel 2 makers | — | both killed ≤5s | planned |
+| S48 | Service | cargo | auto graph demote | bad graph | effective loop + reason | planned |
+| S49 | Service | cargo | forced mode skip planner | loop | no mode_proposal call | planned |
+| S50 | Bun/E2E | — | HITL strip | blocked_human | primary action | planned |
+| S59 | Service | cargo | role cwd = home | workspace-bound run | maker cwd == home path | planned |
+| S60 | Service/CLI | cargo/cli | workspace create | project-bound run | child linked + create_source orchestrator | planned |
+| S61 | Service/CLI | cargo/cli | workspace use | child exists | maker cwd = child | planned |
+| S62 | Service/CLI | cargo/cli | workspace merge | child with change | merge result + status merged | planned |
+| S63 | Service/CLI | cargo/cli | workspace abandon | child | abandoned | planned |
+| S64 | Service | cargo | multi-writer home | 2 makers no isolation | compile fail | planned |
+| S-deferred | — | — | N1–N9 | — | — | planned |
+
+## Scenarios
+
+### Identity & isolation
+
+**S1** — Management Center opens Orchestrator.  
+**S2** — Orchestrator usable without ordinary Canvas open.  
+**S2b** — Empty state copy: runs/Spec/Loop-Graph; not free-form board; optional Canvas link.  
+**S3** — Board only under `orchestrator/boards/`; canvas dir unchanged.  
+**S4** — Invalid workspace binding rejected.
+
+### Modes
+
+**S5** — Create with auto/loop/graph persists `requested_mode`.  
+**S6** — Loop and Graph share Spec/verdict contracts.  
+**S7** — User `loop` wins over planner proposing graph.  
+**S8** — Fixture planner writes `mode_proposal.json` with non-empty reason.  
+**S9** — Missing agent / invalid JSON → actionable error; no keyword auto; no `crates/llm` fallback.  
+**S48** — Auto mode=graph with uncompilable graph → demote Loop + visible reason.  
+**S49** — `requested_mode=loop` never invokes planner role.
+
+### Loop / Graph execution
+
+**S10** — Loop sensor pass → `completed`/`spec_met`.  
+**S11** — Loop fails until `budget_iterations`.  
+**S12** — Graph sequence maker→sensor completes.  
+**S13** — Required branch failed → join fails; not completed.  
+**S14** — Verify pane ≠ maker pane; role=verify.  
+**S14b** — Two agents installed → verify prefers non-maker (Tier B).  
+**S15** — set_mode while running rejected; carry_from creates new draft.  
+**S20** — Graph mode produces real node transitions (not stub).  
+**S41** — One branch never finishes past timeout → join fail / `join_incomplete`.  
+**S42** — Expected 2, observed 1 → fail.  
+**S43** — Cycle without max_cycles → compile fail.  
+**S44** — max_cycles exceeded → explainable stop.  
+**S40** — Fan-out exhausts `max_maker_invocations`.
+
+### Spec & integrity
+
+**S16** — Criteria fixture writes valid Spec v1.  
+**S17** — Empty acceptance rejected.  
+**S18** — Complete without Spec rejected.  
+**S18b** — Sensors pass + open human → not completed (`blocked_human`).  
+**S19 / S19b / S19c** — Confirm policies (human; sensor-only auto; llm_judge+sensor requires confirm).  
+**S21** — Maker cannot update locked Spec.  
+**S21b** — Weakening Spec after gap requires user confirm.  
+**S21c** — Maker edits Spec sensor file → fail closed (not green).  
+**S22** — Verdict binds spec version + criterion ids + evidence.  
+**S25** — Confidence-only path cannot complete.  
+**S25b** — Sensor crash/timeout → `unverified`; not completed.  
+**S25c** — Rejection criterion true → not completed even if acceptance true.  
+**S45** — criteria_gap sets `refining_spec` and parks makers.
+
+### Runtime budgets / I/O / races
+
+**S23** — Identical progress_key ×3 → `failed` + `no_progress`.  
+**S24** — Wall already elapsed at tick → `budget_wall`.  
+**S39** — Long fake maker mid-flight wall kill → `budget_wall`.  
+**S36** — role_invoke timeout → `worker_failed` or `artifact_invalid`.  
+**S37** — Partial JSON never accepted.  
+**S38** — Only post-rename final artifact accepted.  
+**S46** — Simulated restart: running→interrupted; no double runner.  
+**S47** — Cancel with two makers; both interrupted within 5s.
+
+### Chrome / UX
+
+**S26** — Env + pane meta `orchRole`.  
+**S27** — Events distinguish planner/criteria/maker/verify.  
+**S27b** — Same agent brand, different roles → composed headers differ.  
+**S27c** — Live multi-role UI badges; ordinary panes clean.  
+**S27d** — Two makers → distinct instance labels.  
+**S27e** — Activity chip shows waiting_user without scrollback.  
+**S27f** — Truncated tab accessible name keeps role.  
+**S27g** — Role glyph present under grayscale.  
+**S30** — Board/run strip highlights active node/iter.  
+**S30b** — Running: graph free-draw/widgets unavailable.  
+**S50** — HITL strip primary on `blocked_human`.
+
+### Ops / CLI
+
+**S28** — Static gate: no ACP worker path; no llm feature brain for propose/draft.  
+**S29** — Cancel → cancelled + user_cancel.  
+**S31–S33** — Evidence, history, mode_reason.  
+**S34–S35** — skill-dir; CLI create/get.  
+**S51** — CLI `spec draft` → `get` → `confirm` succeeds with fixture Criteria.  
+**S52** — CLI `run start` without Spec → non-zero exit + `ORCH_SPEC_REQUIRED`.  
+**S53** — CLI `evidence attach` + `list` shows file.  
+**S54** — CLI `graph compile` on illegal multi-writer graph → compile error code.  
+**S55** — CLI `context get` returns goal, Spec path, artifact root, roles, **home.cwd**, workspaces list.  
+**S56** — CLI `run cancel` on running run.  
+**S57** — CLI create `--mode loop` then start never requires planner artifact.  
+**S58** — UI Copy agent instructions places skill directory on clipboard (not full SKILL body).  
+**S59** — Role spawn cwd equals run home workspace path (not random).  
+**S60** — CLI/service `workspace create` makes child linked to run with orchestrator source.  
+**S61** — After `workspace use --role maker`, maker launch cwd is child path; `context get` shows binding.  
+**S62** — `workspace merge` produces user-visible success/fail; child status `merged`.  
+**S63** — `workspace abandon` marks abandoned without writing home.  
+**S64** — Graph two writing makers on home without isolation → compile fails.  
+**S4** — Invalid binding still rejected; create run without project/workspace when standalone only if explicit.
+
+---
+
+## Performance & load budgets
+
+- Planner/criteria role_invoke soft p95 dogfood &lt; 60s (CI uses fixtures).  
+- Sensor default 120s; cancel interrupts process group ≤5s best-effort.  
+- Wall watchdog resolution ≤5s.  
+- WS fan-out must not stall PTY streams.
+
+## Regression checklist
+
+- [ ] Ordinary Canvas list/save untouched.  
+- [ ] APP-015 canvas CLI / APP-017 automations unaffected.  
+- [ ] Cancel leaves Spec history immutable.  
+- [ ] Restart does not leave orphan orch panes forever.  
+- [ ] i18n en+zh for roles, activity, empty state.  
+- [ ] Forbidden list behaviors all blocked by tests above.  
+- [ ] Forced mode does not spawn planner.
+
+## Exploratory agent-browser checks
+
+Load Agent Browser skill / `agent-browser skills get core --full`.
+
+1. Empty state vs ordinary Canvas differentiation.  
+2. Auto mode reason + override.  
+3. Spec with human criterion blocks Start until confirm.  
+4. Two same-brand agents: role+instance+activity scannable.  
+5. Graph run strip vs minimap; running cannot free-draw.  
+6. HITL strip steals focus.  
+7. Cancel + stop reason one-liner.  
+8. Narrow viewport: role short forms usable.  
+9. Console/network clean on happy path.
+
+## Acceptance criteria (merge-blocking)
+
+- [ ] All PRD Musts (including M6b, M8b, M11b, M14b, M16b, M18b) have scenarios.  
+- [ ] Runtime pure tests: Spec complete gate, unverified, weaken confirm, mid-flight wall, join hang/partial, compile, demote Loop, atomic artifact I/O, maker Spec deny, sensor integrity.  
+- [ ] Graph Phase-1 bar: sequence + verify fresh + join fail-closed green in service tests.  
+- [ ] Board isolation: no writes to ordinary canvas dir.  
+- [ ] Chrome unit tests: role+instance+activity; multi-maker labels.  
+- [ ] No ACP / crates/llm brain path (static gate).  
+- [ ] CLI skill-dir + full M26 verb coverage including **workspace** (S34–S35, S51–S64) or documented deferrals with reason.
+- [ ] Default role cwd = run home; child create/use/merge/abandon covered.  
+- [ ] `just lint` + scoped cargo/bun tests pass post-impl.  
+- [ ] Coverage Status updated by test-run skill.  
+- [ ] agent-browser notes recorded or `not_run` with reason.
+
+## Manual verification
+
+1. Real agents: Loop in a bound workspace; confirm pane cwd is that workspace.  
+2. Create child workspace mid-run, work there, merge back (or abandon) with visible outcome.  
+3. Graph two-branch + hang one branch → does not complete.  
+4. Same agent for maker+verify shows Tier badge; prefer second agent if installed.  
+5. Kill API mid-run → interrupted after restart.  
+6. Forced loop never opens Planner pane.
+
+## Non-coverage
+
+- Multi-Computer runs; mobile; N1–N9 productization; full agent matrix; token FinOps; nested Loop-in-Graph; auto-resume; Spec prose quality (schema only).
+
+## Coverage Status
+
+> Filled after implementation by `atmos-specs-test-run`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -125,6 +125,7 @@ These files are not requirements sources. Requirements live in `PRD.md`, archite
 | **APP-045** | Desktop Electron Dual Shell (Tauri + Electron parallel) | `specs/APP/APP-045_desktop-electron-dual-shell/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
 | **APP-046** | Terminal TUI Mouse Tracking (hover + reattach restore) | `specs/APP/APP-046_terminal-tui-mouse-tracking/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
 | **APP-047** | Terminal Native OSC Title (agent OSC 0/2 suffix) | `specs/APP/APP-047_terminal-native-osc-title/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
+| **APP-048** | Orchestrator (Loop/Graph; Spec+Runtime; Terminal roles; post-review hardened) | `specs/APP/APP-048_loop-graph-agent-orchestration/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
 | **QUALITY-001** | Large File Code Debt Cleanup | `specs/APP/QUALITY-001_large-file-code-debt-cleanup/` (`TECH.md`, `TEST.md`) |
 | **QUALITY-002** | Spec Test Execution Loop | `specs/APP/QUALITY-002_spec-test-execution-loop/` (`TECH.md`, `TEST.md`) |
 | **QUALITY-003** | Playwright E2E Harness | `specs/APP/QUALITY-003_playwright-e2e-harness/` (`TECH.md`, `TEST.md`) |


### PR DESCRIPTION
## Summary

Implements APP-048 Orchestrator as a first-class product surface for multi-step Loop/Graph agent runs with Judgment Specs, evidence gates, workspace isolation, Terminal role chrome, `atmos orchestrator` CLI, system skill, and Management Center UI entry.

## Related Issue

Specs: `specs/APP/APP-048_loop-graph-agent-orchestration/`

## Type of Change

- [x] New feature
- [x] Documentation

## Validation

- [x] Scoped: `cargo test -p core-service orchestrator` (28 tests)
- [x] `cargo check -p api -p atmos`
- [x] `bun test src/features/orchestrator/lib/role-chrome.test.ts`
- [ ] Full `just test` / `just lint` (CI)

## Checklist

- [x] I updated documentation if behavior changed (specs + skill)
- [x] I added/updated tests where appropriate (runtime, graph, workspace, chrome)
- [x] I followed repository conventions and AGENTS.md guidance

## Notes

- File-backed runs under `~/.atmos/orchestrator/` (boards never touch ordinary canvas).
- HTTP: `/api/orchestrator/v1/*`; CLI: `atmos orchestrator …`.
- Role UI labels use Planner/Criteria/Maker/Verify; craft follows restrained motion (ease-out, short transitions).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces Orchestrator as a first-class surface for multi-step Loop/Graph agent runs with Judgment Specs, evidence gates, workspace isolation, and role chrome. Adds runtime, HTTP API, `atmos orchestrator` CLI, a system skill, and a Management Center UI to satisfy APP-048 PRD/TECH; also cleans up clippy warnings (collapsed guards, merged fixtures) and keeps CI green.

- **New Features**
  - Runtime: file-backed runs in `~/.atmos/orchestrator/`; Loop/Graph executors; compile/join checks; fail-closed without a Spec; sensor integrity in Loop; workspace isolation; advancement owned by runtime (no public tick).
  - API: `/api/orchestrator/v1/*` for runs, Spec, evidence, graph compile, context, and workspace.
  - CLI: `atmos orchestrator …` with JSON output; `skill-dir`/`skill-path`; tick removed; workflow test covers create/spec/start/context/workspace.
  - UI: Management Center `/orchestrator` with role chrome (en/zh); Spec draft/confirm, start, HITL, run strip; unit tests for chrome helpers.
  - System Skill: `atmos-orchestrator` docs/manifest; DB tables for orchestrator runs; system skill sync wired.

- **Migration**
  - Apply database migrations.
  - Restart the API and CLI.
  - Run system skill sync so `atmos-orchestrator` appears.
  - Ensure agents use `atmos orchestrator` (Canvas boards are unaffected).

<sup>Written for commit 5a6905968c8ee9d205f2514ee7e6fdae1799a513. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

