### PR TITLE
feat(infra): local jobs and queue ports (APP-051)

### DIFF
--- a/apps/api/src/app_state.rs
+++ b/apps/api/src/app_state.rs
@@ -8,13 +8,12 @@ use core_service::{
     ProjectService, ReviewService, ServiceError, TerminalService, TestService, WorkspaceService,
 };
 use infra::queue::LocalMemoryQueue;
-use tokio::sync::{oneshot, Mutex};
 use token_usage::TokenUsageService;
+use tokio::sync::{oneshot, Mutex};
 
 use crate::relay::RelaySupervisor;
 
-pub type GithubTriggerReply =
-    oneshot::Sender<Result<ExternalTriggerOutcome, ServiceError>>;
+pub type GithubTriggerReply = oneshot::Sender<Result<ExternalTriggerOutcome, ServiceError>>;
 
 pub struct AppServices {
     pub test_service: Arc<TestService>,

--- a/apps/api/src/app_state.rs
+++ b/apps/api/src/app_state.rs
@@ -1,14 +1,20 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::api::ws::{WsMessageService, WsService};
 use core_service::{
     AgentHooksService, AgentService, AgentSessionService, AutomationService, CanvasAgentRelay,
-    CanvasDocumentService, MessagePushService, NotificationService, ProjectService, ReviewService,
-    TerminalService, TestService, WorkspaceService,
+    CanvasDocumentService, ExternalTriggerOutcome, MessagePushService, NotificationService,
+    ProjectService, ReviewService, ServiceError, TerminalService, TestService, WorkspaceService,
 };
+use infra::queue::LocalMemoryQueue;
+use tokio::sync::{oneshot, Mutex};
 use token_usage::TokenUsageService;
 
 use crate::relay::RelaySupervisor;
+
+pub type GithubTriggerReply =
+    oneshot::Sender<Result<ExternalTriggerOutcome, ServiceError>>;
 
 pub struct AppServices {
     pub test_service: Arc<TestService>,
@@ -46,6 +52,10 @@ pub struct AppState {
     pub ws_service: Arc<WsService>,
     pub api_port: std::sync::atomic::AtomicU16,
     pub relay_supervisor: RelaySupervisor,
+    /// APP-051 local event queue (GitHub deliveries, etc.).
+    pub event_queue: Arc<LocalMemoryQueue>,
+    /// Reply channels for github queue messages awaiting ingress ACK.
+    pub github_trigger_replies: Arc<Mutex<HashMap<String, GithubTriggerReply>>>,
 }
 
 impl Clone for AppState {
@@ -68,12 +78,18 @@ impl Clone for AppState {
             ws_service: Arc::clone(&self.ws_service),
             api_port: std::sync::atomic::AtomicU16::new(self.api_port()),
             relay_supervisor: self.relay_supervisor.clone(),
+            event_queue: Arc::clone(&self.event_queue),
+            github_trigger_replies: Arc::clone(&self.github_trigger_replies),
         }
     }
 }
 
 impl AppState {
-    pub fn new(services: AppServices, default_port: u16) -> Self {
+    pub fn new(
+        services: AppServices,
+        default_port: u16,
+        event_queue: Arc<LocalMemoryQueue>,
+    ) -> Self {
         let ws_service = WsService::new().with_message_handler(services.ws_message_service);
 
         Self {
@@ -94,6 +110,8 @@ impl AppState {
             ws_service: Arc::new(ws_service),
             api_port: std::sync::atomic::AtomicU16::new(default_port),
             relay_supervisor: RelaySupervisor::new(),
+            event_queue,
+            github_trigger_replies: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -507,35 +507,39 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let automation_for_queue = Arc::clone(&automation_for_queue);
                 let replies = Arc::clone(&replies);
                 async move {
-                    let parsed =
-                        serde_json::from_slice::<core_service::GithubTriggerEvent>(&msg.payload);
-                    let reply_key = parsed.as_ref().ok().map(|event| {
-                        crate::relay::external_events::github_reply_key(
-                            &event.delivery_id,
-                            &event.route_id,
-                        )
-                    });
-                    let outcome = match parsed {
-                        Ok(event) => automation_for_queue.handle_external_trigger(event).await,
+                    let envelope = serde_json::from_slice::<
+                        crate::relay::external_events::GithubQueueEnvelope,
+                    >(&msg.payload);
+                    let (reply_id, outcome) = match envelope {
+                        Ok(envelope) => {
+                            let reply_id = envelope.reply_id;
+                            let outcome = automation_for_queue
+                                .handle_external_trigger(envelope.event)
+                                .await;
+                            (Some(reply_id), outcome)
+                        }
                         Err(error) => {
                             warn!(
                                 error = %error,
                                 "github queue payload deserialize failed"
                             );
-                            Err(core_service::ServiceError::Validation(format!(
-                                "invalid github queue payload: {error}"
-                            )))
+                            (
+                                None,
+                                Err(core_service::ServiceError::Validation(format!(
+                                    "invalid github queue payload: {error}"
+                                ))),
+                            )
                         }
                     };
                     let handler_err = outcome.as_ref().err().map(|error| {
                         QueueError::Handler(format!("github delivery failed: {error}"))
                     });
-                    if let Some(reply_key) = reply_key {
-                        if let Some(tx) = replies.lock().await.remove(&reply_key) {
+                    if let Some(reply_id) = reply_id {
+                        if let Some(tx) = replies.lock().await.remove(&reply_id) {
                             let _ = tx.send(outcome);
                         } else if let Some(error) = &handler_err {
                             warn!(
-                                reply_key = %reply_key,
+                                reply_id = %reply_id,
                                 error = %error,
                                 "github queue message processed without reply waiter"
                             );

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -503,56 +503,56 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let automation_for_queue = Arc::clone(&automation_service);
         let replies = Arc::clone(&app_state.github_trigger_replies);
         if let Err(error) = event_queue
-            .subscribe(
-                Topic::new(topics::AUTOMATION_GITHUB_DELIVERY),
-                move |msg| {
-                    let automation_for_queue = Arc::clone(&automation_for_queue);
-                    let replies = Arc::clone(&replies);
-                    async move {
-                        let parsed =
-                            serde_json::from_slice::<core_service::GithubTriggerEvent>(&msg.payload);
-                        let reply_key = parsed.as_ref().ok().map(|event| {
-                            crate::relay::external_events::github_reply_key(
-                                &event.delivery_id,
-                                &event.route_id,
-                            )
-                        });
-                        let outcome = match parsed {
-                            Ok(event) => automation_for_queue.handle_external_trigger(event).await,
-                            Err(error) => {
-                                warn!(
-                                    error = %error,
-                                    "github queue payload deserialize failed"
-                                );
-                                Err(core_service::ServiceError::Validation(format!(
-                                    "invalid github queue payload: {error}"
-                                )))
-                            }
-                        };
-                        let handler_err = outcome.as_ref().err().map(|error| {
-                            QueueError::Handler(format!("github delivery failed: {error}"))
-                        });
-                        if let Some(reply_key) = reply_key {
-                            if let Some(tx) = replies.lock().await.remove(&reply_key) {
-                                let _ = tx.send(outcome);
-                            } else if let Some(error) = &handler_err {
-                                warn!(
-                                    reply_key = %reply_key,
-                                    error = %error,
-                                    "github queue message processed without reply waiter"
-                                );
-                            }
+            .subscribe(Topic::new(topics::AUTOMATION_GITHUB_DELIVERY), move |msg| {
+                let automation_for_queue = Arc::clone(&automation_for_queue);
+                let replies = Arc::clone(&replies);
+                async move {
+                    let parsed =
+                        serde_json::from_slice::<core_service::GithubTriggerEvent>(&msg.payload);
+                    let reply_key = parsed.as_ref().ok().map(|event| {
+                        crate::relay::external_events::github_reply_key(
+                            &event.delivery_id,
+                            &event.route_id,
+                        )
+                    });
+                    let outcome = match parsed {
+                        Ok(event) => automation_for_queue.handle_external_trigger(event).await,
+                        Err(error) => {
+                            warn!(
+                                error = %error,
+                                "github queue payload deserialize failed"
+                            );
+                            Err(core_service::ServiceError::Validation(format!(
+                                "invalid github queue payload: {error}"
+                            )))
                         }
-                        match handler_err {
-                            Some(error) => Err(error),
-                            None => Ok(()),
+                    };
+                    let handler_err = outcome.as_ref().err().map(|error| {
+                        QueueError::Handler(format!("github delivery failed: {error}"))
+                    });
+                    if let Some(reply_key) = reply_key {
+                        if let Some(tx) = replies.lock().await.remove(&reply_key) {
+                            let _ = tx.send(outcome);
+                        } else if let Some(error) = &handler_err {
+                            warn!(
+                                reply_key = %reply_key,
+                                error = %error,
+                                "github queue message processed without reply waiter"
+                            );
                         }
                     }
-                },
-            )
+                    match handler_err {
+                        Some(error) => Err(error),
+                        None => Ok(()),
+                    }
+                }
+            })
             .await
         {
-            warn!("Failed to subscribe github delivery queue consumer: {}", error);
+            warn!(
+                "Failed to subscribe github delivery queue consumer: {}",
+                error
+            );
         }
     }
 

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -32,6 +32,8 @@ use core_service::{
     NotificationService, ProjectService, ReviewService, TerminalService, TestService,
     WorkspaceService,
 };
+use infra::jobs::{IntervalSpec, JobId, LocalScheduler, RetryPolicy};
+use infra::queue::{topics, LocalMemoryQueue, QueueError, Topic};
 use infra::{DbConnection, Migrator};
 use sea_orm_migration::MigratorTrait;
 use serde_json::json;
@@ -240,22 +242,42 @@ fn spawn_non_critical_startup_tasks(
     });
 }
 
-/// Spawn the agent-hook session cleanup task.
-/// Runs every 5 minutes; reads timeouts from
-/// `~/.atmos/agent/terminal_code_agent.json` each tick.
-fn spawn_idle_session_cleanup(agent_hooks_service: Arc<core_service::AgentHooksService>) {
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(5 * 60));
-        interval.tick().await; // skip the immediate first tick
-        loop {
-            interval.tick().await;
-            let timeouts = read_agent_hook_session_timeouts();
-            agent_hooks_service.clear_idle_older_than(timeouts.idle_mins);
-            // Force stuck running / permission sessions idle when hooks never
-            // reported a terminal event after interrupt or process death.
-            agent_hooks_service.clear_stale_active_older_than(timeouts.active_stale_mins);
-        }
-    });
+/// Product job id for agent-hooks idle session cleanup (APP-051).
+const AGENT_HOOKS_IDLE_CLEANUP_JOB_ID: &str = "agent-hooks.idle_session_cleanup";
+
+/// Register the agent-hook session cleanup interval job (every 5 minutes).
+async fn register_idle_session_cleanup_job(
+    jobs: Arc<LocalScheduler>,
+    agent_hooks_service: Arc<core_service::AgentHooksService>,
+) {
+    if let Err(error) = jobs
+        .set_interval_job(
+            JobId::new(AGENT_HOOKS_IDLE_CLEANUP_JOB_ID),
+            IntervalSpec {
+                every: std::time::Duration::from_secs(5 * 60),
+                skip_if_running: true,
+                fire_immediately: false,
+            },
+            RetryPolicy::none(),
+            move || {
+                let agent_hooks_service = Arc::clone(&agent_hooks_service);
+                async move {
+                    let timeouts = read_agent_hook_session_timeouts();
+                    agent_hooks_service.clear_idle_older_than(timeouts.idle_mins);
+                    // Force stuck running / permission sessions idle when hooks never
+                    // reported a terminal event after interrupt or process death.
+                    agent_hooks_service.clear_stale_active_older_than(timeouts.active_stale_mins);
+                    Ok(())
+                }
+            },
+        )
+        .await
+    {
+        warn!(
+            "Failed to register agent-hooks idle session cleanup job: {}",
+            error
+        );
+    }
 }
 
 struct AgentHookSessionTimeouts {
@@ -389,7 +411,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let review_service = Arc::new(ReviewService::new(Arc::clone(&db)));
     let agent_service = Arc::new(AgentService::new());
     let agent_service_for_startup = Arc::clone(&agent_service);
+
+    // APP-051: process-local jobs + event queue (local adapters only).
+    let jobs = Arc::new(LocalScheduler::new());
+    let event_queue = Arc::new(LocalMemoryQueue::builder().capacity(128).build());
+
     let usage_service = Arc::new(UsageService::default());
+    usage_service.attach_jobs(Arc::clone(&jobs)).await;
     let token_usage_service = Arc::new(TokenUsageService::default());
     let terminal_service = Arc::new(TerminalService::new_with_db(Arc::clone(&db)));
     let agent_hooks_service = Arc::new(AgentHooksService::new());
@@ -467,7 +495,66 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             review_service: Arc::clone(&review_service),
         },
         server_config.port,
+        Arc::clone(&event_queue),
     );
+
+    // APP-051: GitHub external events → queue consumer → domain handler.
+    {
+        let automation_for_queue = Arc::clone(&automation_service);
+        let replies = Arc::clone(&app_state.github_trigger_replies);
+        if let Err(error) = event_queue
+            .subscribe(
+                Topic::new(topics::AUTOMATION_GITHUB_DELIVERY),
+                move |msg| {
+                    let automation_for_queue = Arc::clone(&automation_for_queue);
+                    let replies = Arc::clone(&replies);
+                    async move {
+                        let parsed =
+                            serde_json::from_slice::<core_service::GithubTriggerEvent>(&msg.payload);
+                        let reply_key = parsed.as_ref().ok().map(|event| {
+                            crate::relay::external_events::github_reply_key(
+                                &event.delivery_id,
+                                &event.route_id,
+                            )
+                        });
+                        let outcome = match parsed {
+                            Ok(event) => automation_for_queue.handle_external_trigger(event).await,
+                            Err(error) => {
+                                warn!(
+                                    error = %error,
+                                    "github queue payload deserialize failed"
+                                );
+                                Err(core_service::ServiceError::Validation(format!(
+                                    "invalid github queue payload: {error}"
+                                )))
+                            }
+                        };
+                        let handler_err = outcome.as_ref().err().map(|error| {
+                            QueueError::Handler(format!("github delivery failed: {error}"))
+                        });
+                        if let Some(reply_key) = reply_key {
+                            if let Some(tx) = replies.lock().await.remove(&reply_key) {
+                                let _ = tx.send(outcome);
+                            } else if let Some(error) = &handler_err {
+                                warn!(
+                                    reply_key = %reply_key,
+                                    error = %error,
+                                    "github queue message processed without reply waiter"
+                                );
+                            }
+                        }
+                        match handler_err {
+                            Some(error) => Err(error),
+                            None => Ok(()),
+                        }
+                    }
+                },
+            )
+            .await
+        {
+            warn!("Failed to subscribe github delivery queue consumer: {}", error);
+        }
+    }
 
     // Inject WsManager into WsMessageService for server-to-client notifications
     ws_message_service
@@ -491,7 +578,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         automation_service.subscribe_events(),
         Arc::clone(&ws_manager),
     );
-    Arc::clone(&automation_service).start_scheduler();
+    Arc::clone(&automation_service)
+        .start_scheduler(Arc::clone(&jobs))
+        .await;
 
     spawn_disk_analyzer_forwarder(
         ws_message_service
@@ -640,7 +729,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Arc::clone(&agent_hooks_for_startup),
         actual_addr.port(),
     );
-    spawn_idle_session_cleanup(agent_hooks_for_startup);
+    register_idle_session_cleanup_job(Arc::clone(&jobs), agent_hooks_for_startup).await;
 
     // Serve with graceful shutdown — ensures PTY resources are cleaned up
     // when the process receives SIGTERM/SIGINT (e.g., during hot-reload).
@@ -652,8 +741,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .with_graceful_shutdown(shutdown_signal())
     .await?;
 
-    // Graceful shutdown: clean up all terminal sessions and PTY resources
-    info!("Shutdown signal received, cleaning up terminal sessions...");
+    // Graceful shutdown: stop jobs/queue, then clean up terminal sessions / PTY resources.
+    info!("Shutdown signal received, cleaning up jobs, queue, and terminal sessions...");
+    if let Err(err) = jobs.shutdown().await {
+        warn!(error = %err, "jobs shutdown failed");
+    }
+    if let Err(err) = event_queue.shutdown().await {
+        warn!(error = %err, "event queue shutdown failed");
+    }
     if let Err(err) = runtime_manager::remove_runtime_manifest() {
         warn!(target: "atmos_runtime", error = %err, "failed to remove runtime manifest");
     }

--- a/apps/api/src/relay/external_events.rs
+++ b/apps/api/src/relay/external_events.rs
@@ -111,25 +111,32 @@ pub async fn handle_external_event_body(state: &AppState, body: &str) -> Option<
     serialize_ack(ack)
 }
 
-pub(crate) fn github_reply_key(delivery_id: &str, route_id: &str) -> String {
-    format!("{delivery_id}|{route_id}")
+/// Queue envelope so reply correlation uses a unique `reply_id` (not delivery_id).
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct GithubQueueEnvelope {
+    pub reply_id: String,
+    pub event: GithubTriggerEvent,
 }
 
 async fn enqueue_github_trigger(
     state: &AppState,
     event: GithubTriggerEvent,
 ) -> Result<ExternalTriggerOutcome, ServiceError> {
-    let payload = serde_json::to_vec(&event).map_err(|error| {
+    let reply_id = uuid::Uuid::new_v4().to_string();
+    let payload = serde_json::to_vec(&GithubQueueEnvelope {
+        reply_id: reply_id.clone(),
+        event,
+    })
+    .map_err(|error| {
         ServiceError::Validation(format!("github trigger serialize failed: {error}"))
     })?;
-    let reply_key = github_reply_key(&event.delivery_id, &event.route_id);
     let (tx, rx) = oneshot::channel();
     // Register waiter before enqueue so the consumer can always find a reply channel.
     state
         .github_trigger_replies
         .lock()
         .await
-        .insert(reply_key.clone(), tx);
+        .insert(reply_id.clone(), tx);
 
     match state
         .event_queue
@@ -138,7 +145,7 @@ async fn enqueue_github_trigger(
     {
         Ok(_) => {}
         Err(error) => {
-            state.github_trigger_replies.lock().await.remove(&reply_key);
+            state.github_trigger_replies.lock().await.remove(&reply_id);
             return Err(match error {
                 EnqueueError::Full => {
                     ServiceError::Processing("github delivery queue is full".to_string())
@@ -156,13 +163,13 @@ async fn enqueue_github_trigger(
     match tokio::time::timeout(std::time::Duration::from_secs(60), rx).await {
         Ok(Ok(outcome)) => outcome,
         Ok(Err(_)) => {
-            state.github_trigger_replies.lock().await.remove(&reply_key);
+            state.github_trigger_replies.lock().await.remove(&reply_id);
             Err(ServiceError::Processing(
                 "github delivery queue reply channel closed".to_string(),
             ))
         }
         Err(_) => {
-            state.github_trigger_replies.lock().await.remove(&reply_key);
+            state.github_trigger_replies.lock().await.remove(&reply_id);
             Err(ServiceError::Processing(
                 "github delivery queue processing timed out".to_string(),
             ))

--- a/apps/api/src/relay/external_events.rs
+++ b/apps/api/src/relay/external_events.rs
@@ -1,10 +1,15 @@
 //! Relay external-event ingress for APP-019 provider triggers.
+//!
+//! APP-051: validate → enqueue on `automation.github_delivery` → await consumer
+//! domain outcome for ACK parity (LocalRejected / Accepted / Error).
 
 use chrono::{DateTime, Utc};
 use core_service::{
     ExternalTriggerOutcome, ExternalTriggerRejectReason, GithubTriggerEvent, ServiceError,
 };
+use infra::queue::{topics, EnqueueError, Topic};
 use serde::{Deserialize, Serialize};
+use tokio::sync::oneshot;
 use tracing::warn;
 
 use crate::app_state::AppState;
@@ -81,10 +86,7 @@ pub async fn handle_external_event_body(state: &AppState, body: &str) -> Option<
 
     let delivery_id = event.delivery_id.clone();
     let route_id = event.route_id.clone();
-    let outcome = state
-        .automation_service
-        .handle_external_trigger(event)
-        .await;
+    let outcome = enqueue_github_trigger(state, event).await;
     let ack = match outcome {
         Ok(ExternalTriggerOutcome::Accepted { .. }) => ExternalEventAck {
             delivery_id,
@@ -107,6 +109,65 @@ pub async fn handle_external_event_body(state: &AppState, body: &str) -> Option<
     };
 
     serialize_ack(ack)
+}
+
+pub(crate) fn github_reply_key(delivery_id: &str, route_id: &str) -> String {
+    format!("{delivery_id}|{route_id}")
+}
+
+async fn enqueue_github_trigger(
+    state: &AppState,
+    event: GithubTriggerEvent,
+) -> Result<ExternalTriggerOutcome, ServiceError> {
+    let payload = serde_json::to_vec(&event).map_err(|error| {
+        ServiceError::Validation(format!("github trigger serialize failed: {error}"))
+    })?;
+    let reply_key = github_reply_key(&event.delivery_id, &event.route_id);
+    let (tx, rx) = oneshot::channel();
+    // Register waiter before enqueue so the consumer can always find a reply channel.
+    state
+        .github_trigger_replies
+        .lock()
+        .await
+        .insert(reply_key.clone(), tx);
+
+    match state
+        .event_queue
+        .enqueue(&Topic::new(topics::AUTOMATION_GITHUB_DELIVERY), payload)
+        .await
+    {
+        Ok(_) => {}
+        Err(error) => {
+            state.github_trigger_replies.lock().await.remove(&reply_key);
+            return Err(match error {
+                EnqueueError::Full => {
+                    ServiceError::Processing("github delivery queue is full".to_string())
+                }
+                EnqueueError::ShuttingDown => {
+                    ServiceError::Processing("github delivery queue is shutting down".to_string())
+                }
+                EnqueueError::NoConsumer => {
+                    ServiceError::Processing("github delivery queue has no consumer".to_string())
+                }
+            });
+        }
+    }
+
+    match tokio::time::timeout(std::time::Duration::from_secs(60), rx).await {
+        Ok(Ok(outcome)) => outcome,
+        Ok(Err(_)) => {
+            state.github_trigger_replies.lock().await.remove(&reply_key);
+            Err(ServiceError::Processing(
+                "github delivery queue reply channel closed".to_string(),
+            ))
+        }
+        Err(_) => {
+            state.github_trigger_replies.lock().await.remove(&reply_key);
+            Err(ServiceError::Processing(
+                "github delivery queue processing timed out".to_string(),
+            ))
+        }
+    }
 }
 
 fn parse_github_trigger_event(body: &str) -> Result<GithubTriggerEvent, String> {

--- a/apps/api/src/relay/mod.rs
+++ b/apps/api/src/relay/mod.rs
@@ -1,6 +1,6 @@
 //! APP-016 Atmos Computer — outbound relay over Cloudflare Workers + DO.
 
-mod external_events;
+pub(crate) mod external_events;
 mod http_gateway;
 mod ingest;
 mod register;

--- a/crates/ai-usage/src/lib.rs
+++ b/crates/ai-usage/src/lib.rs
@@ -16,5 +16,5 @@ pub use models::{
     UsageSummary,
 };
 pub use runtime::{ProviderDescriptor, UsageProvider};
-pub use service::UsageService;
+pub use service::{UsageService, AI_USAGE_AUTO_REFRESH_JOB_ID};
 pub use support::browser::{load_cursor_session_token, BrowserCookieSource};

--- a/crates/ai-usage/src/service.rs
+++ b/crates/ai-usage/src/service.rs
@@ -1,9 +1,8 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
+use infra::jobs::{IntervalSpec, JobError, JobId, LocalScheduler, RetryPolicy};
 use tokio::sync::{broadcast, RwLock};
-use tokio::task::JoinHandle;
-use tokio::time::MissedTickBehavior;
 use tracing::{debug, info, warn};
 
 use crate::config::{add_provider_api_key, delete_provider_api_key, persist_provider_manual_setup};
@@ -21,6 +20,9 @@ use crate::refresh::{
 use crate::runtime::{default_providers, error_status, UsageProvider};
 use crate::support::{round_metric, unix_now};
 
+/// Product job id for AI usage auto-refresh (APP-051).
+pub const AI_USAGE_AUTO_REFRESH_JOB_ID: &str = "ai-usage.auto_refresh";
+
 #[derive(Debug, Clone)]
 struct CachedOverview {
     overview: UsageOverview,
@@ -33,7 +35,8 @@ pub struct UsageService {
     cache: Arc<RwLock<Option<CachedOverview>>>,
     cache_ttl: Duration,
     auto_refresh_interval_minutes: Arc<RwLock<Option<u64>>>,
-    auto_refresh_task: Arc<Mutex<Option<JoinHandle<()>>>>,
+    /// Set via [`Self::attach_jobs`]; until attached, auto-refresh is not scheduled.
+    jobs: Arc<RwLock<Option<Arc<LocalScheduler>>>>,
     update_tx: broadcast::Sender<UsageOverview>,
 }
 
@@ -44,20 +47,30 @@ impl Default for UsageService {
 }
 
 impl UsageService {
+    /// Construct without starting timers. Call [`Self::attach_jobs`] after the process
+    /// `LocalScheduler` is ready (APP-051 bootstrap order).
     pub fn new(providers: Vec<Arc<dyn UsageProvider>>) -> Self {
         let interval_minutes = load_auto_refresh_interval_minutes();
         let (update_tx, _) = broadcast::channel(32);
 
-        let service = Self {
+        Self {
             providers,
             cache: Arc::new(RwLock::new(None)),
             cache_ttl: Duration::from_secs(CACHE_TTL_SECS),
             auto_refresh_interval_minutes: Arc::new(RwLock::new(interval_minutes)),
-            auto_refresh_task: Arc::new(Mutex::new(None)),
+            jobs: Arc::new(RwLock::new(None)),
             update_tx,
-        };
-        service.schedule_auto_refresh_task(interval_minutes);
-        service
+        }
+    }
+
+    /// Attach the process job scheduler and register auto-refresh if configured.
+    pub async fn attach_jobs(&self, jobs: Arc<LocalScheduler>) {
+        {
+            let mut slot = self.jobs.write().await;
+            *slot = Some(jobs);
+        }
+        let interval_minutes = *self.auto_refresh_interval_minutes.read().await;
+        self.schedule_auto_refresh_task(interval_minutes).await;
     }
 
     pub async fn get_overview(&self, refresh: bool, provider_id: Option<&str>) -> UsageOverview {
@@ -333,7 +346,7 @@ impl UsageService {
         let refresh = interval_minutes.is_some();
         let overview = self.get_overview(refresh, None).await;
         self.publish_overview_update(&overview);
-        self.schedule_auto_refresh_task(interval_minutes);
+        self.schedule_auto_refresh_task(interval_minutes).await;
         Ok(overview)
     }
 
@@ -341,24 +354,23 @@ impl UsageService {
         self.update_tx.subscribe()
     }
 
-    fn schedule_auto_refresh_task(&self, interval_minutes: Option<u64>) {
-        let mut task = match self.auto_refresh_task.lock() {
-            Ok(task) => task,
-            Err(error) => {
-                warn!(
-                    "Failed to lock AI usage auto-refresh task handle: {}",
-                    error
-                );
-                return;
-            }
+    async fn schedule_auto_refresh_task(&self, interval_minutes: Option<u64>) {
+        let jobs = {
+            let guard = self.jobs.read().await;
+            guard.clone()
+        };
+        let Some(jobs) = jobs else {
+            debug!("AI usage auto-refresh deferred until jobs runtime is attached");
+            return;
         };
 
-        if let Some(existing) = task.take() {
-            existing.abort();
-        }
-
+        let job_id = JobId::new(AI_USAGE_AUTO_REFRESH_JOB_ID);
         let Some(interval_minutes) = interval_minutes else {
             info!("AI usage auto-refresh disabled");
+            if let Err(error) = jobs.cancel(&job_id).await {
+                // Not registered is fine when disabling.
+                debug!(error = %error, "AI usage auto-refresh cancel (may be unregistered)");
+            }
             return;
         };
 
@@ -368,21 +380,32 @@ impl UsageService {
         );
 
         let service = self.clone();
-        *task = Some(tokio::spawn(async move {
-            let mut ticker = tokio::time::interval(Duration::from_secs(interval_minutes * 60));
-            ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
-            ticker.tick().await;
-
-            loop {
-                ticker.tick().await;
-                debug!(
-                    "Running scheduled AI usage overview refresh (interval={}m)",
-                    interval_minutes
-                );
-                let overview = service.get_overview(true, None).await;
-                service.publish_overview_update(&overview);
-            }
-        }));
+        if let Err(error) = jobs
+            .set_interval_job(
+                job_id,
+                IntervalSpec {
+                    every: Duration::from_secs(interval_minutes.saturating_mul(60)),
+                    skip_if_running: true,
+                    fire_immediately: false,
+                },
+                RetryPolicy::none(),
+                move || {
+                    let service = service.clone();
+                    async move {
+                        debug!(
+                            "Running scheduled AI usage overview refresh (interval={}m)",
+                            interval_minutes
+                        );
+                        let overview = service.get_overview(true, None).await;
+                        service.publish_overview_update(&overview);
+                        Ok::<(), JobError>(())
+                    }
+                },
+            )
+            .await
+        {
+            warn!("Failed to register AI usage auto-refresh job: {}", error);
+        }
     }
 
     async fn with_auto_refresh_config(&self, mut overview: UsageOverview) -> UsageOverview {

--- a/crates/ai-usage/src/tests.rs
+++ b/crates/ai-usage/src/tests.rs
@@ -1,11 +1,13 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
+use infra::jobs::{JobId, LocalScheduler};
 
 use crate::{
     AuthState, AuthStateStatus, FetchState, FetchStateStatus, ProviderDescriptor, ProviderError,
-    ProviderKind, ProviderStatus, UsageProvider, UsageService,
+    ProviderKind, ProviderStatus, UsageProvider, UsageService, AI_USAGE_AUTO_REFRESH_JOB_ID,
 };
 
 #[derive(Clone)]
@@ -123,4 +125,60 @@ async fn provider_specific_refresh_updates_generated_at() {
         initial.generated_at,
         refreshed.generated_at
     );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn attach_jobs_registers_and_cancels_auto_refresh() {
+    let collect_count = Arc::new(AtomicUsize::new(0));
+    let counter = Arc::clone(&collect_count);
+    let service = UsageService::new(vec![Arc::new(CountingProvider {
+        collect_count: counter,
+    })]);
+    let jobs = Arc::new(LocalScheduler::new());
+    let job_id = JobId::new(AI_USAGE_AUTO_REFRESH_JOB_ID);
+
+    // No timer until jobs are attached.
+    assert!(!jobs.is_registered(&job_id).await);
+
+    service
+        .set_auto_refresh_interval(Some(1))
+        .await
+        .expect("set interval");
+    // Still unregistered until attach_jobs.
+    assert!(!jobs.is_registered(&job_id).await);
+
+    service.attach_jobs(Arc::clone(&jobs)).await;
+    assert!(jobs.is_registered(&job_id).await);
+
+    service
+        .set_auto_refresh_interval(None)
+        .await
+        .expect("disable");
+    assert!(!jobs.is_registered(&job_id).await);
+
+    jobs.shutdown().await.unwrap();
+}
+
+#[derive(Clone)]
+struct CountingProvider {
+    collect_count: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl UsageProvider for CountingProvider {
+    fn descriptor(&self) -> ProviderDescriptor {
+        ProviderDescriptor {
+            id: "counter".to_string(),
+            label: "Counter".to_string(),
+        }
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_millis(500)
+    }
+
+    async fn collect(&self) -> Result<ProviderStatus, ProviderError> {
+        self.collect_count.fetch_add(1, Ordering::SeqCst);
+        Ok(mock_status("counter", "Counter"))
+    }
 }

--- a/crates/core-service/src/service/automation/scheduler_service.rs
+++ b/crates/core-service/src/service/automation/scheduler_service.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use chrono::Utc;
 use infra::db::entities::automation;
 use infra::db::repo::{AutomationRepo, CreateAutomationRunRecord, UpdateAutomationRunStatusRecord};
+use infra::jobs::{IntervalSpec, JobError, JobId, LocalScheduler, RetryPolicy};
 use tracing::warn;
 
 use crate::error::{Result, ServiceError};
@@ -15,24 +16,43 @@ use super::{
     AutomationSummary, AutomationTriggerKind, START_FAILURE_KIND,
 };
 
-impl AutomationService {
-    pub fn start_scheduler(self: Arc<Self>) {
-        tokio::spawn(async move {
-            if let Err(error) = self.recover_running_runs().await {
-                warn!("Automation startup recovery failed: {}", error);
-            }
-            if let Err(error) = self.normalize_missed_schedules().await {
-                warn!("Automation schedule normalization failed: {}", error);
-            }
+/// Product job id for the domain due-schedule poller (APP-051).
+pub const AUTOMATION_SCHEDULE_TICK_JOB_ID: &str = "automation.schedule_tick";
 
-            let mut interval = tokio::time::interval(Duration::from_secs(30));
-            loop {
-                interval.tick().await;
-                if let Err(error) = self.tick_due_schedules().await {
-                    warn!("Automation scheduler tick failed: {}", error);
-                }
-            }
-        });
+impl AutomationService {
+    /// Start recovery/normalize once, then register the 30s due-schedule tick on `jobs`.
+    pub async fn start_scheduler(self: Arc<Self>, jobs: Arc<LocalScheduler>) {
+        if let Err(error) = self.recover_running_runs().await {
+            warn!("Automation startup recovery failed: {}", error);
+        }
+        if let Err(error) = self.normalize_missed_schedules().await {
+            warn!("Automation schedule normalization failed: {}", error);
+        }
+
+        let service = Arc::clone(&self);
+        if let Err(error) = jobs
+            .set_interval_job(
+                JobId::new(AUTOMATION_SCHEDULE_TICK_JOB_ID),
+                IntervalSpec {
+                    every: Duration::from_secs(30),
+                    skip_if_running: true,
+                    // Match prior tokio::interval first-tick immediacy after recover/normalize.
+                    fire_immediately: true,
+                },
+                RetryPolicy::none(),
+                move || {
+                    let service = Arc::clone(&service);
+                    async move {
+                        service.tick_due_schedules().await.map_err(|error| {
+                            JobError::Retryable(format!("automation schedule tick failed: {error}"))
+                        })
+                    }
+                },
+            )
+            .await
+        {
+            warn!("Failed to register automation schedule tick job: {}", error);
+        }
     }
 
     pub async fn recover_running_runs(&self) -> Result<()> {

--- a/crates/infra/AGENTS.md
+++ b/crates/infra/AGENTS.md
@@ -1,6 +1,6 @@
 # Infrastructure Layer (L1) - AGENTS.md
 
-> **🔧 L1: The Backbone**: Handles persistence, local infrastructure primitives, and low-level data utilities. User-facing HTTP/WebSocket entry code lives in `apps/api`.
+> **🔧 L1: The Backbone**: Handles persistence, **local runtime primitives** (`jobs`, `queue`), and low-level data utilities. User-facing HTTP/WebSocket entry code lives in `apps/api`.
 
 ---
 
@@ -21,11 +21,20 @@ crates/infra/
     │   ├── entities/        # SeaORM entities
     │   ├── repo/            # Repository pattern
     │   └── migration/       # Database migrations
-    ├── jobs/                # Background job processing
-    ├── queue/               # Job queue management
-    ├── cache/               # Caching layer
+    ├── jobs/                # Local product job scheduler (APP-051 LocalScheduler)
+    ├── queue/               # Local event queue (APP-051 LocalMemoryQueue)
     └── utils/               # Utilities
 ```
+
+### Jobs vs Queue vs Direct (APP-051)
+
+| Driver | Port | Use for |
+|--------|------|---------|
+| Time (interval) | `infra::jobs` (`LocalScheduler`) | Product timers: automation tick, AI usage refresh, idle cleanup |
+| External events | `infra::queue` (`LocalMemoryQueue`) | GitHub delivery → consumer |
+| Interactive user action | **Direct service call** | Manual automation run — never jobs/queue |
+
+v1 adapters are **process-local only** (Tokio). No apalis / external MQ in default deps.
 
 ---
 
@@ -38,6 +47,11 @@ crates/infra/
 ### Repositories
 - Use Repository pattern in `db/repo/` to abstract SeaORM away from business logic
 
+### Jobs / Queue
+- Handlers and domain rules live in service / capability crates / `apps/api`
+- Ports only own timers, channels, retry primitives, lifecycle
+- Prefer named `JobId` / `Topic` strings from the APP-051 catalog
+
 ### Transports
 - Inbound browser/client WebSocket code belongs in `apps/api/src/api/ws`
 - External-service clients may live in a dedicated capability crate when they are not API entry adapters
@@ -47,10 +61,12 @@ crates/infra/
 ## Safety Rails
 
 ### NEVER
-- Put business logic here — this is data access only
+- Put **domain** business rules in `jobs`/`queue` adapters (no automation pause policy, no provider collect, no GitHub matching)
 - Access repositories directly from `apps/api` — go through `core-service`
 - Add inbound HTTP/WebSocket handlers, browser connection managers, or API protocol DTOs here
+- Force-migrate connection keepalives / PTY pumps onto jobs
 
 ### ALWAYS
 - Keep entities inheriting from `base.rs`
 - Use Repository pattern to abstract SeaORM
+- Register product timers via `LocalScheduler`; event work via `LocalMemoryQueue`

--- a/crates/infra/src/jobs/local.rs
+++ b/crates/infra/src/jobs/local.rs
@@ -9,11 +9,10 @@ use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
 use tracing::{debug, warn};
 
-use super::types::{
-    IntervalSpec, JobError, JobId, JobResult, JobsError, RetryPolicy,
-};
+use super::types::{IntervalSpec, JobError, JobId, JobResult, JobsError, RetryPolicy};
 
-type DynHandler = Arc<dyn Fn() -> std::pin::Pin<Box<dyn Future<Output = JobResult> + Send>> + Send + Sync>;
+type DynHandler =
+    Arc<dyn Fn() -> std::pin::Pin<Box<dyn Future<Output = JobResult> + Send>> + Send + Sync>;
 
 struct RegisteredJob {
     cancel: Arc<AtomicBool>,
@@ -139,13 +138,7 @@ impl LocalScheduler {
             previous.cancel.store(true, Ordering::SeqCst);
             previous.handle.abort();
         }
-        jobs.insert(
-            id,
-            RegisteredJob {
-                cancel,
-                handle,
-            },
-        );
+        jobs.insert(id, RegisteredJob { cancel, handle });
         Ok(())
     }
 
@@ -197,7 +190,11 @@ async fn run_with_retry(job_id: &JobId, retry: &RetryPolicy, handler: DynHandler
             let next = Duration::from_secs_f64(
                 (delay.as_secs_f64() * retry.multiplier).min(retry.max_delay.as_secs_f64()),
             );
-            delay = if next.is_zero() { retry.max_delay } else { next };
+            delay = if next.is_zero() {
+                retry.max_delay
+            } else {
+                next
+            };
         }
 
         match handler().await {

--- a/crates/infra/src/jobs/local.rs
+++ b/crates/infra/src/jobs/local.rs
@@ -1,0 +1,538 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio::time::MissedTickBehavior;
+use tracing::{debug, warn};
+
+use super::types::{
+    IntervalSpec, JobError, JobId, JobResult, JobsError, RetryPolicy,
+};
+
+type DynHandler = Arc<dyn Fn() -> std::pin::Pin<Box<dyn Future<Output = JobResult> + Send>> + Send + Sync>;
+
+struct RegisteredJob {
+    cancel: Arc<AtomicBool>,
+    handle: JoinHandle<()>,
+}
+
+/// Process-local interval job scheduler (APP-051 LocalScheduler).
+pub struct LocalScheduler {
+    jobs: Mutex<HashMap<JobId, RegisteredJob>>,
+    shutting_down: AtomicBool,
+}
+
+impl Default for LocalScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LocalScheduler {
+    pub fn new() -> Self {
+        Self {
+            jobs: Mutex::new(HashMap::new()),
+            shutting_down: AtomicBool::new(false),
+        }
+    }
+
+    /// Register or replace an interval job with the same [`JobId`].
+    pub async fn set_interval_job<F, Fut>(
+        &self,
+        id: JobId,
+        spec: IntervalSpec,
+        retry: RetryPolicy,
+        handler: F,
+    ) -> Result<(), JobsError>
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = JobResult> + Send + 'static,
+    {
+        if self.shutting_down.load(Ordering::SeqCst) {
+            return Err(JobsError::ShuttingDown);
+        }
+        if spec.every.is_zero() {
+            return Err(JobsError::InvalidInterval);
+        }
+
+        let dyn_handler: DynHandler = Arc::new(move || {
+            let fut = handler();
+            Box::pin(fut) as std::pin::Pin<Box<dyn Future<Output = JobResult> + Send>>
+        });
+
+        let cancel = Arc::new(AtomicBool::new(false));
+        let cancel_for_task = Arc::clone(&cancel);
+        let id_for_task = id.clone();
+        let every = spec.every;
+        let skip_if_running = spec.skip_if_running;
+        let fire_immediately = spec.fire_immediately;
+        let retry = retry.clone();
+
+        let handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(every);
+            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+            // First interval.tick() completes immediately; absorb it when not firing immediately.
+            interval.tick().await;
+            if !fire_immediately {
+                // Wait one full period before the first real firing.
+                tokio::select! {
+                    _ = interval.tick() => {}
+                    _ = wait_cancelled(&cancel_for_task) => return,
+                }
+            }
+
+            let running = Arc::new(AtomicBool::new(false));
+
+            loop {
+                if cancel_for_task.load(Ordering::SeqCst) {
+                    break;
+                }
+
+                if skip_if_running && running.swap(true, Ordering::SeqCst) {
+                    debug!(
+                        job_id = %id_for_task,
+                        "skipping interval tick; previous firing still running"
+                    );
+                    tokio::select! {
+                        _ = interval.tick() => {}
+                        _ = wait_cancelled(&cancel_for_task) => break,
+                    }
+                    continue;
+                }
+
+                if !skip_if_running {
+                    running.store(true, Ordering::SeqCst);
+                }
+
+                let handler = Arc::clone(&dyn_handler);
+                let job_id = id_for_task.clone();
+                let retry_policy = retry.clone();
+                let running_flag = Arc::clone(&running);
+
+                // Run firing without blocking the interval loop when skip_if_running
+                // is false we still wait (sequential). When skip_if_running is true,
+                // spawn the work so the next tick can observe in-flight and skip.
+                if skip_if_running {
+                    tokio::spawn(async move {
+                        run_with_retry(&job_id, &retry_policy, handler).await;
+                        running_flag.store(false, Ordering::SeqCst);
+                    });
+                } else {
+                    run_with_retry(&job_id, &retry_policy, handler).await;
+                    running_flag.store(false, Ordering::SeqCst);
+                }
+
+                tokio::select! {
+                    _ = interval.tick() => {}
+                    _ = wait_cancelled(&cancel_for_task) => break,
+                }
+            }
+        });
+
+        let mut jobs = self.jobs.lock().await;
+        if let Some(previous) = jobs.remove(&id) {
+            previous.cancel.store(true, Ordering::SeqCst);
+            previous.handle.abort();
+        }
+        jobs.insert(
+            id,
+            RegisteredJob {
+                cancel,
+                handle,
+            },
+        );
+        Ok(())
+    }
+
+    pub async fn cancel(&self, id: &JobId) -> Result<(), JobsError> {
+        let mut jobs = self.jobs.lock().await;
+        if let Some(job) = jobs.remove(id) {
+            job.cancel.store(true, Ordering::SeqCst);
+            job.handle.abort();
+            Ok(())
+        } else {
+            Err(JobsError::NotRegistered(id.as_str().to_string()))
+        }
+    }
+
+    pub async fn is_registered(&self, id: &JobId) -> bool {
+        self.jobs.lock().await.contains_key(id)
+    }
+
+    pub async fn shutdown(&self) -> Result<(), JobsError> {
+        self.shutting_down.store(true, Ordering::SeqCst);
+        let mut jobs = self.jobs.lock().await;
+        for (_, job) in jobs.drain() {
+            job.cancel.store(true, Ordering::SeqCst);
+            job.handle.abort();
+        }
+        Ok(())
+    }
+}
+
+async fn wait_cancelled(cancel: &AtomicBool) {
+    while !cancel.load(Ordering::SeqCst) {
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+async fn run_with_retry(job_id: &JobId, retry: &RetryPolicy, handler: DynHandler) {
+    let max_attempts = retry.max_attempts.max(1);
+    let mut delay = retry.initial_delay;
+
+    for attempt in 1..=max_attempts {
+        if attempt > 1 {
+            debug!(
+                job_id = %job_id,
+                attempt,
+                delay_ms = delay.as_millis() as u64,
+                "retrying job firing"
+            );
+            tokio::time::sleep(delay).await;
+            let next = Duration::from_secs_f64(
+                (delay.as_secs_f64() * retry.multiplier).min(retry.max_delay.as_secs_f64()),
+            );
+            delay = if next.is_zero() { retry.max_delay } else { next };
+        }
+
+        match handler().await {
+            Ok(()) => return,
+            Err(JobError::Fatal(message)) => {
+                warn!(job_id = %job_id, attempt, error = %message, "job firing failed fatally");
+                return;
+            }
+            Err(JobError::Retryable(message)) => {
+                warn!(
+                    job_id = %job_id,
+                    attempt,
+                    max_attempts,
+                    error = %message,
+                    "job firing failed (retryable)"
+                );
+                if attempt == max_attempts {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn interval_job_fires_with_fire_immediately() {
+        let scheduler = LocalScheduler::new();
+        let counter = Arc::new(AtomicUsize::new(0));
+        let c = Arc::clone(&counter);
+        scheduler
+            .set_interval_job(
+                JobId::new("test.fire"),
+                IntervalSpec {
+                    every: Duration::from_millis(40),
+                    skip_if_running: true,
+                    fire_immediately: true,
+                },
+                RetryPolicy::none(),
+                move || {
+                    let c = Arc::clone(&c);
+                    async move {
+                        c.fetch_add(1, Ordering::SeqCst);
+                        Ok(())
+                    }
+                },
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(130)).await;
+        let count = counter.load(Ordering::SeqCst);
+        assert!(count >= 2, "expected >=2 firings, got {count}");
+        scheduler.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn fire_immediately_false_waits_one_period() {
+        let scheduler = LocalScheduler::new();
+        let counter = Arc::new(AtomicUsize::new(0));
+        let c = Arc::clone(&counter);
+        scheduler
+            .set_interval_job(
+                JobId::new("test.delayed"),
+                IntervalSpec {
+                    every: Duration::from_millis(80),
+                    skip_if_running: true,
+                    fire_immediately: false,
+                },
+                RetryPolicy::none(),
+                move || {
+                    let c = Arc::clone(&c);
+                    async move {
+                        c.fetch_add(1, Ordering::SeqCst);
+                        Ok(())
+                    }
+                },
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        assert_eq!(counter.load(Ordering::SeqCst), 0);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(counter.load(Ordering::SeqCst) >= 1);
+        scheduler.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancel_stops_future_ticks() {
+        let scheduler = LocalScheduler::new();
+        let counter = Arc::new(AtomicUsize::new(0));
+        let c = Arc::clone(&counter);
+        let id = JobId::new("test.cancel");
+        scheduler
+            .set_interval_job(
+                id.clone(),
+                IntervalSpec {
+                    every: Duration::from_millis(30),
+                    skip_if_running: true,
+                    fire_immediately: true,
+                },
+                RetryPolicy::none(),
+                move || {
+                    let c = Arc::clone(&c);
+                    async move {
+                        c.fetch_add(1, Ordering::SeqCst);
+                        Ok(())
+                    }
+                },
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(70)).await;
+        scheduler.cancel(&id).await.unwrap();
+        let after_cancel = counter.load(Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(counter.load(Ordering::SeqCst), after_cancel);
+        assert!(!scheduler.is_registered(&id).await);
+    }
+
+    #[tokio::test]
+    async fn replace_same_id_switches_handler() {
+        let scheduler = LocalScheduler::new();
+        let gen = Arc::new(AtomicUsize::new(0));
+        let g1 = Arc::clone(&gen);
+        let id = JobId::new("test.replace");
+        scheduler
+            .set_interval_job(
+                id.clone(),
+                IntervalSpec {
+                    every: Duration::from_millis(40),
+                    skip_if_running: true,
+                    fire_immediately: true,
+                },
+                RetryPolicy::none(),
+                move || {
+                    let g1 = Arc::clone(&g1);
+                    async move {
+                        g1.store(1, Ordering::SeqCst);
+                        Ok(())
+                    }
+                },
+            )
+            .await
+            .unwrap();
+
+        let g2 = Arc::clone(&gen);
+        scheduler
+            .set_interval_job(
+                id.clone(),
+                IntervalSpec {
+                    every: Duration::from_millis(40),
+                    skip_if_running: true,
+                    fire_immediately: true,
+                },
+                RetryPolicy::none(),
+                move || {
+                    let g2 = Arc::clone(&g2);
+                    async move {
+                        g2.store(2, Ordering::SeqCst);
+                        Ok(())
+                    }
+                },
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(90)).await;
+        assert_eq!(gen.load(Ordering::SeqCst), 2);
+        assert!(scheduler.is_registered(&id).await);
+        scheduler.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn skip_if_running_prevents_overlap() {
+        let scheduler = LocalScheduler::new();
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let inflight = Arc::clone(&in_flight);
+        let max = Arc::clone(&max_in_flight);
+        scheduler
+            .set_interval_job(
+                JobId::new("test.skip"),
+                IntervalSpec {
+                    every: Duration::from_millis(20),
+                    skip_if_running: true,
+                    fire_immediately: true,
+                },
+                RetryPolicy::none(),
+                move || {
+                    let inflight = Arc::clone(&inflight);
+                    let max = Arc::clone(&max);
+                    async move {
+                        let current = inflight.fetch_add(1, Ordering::SeqCst) + 1;
+                        max.fetch_max(current, Ordering::SeqCst);
+                        tokio::time::sleep(Duration::from_millis(70)).await;
+                        inflight.fetch_sub(1, Ordering::SeqCst);
+                        Ok(())
+                    }
+                },
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert_eq!(max_in_flight.load(Ordering::SeqCst), 1);
+        scheduler.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn retryable_errors_are_retried() {
+        let scheduler = LocalScheduler::new();
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let a = Arc::clone(&attempts);
+        let done = Arc::new(AtomicBool::new(false));
+        let d = Arc::clone(&done);
+        scheduler
+            .set_interval_job(
+                JobId::new("test.retry"),
+                IntervalSpec {
+                    every: Duration::from_secs(10),
+                    skip_if_running: true,
+                    fire_immediately: true,
+                },
+                RetryPolicy {
+                    max_attempts: 3,
+                    initial_delay: Duration::from_millis(5),
+                    max_delay: Duration::from_millis(20),
+                    multiplier: 2.0,
+                },
+                move || {
+                    let a = Arc::clone(&a);
+                    let d = Arc::clone(&d);
+                    async move {
+                        let n = a.fetch_add(1, Ordering::SeqCst) + 1;
+                        if n < 3 {
+                            Err(JobError::Retryable("transient".into()))
+                        } else {
+                            d.store(true, Ordering::SeqCst);
+                            Ok(())
+                        }
+                    }
+                },
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(done.load(Ordering::SeqCst));
+        assert!(attempts.load(Ordering::SeqCst) >= 3);
+        scheduler.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn fatal_errors_do_not_retry() {
+        let scheduler = LocalScheduler::new();
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let a = Arc::clone(&attempts);
+        scheduler
+            .set_interval_job(
+                JobId::new("test.fatal"),
+                IntervalSpec {
+                    every: Duration::from_secs(10),
+                    skip_if_running: true,
+                    fire_immediately: true,
+                },
+                RetryPolicy {
+                    max_attempts: 5,
+                    initial_delay: Duration::from_millis(5),
+                    max_delay: Duration::from_millis(20),
+                    multiplier: 2.0,
+                },
+                move || {
+                    let a = Arc::clone(&a);
+                    async move {
+                        a.fetch_add(1, Ordering::SeqCst);
+                        Err(JobError::Fatal("boom".into()))
+                    }
+                },
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        scheduler.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn shutdown_stops_jobs() {
+        let scheduler = LocalScheduler::new();
+        let counter = Arc::new(AtomicUsize::new(0));
+        let c = Arc::clone(&counter);
+        scheduler
+            .set_interval_job(
+                JobId::new("test.shutdown"),
+                IntervalSpec {
+                    every: Duration::from_millis(30),
+                    skip_if_running: true,
+                    fire_immediately: true,
+                },
+                RetryPolicy::none(),
+                move || {
+                    let c = Arc::clone(&c);
+                    async move {
+                        c.fetch_add(1, Ordering::SeqCst);
+                        Ok(())
+                    }
+                },
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        scheduler.shutdown().await.unwrap();
+        let after = counter.load(Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert_eq!(counter.load(Ordering::SeqCst), after);
+        assert!(matches!(
+            scheduler
+                .set_interval_job(
+                    JobId::new("after"),
+                    IntervalSpec::every(Duration::from_millis(10)),
+                    RetryPolicy::none(),
+                    || async { Ok(()) },
+                )
+                .await,
+            Err(JobsError::ShuttingDown)
+        ));
+    }
+}

--- a/crates/infra/src/jobs/local.rs
+++ b/crates/infra/src/jobs/local.rs
@@ -160,9 +160,21 @@ impl LocalScheduler {
     pub async fn shutdown(&self) -> Result<(), JobsError> {
         self.shutting_down.store(true, Ordering::SeqCst);
         let mut jobs = self.jobs.lock().await;
-        for (_, job) in jobs.drain() {
-            job.cancel.store(true, Ordering::SeqCst);
-            job.handle.abort();
+        let handles: Vec<(Arc<AtomicBool>, JoinHandle<()>)> = jobs
+            .drain()
+            .map(|(_, job)| (job.cancel, job.handle))
+            .collect();
+        drop(jobs);
+        for (cancel, handle) in handles {
+            cancel.store(true, Ordering::SeqCst);
+            let abort = handle.abort_handle();
+            // Prefer cooperative stop; abort only if the task is stuck.
+            match tokio::time::timeout(Duration::from_secs(2), handle).await {
+                Ok(_) => {}
+                Err(_) => {
+                    abort.abort();
+                }
+            }
         }
         Ok(())
     }

--- a/crates/infra/src/jobs/mod.rs
+++ b/crates/infra/src/jobs/mod.rs
@@ -1,2 +1,14 @@
-// Jobs module placeholder
-// TODO: Implement background job infrastructure
+//! Local-first product job scheduler (APP-051).
+//!
+//! Time-driven work registers here. Business crates supply handlers; this module
+//! owns timers, cancel/replace, optional per-firing retry, and shutdown.
+//!
+//! v1 adapter: [`LocalScheduler`] (Tokio). No distributed job engines.
+
+mod local;
+mod types;
+
+pub use local::LocalScheduler;
+pub use types::{
+    IntervalSpec, JobError, JobId, JobResult, JobsError, RetryPolicy,
+};

--- a/crates/infra/src/jobs/mod.rs
+++ b/crates/infra/src/jobs/mod.rs
@@ -9,6 +9,4 @@ mod local;
 mod types;
 
 pub use local::LocalScheduler;
-pub use types::{
-    IntervalSpec, JobError, JobId, JobResult, JobsError, RetryPolicy,
-};
+pub use types::{IntervalSpec, JobError, JobId, JobResult, JobsError, RetryPolicy};

--- a/crates/infra/src/jobs/types.rs
+++ b/crates/infra/src/jobs/types.rs
@@ -1,0 +1,108 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use thiserror::Error;
+
+/// Stable product job identifier (e.g. `automation.schedule_tick`).
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct JobId(pub Arc<str>);
+
+impl JobId {
+    pub fn new(id: impl AsRef<str>) -> Self {
+        Self(Arc::from(id.as_ref()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for JobId {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for JobId {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+impl std::fmt::Display for JobId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Interval schedule for a local job.
+#[derive(Clone, Debug)]
+pub struct IntervalSpec {
+    pub every: Duration,
+    /// When true, skip starting a new run if the previous firing is still in flight.
+    pub skip_if_running: bool,
+    /// When true, run soon after registration; when false, wait one full period first.
+    pub fire_immediately: bool,
+}
+
+impl IntervalSpec {
+    pub fn every(every: Duration) -> Self {
+        Self {
+            every,
+            skip_if_running: true,
+            fire_immediately: false,
+        }
+    }
+}
+
+/// Per-firing retry policy (max_attempts = 1 means no extra retries).
+#[derive(Clone, Debug)]
+pub struct RetryPolicy {
+    pub max_attempts: u32,
+    pub initial_delay: Duration,
+    pub max_delay: Duration,
+    pub multiplier: f64,
+}
+
+impl RetryPolicy {
+    pub fn none() -> Self {
+        Self {
+            max_attempts: 1,
+            initial_delay: Duration::from_millis(0),
+            max_delay: Duration::from_millis(0),
+            multiplier: 1.0,
+        }
+    }
+
+    pub fn exponential(max_attempts: u32, initial_delay: Duration, max_delay: Duration) -> Self {
+        Self {
+            max_attempts: max_attempts.max(1),
+            initial_delay,
+            max_delay,
+            multiplier: 2.0,
+        }
+    }
+}
+
+/// Result of a single job firing attempt.
+#[derive(Debug, Error)]
+pub enum JobError {
+    #[error("retryable job error: {0}")]
+    Retryable(String),
+    #[error("fatal job error: {0}")]
+    Fatal(String),
+}
+
+pub type JobResult = Result<(), JobError>;
+
+#[derive(Debug, Error)]
+pub enum JobsError {
+    #[error("jobs runtime is shutting down")]
+    ShuttingDown,
+    #[error("job not registered: {0}")]
+    NotRegistered(String),
+    #[error("invalid job interval: duration must be non-zero")]
+    InvalidInterval,
+    #[error("jobs internal error: {0}")]
+    Internal(String),
+}

--- a/crates/infra/src/lib.rs
+++ b/crates/infra/src/lib.rs
@@ -9,9 +9,7 @@ pub use db::{
     UpsertTerminalSideChatInput,
 };
 pub use error::{InfraError, Result};
-pub use jobs::{
-    IntervalSpec, JobError, JobId, JobResult, JobsError, LocalScheduler, RetryPolicy,
-};
+pub use jobs::{IntervalSpec, JobError, JobId, JobResult, JobsError, LocalScheduler, RetryPolicy};
 pub use queue::{
     topics as queue_topics, EnqueueError, LocalMemoryQueue, QueueError, QueueMessage, Topic,
 };

--- a/crates/infra/src/lib.rs
+++ b/crates/infra/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod db;
 pub mod error;
+pub mod jobs;
+pub mod queue;
 pub mod utils;
 
 pub use db::{
@@ -7,3 +9,9 @@ pub use db::{
     UpsertTerminalSideChatInput,
 };
 pub use error::{InfraError, Result};
+pub use jobs::{
+    IntervalSpec, JobError, JobId, JobResult, JobsError, LocalScheduler, RetryPolicy,
+};
+pub use queue::{
+    topics as queue_topics, EnqueueError, LocalMemoryQueue, QueueError, QueueMessage, Topic,
+};

--- a/crates/infra/src/queue/local.rs
+++ b/crates/infra/src/queue/local.rs
@@ -84,8 +84,7 @@ impl LocalMemoryQueue {
 
         let dyn_handler: DynHandler = Arc::new(move |msg| {
             let fut = handler(msg);
-            Box::pin(fut)
-                as std::pin::Pin<Box<dyn Future<Output = Result<(), QueueError>> + Send>>
+            Box::pin(fut) as std::pin::Pin<Box<dyn Future<Output = Result<(), QueueError>> + Send>>
         });
 
         let (tx, mut rx) = mpsc::channel::<QueueMessage>(self.capacity);

--- a/crates/infra/src/queue/local.rs
+++ b/crates/infra/src/queue/local.rs
@@ -1,0 +1,283 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use chrono::Utc;
+use tokio::sync::{mpsc, Mutex};
+use tokio::task::JoinHandle;
+use tracing::{debug, warn};
+use uuid::Uuid;
+
+use super::types::{EnqueueError, QueueError, QueueMessage, Topic};
+
+type DynHandler = Arc<
+    dyn Fn(QueueMessage) -> std::pin::Pin<Box<dyn Future<Output = Result<(), QueueError>> + Send>>
+        + Send
+        + Sync,
+>;
+
+struct TopicState {
+    tx: mpsc::Sender<QueueMessage>,
+    consumer: JoinHandle<()>,
+}
+
+/// Process-local bounded in-memory queue (APP-051 LocalMemoryQueue).
+///
+/// Backed by `tokio::sync::mpsc` per topic. Full enqueue returns [`EnqueueError::Full`].
+pub struct LocalMemoryQueue {
+    capacity: usize,
+    topics: Mutex<HashMap<Topic, TopicState>>,
+    shutting_down: AtomicBool,
+}
+
+impl LocalMemoryQueue {
+    pub fn builder() -> LocalMemoryQueueBuilder {
+        LocalMemoryQueueBuilder { capacity: 128 }
+    }
+
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            capacity: capacity.max(1),
+            topics: Mutex::new(HashMap::new()),
+            shutting_down: AtomicBool::new(false),
+        }
+    }
+
+    /// Enqueue a payload. Requires a subscribed consumer for the topic.
+    pub async fn enqueue(&self, topic: &Topic, payload: Vec<u8>) -> Result<String, EnqueueError> {
+        if self.shutting_down.load(Ordering::SeqCst) {
+            return Err(EnqueueError::ShuttingDown);
+        }
+
+        let msg = QueueMessage {
+            id: Uuid::new_v4().to_string(),
+            payload,
+            enqueued_at: Utc::now(),
+        };
+        let msg_id = msg.id.clone();
+
+        let topics = self.topics.lock().await;
+        let Some(state) = topics.get(topic) else {
+            return Err(EnqueueError::NoConsumer);
+        };
+
+        match state.tx.try_send(msg) {
+            Ok(()) => {
+                debug!(topic = %topic, msg_id = %msg_id, "queue enqueued");
+                Ok(msg_id)
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => Err(EnqueueError::Full),
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(EnqueueError::ShuttingDown),
+        }
+    }
+
+    /// Register a single consumer for `topic` (v1: one consumer per topic).
+    pub async fn subscribe<F, Fut>(&self, topic: Topic, handler: F) -> Result<(), QueueError>
+    where
+        F: Fn(QueueMessage) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<(), QueueError>> + Send + 'static,
+    {
+        if self.shutting_down.load(Ordering::SeqCst) {
+            return Err(QueueError::ShuttingDown);
+        }
+
+        let dyn_handler: DynHandler = Arc::new(move |msg| {
+            let fut = handler(msg);
+            Box::pin(fut)
+                as std::pin::Pin<Box<dyn Future<Output = Result<(), QueueError>> + Send>>
+        });
+
+        let (tx, mut rx) = mpsc::channel::<QueueMessage>(self.capacity);
+        let topic_for_task = topic.clone();
+        let consumer = tokio::spawn(async move {
+            while let Some(msg) = rx.recv().await {
+                let msg_id = msg.id.clone();
+                if let Err(error) = dyn_handler(msg).await {
+                    warn!(
+                        topic = %topic_for_task,
+                        msg_id = %msg_id,
+                        error = %error,
+                        "queue consumer handler failed; dropping message"
+                    );
+                }
+            }
+        });
+
+        let mut topics = self.topics.lock().await;
+        if topics.contains_key(&topic) {
+            consumer.abort();
+            return Err(QueueError::ConsumerExists(topic.as_str().to_string()));
+        }
+        topics.insert(topic, TopicState { tx, consumer });
+        Ok(())
+    }
+
+    pub async fn shutdown(&self) -> Result<(), QueueError> {
+        self.shutting_down.store(true, Ordering::SeqCst);
+        let mut topics = self.topics.lock().await;
+        for (_, state) in topics.drain() {
+            drop(state.tx);
+            state.consumer.abort();
+        }
+        Ok(())
+    }
+}
+
+pub struct LocalMemoryQueueBuilder {
+    capacity: usize,
+}
+
+impl LocalMemoryQueueBuilder {
+    pub fn capacity(mut self, capacity: usize) -> Self {
+        self.capacity = capacity.max(1);
+        self
+    }
+
+    pub fn build(self) -> LocalMemoryQueue {
+        LocalMemoryQueue::new(self.capacity)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+    use tokio::sync::oneshot;
+
+    #[tokio::test]
+    async fn enqueue_and_consume() {
+        let queue = LocalMemoryQueue::builder().capacity(8).build();
+        let (tx, rx) = oneshot::channel::<Vec<u8>>();
+        let tx = Arc::new(Mutex::new(Some(tx)));
+        let topic = Topic::new("test.topic");
+
+        let tx_handler = Arc::clone(&tx);
+        queue
+            .subscribe(topic.clone(), move |msg| {
+                let tx_handler = Arc::clone(&tx_handler);
+                async move {
+                    if let Some(sender) = tx_handler.lock().await.take() {
+                        let _ = sender.send(msg.payload);
+                    }
+                    Ok(())
+                }
+            })
+            .await
+            .unwrap();
+
+        let id = queue
+            .enqueue(&topic, b"hello".to_vec())
+            .await
+            .expect("enqueue");
+        assert!(!id.is_empty());
+        let payload = tokio::time::timeout(std::time::Duration::from_secs(1), rx)
+            .await
+            .expect("timeout")
+            .expect("rx");
+        assert_eq!(payload, b"hello");
+        queue.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn queue_full_returns_error() {
+        let queue = LocalMemoryQueue::builder().capacity(1).build();
+        let topic = Topic::new("test.full");
+        // Consumer that never drains quickly: sleep on each message.
+        queue
+            .subscribe(topic.clone(), |_msg| async {
+                tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+        // Fill buffer (capacity 1) + one in-flight to consumer may free a slot;
+        // keep sending until Full is observed.
+        let mut saw_full = false;
+        for i in 0..8 {
+            match queue.enqueue(&topic, vec![i]).await {
+                Ok(_) => {}
+                Err(EnqueueError::Full) => {
+                    saw_full = true;
+                    break;
+                }
+                Err(other) => panic!("unexpected error: {other}"),
+            }
+        }
+        assert!(saw_full, "expected EnqueueError::Full");
+        queue.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn fifo_order_with_single_consumer() {
+        let queue = LocalMemoryQueue::builder().capacity(32).build();
+        let topic = Topic::new("test.fifo");
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let (done_tx, done_rx) = oneshot::channel::<()>();
+        let done_tx = Arc::new(Mutex::new(Some(done_tx)));
+        let seen_h = Arc::clone(&seen);
+        let done_h = Arc::clone(&done_tx);
+
+        queue
+            .subscribe(topic.clone(), move |msg| {
+                let seen_h = Arc::clone(&seen_h);
+                let done_h = Arc::clone(&done_h);
+                async move {
+                    let n = msg.payload[0];
+                    seen_h.lock().await.push(n);
+                    if n == 4 {
+                        if let Some(tx) = done_h.lock().await.take() {
+                            let _ = tx.send(());
+                        }
+                    }
+                    Ok(())
+                }
+            })
+            .await
+            .unwrap();
+
+        for i in 0..5u8 {
+            queue.enqueue(&topic, vec![i]).await.unwrap();
+        }
+        tokio::time::timeout(std::time::Duration::from_secs(2), done_rx)
+            .await
+            .expect("timeout")
+            .unwrap();
+        assert_eq!(*seen.lock().await, vec![0, 1, 2, 3, 4]);
+        queue.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn enqueue_without_consumer_errors() {
+        let queue = LocalMemoryQueue::builder().capacity(4).build();
+        let err = queue
+            .enqueue(&Topic::new("missing"), b"x".to_vec())
+            .await
+            .unwrap_err();
+        assert_eq!(err, EnqueueError::NoConsumer);
+    }
+
+    #[tokio::test]
+    async fn shutdown_rejects_enqueue() {
+        let queue = LocalMemoryQueue::builder().capacity(4).build();
+        let topic = Topic::new("test.sd");
+        let count = Arc::new(AtomicUsize::new(0));
+        let c = Arc::clone(&count);
+        queue
+            .subscribe(topic.clone(), move |_| {
+                let c = Arc::clone(&c);
+                async move {
+                    c.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }
+            })
+            .await
+            .unwrap();
+        queue.shutdown().await.unwrap();
+        assert_eq!(
+            queue.enqueue(&topic, b"x".to_vec()).await.unwrap_err(),
+            EnqueueError::ShuttingDown
+        );
+    }
+}

--- a/crates/infra/src/queue/local.rs
+++ b/crates/infra/src/queue/local.rs
@@ -115,9 +115,21 @@ impl LocalMemoryQueue {
     pub async fn shutdown(&self) -> Result<(), QueueError> {
         self.shutting_down.store(true, Ordering::SeqCst);
         let mut topics = self.topics.lock().await;
-        for (_, state) in topics.drain() {
-            drop(state.tx);
-            state.consumer.abort();
+        let consumers: Vec<(mpsc::Sender<QueueMessage>, JoinHandle<()>)> = topics
+            .drain()
+            .map(|(_, state)| (state.tx, state.consumer))
+            .collect();
+        drop(topics);
+        for (tx, consumer) in consumers {
+            // Close the channel so recv returns None after draining remaining items.
+            drop(tx);
+            let abort = consumer.abort_handle();
+            match tokio::time::timeout(std::time::Duration::from_secs(5), consumer).await {
+                Ok(_) => {}
+                Err(_) => {
+                    abort.abort();
+                }
+            }
         }
         Ok(())
     }

--- a/crates/infra/src/queue/mod.rs
+++ b/crates/infra/src/queue/mod.rs
@@ -1,2 +1,12 @@
-// Queue module placeholder
-// TODO: Implement message queue infrastructure
+//! Local-first event queue (APP-051).
+//!
+//! External/event-driven work enqueues here; consumers run business handlers.
+//! Interactive user actions must not use this path (call services directly).
+//!
+//! v1 adapter: [`LocalMemoryQueue`] (`tokio::sync::mpsc`, bounded). Not a message broker.
+
+mod local;
+mod types;
+
+pub use local::{LocalMemoryQueue, LocalMemoryQueueBuilder};
+pub use types::{topics, EnqueueError, QueueError, QueueMessage, Topic};

--- a/crates/infra/src/queue/types.rs
+++ b/crates/infra/src/queue/types.rs
@@ -1,0 +1,71 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use thiserror::Error;
+
+/// Named queue topic (e.g. `automation.github_delivery`).
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Topic(pub Arc<str>);
+
+impl Topic {
+    pub fn new(name: impl AsRef<str>) -> Self {
+        Self(Arc::from(name.as_ref()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for Topic {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for Topic {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+impl std::fmt::Display for Topic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Opaque queue message delivered to a consumer.
+#[derive(Clone, Debug)]
+pub struct QueueMessage {
+    pub id: String,
+    pub payload: Vec<u8>,
+    pub enqueued_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum EnqueueError {
+    #[error("queue is full")]
+    Full,
+    #[error("queue is shutting down")]
+    ShuttingDown,
+    #[error("no consumer subscribed for topic")]
+    NoConsumer,
+}
+
+#[derive(Debug, Error)]
+pub enum QueueError {
+    #[error("queue is shutting down")]
+    ShuttingDown,
+    #[error("topic already has a consumer: {0}")]
+    ConsumerExists(String),
+    #[error("queue consumer error: {0}")]
+    Handler(String),
+    #[error("queue internal error: {0}")]
+    Internal(String),
+}
+
+/// Well-known product topics (APP-051 catalog).
+pub mod topics {
+    pub const AUTOMATION_GITHUB_DELIVERY: &str = "automation.github_delivery";
+}

--- a/specs/APP/APP-051_infra-jobs/BRAINSTORM.md
+++ b/specs/APP/APP-051_infra-jobs/BRAINSTORM.md
@@ -1,0 +1,83 @@
+# Brainstorm · APP-051: Infra Jobs & Queue (Local-First)
+
+> Problem space and exploration. Settled content graduates to PRD.md; committed architecture graduates to TECH.md.
+
+## Context
+
+- **Trigger**: Refactoring found `crates/infra` `jobs/` and `queue/` as empty placeholders, while product scheduled work and event work are ad-hoc (`tokio::interval`, inline spawns).
+- **Product shape**: Atmos is a **local, single-user, single-process Computer** today—not a multi-tenant job cluster.
+- **Who feels it**: Backend engineers (duplicated timers, no shared cancel/retry/shutdown story). End users only feel regressions if automation / AI usage / hooks timing breaks.
+- **Current workarounds**:
+  - Automations: 30s poll loop + domain cron/`next_run_at` (APP-017).
+  - AI usage: private interval `JoinHandle` with abort/replace.
+  - Agent hooks idle cleanup: raw interval in `apps/api` main.
+  - GitHub/event paths: sync or ad-hoc async inside handlers (no shared queue port).
+  - Manual run: direct service call (correct; keep).
+
+## Goals (draft)
+
+- Primary: **Stable infra ports** — `jobs` (time-driven) and `queue` (event-driven) so business code stops owning timers/buffers.
+- Primary: **Local adapters only in v1** — simple, correct for single-process.
+- Primary: Migrate **product** scheduled loops onto `jobs`; route **external events** through `queue`; keep **manual** as direct API→service.
+- Secondary: Leave a **narrow extension path** for future cloud/distributed adapters without promising zero business change.
+- Non-goal: apalis / Rabbit / Redis / distributed schedulers in v1.
+
+## Options (historical)
+
+### Option A — apalis (or similar) as v1 job engine
+
+**Pros**: Real worker/retry ecosystem.  
+**Cons**: Heavy for local single-user; poor fit for dynamic closures; blurs job vs MQ; API churn.  
+**Verdict**: Rejected for v1.
+
+### Option B — Hand-rolled local scheduler + in-memory queue behind traits (chosen)
+
+**Pros**: Matches Atmos scale; thin; testable; business sees one API.  
+**Cons**: Must reimplement cloud later if needed—acceptable.  
+**Verdict**: **Chosen.**
+
+### Option C — Per-automation apalis/cron job as schedule truth
+
+**Pros**: “Pure” scheduler textbook model.  
+**Cons**: Dual source of truth with APP-017 DB (pause, next_run, no backfill); rehydrate cost; little benefit single-process.  
+**Verdict**: Rejected as v1 automation model. Domain tables remain schedule authority; one meta tick job drives polling.
+
+### Option D — Everything is a job (including manual and events)
+
+**Pros**: One concept.  
+**Cons**: Manual needs sync errors/run id; events need buffer/ack semantics → wrong tools.  
+**Verdict**: Rejected. Three entry styles: Jobs / Queue / Direct.
+
+## Key forks (resolved)
+
+| Fork | Decision |
+|------|----------|
+| Job library in v1 | **No apalis**; local Tokio-based adapter |
+| Queue implementation | **In-process bounded memory**; not external MQ; not apalis |
+| Automation schedule | **One interval job** `automation.schedule_tick` + domain `next_run_at` |
+| Manual run | **Direct service**; never jobs/queue |
+| GitHub / external events | **`infra::queue`** then consumer → domain |
+| Cloud later | **Adapter/trait seam only**; no full distributed semantics in v1 |
+| AI usage retry | **Parity first** (`RetryPolicy::none` default); optional later |
+| Automation first tick | **`fire_immediately: true`** (match today’s interval) |
+
+## Open questions
+
+- [x] apalis in v1? → No.
+- [x] Queue = MQ library? → No for v1.
+- [x] Automation meta tick vs per-automation job? → Meta tick.
+- [ ] Exact bounded-queue full policy (block vs error) — decide in TECH.
+- [ ] Whether durable local outbox for queue is N1 — decide in PRD/TECH (default N1, not M).
+
+## References
+
+- Code: `crates/infra/src/jobs/mod.rs`, `queue/mod.rs`, `lib.rs`
+- `crates/core-service/src/service/automation/scheduler_service.rs`, `scheduler.rs`
+- `crates/ai-usage/src/service.rs`
+- `apps/api/src/main.rs` (`start_scheduler`, `spawn_idle_session_cleanup`)
+- Specs: `APP-017_atmos-automations`, `APP-019_github-automation-triggers`
+
+## Ready to promote
+
+- Promote to PRD: dual ports Jobs+Queue; local-first; migration inventory; manual exclusion; cloud as future adapter only.
+- Promote to TECH: trait shapes, Local adapters, automation tick job, queue topics, bootstrap, tests.

--- a/specs/APP/APP-051_infra-jobs/PRD.md
+++ b/specs/APP/APP-051_infra-jobs/PRD.md
@@ -1,0 +1,110 @@
+# PRD · APP-051: Infra Jobs & Queue (Local-First)
+
+> Product Requirements · WHAT and WHY. Unified L1 ports for time-driven work (**jobs**) and event-driven work (**queue**), implemented with **local adapters** for single-user Atmos; business layers depend only on the ports.
+
+## Context
+
+- **Problem**: Product background work is ad-hoc. There is no shared place to register named schedules, cancel/replace them, buffer external events, or shut them down cleanly. `infra/jobs` and `infra/queue` are empty placeholders.
+- **Why now**: Refactors already surface multiple timers (automations, AI usage, agent-hooks cleanup) and event-driven automation triggers (GitHub). Without a port, every feature reinvents the same loops.
+- **Product constraint**: Atmos today is a **local, single-user, single-process Computer**. v1 must not require distributed brokers or multi-worker clusters.
+- **Related specs**:
+  - `APP-017_atmos-automations` — schedule semantics, pause, no sleep backfill (must not regress).
+  - `APP-019_github-automation-triggers` — event delivery / claim patterns (queue must cooperate).
+  - Layering: `infra` → services → `apps/api`.
+
+## Goals
+
+1. **Primary**: Ship **stable `infra::jobs` and `infra::queue` abstractions** used by business code for all *product* time-driven and *external event* async work.
+2. **Primary**: Implement **Local adapters only** in v1 (process-local scheduler + bounded in-memory queue).
+3. **Primary**: Migrate existing product scheduled loops onto `jobs`; route GitHub/external event intake through `queue`; keep **manual user actions as direct service calls**.
+4. **Secondary**: Document an **adapter seam** so a future cloud/distributed implementation can be introduced without rewriting domain rules—without promising zero business change on day one of cloud.
+5. **Secondary**: Named job/queue ids, simple retry hooks, graceful shutdown, testability via injection.
+
+## Users & Scenarios
+
+- **Primary persona**: Backend engineer adding scheduled or event-driven work.
+- **Secondary persona**: End user of Automations / AI usage / hooks (behavior parity; no new Jobs UI).
+
+### Key scenarios
+
+1. API process starts → local jobs/queue runtimes start → automation tick, optional AI usage refresh, agent-hooks cleanup are registered.
+2. User changes AI usage auto-refresh interval → previous job cancelled/replaced; no double timers.
+3. Scheduled automation becomes due → tick job runs domain logic → run starts (or domain pause/failure rules apply).
+4. GitHub delivery arrives → handler enqueues quickly → consumer runs domain matching/start with idempotency/claim.
+5. User clicks **Run now** → API/WS calls service **directly** (no enqueue, no schedule job).
+6. Process shutdown → jobs and queue stop without panics or orphaned tight loops.
+
+## User Stories
+
+- As a backend engineer, I want one jobs API for timers and one queue API for events, so I do not copy `tokio::interval` / ad-hoc channels per feature.
+- As a backend engineer, I want handlers to stay in service crates, so `infra` remains free of automation/usage domain rules.
+- As an Automations user, I want schedule/pause/next-run/manual-run behavior unchanged after the infra move.
+- As a platform owner, I want local-first implementations now and a clear path to swap adapters if Atmos later runs multi-tenant cloud workers.
+
+## Functional Requirements
+
+### Must Have
+
+- **M1 · Jobs port**: `crates/infra` exposes a documented **jobs** API (trait + types). Business crates depend on this port, not on a specific distributed job product.
+- **M2 · Queue port**: `crates/infra` exposes a documented **queue** API (trait + types) for named topics, enqueue, and consumer registration.
+- **M3 · Local jobs adapter**: v1 ships **only** a process-local scheduler (Tokio-based). Supports named interval jobs at minimum; cancel and replace-by-id.
+- **M4 · Local queue adapter**: v1 ships **only** a process-local **bounded in-memory** queue with one or more consumers per topic. No external MQ dependency.
+- **M5 · Lifecycle**: `apps/api` (or runtime owner) constructs adapters, starts them, injects into services, and shuts them down on process exit.
+- **M6 · Automations schedule via jobs**: Domain schedule truth stays APP-017 (DB: expr, tz, pause, `next_run_at`). Infrastructure is **one interval job** (e.g. `automation.schedule_tick`) that invokes existing due-scan / start logic—not per-automation distributed cron in v1.
+- **M7 · Automations manual run stays direct**: User-initiated run goes API/WS → service. **Must not** require jobs or queue.
+- **M8 · External events via queue**: GitHub (and similar) trigger intake **enqueues** work; consumers execute domain logic (including existing idempotency/claim rules). Webhook/HTTP path must not own long business work when queue is available.
+- **M9 · Migrate AI usage auto-refresh** onto jobs (cancel/replace on interval change/disable).
+- **M10 · Migrate agent-hooks idle session cleanup** onto jobs (today’s ~5 minute loop in `apps/api`).
+- **M11 · Layering**: Jobs/queue adapters contain **no** domain rules (no pause-schedule policy, no provider collect, no GitHub matching). Handlers are registered by upper layers.
+- **M12 · Inventory discipline**: Spec lists migrate vs do-not-migrate. Connection keepalives, PTY/stream pumps, and request-scoped one-shot spawns are **not** force-migrated.
+
+### Nice to Have
+
+- **N1 · Cron helper on jobs port**: First-class cron schedule on the jobs API for *new* non-domain schedules (Automations still use domain cron + tick job).
+- **N2 · Execution retry policy on jobs**: Optional max attempts + backoff for a single firing (default none for automation tick and AI usage in v1 parity mode).
+- **N3 · Durable local queue**: SQLite/outbox-backed queue adapter for “ack then crash” safety—**not** required for v1 if upstream retries (e.g. GitHub) + claim cover the product risk.
+- **N4 · Cloud adapter sketches**: Non-normative notes for future Redis/NATS/apalis-style backends; not implemented in this spec’s ship gate.
+- **N5 · Debug listing**: List active job ids / queue depths for tracing/debug logs.
+
+## Out of Scope
+
+- **Distributed job systems / external MQ as v1 dependencies** (apalis, RabbitMQ, NATS, Redis Streams, Kafka, etc.).
+- **Promising zero business-code change when moving to cloud** — adapters reduce coupling; cloud may still require serializable payloads or split workers.
+- **Per-automation job registration as schedule authority** in v1 (rejected dual source of truth).
+- **Jobs/Queue admin UI** for end users.
+- **Guaranteed execution while Computer is asleep** (unchanged from APP-017).
+- **Migrating every `tokio::spawn`** (IO pumps, relay pings, etc.).
+- **Changing APP-017 product schedule semantics** (presets, pause, no backfill)—only the timer/event plumbing moves.
+
+## Success Metrics
+
+- **Leading**: No remaining *product* scheduled loops for automation tick, AI usage auto-refresh, or agent-hooks idle cleanup using raw private intervals outside `infra::jobs`.
+- **Leading**: GitHub (or equivalent) automation event path enqueues via `infra::queue` rather than running full domain work inline on the ingress task (except thin validate + enqueue).
+- **Leading**: Manual run path has zero jobs/queue dependency.
+- **Lagging**: APP-017 schedule scenarios and AI usage interval change/disable remain green.
+- **Qualitative**: Engineers describe “register job / enqueue message,” not “copy the automation interval loop.”
+
+## Risks & Open Questions
+
+- **Risk**: Over-abstracting for cloud early → fat traits. Mitigation: keep ports narrow (see TECH).
+- **Risk**: Dual loops during migration. Mitigation: atomic cutover per registration site.
+- **Risk**: In-memory queue loss on crash after HTTP 2xx. Mitigation: document; rely on provider retry + claim; N3 if product requires stronger durability.
+- **Risk**: Treating queue as MQ in reviews. Mitigation: PRD/TECH state local buffer semantics explicitly.
+- **Open (TECH)**: Queue full policy; exact job id catalog; bootstrap order with `UsageService` (no timer before jobs attach).
+
+## Milestones
+
+- **Phase 1 — Ports + Local adapters + tests** (M1–M5, core of M11).
+- **Phase 2 — Migrate product call sites** (M6–M10, M12) with parity tests.
+- **Phase 3 — Optional** N1–N5 as separate PRs after Phase 2 is green.
+
+## Resolved product forks
+
+| Topic | Decision |
+|-------|----------|
+| v1 engine | **Local only** (no apalis/MQ) |
+| Extensibility | **Trait/adapter seam**; cloud later |
+| Automation schedule | **Meta tick job + domain DB authority** |
+| Manual | **Direct service** |
+| Events | **Queue** |
+| Default retries | **None** for migrated timers unless TECH opts in per job |

--- a/specs/APP/APP-051_infra-jobs/TECH.md
+++ b/specs/APP/APP-051_infra-jobs/TECH.md
@@ -1,0 +1,531 @@
+# TECH · APP-051: Infra Jobs & Queue (Local-First)
+
+> Technical Design · HOW. Implements PRD APP-051 (M1–M12). N1–N5 optional.
+
+## Scope summary
+
+Introduce **two narrow L1 ports** in `crates/infra`:
+
+| Port | Driver | v1 adapter |
+|------|--------|------------|
+| `jobs` | Time (interval; optional cron later) | `LocalScheduler` (Tokio) |
+| `queue` | Events (enqueue → consumer) | `LocalMemoryQueue` (bounded channel) |
+
+Wire them from `apps/api`, migrate product timers and event intake, keep **manual runs direct**.  
+**No apalis, no external MQ in v1.** Future cloud backends are adapter-shaped notes only.
+
+---
+
+## Architecture overview
+
+```text
+┌──────────────────────────────────────────────────────────────────┐
+│ apps/api                                                          │
+│  build LocalScheduler + LocalMemoryQueue                          │
+│  start / inject Arc<dyn Jobs> + Arc<dyn Queue> (or concrete Arc)│
+│  shutdown on process exit                                         │
+└───────────────┬─────────────────────────────┬────────────────────┘
+                │                             │
+                ▼                             ▼
+         jobs port                      queue port
+         (time)                         (events)
+                │                             │
+    ┌───────────┼───────────┐                 │
+    ▼           ▼           ▼                 ▼
+ automation  ai-usage   agent-hooks     github/hooks
+ schedule_   auto_      idle_           consumer →
+ tick job    refresh    cleanup         domain service
+    │
+    ▼
+ domain: next_run_at / pause / start_run  (APP-017)
+                ▲
+ manual Run ────┘  direct service call (no port)
+```
+
+### Layer rules
+
+| Layer | Owns | Must not |
+|-------|------|----------|
+| `infra::jobs` / `queue` | timers, channels, retry *primitives*, lifecycle | automation pause, agent start, GitHub matching, usage providers |
+| `core-service` / `ai-usage` | domain handlers, when to upsert/cancel/enqueue | raw product-level `tokio::interval` loops for migrated sites |
+| `apps/api` | compose adapters, bootstrap order, thin HTTP/WS ingress | long domain work on webhook task when queue path exists |
+
+```text
+apps/api → core-service / ai-usage → infra
+infra does not depend on core-service or ai-usage
+```
+
+---
+
+## Design principles (normative)
+
+1. **Local-first**: v1 adapters are in-process only; correct for single-user Atmos Computer.
+2. **Narrow ports**: Prefer small traits over a mini-Celery API.
+3. **Adapter seam**: Business depends on ports; `apps/api` selects Local implementation. Future `Cloud*` adapters may exist without rewriting domain *rules*, but may require new payload types—**do not claim zero-change cloud swap**.
+4. **Three entry styles**:
+   - **Jobs** — time-driven product work  
+   - **Queue** — external/async event work  
+   - **Direct** — interactive user commands (manual run)
+5. **Automation schedule authority** remains domain DB + `scheduler.rs`; jobs only supply the tick.
+
+---
+
+## Module-by-module design
+
+### crates/infra
+
+```text
+crates/infra/src/
+├── jobs/
+│   ├── mod.rs           # re-exports
+│   ├── types.rs         # JobId, IntervalSpec, RetryPolicy, JobError
+│   ├── port.rs          # trait Jobs
+│   ├── local.rs         # LocalScheduler
+│   └── tests.rs
+├── queue/
+│   ├── mod.rs
+│   ├── types.rs         # Topic, QueueMessage, EnqueueError, ...
+│   ├── port.rs          # trait Queue
+│   ├── local.rs         # LocalMemoryQueue
+│   └── tests.rs
+└── lib.rs               # pub mod jobs; pub mod queue;
+```
+
+Remove “TODO placeholder” comments; document real modules in `crates/infra/AGENTS.md`:
+
+- L1 includes **persistence and local runtime primitives** (db, jobs, queue).
+- NEVER domain business rules inside adapters.
+
+#### Jobs public API (intent)
+
+```rust
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct JobId(pub Arc<str>);
+
+#[derive(Clone, Debug)]
+pub struct IntervalSpec {
+    pub every: Duration,
+    /// Default true for product jobs that must not overlap.
+    pub skip_if_running: bool,
+    /// If true, first run soon after register (automation tick).
+    /// If false, wait one period (AI usage, hooks cleanup — match prior “skip first tick”).
+    pub fire_immediately: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct RetryPolicy {
+    pub max_attempts: u32, // 1 = no extra retries
+    pub initial_delay: Duration,
+    pub max_delay: Duration,
+    pub multiplier: f64,
+}
+
+impl RetryPolicy {
+    pub fn none() -> Self { /* max_attempts = 1 */ }
+}
+
+pub enum JobError {
+    Retryable(String),
+    Fatal(String),
+}
+pub type JobResult = Result<(), JobError>;
+
+#[async_trait]
+pub trait Jobs: Send + Sync {
+    async fn set_interval_job<F, Fut>(
+        &self,
+        id: JobId,
+        spec: IntervalSpec,
+        retry: RetryPolicy,
+        handler: F,
+    ) -> Result<(), JobsError>
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = JobResult> + Send + 'static;
+
+    async fn cancel(&self, id: &JobId) -> Result<(), JobsError>;
+    fn is_registered(&self, id: &JobId) -> bool;
+    async fn shutdown(&self) -> Result<(), JobsError>;
+}
+
+pub struct LocalScheduler { /* private registry + JoinHandles */ }
+
+impl LocalScheduler {
+    pub fn new() -> Self;
+    // implements Jobs
+}
+```
+
+**Semantics:**
+
+- `set_interval_job` with an existing `JobId` **replaces** the previous registration (cancel old, start new).
+- `skip_if_running`: if a tick is still executing, skip starting another (no burst catch-up). Document as intentional vs old `MissedTickBehavior::Burst`.
+- Retry: if `max_attempts > 1`, LocalScheduler wraps a single firing with simple backoff; default for migrated timers is **`RetryPolicy::none()`**.
+- No apalis types in the public surface.
+
+**N1 (optional later):** `set_cron_job(...)` on the same trait—still local.
+
+#### Queue public API (intent)
+
+```rust
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Topic(pub Arc<str>);
+
+/// Opaque bytes or a small enum; prefer typed wrappers in business crates.
+pub struct QueueMessage {
+    pub id: String,              // unique message id (uuid)
+    pub payload: Vec<u8>,        // or Bytes; business serializes JSON
+    pub enqueued_at: DateTime<Utc>,
+}
+
+pub enum EnqueueError {
+    Full,
+    ShuttingDown,
+    // ...
+}
+
+#[async_trait]
+pub trait Queue: Send + Sync {
+    /// Bounded; on full → EnqueueError::Full (v1 default: fail fast, no unbounded growth).
+    async fn enqueue(&self, topic: &Topic, payload: Vec<u8>) -> Result<String /* msg id */, EnqueueError>;
+
+    /// Register a consumer. Multiple consumers optional later; v1: one consumer task per topic is enough.
+    async fn subscribe<F, Fut>(&self, topic: Topic, handler: F) -> Result<(), QueueError>
+    where
+        F: Fn(QueueMessage) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<(), QueueError>> + Send + 'static;
+
+    async fn shutdown(&self) -> Result<(), QueueError>;
+}
+
+pub struct LocalMemoryQueue {
+    // per-topic: mpsc/flume with capacity C
+}
+```
+
+**v1 queue policy (decisive):**
+
+| Concern | Choice |
+|---------|--------|
+| Capacity | Fixed per topic (e.g. 64–256; constant in LocalMemoryQueue builder) |
+| Full behavior | **`EnqueueError::Full`** (ingress logs + returns retryable error to upstream if HTTP) |
+| Persistence | **None** (memory only) |
+| Retry on handler failure | Optional simple re-attempt count inside consumer **or** log + drop; prefer **log + drop** for v1 if domain + GitHub retry cover correctness; document |
+| Ordering | Best-effort FIFO per topic, single consumer |
+
+**Not an MQ:** no consumer groups, no cross-process delivery, no broker.
+
+#### Injection style
+
+Prefer concrete `Arc<LocalScheduler>` / `Arc<LocalMemoryQueue>` in `apps/api` **or** `Arc<dyn Jobs>` / `Arc<dyn Queue>` if object-safety is solved (async trait + boxed futures).  
+
+**Recommendation:** use **concrete Arc types** exported from infra for v1 simplicity; keep logic behind `impl Jobs for LocalScheduler` so a future type can share the trait in tests/mocks.
+
+Provide test helpers: `LocalScheduler::new()`, `LocalMemoryQueue::builder().capacity(16).build()`.
+
+---
+
+### Automations (`core-service`)
+
+#### Schedule tick (M6)
+
+**Keep:**
+
+- `scheduler.rs` — cron math, normalize, preview  
+- DB fields and repo `list_due_scheduled_automations`, pause, etc.  
+- `tick_due_schedules`, `recover_running_runs`, `normalize_missed_schedules`
+
+**Change `start_scheduler`:**
+
+```text
+async fn start_scheduler(self: Arc<Self>, jobs: Arc<LocalScheduler> /* or dyn Jobs */) {
+  recover_running_runs().await?;
+  normalize_missed_schedules().await?;
+  jobs.set_interval_job(
+    JobId::from("automation.schedule_tick"),
+    IntervalSpec {
+      every: Duration::from_secs(30),
+      skip_if_running: true,
+      fire_immediately: true,  // parity with tokio::interval first tick
+    },
+    RetryPolicy::none(),
+    { let this = self.clone(); move || {
+        let this = this.clone();
+        async move {
+          this.tick_due_schedules().await
+            .map_err(|e| JobError::Retryable(e.to_string()))
+        }
+    }},
+  ).await?;
+}
+```
+
+Remove the private `tokio::time::interval` loop from `scheduler_service.rs`.
+
+**Not in v1:** registering one cron job per automation id.
+
+#### Manual run (M7)
+
+Unchanged path: WS/API → `start_run` / equivalent. **No** `jobs` / `queue` calls.
+
+#### GitHub / external triggers (M8)
+
+**Ingress (apps/api or existing trigger module):**
+
+1. Validate request  
+2. Cheap idempotency gate if already claimed (optional pre-check)  
+3. `queue.enqueue(Topic::from("automation.github_delivery"), payload_json)`  
+4. Return success to upstream when enqueue succeeds  
+
+**Consumer (registered at bootstrap from core-service or api):**
+
+- Deserialize payload  
+- Existing domain: delivery claim, match automations, `start_run`  
+- On domain “already processed,” ack as success  
+
+Do not move claim tables into infra.
+
+---
+
+### AI usage (M9)
+
+**Bootstrap order (fixes current `UsageService::new` starting a timer too early):**
+
+1. Construct `UsageService` **without** starting auto-refresh (or with jobs handle optional and inert).  
+2. `jobs` ready.  
+3. `usage.attach_jobs(jobs.clone())` reads persisted interval and `set_interval_job` / `cancel`.  
+4. `set_auto_refresh_interval` only goes through jobs after attach.
+
+```text
+JobId: "ai-usage.auto_refresh"
+IntervalSpec: every = minutes * 60s, skip_if_running: true, fire_immediately: false
+RetryPolicy: none()  // parity with “fail once, wait next interval”
+```
+
+Remove private `JoinHandle` interval path after cutover.
+
+---
+
+### Agent-hooks idle cleanup (M10)
+
+Move `spawn_idle_session_cleanup` in `apps/api/src/main.rs` to:
+
+```text
+JobId: "agent-hooks.idle_session_cleanup"
+every: 5 minutes
+fire_immediately: false  // match current skip first tick
+handler: clear_idle_older_than / clear_stale_active_older_than
+```
+
+---
+
+### apps/api bootstrap
+
+```text
+let jobs = Arc::new(LocalScheduler::new());
+let queue = Arc::new(LocalMemoryQueue::builder().capacity(128).build());
+
+// subscribe queue consumers (github, etc.)
+// construct services with jobs/queue arcs
+// attach ai-usage jobs
+// automation.start_scheduler(jobs.clone()).await
+// register agent-hooks cleanup job
+
+// on shutdown signal:
+jobs.shutdown().await?;
+queue.shutdown().await?;
+// then close DB
+```
+
+Store on `AppState` if useful for future registrations.
+
+---
+
+## Data model
+
+### v1
+
+- **No new SeaORM tables** for jobs/queue.  
+- Automation schedule tables **unchanged** (APP-017).  
+- In-process maps + channels only.
+
+### Future (N3 / cloud) — non-normative
+
+- Durable queue: SQLite outbox table or external broker adapter.  
+- Cloud jobs: may require serializable job payloads; Local’s `'static` closures would not port 1:1.
+
+---
+
+## Job id & topic catalog (v1)
+
+### Jobs
+
+| JobId | Owner | fire_immediately | Notes |
+|-------|--------|------------------|-------|
+| `automation.schedule_tick` | core-service | true | 30s due poll |
+| `ai-usage.auto_refresh` | ai-usage | false | replace on config change |
+| `agent-hooks.idle_session_cleanup` | apps/api + AgentHooksService | false | 5m |
+
+### Queue topics
+
+| Topic | Producer | Consumer |
+|-------|----------|----------|
+| `automation.github_delivery` | API/webhook ingress | automation github trigger domain |
+
+Add new product ids to this catalog (or AGENTS) when introduced.
+
+---
+
+## Scheduled / event inventory (M12)
+
+### Migrate
+
+| Site | Mechanism today | Target |
+|------|-----------------|--------|
+| Automation schedule tick | `scheduler_service` interval | **jobs** |
+| AI usage auto-refresh | `service.rs` JoinHandle interval | **jobs** |
+| Agent-hooks idle cleanup | `main.rs` `spawn_idle_session_cleanup` | **jobs** |
+| GitHub automation delivery | inline / ad-hoc async in trigger path | **queue** |
+
+### Do not migrate
+
+| Site | Reason |
+|------|--------|
+| Relay ingest ping interval | Connection keepalive |
+| PTY / stream reader spawns | Long-lived IO |
+| Request-scoped `tokio::spawn` in WS handlers | One-shot request work |
+| Automation process_runner cancel poll (~500ms) | Per-run supervision, not product schedule |
+| Manual automation run | Direct service (M7) |
+
+---
+
+## Transport
+
+No new user-facing WS/REST for job/queue admin.  
+Webhook/HTTP for GitHub remains; body handling becomes validate + enqueue.
+
+---
+
+## Observability
+
+- `tracing` fields: `job_id` / `topic` / `msg_id` / `duration_ms` / `outcome`.  
+- Queue full: `warn!` + metric-friendly log.  
+- Do not log secrets (cookies, tokens) from AI usage or webhook bodies at error level without redaction.
+
+---
+
+## Rollout plan
+
+1. **Infra ports + Local adapters + unit tests** (`cargo test -p infra`). Export from `lib.rs`. Update `crates/infra/AGENTS.md`.
+2. **API bootstrap** empty consumers/jobs (runtime up, no product migration).
+3. **Migrate AI usage** (attach_jobs + parity tests).
+4. **Migrate agent-hooks cleanup**.
+5. **Migrate automation schedule tick** (`fire_immediately: true`, recover→normalize→register order).
+6. **Migrate GitHub path to queue** (enqueue + consumer; claim semantics preserved).
+7. **Docs**: root/`crates` AGENTS decision tree — scheduled → jobs, events → queue, interactive → direct.
+
+Atomic cutover per site; no dual interval loops.
+
+---
+
+## Future cloud adapters (N4, non-ship)
+
+Document only:
+
+```text
+trait Jobs / Queue remain the business dependency.
+CloudJobs / CloudQueue would implement the same traits with:
+  - serializable payloads (handlers re-bound in worker processes)
+  - durable storage / broker
+  - different cancel semantics (best-effort)
+Migration may require business payload DTOs; not free.
+```
+
+v1 **must not** implement these.
+
+---
+
+## Risks & tradeoffs
+
+| Item | Mitigation |
+|------|------------|
+| Memory queue drop on crash after 2xx | GitHub retries + domain claim; N3 if needed |
+| Queue full | Bounded + Full error; ingress returns retryable |
+| `skip_if_running` vs old Burst catch-up | Intentional; lag ≤ interval + tick duration |
+| Over-wide traits for “cloud ready” | Keep API minimal; evolve when cloud exists |
+| UsageService early timer | attach_jobs bootstrap order (M9) |
+| Dual source of truth if per-automation jobs | Explicitly not doing that in v1 |
+
+**Rollback:** revert call-site PRs; Local adapters can remain unused.
+
+**Tradeoff — meta tick vs per-automation job:** Meta tick matches APP-017 authority and single-process cost model; chosen as optimal for Atmos.
+
+**Tradeoff — no apalis/MQ:** Correct for local app scale; re-evaluate only with multi-instance cloud requirements.
+
+---
+
+## Testing (see TEST.md)
+
+- Unit: LocalScheduler register/cancel/replace/skip_if_running/shutdown.  
+- Unit: LocalMemoryQueue enqueue/subscribe/full/shutdown.  
+- Service: automation tick parity; AI usage attach/replace/disable; hooks job registered.  
+- Queue: github payload consumer calls domain (mock).  
+- Static: no raw interval at migrated sites; manual path free of queue/jobs.
+
+---
+
+## Dependencies & compatibility
+
+- **No new heavy deps required** for v1 (Tokio already in infra). Optional: `flume` if preferred over `tokio::sync::mpsc`.  
+- Depends on APP-017/019 behavior remaining stable.  
+- `ai-usage` already depends on `infra` — OK for jobs port.
+
+---
+
+## AGENTS updates (implementation checklist)
+
+| File | Change |
+|------|--------|
+| `crates/infra/AGENTS.md` | jobs/queue real; local adapters; NEVER domain rules |
+| Root / `crates/AGENTS.md` | Decision: time → jobs, events → queue, interactive → direct |
+| `core-service` / `ai-usage` AGENTS | Point at ports for timers |
+
+---
+
+## Open questions
+
+- [x] Engine = Local  
+- [x] Automation = meta tick  
+- [x] Manual = direct  
+- [x] Events = queue  
+- [x] Default retry = none  
+- [x] Queue full = error  
+- [ ] Exact default capacity number (suggest **128**) — confirm at impl if needed  
+- [ ] Object-safe dyn vs concrete Arc — prefer concrete Arc + trait for tests  
+
+---
+
+## Pseudocode reference
+
+```rust
+// apps/api
+let jobs = Arc::new(LocalScheduler::new());
+let queue = Arc::new(LocalMemoryQueue::builder().capacity(128).build());
+
+queue.subscribe(Topic::from("automation.github_delivery"), {
+  let automation = automation.clone();
+  move |msg| {
+    let automation = automation.clone();
+    async move { automation.handle_github_queue_message(msg.payload).await }
+  }
+}).await?;
+
+automation.start_scheduler(jobs.clone()).await?;
+usage.attach_jobs(jobs.clone()).await?;
+jobs.set_interval_job(
+  JobId::from("agent-hooks.idle_session_cleanup"),
+  IntervalSpec { every: Duration::from_secs(300), skip_if_running: true, fire_immediately: false },
+  RetryPolicy::none(),
+  { /* clear idle */ },
+).await?;
+```

--- a/specs/APP/APP-051_infra-jobs/TEST.md
+++ b/specs/APP/APP-051_infra-jobs/TEST.md
@@ -1,0 +1,297 @@
+# TEST · APP-051: Infra Jobs & Queue (Local-First)
+
+> Test Plan · verify local `jobs` / `queue` ports, migrations, and entry-style rules (jobs vs queue vs direct). References PRD APP-051 and TECH APP-051.
+
+## Test strategy
+
+Backend infrastructure. Proof is **Rust unit tests** in `infra` plus **service-level** parity tests. No new user UI; no Playwright required. No agent-browser checks.
+
+- **Unit (`infra`)**: LocalScheduler + LocalMemoryQueue behavior.
+- **Service**: automation tick wiring, AI usage attach/replace, agent-hooks job, github queue consumer (mocked domain).
+- **Static / review**: inventory, no dual loops, manual path free of ports.
+- **Manual (optional)**: local smoke of schedule + refresh + webhook enqueue.
+
+## Coverage map
+
+| PRD item | Scenario IDs |
+|----------|--------------|
+| M1 Jobs port | S1, S2 |
+| M2 Queue port | S10, S11 |
+| M3 Local jobs | S1–S7 |
+| M4 Local queue | S10–S13 |
+| M5 Lifecycle | S7, S13 |
+| M6 Automation tick | S14, S15, S16 |
+| M7 Manual direct | S17 |
+| M8 Events via queue | S18, S19 |
+| M9 AI usage | S20, S21, S22 |
+| M10 Agent-hooks cleanup | S23 |
+| M11 Layering | S24 |
+| M12 Inventory | S25 |
+| N1–N5 | deferred |
+
+## Execution map
+
+| Scenario | Level | Expected tool | Target command / method | Fixture / data | Signals | Status |
+|----------|-------|---------------|-------------------------|----------------|---------|--------|
+| S1 | Rust unit | `cargo test -p infra` | interval fires | short interval | counter ≥ 2 | planned |
+| S2 | Rust unit / API | `cargo test -p infra` | public surface | exports | no apalis/mq deps in infra for v1 | planned |
+| S3 | Rust unit | `cargo test -p infra` | cancel | running job | counter stops | planned |
+| S4 | Rust unit | `cargo test -p infra` | replace same id | two specs | single active cadence | planned |
+| S5 | Rust unit | `cargo test -p infra` | skip_if_running | long handler | no overlap starts | planned |
+| S6 | Rust unit | `cargo test -p infra` | fire_immediately true/false | both specs | true runs soon; false waits | planned |
+| S7 | Rust unit | `cargo test -p infra` | jobs shutdown | running job | clean stop | planned |
+| S10 | Rust unit | `cargo test -p infra` | enqueue + consume | capacity 8 | handler sees payload | planned |
+| S11 | Rust unit | `cargo test -p infra` | queue full | fill capacity | `EnqueueError::Full` | planned |
+| S12 | Rust unit | `cargo test -p infra` | FIFO best-effort | ordered msgs | order preserved with 1 consumer | planned |
+| S13 | Rust unit | `cargo test -p infra` | queue shutdown | active consumer | clean stop | planned |
+| S14 | Service | `cargo test -p core-service` | due tick via jobs wiring | due automation | run / next_run advanced | planned |
+| S15 | Service | `cargo test -p core-service` | pause / already_running | fixtures | domain rules hold | planned |
+| S16 | Service / static | `cargo test` + `rg` | no raw interval in scheduler_service | source | jobs registration only | planned |
+| S17 | Service / static | `rg` + existing tests | manual run path | start_run API | no enqueue/set_interval in path | planned |
+| S18 | Service / API | `cargo test` | enqueue on github ingress | mock queue | message enqueued | planned |
+| S19 | Service | `cargo test` | consumer → domain | payload fixture | claim/start path invoked | planned |
+| S20 | Service | `cargo test -p ai-usage` | attach_jobs enables refresh | short interval / mock | refresh runs | planned |
+| S21 | Service | `cargo test -p ai-usage` | change interval | replace | one registration | planned |
+| S22 | Service | `cargo test -p ai-usage` | disable | cancel | no further refresh | planned |
+| S23 | Unit / integration | `cargo test` or api test | hooks cleanup job | jobs registry | id registered; no main.rs raw loop | planned |
+| S24 | Static | `rg` | jobs/queue modules | infra | no domain imports | planned |
+| S25 | Static | `rg` / review | inventory | relay/pty/manual | non-migrate list respected | planned |
+
+## Scenarios
+
+### S1 — Interval job fires
+
+- **Level**: Unit (`infra`)
+- **Given**: `LocalScheduler`, job every ~50–100ms, atomic counter handler, `fire_immediately: true`.
+- **When**: wait ≥ 2 periods.
+- **Then**: counter ≥ 2.
+- **Signals**: counter; test completes.
+
+### S2 — No distributed job/MQ dependency in v1
+
+- **Level**: Unit / crate deps
+- **Given**: `crates/infra/Cargo.toml` after implementation.
+- **When**: inspected.
+- **Then**: no apalis / lapin / redis-streams / nats required for default features.
+- **Signals**: Cargo.toml; build graph.
+
+### S3 — Cancel stops future ticks
+
+- **Level**: Unit
+- **Given**: running interval job.
+- **When**: `cancel(id)`.
+- **Then**: counter stable across former periods.
+- **Signals**: counter.
+
+### S4 — Replace-by-id
+
+- **Level**: Unit
+- **Given**: job `demo` registered.
+- **When**: `set_interval_job` again with same id and different generation marker.
+- **Then**: only new handler generation runs.
+- **Signals**: generation atomic.
+
+### S5 — skip_if_running
+
+- **Level**: Unit
+- **Given**: handler sleeps longer than `every`, `skip_if_running: true`.
+- **When**: multiple periods elapse during one run.
+- **Then**: concurrent executions do not stack (in-flight ≤ 1).
+- **Signals**: concurrency gauge.
+
+### S6 — fire_immediately semantics
+
+- **Level**: Unit
+- **Given**: two jobs, true vs false, same short period.
+- **When**: register both.
+- **Then**: true increments before one full period; false does not until ~one period.
+- **Signals**: timestamps / counters.
+
+### S7 — Jobs shutdown
+
+- **Level**: Unit
+- **Given**: running job(s).
+- **When**: `shutdown()`.
+- **Then**: completes without panic; no further handler calls.
+- **Signals**: `Result::Ok`; counter stable.
+
+### S10 — Enqueue and consume
+
+- **Level**: Unit (`infra`)
+- **Given**: `LocalMemoryQueue` capacity ≥ 1; subscribed handler.
+- **When**: `enqueue(topic, payload)`.
+- **Then**: handler receives equal payload.
+- **Signals**: oneshot/channel assertion.
+
+### S11 — Queue full
+
+- **Level**: Unit
+- **Given**: capacity N; no consumer (or stuck consumer).
+- **When**: N+1 enqueues without drain.
+- **Then**: at least one `EnqueueError::Full` (or after buffer filled).
+- **Signals**: error variant.
+
+### S12 — Ordering with single consumer
+
+- **Level**: Unit
+- **Given**: consumer records order.
+- **When**: enqueue 1..k quickly.
+- **Then**: processed order is 1..k.
+- **Signals**: vec equality.
+
+### S13 — Queue shutdown
+
+- **Level**: Unit
+- **Given**: active subscribe.
+- **When**: `shutdown()`.
+- **Then**: clean; further enqueue fails with shutting down (or documented error).
+- **Signals**: result codes.
+
+### S14 — Automation due run via jobs-wired tick
+
+- **Level**: Service
+- **Given**: scheduled automation due; scheduler started with `LocalScheduler` (not only direct `tick_due_schedules` bypass).
+- **When**: first tick (immediate) or short test interval.
+- **Then**: run starts or domain start-failure rules apply; `next_run_at` advances when scheduled.
+- **Signals**: DB/run fixtures; existing APP-017 assertions updated for jobs wiring.
+
+### S15 — Pause and already_running unchanged
+
+- **Level**: Service
+- **Given**: paused automation or active run.
+- **When**: tick fires.
+- **Then**: no illegal double start; paused not started.
+- **Signals**: existing validation.
+
+### S16 — No raw schedule interval loop
+
+- **Level**: Service + static
+- **Given**: migrated `scheduler_service.rs`.
+- **When**: `rg` / review.
+- **Then**: no product `tokio::time::interval` loop for schedule tick; recover → normalize → `set_interval_job` order preserved.
+- **Signals**: source structure.
+
+### S17 — Manual run does not use jobs/queue
+
+- **Level**: Service + static
+- **Given**: manual run entrypoints.
+- **When**: reviewed / tested.
+- **Then**: path calls service start directly; no `enqueue` / `set_interval_job` for that action.
+- **Signals**: `rg` on call path; unit/service tests still pass.
+
+### S18 — GitHub ingress enqueues
+
+- **Level**: Service / API
+- **Given**: mock `Queue` recording enqueues.
+- **When**: valid delivery hits ingress.
+- **Then**: one message on `automation.github_delivery` (or catalog topic); ingress does not run full start_run inline.
+- **Signals**: mock enqueue count.
+
+### S19 — Consumer invokes domain
+
+- **Level**: Service
+- **Given**: enqueued payload; consumer registered.
+- **When**: message processed.
+- **Then**: domain handler/claim/start path invoked once per new delivery.
+- **Signals**: mock service; claim table if used.
+
+### S20 — AI usage attach_jobs
+
+- **Level**: Service
+- **Given**: service constructed without running timer; interval configured; `attach_jobs`.
+- **When**: period elapses (`fire_immediately: false` respected).
+- **Then**: refresh runs and publishes.
+- **Signals**: mock provider / broadcast.
+
+### S21 — AI usage interval replace
+
+- **Level**: Service
+- **Given**: auto-refresh on.
+- **When**: interval changed.
+- **Then**: single job id registration; old cadence gone.
+- **Signals**: scheduler `is_registered`; generation.
+
+### S22 — AI usage disable
+
+- **Level**: Service
+- **Given**: auto-refresh on.
+- **When**: interval `None`.
+- **Then**: job cancelled; no further refresh.
+- **Signals**: cancel + counter stop.
+
+### S23 — Agent-hooks cleanup on jobs
+
+- **Level**: Integration / static
+- **Given**: API bootstrap after migration.
+- **When**: inspect registration / source.
+- **Then**: `agent-hooks.idle_session_cleanup` registered via jobs; `spawn_idle_session_cleanup` raw loop removed from main.
+- **Signals**: `rg`; optional test that job id is registered.
+
+### S24 — Layering
+
+- **Level**: Static
+- **Given**: `infra/src/jobs/**`, `infra/src/queue/**`.
+- **When**: import review.
+- **Then**: no automation/agent/usage domain modules imported.
+- **Signals**: `rg`.
+
+### S25 — Inventory non-migration
+
+- **Level**: Review
+- **Given**: TECH do-not-migrate list.
+- **When**: PR diff.
+- **Then**: relay ping, PTY pumps, process_runner cancel poll, manual run not force-moved into jobs/queue incorrectly.
+- **Signals**: review checklist.
+
+## Performance & load budgets
+
+- Unit tests use short intervals (ms) where possible.
+- Queue capacity tests must not hang (timeout).
+- Automation 30s period not used as real sleep in default unit tests—inject short period or call tick via jobs with test interval if scheduler allows override in tests.
+
+## Regression checklist
+
+- [ ] recover_running_runs + normalize_missed_schedules still run **before** first automation tick registration completes its first due scan order as today.
+- [ ] Automation start-failure still **pauses schedule** (domain), not infinite job retry.
+- [ ] No dual automation tick loops.
+- [ ] UsageService does not start a private timer before `attach_jobs`.
+- [ ] GitHub duplicate delivery still idempotent via claim/domain.
+- [ ] Manual run latency/error shape unchanged (sync validation errors still returned).
+- [ ] Shutdown does not hang on jobs/queue.
+
+## Exploratory agent-browser checks
+
+None (no UI surface).
+
+## Acceptance criteria
+
+- [ ] M1–M12 each have scenario coverage paths above.
+- [ ] `cargo test -p infra` covers S1–S7 and S10–S13 (or documented equivalents).
+- [ ] Migrated product sites have passing service/static proof (S14–S23).
+- [ ] No apalis/external MQ required for v1 default build.
+- [ ] AGENTS docs updated (jobs/queue ports; entry-style rules).
+- [ ] Scoped `cargo test` / clippy on `infra`, `core-service`, `ai-usage`, `api` pass.
+- [ ] Coverage Status filled by `atmos-specs-test-run` after implementation.
+
+## Manual verification steps
+
+Optional:
+
+1. `just dev-api` — enable AI usage 1m refresh; confirm updates without errors.
+2. Near-term scheduled automation fires once; pause stops further scheduled starts.
+3. Manual Run still immediate with clear errors.
+4. GitHub (or fixture) delivery: ingress returns promptly; run/claim occurs via consumer path.
+5. Clean process shutdown.
+
+## Non-coverage
+
+- Cloud/distributed adapters.
+- Durable SQLite queue (N3).
+- Per-automation cron job registration.
+- Job/queue admin UI.
+- Load tests for thousands of topics.
+- Exactly-once cross-process delivery.
+
+## Coverage Status
+
+> Filled after implementation by `atmos-specs-test-run`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -128,6 +128,7 @@ These files are not requirements sources. Requirements live in `PRD.md`, archite
 | **APP-048** | API Types (`@atmos/api-types` main `/ws` wire types; Rust enum drift) | `specs/APP/APP-048_api-types/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
 | **APP-049** | API Client (`@atmos/api-client` WS session kernel; app-owned URL/auth) | `specs/APP/APP-049_api-client/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
 | **APP-050** | Shared Package Layering (roles, edges, AGENTS rewrite, cheap gate) | `specs/APP/APP-050_shared-package-layering/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
+| **APP-051** | Infra Jobs & Queue (local-first ports; timers + events; no apalis/MQ in v1) | `specs/APP/APP-051_infra-jobs/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
 | **QUALITY-001** | Large File Code Debt Cleanup | `specs/APP/QUALITY-001_large-file-code-debt-cleanup/` (`TECH.md`, `TEST.md`) |
 | **QUALITY-002** | Spec Test Execution Loop | `specs/APP/QUALITY-002_spec-test-execution-loop/` (`TECH.md`, `TEST.md`) |
 | **QUALITY-003** | Playwright E2E Harness | `specs/APP/QUALITY-003_playwright-e2e-harness/` (`TECH.md`, `TEST.md`) |


### PR DESCRIPTION
## Summary

- Implement APP-051 local-first `infra::jobs` (`LocalScheduler`) and `infra::queue` (`LocalMemoryQueue` via Tokio mpsc).
- Migrate product timers: automation schedule tick, AI usage auto-refresh, agent-hooks idle cleanup.
- Route GitHub external automation events through the queue (consumer → domain) while preserving ACK outcomes via reply waiters.
- Manual automation run remains a direct service call; no apalis/external MQ in v1.
- Specs: `specs/APP/APP-051_infra-jobs/` + inventory in `specs/README.md`.

## Related Issue

N/A (APP-051)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] `cargo test -p infra -p ai-usage -p core-service --lib`
- [x] `cargo clippy -p infra -p ai-usage -p core-service -p api -- -D warnings`
- [x] Static inventory: no dual intervals at migrated sites; no apalis dep

## Checklist

- [x] I updated documentation if behavior changed (`crates/infra/AGENTS.md`, APP-051 specs)
- [x] I added/updated tests where appropriate (infra jobs/queue unit tests; ai-usage attach_jobs)
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds local-first `infra::jobs` (`LocalScheduler`) and `infra::queue` (`LocalMemoryQueue`) per APP-051 to unify timers and event processing; migrates automation schedule tick, AI usage auto-refresh, agent-hook cleanup, and GitHub external events to these ports. Also hardens shutdown and GitHub ACK correlation with unique reply envelopes.

- New Features
  - `LocalScheduler`: named interval jobs with cancel/replace, optional retry, and graceful shutdown.
  - `LocalMemoryQueue`: bounded per-topic mpsc; consumer handlers; reply waiters on `automation.github_delivery` for ACK parity.
  - Wired in `apps/api`: starts scheduler/queue and registers product jobs and the GitHub consumer; specs/tests under `specs/APP/APP-051_infra-jobs/` and `crates/infra`.

- Bug Fixes
  - Drain and stop jobs/queue on shutdown with a timeout before aborting tasks.
  - Use unique `reply_id` per GitHub delivery to ensure safe request/response correlation.

<sup>Written for commit 4ef572160d2a2e3811867d25cf93dcc8f1871f45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local background job scheduling with cancellation, retries, overlap prevention, and graceful shutdown.
  * Added bounded in-memory event queues for reliable asynchronous processing.
  * GitHub automation events are now queued and correlated with processing results.
  * AI usage refresh, automation scheduling, and agent-hook cleanup use the shared scheduler.

* **Documentation**
  * Added product, technical, and testing specifications for local jobs and queues.
  * Documented infrastructure conventions, lifecycle behavior, and safety guidelines.

* **Tests**
  * Added coverage for scheduling, retries, cancellation, queue behavior, shutdown, and usage refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->