### PR TITLE
fix(release): sync Electron desktop to Homebrew and R2

### DIFF
--- a/.github/workflows/sync-homebrew-tap.yml
+++ b/.github/workflows/sync-homebrew-tap.yml
@@ -9,26 +9,36 @@ on:
       - published
   workflow_run:
     workflows:
+      # Production Electron desktop ship path
+      - Desktop Electron CI & Release
+      # Legacy Tauri emergency rebuilds only
+      - Desktop CI & Release (DEPRECATED Tauri)
       - Desktop CI & Release
     types:
       - completed
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Desktop release tag to sync (example: desktop-2026.7.2)"
+        description: "Desktop release tag to sync (example: desktop-electron-2026.7.2)"
         required: false
 
 jobs:
   sync-homebrew-tap:
     name: Update shared homebrew-tap
     # Allow stable desktop releases and explicit manual dispatch.
-    # Prerelease detection (e.g. desktop-2026.7.2-rc.1, -beta.x, -alpha.x) for
-    # the workflow_run path is enforced inside the "Resolve release tag" step
-    # because GitHub Actions expressions cannot match the calendar prerelease shape.
+    # Prerelease detection for the workflow_run path is enforced inside the
+    # "Resolve release tag" step (Actions expressions cannot match the calendar
+    # prerelease shape cleanly for both tag prefixes).
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'desktop-') && github.event.release.prerelease == false) ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && startsWith(github.event.workflow_run.head_branch, 'desktop-'))
+      (github.event_name == 'release' &&
+       (startsWith(github.event.release.tag_name, 'desktop-electron-') ||
+        startsWith(github.event.release.tag_name, 'desktop-')) &&
+       github.event.release.prerelease == false) ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       startsWith(github.event.workflow_run.head_branch, 'desktop-'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -42,6 +52,8 @@ jobs:
         id: release
         shell: bash
         run: |
+          set -euo pipefail
+
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             TAG="${{ github.event.inputs.release_tag }}"
             if [ -z "$TAG" ]; then
@@ -50,20 +62,19 @@ jobs:
             fi
           elif [ "${{ github.event_name }}" = "workflow_run" ]; then
             TAG="${{ github.event.workflow_run.head_branch }}"
-            if [[ ! "$TAG" =~ ^desktop-[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
-              echo "workflow_run event but branch is not a desktop tag: $TAG"
-              exit 1
-            fi
           else
             TAG="${{ github.event.release.tag_name }}"
           fi
 
-          if [[ ! "$TAG" =~ ^desktop-[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
-            echo "Only desktop-<YYYY.M.D> tags are supported. Got: $TAG"
+          # Prefer Electron production tags; keep legacy Tauri `desktop-*`.
+          if [[ "$TAG" =~ ^desktop-electron-[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            VERSION="${TAG#desktop-electron-}"
+          elif [[ "$TAG" =~ ^desktop-[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            VERSION="${TAG#desktop-}"
+          else
+            echo "Only desktop-electron-<YYYY.M.D> (or legacy desktop-<YYYY.M.D>) tags are supported. Got: $TAG"
             exit 1
           fi
-
-          VERSION="${TAG#desktop-}"
 
           # Skip calendar prereleases on the workflow_run path so they do not
           # overwrite the stable cask. workflow_dispatch is always allowed

--- a/.github/workflows/sync-r2.yml
+++ b/.github/workflows/sync-r2.yml
@@ -8,6 +8,10 @@ on:
     types: [published]
   workflow_run:
     workflows:
+      # Production Electron desktop ship path
+      - Desktop Electron CI & Release
+      # Legacy Tauri emergency rebuilds only
+      - Desktop CI & Release (DEPRECATED Tauri)
       - Desktop CI & Release
       - CLI Release
       - Local Runtime Release
@@ -16,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Release tag to sync (e.g., desktop-2026.7.2)'
+        description: 'Release tag to sync (e.g., desktop-electron-2026.7.2)'
         required: true
 
 env:
@@ -65,7 +69,8 @@ jobs:
           fi
 
           SKIP_ASSETS=false
-          if [[ ! "$TAG" =~ ^(desktop|cli|local-web-runtime)-[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+          # desktop-electron-* is production; desktop-* is legacy Tauri.
+          if [[ ! "$TAG" =~ ^(desktop-electron|desktop|cli|local-web-runtime)-[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
             if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "workflow_run" ]; then
               echo "Unsupported release tag: $TAG" >&2
               exit 1
@@ -78,7 +83,9 @@ jobs:
             exit 0
           fi
 
+          # Order matters: desktop-electron- must be checked before desktop-.
           case "$TAG" in
+            desktop-electron-*) VERSION="${TAG#desktop-electron-}" ;;
             desktop-*) VERSION="${TAG#desktop-}" ;;
             cli-*) VERSION="${TAG#cli-}" ;;
             local-web-runtime-*) VERSION="${TAG#local-web-runtime-}" ;;
@@ -304,14 +311,38 @@ jobs:
           TAG: ${{ needs.resolve-release.outputs.tag }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [[ ! "$TAG" =~ ^desktop-[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}$ ]]; then
+          set -euo pipefail
+          # Production Electron: desktop-electron-YYYY.M.D
+          # Legacy Tauri emergency: desktop-YYYY.M.D
+          if [[ "$TAG" =~ ^desktop-electron-[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}$ ]]; then
+            KIND=electron
+          elif [[ "$TAG" =~ ^desktop-[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}$ ]]; then
+            KIND=tauri
+          else
             echo "Unexpected desktop release tag: $TAG" >&2
             exit 1
           fi
-          echo "Downloading assets for tag: $TAG"
-          gh release download "$TAG" --dir /tmp/assets --pattern "*.app.tar.gz"
+          mkdir -p /tmp/assets
+          echo "Downloading assets for tag: $TAG (kind=$KIND)"
+          if [ "$KIND" = "electron" ]; then
+            # Electron ship path: versioned dmg/zip/exe/AppImage (no .app.tar.gz).
+            gh release download "$TAG" --dir /tmp/assets \
+              --pattern "*.dmg" \
+              --pattern "*.zip" \
+              --pattern "*-setup.exe" \
+              --pattern "*.AppImage"
+          else
+            # Legacy Tauri installer used by install-desktop.sh historically.
+            gh release download "$TAG" --dir /tmp/assets --pattern "*.app.tar.gz"
+          fi
+          # Drop intermediate updater blockmaps from public mirror paths.
+          find /tmp/assets -maxdepth 1 -type f -name '*.blockmap' -delete || true
           echo "Downloaded files:"
           ls -la /tmp/assets/
+          if [ -z "$(find /tmp/assets -mindepth 1 -maxdepth 1 -type f -print -quit)" ]; then
+            echo "❌ No desktop assets downloaded for $TAG" >&2
+            exit 1
+          fi
 
       - name: Configure AWS CLI for R2
         env:
@@ -345,27 +376,89 @@ jobs:
         env:
           AWS_ENDPOINT_URL: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
           TAG: ${{ needs.resolve-release.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           echo "Checking if this is the latest desktop release..."
-          LATEST_TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100" | python3 -c 'import json,re,sys; prefix="desktop-"; candidates=[(tuple(map(int, tag[len(prefix):].split("."))), tag) for release in json.load(sys.stdin) for tag in [str(release.get("tag_name") or "")] if not release.get("draft") and not release.get("prerelease") and tag.startswith(prefix) and re.fullmatch(r"\d{4}\.\d{1,2}\.\d{1,2}", tag[len(prefix):])]; print(max(candidates)[1] if candidates else "")')
+          # Prefer production Electron tags; fall back to legacy Tauri tags only if
+          # no stable Electron release exists.
+          LATEST_TAG=$(
+            curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${REPO}/releases?per_page=100" \
+            | python3 -c '
+import json, re, sys
+
+releases = json.load(sys.stdin)
+
+def candidates(prefix):
+    out = []
+    for release in releases:
+        tag = str(release.get("tag_name") or "")
+        if release.get("draft") or release.get("prerelease"):
+            continue
+        if not tag.startswith(prefix):
+            continue
+        version = tag[len(prefix):]
+        if not re.fullmatch(r"\d{4}\.\d{1,2}\.\d{1,2}", version):
+            continue
+        parts = tuple(int(p) for p in version.split("."))
+        out.append((parts, tag))
+    return out
+
+electron = candidates("desktop-electron-")
+legacy = candidates("desktop-")
+# Drop legacy tags that are actually electron (startswith desktop- matches both).
+legacy = [(p, t) for (p, t) in legacy if not t.startswith("desktop-electron-")]
+pool = electron or legacy
+print(max(pool)[1] if pool else "")
+'
+          )
 
           echo "Latest stable desktop release: ${LATEST_TAG}"
           echo "Current release being synced: ${TAG}"
 
-          if [[ "$TAG" == "$LATEST_TAG" ]]; then
-            echo "This is the latest stable desktop release, updating latest path..."
+          if [[ "$TAG" != "$LATEST_TAG" ]]; then
+            echo "This is not the latest stable desktop release, skipping latest path update"
+            exit 0
+          fi
+
+          echo "This is the latest stable desktop release, updating latest path..."
+          if [[ "$TAG" == desktop-electron-* ]]; then
+            # install-desktop.sh expects unversioned zip names under desktop/latest/.
+            shopt -s nullglob
+            for file in /tmp/assets/Atmos_*_aarch64.zip /tmp/assets/Atmos_*_x64.zip; do
+              base="$(basename "$file")"
+              if [[ "$base" == *_aarch64.zip ]]; then
+                dest="Atmos_aarch64.zip"
+              else
+                dest="Atmos_x64.zip"
+              fi
+              aws s3 cp "$file" "s3://${{ secrets.CLOUDFLARE_R2_BUCKET }}/desktop/latest/${dest}" \
+                --endpoint-url "$AWS_ENDPOINT_URL" \
+                --cache-control "public, max-age=60"
+              echo "  $base → latest/${dest}"
+            done
+            # Also mirror full installer set under latest/ with original names for
+            # landing/custom-domain links that reuse release asset names.
+            for file in /tmp/assets/*; do
+              [ -f "$file" ] || continue
+              aws s3 cp "$file" "s3://${{ secrets.CLOUDFLARE_R2_BUCKET }}/desktop/latest/$(basename "$file")" \
+                --endpoint-url "$AWS_ENDPOINT_URL" \
+                --cache-control "public, max-age=60"
+            done
+          else
             for file in /tmp/assets/*.app.tar.gz; do
-              aws s3 cp "$file" s3://${{ secrets.CLOUDFLARE_R2_BUCKET }}/desktop/latest/$(basename "$file") \
-                --endpoint-url $AWS_ENDPOINT_URL \
+              aws s3 cp "$file" "s3://${{ secrets.CLOUDFLARE_R2_BUCKET }}/desktop/latest/$(basename "$file")" \
+                --endpoint-url "$AWS_ENDPOINT_URL" \
                 --cache-control "public, max-age=60" || {
                 echo "Failed to copy $file to latest"
                 exit 1
               }
             done
-            echo "Successfully updated latest files"
-          else
-            echo "This is not the latest stable desktop release, skipping latest path update"
           fi
+          echo "Successfully updated latest files"
 
   sync-local-web-runtime:
     needs: resolve-release
@@ -487,6 +580,25 @@ jobs:
 
           FILES=()
           case "$TAG" in
+            desktop-electron-*)
+              VERSION="${TAG#desktop-electron-}"
+              FILES+=(
+                "${PUBLIC_DOWNLOAD_BASE_URL}/desktop/latest/Atmos_aarch64.zip"
+                "${PUBLIC_DOWNLOAD_BASE_URL}/desktop/latest/Atmos_x64.zip"
+                "${PUBLIC_DOWNLOAD_BASE_URL}/desktop/latest/Atmos_${VERSION}_aarch64.dmg"
+                "${PUBLIC_DOWNLOAD_BASE_URL}/desktop/latest/Atmos_${VERSION}_x64.dmg"
+                "${PUBLIC_DOWNLOAD_BASE_URL}/desktop/latest/Atmos_${VERSION}_aarch64.zip"
+                "${PUBLIC_DOWNLOAD_BASE_URL}/desktop/latest/Atmos_${VERSION}_x64.zip"
+                "${PUBLIC_DOWNLOAD_BASE_URL}/desktop/latest/Atmos_${VERSION}_x64-setup.exe"
+                "${PUBLIC_DOWNLOAD_BASE_URL}/desktop/latest/Atmos_${VERSION}_x64.AppImage"
+                "${PUBLIC_DOWNLOAD_BASE_URL}/desktop/${TAG}/Atmos_${VERSION}_aarch64.dmg"
+                "${PUBLIC_DOWNLOAD_BASE_URL}/desktop/${TAG}/Atmos_${VERSION}_x64.dmg"
+                "${PUBLIC_DOWNLOAD_BASE_URL}/desktop/${TAG}/Atmos_${VERSION}_aarch64.zip"
+                "${PUBLIC_DOWNLOAD_BASE_URL}/desktop/${TAG}/Atmos_${VERSION}_x64.zip"
+                "${PUBLIC_DOWNLOAD_BASE_URL}/desktop/${TAG}/Atmos_${VERSION}_x64-setup.exe"
+                "${PUBLIC_DOWNLOAD_BASE_URL}/desktop/${TAG}/Atmos_${VERSION}_x64.AppImage"
+              )
+              ;;
             desktop-*)
               FILES+=(
                 "${PUBLIC_DOWNLOAD_BASE_URL}/desktop/latest/Atmos_aarch64.app.tar.gz"

--- a/apps/landing/src/lib/github-desktop-release.ts
+++ b/apps/landing/src/lib/github-desktop-release.ts
@@ -1,7 +1,15 @@
 export const GITHUB_REPO_PATH = "/AruNi-01/atmos";
 export const GITHUB_RELEASES_URL = `https://github.com${GITHUB_REPO_PATH}/releases`;
-export const DESKTOP_RELEASE_TAG_PREFIX = "desktop-";
-const DESKTOP_RELEASE_TAG_RE = /^desktop-\d{4}\.\d{1,2}\.\d{1,2}(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$/;
+
+/** Production Electron desktop tag prefix. */
+export const DESKTOP_RELEASE_TAG_PREFIX = "desktop-electron-";
+/** Legacy Tauri desktop tag prefix (emergency rebuilds only). */
+export const DESKTOP_TAURI_RELEASE_TAG_PREFIX = "desktop-";
+
+const DESKTOP_ELECTRON_RELEASE_TAG_RE =
+  /^desktop-electron-\d{4}\.\d{1,2}\.\d{1,2}(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$/;
+const DESKTOP_TAURI_RELEASE_TAG_RE =
+  /^desktop-\d{4}\.\d{1,2}\.\d{1,2}(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$/;
 
 const GITHUB_RELEASES_API_URL = `https://api.github.com/repos${GITHUB_REPO_PATH}/releases?per_page=100`;
 
@@ -32,7 +40,18 @@ const createGithubHeaders = (): HeadersInit => {
 };
 
 const isPublishedDesktopRelease = (release: GitHubRelease): boolean =>
-  DESKTOP_RELEASE_TAG_RE.test(release.tag_name) && !release.draft && !release.prerelease && Boolean(release.published_at);
+  !release.draft && !release.prerelease && Boolean(release.published_at);
+
+const isElectronDesktopRelease = (release: GitHubRelease): boolean =>
+  isPublishedDesktopRelease(release) && DESKTOP_ELECTRON_RELEASE_TAG_RE.test(release.tag_name);
+
+const isLegacyTauriDesktopRelease = (release: GitHubRelease): boolean =>
+  isPublishedDesktopRelease(release) &&
+  DESKTOP_TAURI_RELEASE_TAG_RE.test(release.tag_name) &&
+  !release.tag_name.startsWith("desktop-electron-");
+
+const byNewest = (a: GitHubRelease, b: GitHubRelease): number =>
+  new Date(b.published_at ?? 0).getTime() - new Date(a.published_at ?? 0).getTime();
 
 export async function fetchLatestDesktopRelease(): Promise<GitHubRelease | null> {
   const res = await fetch(GITHUB_RELEASES_API_URL, {
@@ -46,7 +65,10 @@ export async function fetchLatestDesktopRelease(): Promise<GitHubRelease | null>
 
   const releases = (await res.json()) as GitHubRelease[];
 
-  return releases
-    .filter(isPublishedDesktopRelease)
-    .sort((a, b) => new Date(b.published_at ?? 0).getTime() - new Date(a.published_at ?? 0).getTime())[0] ?? null;
+  const electron = releases.filter(isElectronDesktopRelease).sort(byNewest)[0] ?? null;
+  if (electron) {
+    return electron;
+  }
+
+  return releases.filter(isLegacyTauriDesktopRelease).sort(byNewest)[0] ?? null;
 }

--- a/install-desktop.sh
+++ b/install-desktop.sh
@@ -17,7 +17,8 @@ Usage: install-desktop.sh [options]
 
 Options:
   --version <tag>        Install a specific release tag instead of latest
-  --archive <path>       Install from a prebuilt local .app.tar.gz archive
+                         (example: desktop-electron-2026.7.29)
+  --archive <path>       Install from a prebuilt local .zip or .app.tar.gz archive
   --github-source        Use GitHub Releases instead of custom domain
   --no-cli               Install Desktop only, do not install/update ~/.atmos/bin/atmos
   -h, --help             Show this help
@@ -118,28 +119,6 @@ curl_to_file() {
   local url="$1"
   local output="$2"
   curl -fsSL --retry 3 --retry-delay 1 --retry-all-errors --connect-timeout 10 "$url" -o "$output"
-}
-
-download_with_fallback() {
-  local asset="$1"
-  local version="$2"
-  local custom_url="${DOWNLOAD_BASE}/desktop/${version}/${asset}"
-  local github_url="https://github.com/${REPO}/releases/download/${version}/${asset}"
-
-  if [[ "$USE_GITHUB_SOURCE" -eq 1 ]]; then
-    echo "Downloading from GitHub: ${github_url}"
-    curl -fsSL "$github_url" -o "$ARCHIVE_FILE"
-    return 0
-  fi
-
-  echo "Downloading from custom domain: ${custom_url}"
-  if curl -fsSL "$custom_url" -o "$ARCHIVE_FILE"; then
-    return 0
-  fi
-
-  echo "Failed to download from custom domain, trying GitHub as fallback..."
-  echo "Downloading from GitHub: ${github_url}"
-  curl -fsSL "$github_url" -o "$ARCHIVE_FILE"
 }
 
 ensure_path_hint() {
@@ -387,15 +366,67 @@ install_best_cli() {
   return 1
 }
 
-download_latest_with_fallback() {
-  local asset="$1"
-  local latest_url="${DOWNLOAD_BASE}/desktop/latest/${asset}"
+# Map a release tag to the calendar version segment (no tag prefix).
+desktop_tag_version() {
+  local tag="$1"
+  case "$tag" in
+    desktop-electron-*) echo "${tag#desktop-electron-}" ;;
+    desktop-*) echo "${tag#desktop-}" ;;
+    *) echo "$tag" ;;
+  esac
+}
 
-  echo "Trying to download from custom domain latest path: ${latest_url}"
-  if curl -fsSL "$latest_url" -o "$ARCHIVE_FILE"; then
-    echo "Successfully downloaded from latest path"
+# Asset names differ by channel:
+# - Electron latest path: Atmos_<arch>.zip (unversioned)
+# - Electron tag path:    Atmos_<version>_<arch>.zip
+# - Legacy Tauri:         Atmos_<arch>.app.tar.gz
+desktop_asset_candidates() {
+  local target="$1"
+  local tag_or_latest="$2"
+  local version
+
+  if [[ "$tag_or_latest" == "latest" ]]; then
+    echo "Atmos_${target}.zip"
+    echo "Atmos_${target}.app.tar.gz"
     return 0
   fi
+
+  version="$(desktop_tag_version "$tag_or_latest")"
+  case "$tag_or_latest" in
+    desktop-electron-*)
+      echo "Atmos_${version}_${target}.zip"
+      echo "Atmos_${target}.zip"
+      ;;
+    desktop-*)
+      echo "Atmos_${target}.app.tar.gz"
+      ;;
+    *)
+      echo "Atmos_${version}_${target}.zip"
+      echo "Atmos_${target}.zip"
+      echo "Atmos_${target}.app.tar.gz"
+      ;;
+  esac
+}
+
+download_latest_with_fallback() {
+  local target="$1"
+  local asset candidate_url
+  local -a candidates=()
+
+  while IFS= read -r asset; do
+    candidates+=("$asset")
+  done < <(desktop_asset_candidates "$target" "latest")
+
+  for asset in "${candidates[@]}"; do
+    candidate_url="${DOWNLOAD_BASE}/desktop/latest/${asset}"
+    ARCHIVE_FILE="${TMP_DIR}/${asset}"
+    echo "Trying custom domain latest path: ${candidate_url}"
+    if curl -fsSL "$candidate_url" -o "$ARCHIVE_FILE"; then
+      echo "Successfully downloaded from latest path"
+      ASSET="$asset"
+      return 0
+    fi
+  done
 
   echo "Latest path not available, falling back to GitHub API to resolve version..."
   RESOLVED_VERSION="$(resolve_release_tag)"
@@ -404,7 +435,57 @@ download_latest_with_fallback() {
     exit 1
   fi
 
-  download_with_fallback "$asset" "$RESOLVED_VERSION"
+  download_with_fallback_resolved "$target" "$RESOLVED_VERSION"
+}
+
+download_with_fallback_resolved() {
+  local target="$1"
+  local version="$2"
+  local asset
+  local -a candidates=()
+
+  while IFS= read -r asset; do
+    candidates+=("$asset")
+  done < <(desktop_asset_candidates "$target" "$version")
+
+  for asset in "${candidates[@]}"; do
+    ARCHIVE_FILE="${TMP_DIR}/${asset}"
+    if download_with_fallback "$asset" "$version"; then
+      ASSET="$asset"
+      return 0
+    fi
+  done
+
+  echo "Failed to download a desktop installer for ${version} (${target})." >&2
+  exit 1
+}
+
+# Override download_with_fallback to not fail hard on first URL so candidates can try.
+download_with_fallback() {
+  local asset="$1"
+  local version="$2"
+  local custom_url="${DOWNLOAD_BASE}/desktop/${version}/${asset}"
+  local github_url="https://github.com/${REPO}/releases/download/${version}/${asset}"
+
+  if [[ "$USE_GITHUB_SOURCE" -eq 1 ]]; then
+    echo "Downloading from GitHub: ${github_url}"
+    if curl -fsSL "$github_url" -o "$ARCHIVE_FILE"; then
+      return 0
+    fi
+    return 1
+  fi
+
+  echo "Downloading from custom domain: ${custom_url}"
+  if curl -fsSL "$custom_url" -o "$ARCHIVE_FILE"; then
+    return 0
+  fi
+
+  echo "Failed to download from custom domain, trying GitHub as fallback..."
+  echo "Downloading from GitHub: ${github_url}"
+  if curl -fsSL "$github_url" -o "$ARCHIVE_FILE"; then
+    return 0
+  fi
+  return 1
 }
 
 resolve_release_tag() {
@@ -415,10 +496,11 @@ resolve_release_tag() {
 
   local releases_json
   if ! releases_json="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100")"; then
-    echo "Failed to query GitHub releases. Try again, or pass --version desktop-2026.7.2." >&2
+    echo "Failed to query GitHub releases. Try again, or pass --version desktop-electron-2026.7.29." >&2
     return 1
   fi
 
+  # Prefer production Electron tags; fall back to legacy Tauri desktop-* tags.
   printf '%s' "$releases_json" | awk '
     function extract_string(line, key, value, pattern) {
       pattern = "\"" key "\"[[:space:]]*:[[:space:]]*\"[^\"]*\""
@@ -442,9 +524,20 @@ resolve_release_tag() {
     }
 
     function maybe_select() {
-      if (selected == "" && tag ~ /^desktop-[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}$/ && draft == "false" && prerelease == "false") {
-        selected = tag
+      if (draft != "false" || prerelease != "false" || tag == "") {
+        return
       }
+      if (selected_electron == "" && tag ~ /^desktop-electron-[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}$/) {
+        selected_electron = tag
+      }
+      if (selected_legacy == "" && tag ~ /^desktop-[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}$/) {
+        selected_legacy = tag
+      }
+    }
+
+    BEGIN {
+      selected_electron = ""
+      selected_legacy = ""
     }
 
     /^  \{/ {
@@ -473,35 +566,74 @@ resolve_release_tag() {
     }
 
     END {
-      if (selected != "") {
-        print selected
+      if (selected_electron != "") {
+        print selected_electron
+      } else if (selected_legacy != "") {
+        print selected_legacy
       }
     }
   '
 }
 
+install_app_archive() {
+  local archive="$1"
+  local extract_dir="${TMP_DIR}/app-extract"
+  mkdir -p "$extract_dir"
+
+  case "$archive" in
+    *.zip)
+      if ! command -v unzip >/dev/null 2>&1; then
+        echo "unzip is required to install Electron desktop zip archives." >&2
+        exit 1
+      fi
+      echo "Extracting zip archive..."
+      unzip -q -o "$archive" -d "$extract_dir"
+      ;;
+    *.tar.gz|*.tgz)
+      echo "Extracting tar archive..."
+      tar -xzf "$archive" -C "$extract_dir"
+      ;;
+    *)
+      echo "Unsupported archive format: $archive" >&2
+      exit 1
+      ;;
+  esac
+
+  local app_bundle
+  app_bundle="$(find "$extract_dir" -maxdepth 3 -type d -name 'Atmos.app' | head -n 1)"
+  if [[ -z "$app_bundle" ]]; then
+    echo "Archive did not contain Atmos.app" >&2
+    exit 1
+  fi
+
+  echo "Installing to /Applications..."
+  rm -rf /Applications/Atmos.app
+  cp -R "$app_bundle" /Applications/Atmos.app
+}
+
 TARGET="$(detect_target)"
 CLI_TARGET="$(detect_cli_target)"
-ASSET="Atmos_${TARGET}.app.tar.gz"
+ASSET=""
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-ARCHIVE_FILE="${TMP_DIR}/${ASSET}"
+ARCHIVE_FILE=""
 if [[ -n "$ARCHIVE_PATH" ]]; then
+  ARCHIVE_FILE="${TMP_DIR}/$(basename "$ARCHIVE_PATH")"
   cp "$ARCHIVE_PATH" "$ARCHIVE_FILE"
   RESOLVED_VERSION="$VERSION"
+  ASSET="$(basename "$ARCHIVE_PATH")"
 else
   if [[ "$VERSION" == "latest" ]]; then
-    download_latest_with_fallback "$ASSET"
+    download_latest_with_fallback "$TARGET"
     RESOLVED_VERSION="latest"
   else
     RESOLVED_VERSION="$VERSION"
-    download_with_fallback "$ASSET" "$RESOLVED_VERSION"
+    download_with_fallback_resolved "$TARGET" "$RESOLVED_VERSION"
   fi
 fi
 
-echo "Extracting to /Applications..."
-tar -xzf "$ARCHIVE_FILE" -C /Applications
+install_app_archive "$ARCHIVE_FILE"
 
 echo "Installed Atmos Desktop app to /Applications"
 if [[ "$NO_CLI" -eq 0 ]]; then

--- a/scripts/homebrew/generate-cask.mjs
+++ b/scripts/homebrew/generate-cask.mjs
@@ -10,12 +10,16 @@ const DEFAULT_REPO = "atmos";
 const DEFAULT_HOMEPAGE = "https://atmos.land";
 const DEFAULT_OUTPUT = "Casks/atmos.rb";
 
+/** Production desktop tag prefix (Electron). Legacy Tauri used `desktop-`. */
+const DESKTOP_ELECTRON_TAG_PREFIX = "desktop-electron-";
+const DESKTOP_TAURI_TAG_PREFIX = "desktop-";
+
 function printUsage() {
   console.error(`Usage:
   node scripts/homebrew/generate-cask.mjs [options]
 
 Options:
-  --tag <tag>           Release tag, e.g. desktop-2026.7.2
+  --tag <tag>           Release tag, e.g. desktop-electron-2026.7.2
   --owner <owner>       GitHub owner (default: ${DEFAULT_OWNER})
   --repo <repo>         GitHub repo (default: ${DEFAULT_REPO})
   --token <token>       Cask token (default: atmos)
@@ -27,8 +31,8 @@ Options:
   --help                Show this message
 
 Examples:
-  node scripts/homebrew/generate-cask.mjs --tag desktop-2026.7.2
-  GITHUB_TOKEN=xxx node scripts/homebrew/generate-cask.mjs --tag desktop-2026.7.2 --output Casks/atmos.rb
+  node scripts/homebrew/generate-cask.mjs --tag desktop-electron-2026.7.2
+  GITHUB_TOKEN=xxx node scripts/homebrew/generate-cask.mjs --tag desktop-electron-2026.7.2 --output Casks/atmos.rb
 `);
 }
 
@@ -122,8 +126,26 @@ function normalizeSha256(digest) {
   return "";
 }
 
+/**
+ * Prefer production Electron tags; keep legacy Tauri `desktop-` for emergency rebuilds.
+ */
 function extractVersionFromTag(tag) {
-  return extractCalendarVersionFromTag(tag, "desktop-");
+  const normalized = String(tag || "").trim();
+  if (normalized.startsWith(DESKTOP_ELECTRON_TAG_PREFIX)) {
+    return {
+      version: extractCalendarVersionFromTag(normalized, DESKTOP_ELECTRON_TAG_PREFIX),
+      tagPrefix: DESKTOP_ELECTRON_TAG_PREFIX,
+    };
+  }
+  if (normalized.startsWith(DESKTOP_TAURI_TAG_PREFIX)) {
+    return {
+      version: extractCalendarVersionFromTag(normalized, DESKTOP_TAURI_TAG_PREFIX),
+      tagPrefix: DESKTOP_TAURI_TAG_PREFIX,
+    };
+  }
+  throw new Error(
+    `Invalid release tag "${normalized}". Expected format: desktop-electron-<version> (or legacy desktop-<version>).`,
+  );
 }
 
 function inferDmgArch(assetName) {
@@ -175,6 +197,7 @@ function buildCaskContent({
   token,
   version,
   assetVersion,
+  tagPrefix,
   armSha,
   intelSha,
   owner,
@@ -183,6 +206,13 @@ function buildCaskContent({
   desc,
   homepage,
 }) {
+  // livecheck prefers Electron production tags; still matches legacy Tauri if needed.
+  // In the emitted Ruby source this must be a single-backslash regex (\d, not \\d).
+  const livecheckTagRe =
+    tagPrefix === DESKTOP_ELECTRON_TAG_PREFIX
+      ? "^desktop-electron-(\\d{4}\\.\\d{1,2}\\.\\d{1,2}(?:[-.a-zA-Z0-9]+)?)$"
+      : "^desktop-(\\d{4}\\.\\d{1,2}\\.\\d{1,2}(?:[-.a-zA-Z0-9]+)?)$";
+
   return `cask "${escapeRubyString(token)}" do
   arch arm: "aarch64", intel: "x64"
 
@@ -190,7 +220,7 @@ function buildCaskContent({
   sha256 arm:   "${armSha}",
          intel: "${intelSha}"
 
-  url "https://github.com/${escapeRubyString(owner)}/${escapeRubyString(repo)}/releases/download/desktop-#{version.csv.first}/Atmos_#{version.csv.second}_#{arch}.dmg",
+  url "https://github.com/${escapeRubyString(owner)}/${escapeRubyString(repo)}/releases/download/${escapeRubyString(tagPrefix)}#{version.csv.first}/Atmos_#{version.csv.second}_#{arch}.dmg",
       verified: "github.com/${escapeRubyString(owner)}/${escapeRubyString(repo)}/"
   name "${escapeRubyString(name)}"
   desc "${escapeRubyString(desc)}"
@@ -199,7 +229,7 @@ function buildCaskContent({
   livecheck do
     url :url
     strategy :github_latest do |json, _regex|
-      match = json["tag_name"]&.match(/^desktop-(\\d{4}\\.\\d{1,2}\\.\\d{1,2}(?:[-.a-zA-Z0-9]+)?)$/)
+      match = json["tag_name"]&.match(/${livecheckTagRe}/)
       next if match.blank?
 
       version = match[1]
@@ -239,7 +269,7 @@ async function main() {
 
   const release = await getRelease(args);
   const tag = ensure(release.tag_name, "Release payload does not contain tag_name");
-  const version = extractVersionFromTag(tag);
+  const { version, tagPrefix } = extractVersionFromTag(tag);
 
   const dmgAssets = (release.assets || []).filter((asset) => String(asset.name || "").endsWith(".dmg"));
   const armAsset = dmgAssets.find((asset) => inferDmgArch(asset.name) === "arm");
@@ -277,6 +307,7 @@ async function main() {
     token: args.token,
     version,
     assetVersion: armAssetVersion,
+    tagPrefix,
     armSha,
     intelSha,
     owner: args.owner,
@@ -293,6 +324,7 @@ async function main() {
 
   console.log(`Generated Homebrew cask: ${outputPath}`);
   console.log(`Release tag: ${tag}`);
+  console.log(`Tag prefix: ${tagPrefix}`);
   console.log(`App version: ${version}`);
   console.log(`DMG version: ${armAssetVersion}`);
   console.log(`arm64 sha256: ${armSha}`);


### PR DESCRIPTION
## Summary
- Wire `sync-homebrew-tap.yml` and `sync-r2.yml` to **Desktop Electron CI & Release** and `desktop-electron-*` tags (production ship path).
- Generate Homebrew cask from Electron release DMGs (`desktop-electron-<ver>/Atmos_<ver>_<arch>.dmg`).
- Mirror Electron installers (dmg/zip/exe/AppImage) to R2 under `desktop/<tag>/` and unversioned zips under `desktop/latest/`.
- Update `install-desktop.sh` and landing release lookup to prefer Electron tags/assets (with legacy Tauri fallback).

## Why
Electron releases currently publish to GitHub only. Custom domain (`install.atmos.land`) and Homebrew still pointed at deprecated Tauri `desktop-*` artifacts, so brew / custom-domain downloads were stale or broken.

## Test plan
- [x] `generate-cask.mjs --tag desktop-electron-2026.7.29` produces valid cask with Electron tag URL + sha256
- [x] `bash -n install-desktop.sh`
- [ ] After merge: dispatch Homebrew + R2 sync for `desktop-electron-2026.7.29`
- [ ] Verify `brew install --cask AruNi-01/tap/atmos` points at Electron 2026.7.29
- [ ] Verify `https://install.atmos.land/desktop/latest/Atmos_aarch64.zip` is reachable

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync Electron desktop releases to Homebrew and R2 so installs via Homebrew and install.atmos.land use `desktop-electron-*` assets. Legacy Tauri `desktop-*` remains as a fallback.

- New Features
  - Workflows now listen to Desktop Electron CI and `desktop-electron-*` tags; legacy `desktop-*` still supported.
  - Homebrew cask is generated from Electron DMGs; livecheck prefers Electron tags, falls back to Tauri.
  - R2 mirrors Electron installers to `desktop/<tag>/` and publishes unversioned `Atmos_<arch>.zip` under `desktop/latest/`; skips `.blockmap` files.
  - `install-desktop.sh` prefers Electron zips, supports `.zip` and `.app.tar.gz`, resolves latest by favoring Electron tags, and falls back to GitHub if custom domain is unavailable.
  - Landing release lookup now selects the newest Electron release first, with Tauri as fallback.

<sup>Written for commit 5a163dd3255e3ade36f6e11e501f9cd504cea6f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

