### PR TITLE
feat(desktop): APP-052 shared overlay surface above native preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@
 | Task | Go To |
 |------|-------|
 | **Cross-Cutting References** (Shortcuts, Debug, etc.) | [agents/AGENTS.md](agents/AGENTS.md) |
+| **Write/edit AGENTS.md** (progressive disclosure) | [agents/references/agents-md-authoring.md](agents/references/agents-md-authoring.md) |
+| **Desktop floating UI over native preview** | [agents/references/desktop-floating-ui.md](agents/references/desktop-floating-ui.md) |
 | **Design System / UI Visual Language** | [DESIGN.md](DESIGN.md) |
 | **Marketing Creative Production** (video/audio/social assets) | [marketing/AGENTS.md](marketing/AGENTS.md) |
 | **Rust crates index** (layer map) | [crates/AGENTS.md](crates/AGENTS.md) |
@@ -135,6 +137,7 @@ Full conventions (zones, naming, the 4-file rule, optional spec logs, review che
 - **Backend Access**: Each app manages its own `api/client.ts` and `types/api.ts`
 - **Rust Services**: Inject `core-service` into `apps/api` via `AppState`; HTTP and browser WebSocket protocols are owned by `apps/api`
 - **Inline Feedback Over Toasts**: Do not show success toasts for direct user actions when the initiating control or nearby UI can reflect the result, such as copy, save, toggle, stash, inline edit, or local state changes. Use inline button states, labels, counts, disabled states, or immediate UI transitions instead. Reserve toasts for errors, background work, cross-context outcomes, or unexpected fallbacks that the current UI cannot clearly show.
+- **Desktop floating UI / native preview**: Host DOM `z-index` cannot cover desktop `WebContentsView` preview. New dialogs, popovers, menus, tooltips, or other portaled chrome that may overlap native preview need the shared overlay + occlusion rules — **load only when relevant**: [agents/references/desktop-floating-ui.md](agents/references/desktop-floating-ui.md) (APP-052 / APP-029).
 
 ### Internationalization
 
@@ -208,6 +211,16 @@ When compressing context, create a continuation-oriented coding handoff summary.
 
 ---
 
+## 📘 AGENTS.md authoring (progressive disclosure)
+
+- **Root / package `AGENTS.md`**: navigation, contracts, short NEVER/ALWAYS — not full playbooks.
+- **Deep rules**: `agents/references/**`, indexed by [agents/AGENTS.md](agents/AGENTS.md). Load only when the task matches “When to load”.
+- **After a non-obvious constraint ships** (cross-layer stacking, security, transport, shared package edges, recurring footguns): **ask the user** whether to add a short pointer and/or a deep reference — do not silently bloat AGENTS files or leave the rule only in chat.
+
+→ **[Full authoring guide](agents/references/agents-md-authoring.md)**
+
+---
+
 ## Coding Behavioral Guidelines
 
 **Tradeoff**: These guidelines bias toward caution over speed. For trivial tasks, use judgment.
@@ -236,6 +249,16 @@ Before implementing:
 - If you write 200 lines and it could be 50, rewrite it.
 
 Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Document recurring constraints (with user consent)
+
+When a change introduces a rule the **next** agent will miss (same class of bug as desktop floating UI vs `WebContentsView`, WS-first exceptions, package boundary edges):
+
+1. State the constraint briefly in the reply.
+2. **Ask** whether to update the relevant package/root AGENTS pointer and/or `agents/references/...`.
+3. Prefer progressive disclosure over pasting long checklists into every AGENTS.md.
+
+→ [agents/references/agents-md-authoring.md](agents/references/agents-md-authoring.md)
 
 ---
 

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -12,6 +12,8 @@ This directory contains cross-cutting references and guidelines that apply acros
 
 | File | When to Load |
 |------|--------------|
+| `references/agents-md-authoring.md` | Creating/editing any `AGENTS.md`, or deciding whether a new constraint should become agent docs (progressive disclosure) |
+| `references/desktop-floating-ui.md` | Dialogs/modals/sheets/popovers/menus/tooltips or other portaled UI that can cover **desktop native preview** (`WebContentsView`); preview occlusion / portal roots / overlay IPC |
 | `references/keyboard-shortcuts.md` | When implementing keyboard shortcuts, global hotkeys, or overlay focus management |
 | `references/debug-logging.md` | When adding debug logging or instrumenting lifecycle flows |
 | `references/compact-instructions.md` | When compressing context or creating coding handoff summaries |
@@ -25,21 +27,15 @@ This directory contains cross-cutting references and guidelines that apply acros
 ```
 agents/
 ├── AGENTS.md              # This file - index and usage guide
-└── references/            # Cross-cutting references
-    ├── keyboard-shortcuts.md  # Keyboard shortcuts and overlay focus
-    ├── debug-logging.md        # Debug logging infrastructure
-    ├── compact-instructions.md # Context compression and handoff summaries
-    ├── mobile/                 # Mobile app setup and native UI references
-    │   ├── dev-setup.md         # Expo mobile native dev environment setup
-    │   └── native-navigation.md # Native headers, titles, bars, and menus
-    ├── design/                 # Design system references for agents
-    │   ├── AGENTS.md
-    │   ├── foundations.md
-    │   ├── components.md
-    │   ├── web-desktop.md
-    │   └── mobile.md
-    └── runtime/                # Local runtime and Atmos Computer references
-        └── AGENTS.md
+└── references/            # Cross-cutting references (load on demand)
+    ├── agents-md-authoring.md   # How to write AGENTS.md (progressive disclosure)
+    ├── desktop-floating-ui.md   # Desktop overlay / native preview stacking (APP-052)
+    ├── keyboard-shortcuts.md
+    ├── debug-logging.md
+    ├── compact-instructions.md
+    ├── mobile/
+    ├── design/
+    └── runtime/
 ```
 
 ## Architecture pointers (not loaded by default)
@@ -56,14 +52,18 @@ For **local runtime**, **Desktop/CLI ensure**, or **Atmos Computer / relay**, st
 When adding a new reference file:
 
 1. Create the file in `agents/references/` or a focused subdirectory such as `agents/references/mobile/`
-2. Add a clear "When to load" section at the top
+2. Add a clear "When to load" / "Do not load" section at the top
 3. Update this index file with the new entry
-4. Link to it from the root `AGENTS.md` if it's a commonly-used reference
+4. Link from the root `Agents.md` **only if** the topic is commonly hit
+5. Add a **short pointer** from the package AGENTS that owns the code — do not paste the full checklist there
 
-## Authoring Guidelines
+Full progressive-disclosure rules and “ask the user before documenting learnings”:
+
+→ **[agents-md-authoring.md](references/agents-md-authoring.md)**
+
+## Authoring Guidelines (summary)
 
 - Keep reference files focused on a single topic
-- Include practical examples and code patterns
-- Provide checklists for verification
-- Link to related files where appropriate
-- Use clear section headers for navigation
+- Include practical examples, real paths, and checklists
+- Prefer **links down** over copy-paste across root / package / reference
+- After a non-obvious constraint ships, **ask** before adding long AGENTS prose

--- a/agents/references/agents-md-authoring.md
+++ b/agents/references/agents-md-authoring.md
@@ -1,0 +1,141 @@
+# AGENTS.md Authoring Guide (Progressive Disclosure)
+
+> **When to load**: Creating or editing any `AGENTS.md` / `Agents.md`, adding cross-cutting agent rules, or deciding whether a learning from a bug/feature should become durable agent docs.
+
+> **Do not load** for ordinary product code with no documentation intent.
+
+---
+
+## Goals
+
+1. **Small default context** — Agents should not load multi-page rules for every task.
+2. **Deep rules on demand** — Full checklists and edge cases live under `agents/references/` (or a package-local deep doc), linked from short AGENTS files.
+3. **Capture learnings without spam** — After shipping a non-obvious constraint, **ask the user** whether to document it in the right AGENTS/reference before adding long prose.
+
+---
+
+## Three layers
+
+| Layer | Path | Holds | Length target |
+|-------|------|--------|----------------|
+| **Root navigation** | `/Agents.md` (or `AGENTS.md`) | Decision tree, monorepo map, short global rails, **links only** to deep refs | Prefer short; avoid pasting full how-tos |
+| **Package / app contract** | `apps/*/AGENTS.md`, `packages/*/AGENTS.md`, `crates/*/AGENTS.md` | How to work **in that tree**: commands, layout, NEVER/ALWAYS, **pointers** to deep refs | One screen of dense rules when possible |
+| **Deep reference** | `agents/references/**` | Topic playbooks: checklists, code paths, anti-patterns, verification | As long as needed; single topic per file |
+
+`agents/AGENTS.md` is the **index** of deep references (when to load each file). It is not a dump of all rules.
+
+---
+
+## Progressive disclosure rules
+
+### Root `Agents.md`
+
+**Do**
+
+- Point “I need to…” rows at package AGENTS or `agents/references/...`
+- Keep 1–3 sentence global policies (e.g. WebSocket-first) with a link if the topic grows
+- Add a **one-line** “when working on X, load Y” for high-traffic cross-cuts (keyboard, debug, desktop floating UI, AGENTS authoring)
+
+**Do not**
+
+- Paste full APP-NNN TECH content
+- Duplicate package-specific build commands already in package AGENTS
+- Add every edge case discovered in one PR without user agreement
+
+### Package / app `AGENTS.md`
+
+**Do**
+
+- Document **contracts** of that package (boundaries, entry points, forbidden imports)
+- Link to `agents/references/<topic>.md` with a clear **When to load** sentence
+- Keep NEVER/ALWAYS short and local
+
+**Do not**
+
+- Embed multi-page implementation histories
+- Copy the entire monorepo tree again
+
+### Deep references (`agents/references/`)
+
+**Do**
+
+- Start with `> **When to load**: ...` and `> **Do not load**: ...`
+- Name real paths and symbols agents can open
+- Prefer tables + checklists over essays
+- Link specs (`specs/APP/...`) as source of product truth when applicable
+
+**Do not**
+
+- Mix unrelated topics in one file
+- Rely on agents loading the whole `agents/` tree by default
+
+---
+
+## After a non-obvious change: ask before documenting
+
+When implementation introduces a **recurring constraint** (something the next agent will miss and re-break), **do not silently dump long docs**. Instead:
+
+1. **Summarize** the constraint in one short paragraph for the user.
+2. **Ask** whether to:
+   - add a **pointer** in the relevant package/root AGENTS, and/or
+   - add or extend a **deep reference** under `agents/references/`, and/or
+   - only leave it in the spec (`specs/...`) if it is product-scoped one-off.
+3. **Only write** the agreed layer(s). Prefer pointer + deep ref over bloating root AGENTS.
+
+### Good candidates to document
+
+- Cross-layer stacking / process boundaries (e.g. desktop native preview vs host DOM)
+- Security or trust boundaries
+- Transport defaults (WS vs REST)
+- Shared package import edges
+- Test harness locations for a class of bugs
+
+### Usually not worth a new AGENTS rule
+
+- One-off bugfixes with no recurrence
+- Purely local refactors
+- Spec content that already lives fully in `TECH.md` and is not agent-facing day-to-day
+
+### Suggested ask (copy-friendly)
+
+> This change adds a non-obvious rule: **\<one sentence\>**.  
+> Should I (a) only keep it in the spec, (b) add a short pointer in `\<package\>/AGENTS.md`, and/or (c) add/update `agents/references/\<topic\>.md` for progressive loading?
+
+---
+
+## Adding a new deep reference (checklist)
+
+1. Create `agents/references/<topic>.md` (or a subdirectory topic with its own short index).
+2. Put **When to load / Do not load** at the top.
+3. Register the file in [agents/AGENTS.md](../AGENTS.md) Reference Files table.
+4. Add a **one-line** link from root `Agents.md` **only if** the topic is commonly hit (keyboard, debug, floating UI, this authoring guide).
+5. Add a **short pointer** from the package AGENTS that owns the code (e.g. desktop-electron, web, ui).
+6. Avoid duplicating the full checklist in three places — **link** down.
+
+---
+
+## Editing existing AGENTS.md
+
+| Situation | Action |
+|-----------|--------|
+| Rule already in a deep ref | Update the ref; keep package AGENTS as a link |
+| Rule is package-local only | Edit package AGENTS only |
+| Rule became monorepo-wide | Move body to `agents/references/`, leave pointers |
+| Spec is the source of truth | Link to `specs/...`; AGENTS stays operational “how agents work here” |
+
+---
+
+## Anti-patterns
+
+- **Everything in root AGENTS** → context bloat, agents skip reading
+- **Everything only in chat/PR** → next agent reintroduces the bug
+- **Copy-paste the same checklist** into web + desktop + ui AGENTS → drift
+- **Silent long docs** after every PR without asking → noise and outdated prose
+
+---
+
+## Related
+
+- Index: [agents/AGENTS.md](../AGENTS.md)
+- Specs conventions: [specs/AGENTS.md](../../specs/AGENTS.md)
+- Compact handoffs (not AGENTS authoring): [compact-instructions.md](./compact-instructions.md)

--- a/agents/references/desktop-floating-ui.md
+++ b/agents/references/desktop-floating-ui.md
@@ -1,0 +1,137 @@
+# Desktop Floating UI Over Native Preview (APP-052)
+
+> **When to load**: Adding or changing **dialogs, modals, sheets, drawers, popovers, dropdowns, selects, tooltips, hover-cards, command palettes, or any portaled/floating chrome** that can appear over **desktop native preview** (`WebContentsView`). Also when changing preview occlusion, portal roots, or desktop overlay IPC.
+
+> **Do not load** for pure web layout work with no floating surface, or mobile-only UI.
+
+---
+
+## Why CSS z-index is not enough
+
+On production desktop (Electron), run/browser preview is a **main-process `WebContentsView`**, not a DOM node. It paints **above** the host shell WebContents.
+
+- Host React `z-index` **cannot** stack above the guest view.
+- Happy path: elevate floating UI into a **shared overlay surface** (one engine per host window).
+- Fallback: **APP-029** geometry occlusion → temporarily **hide** native preview + static React placeholder.
+
+Spec: [specs/APP/APP-052_desktop-overlay-surface/](../../specs/APP/APP-052_desktop-overlay-surface/)  
+Related: [specs/APP/APP-029_native-preview-occlusion/](../../specs/APP/APP-029_native-preview-occlusion/)
+
+---
+
+## Non-negotiables
+
+| Rule | Detail |
+|------|--------|
+| **Web must not change behavior** | Pure browser sessions: portals stay on `document.body` (or existing roots). No overlay engine, no hide-of-iframe for this reason. |
+| **One shared overlay engine** | At most **one** overlay surface per host `BrowserWindow`. Never spawn one WebContentsView/window per popover. |
+| **Lazy + idle reclaim** | Create on first need; tear down after idle with no elevated layers. Do not keep a permanent idle overlay process from app launch. |
+| **Hide is fallback only** | Healthy elevation must not blank live preview solely because a menu/dialog opened. |
+| **All host windows** | Main workbench **and** standalone/detached browser hosts that embed native preview. |
+
+---
+
+## Where the code lives
+
+| Layer | Path / symbol |
+|-------|----------------|
+| Electron overlay manager | `apps/desktop-electron/src/overlay/overlay-surface-manager.ts` |
+| Lifecycle (pure) | `apps/desktop-electron/src/overlay/overlay-lifecycle.ts` |
+| IPC | `overlay_bridge_ensure` / `note_activity` / `release` / `set_pointer_mode` / `destroy`; capability via `get_desktop_capabilities` → `overlaySurface` |
+| Web provider | `apps/web/src/shared/lib/desktop-overlay/floating-elevation-provider.tsx` (mounted in app layout) |
+| Policy (pure, unit-tested) | `apps/web/src/shared/lib/desktop-overlay/elevation-policy.ts` |
+| Layer open detection | `apps/web/src/shared/lib/desktop-overlay/layer-count.ts` |
+| Runtime store | `apps/web/src/shared/lib/desktop-overlay/elevation-store.ts` |
+| Portal container | `packages/ui` → `PortalContainerProvider` / `usePortalContainer` |
+| Occlusion fallback | `apps/web/.../use-native-preview-occlusion.ts` + Preview suspend composition |
+
+---
+
+## Checklist when adding a floating UI primitive
+
+### 1. Prefer `@workspace/ui` portals
+
+Existing primitives (dialog, sheet, drawer, popover, dropdown-menu, select, tooltip, hover-card) already call `usePortalContainer()`.
+
+- **New** Radix/Base UI floating primitive in `packages/ui`: wire **Portal** through `usePortalContainer()` the same way.
+- Default context is unset → document body (web-safe).
+
+### 2. Do not hardcode `document.body` for app chrome that can cover preview
+
+If a feature uses `createPortal(..., document.body)` (or a fixed full-screen root **outside** the portal context):
+
+- Prefer mounting under the shared portal context, **or**
+- Mark with `data-atmos-native-surface-overlay` so APP-029 occlusion can still hide preview when elevation cannot cover it, **or**
+- Use `data-atmos-ignore-native-surface-occlusion` only when the surface must never participate (rare; document why).
+
+Host-only portals that stay on the shell document will remain **under** `WebContentsView` unless elevated or preview is hidden.
+
+### 3. Markers and roles (occlusion + elevation recount)
+
+Stable selectors used by both APP-029 and APP-052 layer counting include:
+
+- `data-slot` values: `dialog-content`, `dialog-overlay`, `sheet-*`, `drawer-*`, `popover-content`, `dropdown-menu-content`, `select-content`, `tooltip-content`, `hover-card-content`, …
+- `role="dialog"`, `aria-modal="true"`, `role="tooltip"`
+- Opt-in: `data-atmos-native-surface-overlay`
+- Opt-out: `data-atmos-ignore-native-surface-occlusion`
+
+**Lifecycle open** (elevation refcount) treats `data-state !== "closed"` without requiring `opacity > 0` (fade-in).  
+**Exception**: permanent markers like peek shells with `data-atmos-native-surface-overlay` still require visible opacity so they do not pin the overlay forever.
+
+### 4. Suspend / hide composition (do not re-hardcode force-hide)
+
+Preview suspend is composed in `shouldSuspendDesktopNativePreview` (`elevation-policy.ts`):
+
+- **Always suspend**: loading, standalone handoff (embedded → detached).
+- **Occlusion**: geometry intersect **and** elevation does **not** cover.
+- **Elevatable chrome** (favorites / header / global search, etc.): suspend **only if** `!elevationCovers`.
+
+When adding a new “chrome open” flag that used to force-hide preview, **gate it on `!elevationCovers`** (or rely on occlusion + markers). Do not OR unconditional force-hide for elevatable popovers.
+
+### 5. Presence of native preview
+
+Desktop-native active preview instances use **refcount** (`acquireNativePreviewSurface` / `releaseNativePreviewSurface`) so multi-preview and standalone hosts do not clear each other. Include standalone browser windows when the surface is desktop-native and active.
+
+### 6. Electron shell (only when changing overlay behavior)
+
+- Attach overlay host handling on **every** product window that can host preview (`main-window`, `secondary`, etc.).
+- `ensure` prepares; **show/capture only when portal has open layers**; `release` hides and stops capturing input (empty overlay must not steal clicks).
+- Do not reintroduce per-widget native windows as the default path.
+
+---
+
+## Web vs desktop matrix
+
+| Runtime | Floating UI stacking |
+|---------|----------------------|
+| Browser web | Normal document stack; portal default body |
+| Desktop, no native preview | Portal default body; no overlay ensure |
+| Desktop + native preview | Elevate via portal container when capability on; APP-029 hide if elevation unavailable |
+
+Capability: Electron `get_desktop_capabilities().overlaySurface === true` and `isDesktopRuntime()`.
+
+---
+
+## Anti-patterns
+
+- Tuning `z-index` expecting to cover `WebContentsView`
+- One `BrowserWindow` / `WebContentsView` per menu
+- `createPortal` to `document.body` for large chrome over preview without markers or elevation
+- Unconditional `shouldSuspendDesktopPreview ||= myPopoverOpen` for elevatable UI
+- Loading this entire file for every UI tweak — only when floating surfaces or preview stacking are in scope
+
+---
+
+## Verification (lightweight)
+
+- Unit: `apps/web/src/shared/lib/desktop-overlay/__tests__/*`, desktop `overlay-lifecycle.test.ts`
+- Web e2e non-regression: `e2e/tests/specs/APP-052_desktop-overlay-surface.web.e2e.ts`
+- Manual desktop: open dialog/menu/tooltip over live native preview — preview stays live when elevation healthy; hide fallback if overlay fails
+
+---
+
+## Related
+
+- Spec APP-052 / APP-029 under `specs/APP/`
+- Keyboard focus when opening overlays from terminal: [keyboard-shortcuts.md](./keyboard-shortcuts.md)
+- Desktop package map: [apps/desktop-electron/AGENTS.md](../../apps/desktop-electron/AGENTS.md)

--- a/agents/references/desktop-floating-ui.md
+++ b/agents/references/desktop-floating-ui.md
@@ -78,15 +78,19 @@ Stable selectors used by both APP-029 and APP-052 layer counting include:
 **Lifecycle open** (elevation refcount) treats `data-state !== "closed"` without requiring `opacity > 0` (fade-in).  
 **Exception**: permanent markers like peek shells with `data-atmos-native-surface-overlay` still require visible opacity so they do not pin the overlay forever.
 
+**Cross-realm footgun**: layer counting runs against the **overlay document** (a different window realm). Never use host-realm `instanceof HTMLElement` or host `window.getComputedStyle` on overlay nodes — use `nodeType === 1` and `el.ownerDocument.defaultView.getComputedStyle(el)` (`layer-count.ts`).
+
+**Pointer classification**: tooltip / hover-card–only frames keep the overlay window `pass-through` (click-through, `showInactive`); any menu / popover / dialog layer switches to `capture` (+ keyboard focus moves to the overlay window; returned to host on release).
+
 ### 4. Suspend / hide composition (do not re-hardcode force-hide)
 
 Preview suspend is composed in `shouldSuspendDesktopNativePreview` (`elevation-policy.ts`):
 
 - **Always suspend**: loading, standalone handoff (embedded → detached).
-- **Occlusion**: geometry intersect **and** elevation does **not** cover.
-- **Elevatable chrome** (favorites / header / global search, etc.): suspend **only if** `!elevationCovers`.
+- **Host occlusion**: geometry intersect against **host-document** floaters always suspends — elevated layers live in the overlay document and never appear as host occlusion candidates, so anything the geometry check still sees is by definition not covered.
+- **Elevatable chrome** (favorites / header / global search, etc.): suspend **only if** `!elevationHealthy` (capability + surface ready + portal published; deliberately no layer-count so opening a popover cannot race a hide flash).
 
-When adding a new “chrome open” flag that used to force-hide preview, **gate it on `!elevationCovers`** (or rely on occlusion + markers). Do not OR unconditional force-hide for elevatable popovers.
+When adding a new “chrome open” flag that used to force-hide preview, **gate it on `!elevationHealthy`** (or rely on occlusion + markers). Do not OR unconditional force-hide for elevatable popovers.
 
 ### 5. Presence of native preview
 
@@ -95,7 +99,8 @@ Desktop-native active preview instances use **refcount** (`acquireNativePreviewS
 ### 6. Electron shell (only when changing overlay behavior)
 
 - Attach overlay host handling on **every** product window that can host preview (`main-window`, `secondary`, etc.).
-- `ensure` prepares; **show/capture only when portal has open layers**; `release` hides and stops capturing input (empty overlay must not steal clicks).
+- `ensure` prepares; **show/capture only when portal has open layers**; `release` hides, stops capturing input, and refocuses the host (empty overlay must not steal clicks or keyboard focus).
+- The overlay `BrowserWindow` **must be constructed by main** via the `setWindowOpenHandler` `createWindow` callback — `transparent: true` through `overrideBrowserWindowOptions` alone is unreliable for renderer-initiated windows (electron#22281: paints opaque black).
 - Do not reintroduce per-widget native windows as the default path.
 
 ---

--- a/apps/desktop-electron/AGENTS.md
+++ b/apps/desktop-electron/AGENTS.md
@@ -56,7 +56,8 @@ Release notes: `releasenotes/Atmos Desktop <version>.md`.
 - Preload: `window.__ATMOS_DESKTOP__` (`shell: 'electron'`, `invoke`, `on`)
 - UI from Atmos Server loopback static
 - Preview: `WebContentsView` + `persist:atmos-preview`
-- Commands match historical names (`get_api_config`, `preview_bridge_*`, `appshot_*`, `tunnel_connector_*`, …)
+- **Overlay surface (APP-052)**: one shared elevatable overlay per host window (`src/overlay/`, `overlay_bridge_*`, `get_desktop_capabilities.overlaySurface`) so host floating UI can stack above live preview; APP-029 hide remains fallback
+- Commands match historical names (`get_api_config`, `preview_bridge_*`, `overlay_bridge_*`, `appshot_*`, `tunnel_connector_*`, …)
 - AppShot: dual-shift, live TCC, frontmost capture, target-window border/flash overlay, pending auto-accept + fly-in preview (`source_bounds`), shared `appshots` layout
 - Cookies: `atmos-browser-cookies` under `resources/bin`
 - Tunnel: shared local gateway + share URL
@@ -64,9 +65,18 @@ Release notes: `releasenotes/Atmos Desktop <version>.md`.
 - Dev Dock branding: `scripts/prepare-dev-app.ts` → `.cache/dev-app/Atmos.app`
 - Packaging: `electron-builder.yml`; ad-hoc sign by default (`identity: "-"`)
 
+### Floating UI over native preview
+
+Host DOM cannot cover `WebContentsView` via CSS. Product rules, portal checklist, and anti-patterns live in a **load-on-demand** reference (not duplicated here):
+
+→ [agents/references/desktop-floating-ui.md](../../agents/references/desktop-floating-ui.md)
+
+Attach overlay host wiring on every product window that can host preview (`main-window`, `secondary`, …). Do not spawn one native surface per popover.
+
 ## Never
 
 - Implement desktop product changes under deprecated `apps/desktop` (Tauri) — **always this package**
 - Ship from `apps/desktop`
 - Enable `nodeIntegration` for product UI or preview
 - Fork AppShot/Server on-disk contracts
+- Expect host `z-index` alone to paint above preview WebContentsView

--- a/apps/desktop-electron/src/app-state.ts
+++ b/apps/desktop-electron/src/app-state.ts
@@ -1,12 +1,14 @@
 import type { BrowserWindow } from "electron";
 import type { PreviewSurfaceManager } from "./preview/surface-manager.js";
 import type { TunnelService } from "./tunnel/service.js";
+import type { OverlaySurfaceManager } from "./overlay/overlay-surface-manager.js";
 
 export type AppState = {
   apiHost: string;
   apiPort: number | null;
   mainWindow: BrowserWindow | null;
   preview: PreviewSurfaceManager | null;
+  overlay: OverlaySurfaceManager | null;
   tunnel: TunnelService | null;
   /** Whether this Electron process started the Server (vs reused existing). */
   startedServer: boolean;
@@ -18,6 +20,7 @@ export function createAppState(): AppState {
     apiPort: null,
     mainWindow: null,
     preview: null,
+    overlay: null,
     tunnel: null,
     startedServer: false,
   };

--- a/apps/desktop-electron/src/ipc/handlers.ts
+++ b/apps/desktop-electron/src/ipc/handlers.ts
@@ -70,6 +70,14 @@ export function createAllHandlers(
       return { host: state.apiHost, port: state.apiPort };
     },
 
+    /** APP-052: shell capability discovery for web elevation gate. */
+    async get_desktop_capabilities() {
+      return {
+        overlaySurface: state.overlay != null,
+        shell: "electron",
+      };
+    },
+
     async get_version_info() {
       const { APP_ID, APP_PRODUCT_NAME } = await import("../branding-paths.js");
       let version = process.env.npm_package_version ?? "0.0.0";
@@ -485,6 +493,38 @@ export function createAllHandlers(
       } catch {
         throw new Error(`Invalid URL: ${url}`);
       }
+      return null;
+    },
+
+    // --- overlay surface (APP-052) ---
+    async overlay_bridge_ensure(args) {
+      const host = await hostWindowFromArgs(args, state);
+      const result = await state.overlay?.ensure(host);
+      return result ?? { ok: false, ready: false };
+    },
+
+    async overlay_bridge_set_pointer_mode(args) {
+      const host = await hostWindowFromArgs(args, state);
+      const mode = str(args.mode) === "capture" ? "capture" : "pass-through";
+      state.overlay?.setPointerMode(host, mode);
+      return null;
+    },
+
+    async overlay_bridge_note_activity(args) {
+      const host = await hostWindowFromArgs(args, state);
+      state.overlay?.noteActivity(host);
+      return null;
+    },
+
+    async overlay_bridge_release(args) {
+      const host = await hostWindowFromArgs(args, state);
+      state.overlay?.release(host);
+      return null;
+    },
+
+    async overlay_bridge_destroy(args) {
+      const host = await hostWindowFromArgs(args, state);
+      if (host) state.overlay?.destroyForHost(host);
       return null;
     },
 

--- a/apps/desktop-electron/src/main.ts
+++ b/apps/desktop-electron/src/main.ts
@@ -17,6 +17,7 @@ import { createMainWindow, uiBaseUrl } from "./windows/main-window.js";
 import { markAllowWindowDestroy } from "./windows/close-behavior.js";
 import { ensureMacDockVisible } from "./windows/mac-dock.js";
 import { PreviewSurfaceManager } from "./preview/surface-manager.js";
+import { OverlaySurfaceManager } from "./overlay/overlay-surface-manager.js";
 import { ALL_PROVIDERS, TunnelService } from "./tunnel/service.js";
 import { mainLog, mainLogPath } from "./main-log.js";
 import { existsSync } from "node:fs";
@@ -89,6 +90,9 @@ async function boot() {
   // Only create services once — activate must not clobber live tunnels/previews.
   if (!state.preview) {
     state.preview = new PreviewSurfaceManager(state);
+  }
+  if (!state.overlay) {
+    state.overlay = new OverlaySurfaceManager(state);
   }
   if (!state.tunnel) {
     state.tunnel = new TunnelService();

--- a/apps/desktop-electron/src/overlay/constants.ts
+++ b/apps/desktop-electron/src/overlay/constants.ts
@@ -1,0 +1,11 @@
+/** Idle with no elevated layers before destroying the overlay surface (M6). */
+export const OVERLAY_IDLE_MS = 30_000;
+
+/** Max wait for overlay ready before APP-029 hide fallback may engage. */
+export const OVERLAY_CREATE_BUDGET_MS = 200;
+
+/** Padding around elevated layer union for pass-through bounds. */
+export const OVERLAY_BOUNDS_PADDING_PX = 16;
+
+/** Stable window.open name prefix; host id is appended. */
+export const OVERLAY_WINDOW_NAME_PREFIX = "atmos-desktop-overlay";

--- a/apps/desktop-electron/src/overlay/overlay-lifecycle.test.ts
+++ b/apps/desktop-electron/src/overlay/overlay-lifecycle.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "bun:test";
+import { OverlayLifecycleController } from "./overlay-lifecycle.js";
+
+describe("OverlayLifecycleController", () => {
+  it("creates once on ensure and reuses", async () => {
+    let creates = 0;
+    let destroys = 0;
+    const timers: Array<{ id: number; fn: () => void; ms: number }> = [];
+    let nextId = 1;
+    let now = 0;
+
+    const ctrl = new OverlayLifecycleController({
+      now: () => now,
+      setTimeout: (fn, ms) => {
+        const id = nextId++;
+        timers.push({ id, fn, ms });
+        return id;
+      },
+      clearTimeout: (id) => {
+        const i = timers.findIndex((t) => t.id === id);
+        if (i >= 0) timers.splice(i, 1);
+      },
+      idleMs: 1000,
+      create: () => {
+        creates += 1;
+      },
+      destroy: () => {
+        destroys += 1;
+      },
+    });
+
+    await ctrl.ensure();
+    await ctrl.ensure();
+    expect(creates).toBe(1);
+    expect(ctrl.getState().ready).toBe(true);
+
+    ctrl.release();
+    expect(timers.length).toBe(1);
+    // Fire idle timer
+    const t = timers[0]!;
+    t.fn();
+    expect(destroys).toBe(1);
+    expect(ctrl.getState().created).toBe(false);
+
+    await ctrl.ensure();
+    expect(creates).toBe(2);
+  });
+
+  it("noteActivity cancels idle destroy", async () => {
+    let destroys = 0;
+    const timers: Array<{ id: number; fn: () => void }> = [];
+    let nextId = 1;
+
+    const ctrl = new OverlayLifecycleController({
+      now: () => 0,
+      setTimeout: (fn) => {
+        const id = nextId++;
+        timers.push({ id, fn });
+        return id;
+      },
+      clearTimeout: (id) => {
+        const i = timers.findIndex((t) => t.id === id);
+        if (i >= 0) timers.splice(i, 1);
+      },
+      idleMs: 1000,
+      create: () => {},
+      destroy: () => {
+        destroys += 1;
+      },
+    });
+
+    await ctrl.ensure();
+    ctrl.release();
+    expect(timers.length).toBe(1);
+    const stale = timers[0]!;
+    ctrl.noteActivity();
+    expect(timers.length).toBe(0);
+    // Stale timer must not destroy
+    stale.fn();
+    expect(destroys).toBe(0);
+  });
+
+  it("forceDestroy tears down without idle", async () => {
+    let destroys = 0;
+    const ctrl = new OverlayLifecycleController({
+      now: () => 0,
+      setTimeout: (fn) => {
+        fn();
+        return 1;
+      },
+      clearTimeout: () => {},
+      idleMs: 1000,
+      create: () => {},
+      destroy: () => {
+        destroys += 1;
+      },
+    });
+    await ctrl.ensure();
+    ctrl.forceDestroy();
+    expect(destroys).toBe(1);
+    expect(ctrl.getState().created).toBe(false);
+  });
+});

--- a/apps/desktop-electron/src/overlay/overlay-lifecycle.test.ts
+++ b/apps/desktop-electron/src/overlay/overlay-lifecycle.test.ts
@@ -100,4 +100,66 @@ describe("OverlayLifecycleController", () => {
     expect(destroys).toBe(1);
     expect(ctrl.getState().created).toBe(false);
   });
+
+  it("resets created on create rejection so ensure can retry", async () => {
+    let creates = 0;
+    const ctrl = new OverlayLifecycleController({
+      now: () => 0,
+      setTimeout: () => 1,
+      clearTimeout: () => {},
+      idleMs: 1000,
+      create: () => {
+        creates += 1;
+        if (creates === 1) throw new Error("create failed");
+      },
+      destroy: () => {},
+    });
+
+    await expect(ctrl.ensure()).rejects.toThrow("create failed");
+    expect(ctrl.getState().created).toBe(false);
+    expect(ctrl.getState().ready).toBe(false);
+
+    await ctrl.ensure();
+    expect(creates).toBe(2);
+    expect(ctrl.getState().ready).toBe(true);
+  });
+
+  it("ignores create completion after forceDestroy during in-flight create", async () => {
+    let resolveCreate!: () => void;
+    let destroys = 0;
+    let readyCalls = 0;
+    const createPromise = new Promise<void>((resolve) => {
+      resolveCreate = resolve;
+    });
+
+    const ctrl = new OverlayLifecycleController({
+      now: () => 0,
+      setTimeout: () => 1,
+      clearTimeout: () => {},
+      idleMs: 1000,
+      create: () => createPromise,
+      destroy: () => {
+        destroys += 1;
+      },
+      onReady: () => {
+        readyCalls += 1;
+      },
+    });
+
+    const ensurePromise = ctrl.ensure();
+    expect(ctrl.getState().created).toBe(true);
+    expect(ctrl.getState().ready).toBe(false);
+
+    ctrl.forceDestroy();
+    expect(destroys).toBe(1);
+    expect(ctrl.getState().created).toBe(false);
+    expect(ctrl.getState().ready).toBe(false);
+
+    resolveCreate();
+    const result = await ensurePromise;
+    expect(result.ready).toBe(false);
+    expect(ctrl.getState().created).toBe(false);
+    expect(ctrl.getState().ready).toBe(false);
+    expect(readyCalls).toBe(0);
+  });
 });

--- a/apps/desktop-electron/src/overlay/overlay-lifecycle.ts
+++ b/apps/desktop-electron/src/overlay/overlay-lifecycle.ts
@@ -28,6 +28,9 @@ export class OverlayLifecycleController {
     idleTimerToken: null,
   };
 
+  /** Bumps on forceDestroy so in-flight create completions cannot mark ready. */
+  private createGeneration = 0;
+
   constructor(private readonly deps: OverlayLifecycleDeps) {}
 
   getState(): Readonly<OverlayLifecycleState> {
@@ -40,7 +43,21 @@ export class OverlayLifecycleController {
     if (!this.state.created) {
       this.state.created = true;
       this.state.ready = false;
-      await this.deps.create();
+      const gen = this.createGeneration;
+      try {
+        await this.deps.create();
+      } catch (err) {
+        // Retry-safe: only reset if this ensure attempt still owns the slot.
+        if (this.createGeneration === gen && this.state.created && !this.state.ready) {
+          this.state.created = false;
+          this.state.ready = false;
+        }
+        throw err;
+      }
+      // Stale completion after forceDestroy (or a newer ensure) — do not resurrect.
+      if (this.createGeneration !== gen || !this.state.created) {
+        return { created: this.state.created, ready: this.state.ready };
+      }
       this.state.ready = true;
       this.deps.onReady?.();
     }
@@ -63,6 +80,7 @@ export class OverlayLifecycleController {
   /** Force teardown (host closed / tests). */
   forceDestroy(): void {
     this.cancelIdle();
+    this.createGeneration += 1;
     if (!this.state.created) return;
     this.deps.destroy();
     this.state.created = false;

--- a/apps/desktop-electron/src/overlay/overlay-lifecycle.ts
+++ b/apps/desktop-electron/src/overlay/overlay-lifecycle.ts
@@ -1,0 +1,92 @@
+/**
+ * Pure lifecycle controller for a single host's overlay surface.
+ * Injectable clock + create/destroy for unit tests (no Electron imports).
+ */
+
+export type OverlayLifecycleState = {
+  created: boolean;
+  ready: boolean;
+  activityGeneration: number;
+  idleTimerToken: number | null;
+};
+
+export type OverlayLifecycleDeps = {
+  now: () => number;
+  setTimeout: (fn: () => void, ms: number) => number;
+  clearTimeout: (token: number) => void;
+  idleMs: number;
+  create: () => void | Promise<void>;
+  destroy: () => void;
+  onReady?: () => void;
+};
+
+export class OverlayLifecycleController {
+  private state: OverlayLifecycleState = {
+    created: false,
+    ready: false,
+    activityGeneration: 0,
+    idleTimerToken: null,
+  };
+
+  constructor(private readonly deps: OverlayLifecycleDeps) {}
+
+  getState(): Readonly<OverlayLifecycleState> {
+    return { ...this.state };
+  }
+
+  /** First need → create; cancels idle destroy. */
+  async ensure(): Promise<{ created: boolean; ready: boolean }> {
+    this.cancelIdle();
+    if (!this.state.created) {
+      this.state.created = true;
+      this.state.ready = false;
+      await this.deps.create();
+      this.state.ready = true;
+      this.deps.onReady?.();
+    }
+    return { created: this.state.created, ready: this.state.ready };
+  }
+
+  /** Elevated layers still active — keep surface, reset idle. */
+  noteActivity(): void {
+    if (!this.state.created) return;
+    this.cancelIdle();
+    this.state.activityGeneration += 1;
+  }
+
+  /** Zero elevated layers — start idle countdown to destroy. */
+  release(): void {
+    if (!this.state.created) return;
+    this.scheduleIdle();
+  }
+
+  /** Force teardown (host closed / tests). */
+  forceDestroy(): void {
+    this.cancelIdle();
+    if (!this.state.created) return;
+    this.deps.destroy();
+    this.state.created = false;
+    this.state.ready = false;
+  }
+
+  private scheduleIdle(): void {
+    this.cancelIdle();
+    const gen = this.state.activityGeneration;
+    this.state.idleTimerToken = this.deps.setTimeout(() => {
+      this.state.idleTimerToken = null;
+      // Stale timer if activity resumed.
+      if (this.state.activityGeneration !== gen) return;
+      if (!this.state.created) return;
+      this.deps.destroy();
+      this.state.created = false;
+      this.state.ready = false;
+    }, this.deps.idleMs);
+  }
+
+  private cancelIdle(): void {
+    if (this.state.idleTimerToken != null) {
+      this.deps.clearTimeout(this.state.idleTimerToken);
+      this.state.idleTimerToken = null;
+    }
+  }
+}

--- a/apps/desktop-electron/src/overlay/overlay-surface-manager.ts
+++ b/apps/desktop-electron/src/overlay/overlay-surface-manager.ts
@@ -64,6 +64,8 @@ export function overlayWindowOpenHandler(
         ...bounds,
         frame: false,
         transparent: true,
+        // Critical for macOS: without this, transparent windows often paint opaque black.
+        backgroundColor: "#00000000",
         hasShadow: false,
         resizable: false,
         maximizable: false,
@@ -72,10 +74,12 @@ export function overlayWindowOpenHandler(
         skipTaskbar: true,
         show: false,
         focusable: true,
+        // Avoid stealing key focus from the host when the overlay appears.
         webPreferences: {
           contextIsolation: true,
           nodeIntegration: false,
           sandbox: true,
+          backgroundThrottling: false,
         },
       },
     };
@@ -169,8 +173,20 @@ export class OverlaySurfaceManager {
       }
     }
     entry.overlay = child;
+    try {
+      // Reinforce transparency after create (some platforms ignore options alone).
+      child.setBackgroundColor("#00000000");
+    } catch {
+      /* ignore */
+    }
     this.syncBounds(entry);
-    this.applyPointerMode(entry);
+    // Start non-interactive + hidden until noteActivity.
+    try {
+      child.setIgnoreMouseEvents(true, { forward: true });
+      if (child.isVisible()) child.hide();
+    } catch {
+      /* ignore */
+    }
 
     child.on("closed", () => {
       if (entry.overlay === child) entry.overlay = null;
@@ -229,10 +245,13 @@ export class OverlaySurfaceManager {
     const win = entry.overlay;
     if (!win || win.isDestroyed()) return;
     try {
-      // v1: always receive mouse events so elevated menus/dialogs are clickable.
-      // setIgnoreMouseEvents(true) makes the whole window unclickable; CSS cannot override.
-      void entry.pointerMode;
-      win.setIgnoreMouseEvents(false);
+      // Only capture while elevated content is active (noteActivity path).
+      // release() always forces ignore+hide separately.
+      if (entry.pointerMode === "pass-through") {
+        win.setIgnoreMouseEvents(true, { forward: true });
+      } else {
+        win.setIgnoreMouseEvents(false);
+      }
     } catch {
       /* ignore */
     }
@@ -278,12 +297,18 @@ export class OverlaySurfaceManager {
     const entry = this.byHostId.get(this.hostKey(h));
     if (!entry) return;
     entry.lifecycle.noteActivity();
+    entry.pointerMode = "capture";
     // Layers open: surface must be visible and receive input.
     const win = entry.overlay;
     if (win && !win.isDestroyed()) {
       try {
-        if (!win.isVisible()) win.showInactive();
-        win.setIgnoreMouseEvents(false);
+        win.setBackgroundColor("#00000000");
+        this.syncBounds(entry);
+        this.applyPointerMode(entry);
+        if (!win.isVisible()) {
+          // showInactive: do not steal keyboard focus from the host shell.
+          win.showInactive();
+        }
       } catch {
         /* ignore */
       }
@@ -296,12 +321,13 @@ export class OverlaySurfaceManager {
     const entry = this.byHostId.get(this.hostKey(h));
     if (!entry) return;
     entry.lifecycle.release();
-    // R1: empty overlay must not block host/preview input during idle window.
+    entry.pointerMode = "pass-through";
+    // Empty overlay must not block host/preview input (and must not stay painted black).
     const win = entry.overlay;
     if (win && !win.isDestroyed()) {
       try {
         win.setIgnoreMouseEvents(true, { forward: true });
-        win.hide();
+        if (win.isVisible()) win.hide();
       } catch {
         /* ignore */
       }

--- a/apps/desktop-electron/src/overlay/overlay-surface-manager.ts
+++ b/apps/desktop-electron/src/overlay/overlay-surface-manager.ts
@@ -13,7 +13,11 @@ import {
   type HandlerDetails,
 } from "electron";
 import type { AppState } from "../app-state.js";
-import { OVERLAY_IDLE_MS, OVERLAY_WINDOW_NAME_PREFIX } from "./constants.js";
+import {
+  OVERLAY_CREATE_BUDGET_MS,
+  OVERLAY_IDLE_MS,
+  OVERLAY_WINDOW_NAME_PREFIX,
+} from "./constants.js";
 import { OverlayLifecycleController } from "./overlay-lifecycle.js";
 
 export type OverlayPointerMode = "pass-through" | "capture";
@@ -129,10 +133,11 @@ export class OverlaySurfaceManager {
       clearTimeout: (t) => clearTimeout(t),
       idleMs: OVERLAY_IDLE_MS,
       create: async () => {
-        // Prefer host window.open registration. If host already opened the
-        // portal window, did-create-window registered it. Otherwise wait briefly
-        // for registration; only then fall back to main-owned window.
-        const deadline = Date.now() + 400;
+        // Overlay must be opened by the host renderer via window.open so the
+        // web side can install a createPortal root. Wait briefly for
+        // did-create-window registration; if none arrives, fail so lifecycle
+        // stays retryable and elevation falls back to APP-029 hide.
+        const deadline = Date.now() + OVERLAY_CREATE_BUDGET_MS;
         while (
           (!entryRef.overlay || entryRef.overlay.isDestroyed()) &&
           Date.now() < deadline
@@ -140,7 +145,9 @@ export class OverlaySurfaceManager {
           await new Promise((r) => setTimeout(r, 16));
         }
         if (!entryRef.overlay || entryRef.overlay.isDestroyed()) {
-          await this.createFallbackOverlay(entryRef);
+          throw new Error(
+            "overlay window not registered by host window.open within create budget",
+          );
         }
       },
       destroy: () => {
@@ -171,47 +178,6 @@ export class OverlaySurfaceManager {
 
     this.emitToHost(host, "desktop-overlay:ready", {
       windowId: child.id,
-      hostId: host.id,
-    });
-  }
-
-  private async createFallbackOverlay(entry: HostOverlay): Promise<void> {
-    if (entry.overlay && !entry.overlay.isDestroyed()) return;
-    const host = entry.host;
-    if (host.isDestroyed()) throw new Error("host window destroyed");
-
-    const bounds = host.getContentBounds();
-    const win = new BrowserWindow({
-      parent: host,
-      ...bounds,
-      frame: false,
-      transparent: true,
-      hasShadow: false,
-      resizable: false,
-      maximizable: false,
-      minimizable: false,
-      fullscreenable: false,
-      skipTaskbar: true,
-      show: false,
-      focusable: true,
-      webPreferences: {
-        contextIsolation: true,
-        nodeIntegration: false,
-        sandbox: true,
-      },
-    });
-    entry.overlay = win;
-    await win.loadURL("about:blank");
-    this.syncBounds(entry);
-    // Stay hidden until noteActivity (portal has real layers) — R4.
-    try {
-      win.setIgnoreMouseEvents(true, { forward: true });
-      if (win.isVisible()) win.hide();
-    } catch {
-      /* ignore */
-    }
-    this.emitToHost(host, "desktop-overlay:ready", {
-      windowId: win.id,
       hostId: host.id,
     });
   }

--- a/apps/desktop-electron/src/overlay/overlay-surface-manager.ts
+++ b/apps/desktop-electron/src/overlay/overlay-surface-manager.ts
@@ -23,6 +23,8 @@ type HostOverlay = {
   overlay: BrowserWindow | null;
   lifecycle: OverlayLifecycleController;
   pointerMode: OverlayPointerMode;
+  /** Bound once per host entry so recreate cycles do not leak listeners. */
+  syncBounds: () => void;
 };
 
 function isOverlayFrame(details: HandlerDetails): boolean {
@@ -92,10 +94,8 @@ export class OverlaySurfaceManager {
     );
 
     host.webContents.on("did-create-window", (child, details) => {
-      if (
-        details.frameName === "atmos-desktop-overlay" ||
-        (details.frameName ?? "").startsWith(OVERLAY_WINDOW_NAME_PREFIX)
-      ) {
+      // Same predicate as open-handler so every styled overlay is registered.
+      if (isOverlayFrame(details)) {
         this.registerOverlayWindow(host, child);
       }
     });
@@ -115,7 +115,13 @@ export class OverlaySurfaceManager {
       overlay: null,
       pointerMode: "pass-through",
       lifecycle: null as unknown as OverlayLifecycleController,
+      syncBounds: () => {},
     };
+
+    entryRef.syncBounds = () => this.syncBounds(entryRef);
+    // Once per host — overlay recreate cycles must not re-add listeners.
+    host.on("resize", entryRef.syncBounds);
+    host.on("move", entryRef.syncBounds);
 
     entryRef.lifecycle = new OverlayLifecycleController({
       now: () => Date.now(),
@@ -158,10 +164,6 @@ export class OverlaySurfaceManager {
     entry.overlay = child;
     this.syncBounds(entry);
     this.applyPointerMode(entry);
-
-    const syncBounds = () => this.syncBounds(entry);
-    host.on("resize", syncBounds);
-    host.on("move", syncBounds);
 
     child.on("closed", () => {
       if (entry.overlay === child) entry.overlay = null;
@@ -345,12 +347,28 @@ export class OverlaySurfaceManager {
     const entry = this.byHostId.get(id);
     if (!entry) return;
     entry.lifecycle.forceDestroy();
+    try {
+      if (!host.isDestroyed()) {
+        host.removeListener("resize", entry.syncBounds);
+        host.removeListener("move", entry.syncBounds);
+      }
+    } catch {
+      /* ignore */
+    }
     this.byHostId.delete(id);
   }
 
   destroyAll(): void {
     for (const entry of this.byHostId.values()) {
       entry.lifecycle.forceDestroy();
+      try {
+        if (!entry.host.isDestroyed()) {
+          entry.host.removeListener("resize", entry.syncBounds);
+          entry.host.removeListener("move", entry.syncBounds);
+        }
+      } catch {
+        /* ignore */
+      }
     }
     this.byHostId.clear();
   }

--- a/apps/desktop-electron/src/overlay/overlay-surface-manager.ts
+++ b/apps/desktop-electron/src/overlay/overlay-surface-manager.ts
@@ -1,0 +1,363 @@
+/**
+ * Per-host singleton overlay BrowserWindow for APP-052.
+ * Lazy create + idle destroy. Stacks above WebContentsView previews via parented window.
+ *
+ * Host renderer opens about:blank (same-origin) via window.open for createPortal access;
+ * main process intercepts and applies transparent parented window options, then tracks
+ * lifecycle / idle destroy here.
+ */
+
+import {
+  BrowserWindow,
+  type BrowserWindowConstructorOptions,
+  type HandlerDetails,
+} from "electron";
+import type { AppState } from "../app-state.js";
+import { OVERLAY_IDLE_MS, OVERLAY_WINDOW_NAME_PREFIX } from "./constants.js";
+import { OverlayLifecycleController } from "./overlay-lifecycle.js";
+
+export type OverlayPointerMode = "pass-through" | "capture";
+
+type HostOverlay = {
+  host: BrowserWindow;
+  overlay: BrowserWindow | null;
+  lifecycle: OverlayLifecycleController;
+  pointerMode: OverlayPointerMode;
+};
+
+function isOverlayFrame(details: HandlerDetails): boolean {
+  const name = details.frameName ?? "";
+  if (name.startsWith(OVERLAY_WINDOW_NAME_PREFIX) || name === "atmos-desktop-overlay") {
+    return true;
+  }
+  // about:blank from product host for portal bootstrap
+  if (details.url === "about:blank" && name.includes("overlay")) return true;
+  return false;
+}
+
+export function overlayWindowOpenHandler(
+  host: BrowserWindow,
+  manager: OverlaySurfaceManager,
+): (details: HandlerDetails) =>
+  | { action: "deny" }
+  | {
+      action: "allow";
+      overrideBrowserWindowOptions?: BrowserWindowConstructorOptions;
+    } {
+  return (details) => {
+    if (!isOverlayFrame(details) && details.frameName !== "atmos-desktop-overlay") {
+      // Default: allow normal popups (rare); product mostly blocks elsewhere.
+      return { action: "allow" };
+    }
+
+    const bounds = host.getContentBounds();
+    return {
+      action: "allow",
+      overrideBrowserWindowOptions: {
+        parent: host,
+        ...bounds,
+        frame: false,
+        transparent: true,
+        hasShadow: false,
+        resizable: false,
+        maximizable: false,
+        minimizable: false,
+        fullscreenable: false,
+        skipTaskbar: true,
+        show: false,
+        focusable: true,
+        webPreferences: {
+          contextIsolation: true,
+          nodeIntegration: false,
+          sandbox: true,
+        },
+      },
+    };
+  };
+}
+
+export class OverlaySurfaceManager {
+  private readonly byHostId = new Map<number, HostOverlay>();
+
+  constructor(private readonly state: AppState) {}
+
+  private hostKey(host: BrowserWindow): number {
+    return host.id;
+  }
+
+  /** Wire window.open intercept on a product host window. */
+  attachHost(host: BrowserWindow): void {
+    host.webContents.setWindowOpenHandler(
+      overlayWindowOpenHandler(host, this),
+    );
+
+    host.webContents.on("did-create-window", (child, details) => {
+      if (
+        details.frameName === "atmos-desktop-overlay" ||
+        (details.frameName ?? "").startsWith(OVERLAY_WINDOW_NAME_PREFIX)
+      ) {
+        this.registerOverlayWindow(host, child);
+      }
+    });
+
+    host.once("closed", () => {
+      this.destroyForHost(host);
+    });
+  }
+
+  private getOrCreateEntry(host: BrowserWindow): HostOverlay {
+    const id = this.hostKey(host);
+    let entry = this.byHostId.get(id);
+    if (entry) return entry;
+
+    const entryRef: HostOverlay = {
+      host,
+      overlay: null,
+      pointerMode: "pass-through",
+      lifecycle: null as unknown as OverlayLifecycleController,
+    };
+
+    entryRef.lifecycle = new OverlayLifecycleController({
+      now: () => Date.now(),
+      setTimeout: (fn, ms) => setTimeout(fn, ms) as unknown as number,
+      clearTimeout: (t) => clearTimeout(t),
+      idleMs: OVERLAY_IDLE_MS,
+      create: async () => {
+        // Prefer host window.open registration. If host already opened the
+        // portal window, did-create-window registered it. Otherwise wait briefly
+        // for registration; only then fall back to main-owned window.
+        const deadline = Date.now() + 400;
+        while (
+          (!entryRef.overlay || entryRef.overlay.isDestroyed()) &&
+          Date.now() < deadline
+        ) {
+          await new Promise((r) => setTimeout(r, 16));
+        }
+        if (!entryRef.overlay || entryRef.overlay.isDestroyed()) {
+          await this.createFallbackOverlay(entryRef);
+        }
+      },
+      destroy: () => {
+        this.destroyOverlayWindow(entryRef);
+      },
+    });
+
+    this.byHostId.set(id, entryRef);
+    return entryRef;
+  }
+
+  private registerOverlayWindow(host: BrowserWindow, child: BrowserWindow): void {
+    const entry = this.getOrCreateEntry(host);
+    if (entry.overlay && !entry.overlay.isDestroyed() && entry.overlay !== child) {
+      try {
+        entry.overlay.close();
+      } catch {
+        /* ignore */
+      }
+    }
+    entry.overlay = child;
+    this.syncBounds(entry);
+    this.applyPointerMode(entry);
+
+    const syncBounds = () => this.syncBounds(entry);
+    host.on("resize", syncBounds);
+    host.on("move", syncBounds);
+
+    child.on("closed", () => {
+      if (entry.overlay === child) entry.overlay = null;
+    });
+
+    this.emitToHost(host, "desktop-overlay:ready", {
+      windowId: child.id,
+      hostId: host.id,
+    });
+  }
+
+  private async createFallbackOverlay(entry: HostOverlay): Promise<void> {
+    if (entry.overlay && !entry.overlay.isDestroyed()) return;
+    const host = entry.host;
+    if (host.isDestroyed()) throw new Error("host window destroyed");
+
+    const bounds = host.getContentBounds();
+    const win = new BrowserWindow({
+      parent: host,
+      ...bounds,
+      frame: false,
+      transparent: true,
+      hasShadow: false,
+      resizable: false,
+      maximizable: false,
+      minimizable: false,
+      fullscreenable: false,
+      skipTaskbar: true,
+      show: false,
+      focusable: true,
+      webPreferences: {
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+      },
+    });
+    entry.overlay = win;
+    await win.loadURL("about:blank");
+    this.syncBounds(entry);
+    // Stay hidden until noteActivity (portal has real layers) — R4.
+    try {
+      win.setIgnoreMouseEvents(true, { forward: true });
+      if (win.isVisible()) win.hide();
+    } catch {
+      /* ignore */
+    }
+    this.emitToHost(host, "desktop-overlay:ready", {
+      windowId: win.id,
+      hostId: host.id,
+    });
+  }
+
+  private syncBounds(entry: HostOverlay): void {
+    const { host, overlay } = entry;
+    if (!overlay || overlay.isDestroyed() || host.isDestroyed()) return;
+    try {
+      overlay.setBounds(host.getContentBounds());
+    } catch {
+      /* ignore */
+    }
+  }
+
+  private destroyOverlayWindow(entry: HostOverlay): void {
+    const win = entry.overlay;
+    entry.overlay = null;
+    if (win && !win.isDestroyed()) {
+      const hostId = entry.host.isDestroyed() ? null : entry.host.id;
+      try {
+        win.close();
+      } catch {
+        /* ignore */
+      }
+      if (hostId != null && !entry.host.isDestroyed()) {
+        this.emitToHost(entry.host, "desktop-overlay:destroyed", {
+          windowId: win.id,
+          hostId,
+        });
+      }
+    }
+  }
+
+  private emitToHost(
+    host: BrowserWindow,
+    channel: string,
+    payload: unknown,
+  ): void {
+    try {
+      if (!host.isDestroyed()) {
+        host.webContents.send(`atmos:desktop-event:${channel}`, payload);
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  private applyPointerMode(entry: HostOverlay): void {
+    const win = entry.overlay;
+    if (!win || win.isDestroyed()) return;
+    try {
+      // v1: always receive mouse events so elevated menus/dialogs are clickable.
+      // setIgnoreMouseEvents(true) makes the whole window unclickable; CSS cannot override.
+      void entry.pointerMode;
+      win.setIgnoreMouseEvents(false);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  async ensure(host: BrowserWindow | null): Promise<{
+    ok: boolean;
+    ready: boolean;
+    windowId?: number;
+  }> {
+    const h = host ?? this.state.mainWindow;
+    if (!h || h.isDestroyed()) {
+      return { ok: false, ready: false };
+    }
+    const entry = this.getOrCreateEntry(h);
+    try {
+      // Ensure only prepares the surface; do not show/capture here (B5).
+      // Host calls note_activity when portal has real layers.
+      const { ready } = await entry.lifecycle.ensure();
+      const windowId =
+        entry.overlay && !entry.overlay.isDestroyed()
+          ? entry.overlay.id
+          : undefined;
+      return { ok: true, ready, windowId };
+    } catch (err) {
+      console.error("[overlay] ensure failed", err);
+      return { ok: false, ready: false };
+    }
+  }
+
+  setPointerMode(host: BrowserWindow | null, mode: OverlayPointerMode): void {
+    const h = host ?? this.state.mainWindow;
+    if (!h || h.isDestroyed()) return;
+    const entry = this.byHostId.get(this.hostKey(h));
+    if (!entry) return;
+    entry.pointerMode = mode;
+    this.applyPointerMode(entry);
+  }
+
+  noteActivity(host: BrowserWindow | null): void {
+    const h = host ?? this.state.mainWindow;
+    if (!h || h.isDestroyed()) return;
+    const entry = this.byHostId.get(this.hostKey(h));
+    if (!entry) return;
+    entry.lifecycle.noteActivity();
+    // Layers open: surface must be visible and receive input.
+    const win = entry.overlay;
+    if (win && !win.isDestroyed()) {
+      try {
+        if (!win.isVisible()) win.showInactive();
+        win.setIgnoreMouseEvents(false);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  release(host: BrowserWindow | null): void {
+    const h = host ?? this.state.mainWindow;
+    if (!h || h.isDestroyed()) return;
+    const entry = this.byHostId.get(this.hostKey(h));
+    if (!entry) return;
+    entry.lifecycle.release();
+    // R1: empty overlay must not block host/preview input during idle window.
+    const win = entry.overlay;
+    if (win && !win.isDestroyed()) {
+      try {
+        win.setIgnoreMouseEvents(true, { forward: true });
+        win.hide();
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  destroyForHost(host: BrowserWindow): void {
+    const id = this.hostKey(host);
+    const entry = this.byHostId.get(id);
+    if (!entry) return;
+    entry.lifecycle.forceDestroy();
+    this.byHostId.delete(id);
+  }
+
+  destroyAll(): void {
+    for (const entry of this.byHostId.values()) {
+      entry.lifecycle.forceDestroy();
+    }
+    this.byHostId.clear();
+  }
+
+  surfaceCount(): number {
+    return [...this.byHostId.values()].filter(
+      (e) => e.overlay && !e.overlay.isDestroyed(),
+    ).length;
+  }
+}

--- a/apps/desktop-electron/src/overlay/overlay-surface-manager.ts
+++ b/apps/desktop-electron/src/overlay/overlay-surface-manager.ts
@@ -31,7 +31,12 @@ type HostOverlay = {
   syncBounds: () => void;
 };
 
-function isOverlayFrame(details: HandlerDetails): boolean {
+/** Structural subset shared by HandlerDetails and DidCreateWindowDetails. */
+type OverlayFrameDetails = Pick<HandlerDetails, "url"> & {
+  frameName?: string;
+};
+
+function isOverlayFrame(details: OverlayFrameDetails): boolean {
   const name = details.frameName ?? "";
   if (name.startsWith(OVERLAY_WINDOW_NAME_PREFIX) || name === "atmos-desktop-overlay") {
     return true;
@@ -41,46 +46,62 @@ function isOverlayFrame(details: HandlerDetails): boolean {
   return false;
 }
 
+function overlayWindowOptions(
+  host: BrowserWindow,
+): BrowserWindowConstructorOptions {
+  return {
+    parent: host,
+    ...host.getContentBounds(),
+    frame: false,
+    transparent: true,
+    backgroundColor: "#00000000",
+    hasShadow: false,
+    roundedCorners: false,
+    resizable: false,
+    maximizable: false,
+    minimizable: false,
+    fullscreenable: false,
+    skipTaskbar: true,
+    show: false,
+    focusable: true,
+  };
+}
+
 export function overlayWindowOpenHandler(
   host: BrowserWindow,
   manager: OverlaySurfaceManager,
-): (details: HandlerDetails) =>
-  | { action: "deny" }
-  | {
-      action: "allow";
-      overrideBrowserWindowOptions?: BrowserWindowConstructorOptions;
-    } {
+): (details: HandlerDetails) => Electron.WindowOpenHandlerResponse {
   return (details) => {
-    if (!isOverlayFrame(details) && details.frameName !== "atmos-desktop-overlay") {
+    if (!isOverlayFrame(details)) {
       // Default: allow normal popups (rare); product mostly blocks elsewhere.
       return { action: "allow" };
     }
 
-    const bounds = host.getContentBounds();
     return {
       action: "allow",
+      // webPreferences apply to the child webContents which is created
+      // before createWindow runs — they must be returned here.
       overrideBrowserWindowOptions: {
-        parent: host,
-        ...bounds,
-        frame: false,
-        transparent: true,
-        // Critical for macOS: without this, transparent windows often paint opaque black.
-        backgroundColor: "#00000000",
-        hasShadow: false,
-        resizable: false,
-        maximizable: false,
-        minimizable: false,
-        fullscreenable: false,
-        skipTaskbar: true,
-        show: false,
-        focusable: true,
-        // Avoid stealing key focus from the host when the overlay appears.
         webPreferences: {
           contextIsolation: true,
           nodeIntegration: false,
           sandbox: true,
           backgroundThrottling: false,
         },
+      },
+      // Per-pixel transparency only works when the window is constructed
+      // transparent. Renderer-initiated windows (window.open +
+      // overrideBrowserWindowOptions) do not reliably honor `transparent`
+      // (electron#22281 — paints opaque black), so main constructs the
+      // BrowserWindow itself. `options` carries the child webContents that
+      // keeps the opener's window.open proxy wired for createPortal.
+      createWindow: (options) => {
+        const overlay = new BrowserWindow({
+          ...options,
+          ...overlayWindowOptions(host),
+        });
+        manager.registerOverlayWindow(host, overlay);
+        return overlay.webContents;
       },
     };
   };
@@ -102,7 +123,7 @@ export class OverlaySurfaceManager {
     );
 
     host.webContents.on("did-create-window", (child, details) => {
-      // Same predicate as open-handler so every styled overlay is registered.
+      // Safety net; createWindow already registered main-constructed overlays.
       if (isOverlayFrame(details)) {
         this.registerOverlayWindow(host, child);
       }
@@ -163,9 +184,10 @@ export class OverlaySurfaceManager {
     return entryRef;
   }
 
-  private registerOverlayWindow(host: BrowserWindow, child: BrowserWindow): void {
+  registerOverlayWindow(host: BrowserWindow, child: BrowserWindow): void {
     const entry = this.getOrCreateEntry(host);
-    if (entry.overlay && !entry.overlay.isDestroyed() && entry.overlay !== child) {
+    if (entry.overlay === child) return;
+    if (entry.overlay && !entry.overlay.isDestroyed()) {
       try {
         entry.overlay.close();
       } catch {
@@ -173,12 +195,6 @@ export class OverlaySurfaceManager {
       }
     }
     entry.overlay = child;
-    try {
-      // Reinforce transparency after create (some platforms ignore options alone).
-      child.setBackgroundColor("#00000000");
-    } catch {
-      /* ignore */
-    }
     this.syncBounds(entry);
     // Start non-interactive + hidden until noteActivity.
     try {
@@ -214,6 +230,11 @@ export class OverlaySurfaceManager {
     if (win && !win.isDestroyed()) {
       const hostId = entry.host.isDestroyed() ? null : entry.host.id;
       try {
+        if (win.isFocused() && !entry.host.isDestroyed()) entry.host.focus();
+      } catch {
+        /* ignore */
+      }
+      try {
         win.close();
       } catch {
         /* ignore */
@@ -245,13 +266,36 @@ export class OverlaySurfaceManager {
     const win = entry.overlay;
     if (!win || win.isDestroyed()) return;
     try {
-      // Only capture while elevated content is active (noteActivity path).
-      // release() always forces ignore+hide separately.
+      // Pass-through (tooltip/hover-card only): clicks reach host + preview.
+      // Capture (menu/popover/dialog): overlay owns pointer input.
       if (entry.pointerMode === "pass-through") {
         win.setIgnoreMouseEvents(true, { forward: true });
       } else {
         win.setIgnoreMouseEvents(false);
       }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  /** Keyboard (Escape, menu nav, dialog inputs) must reach the overlay document. */
+  private focusOverlayForCapture(entry: HostOverlay): void {
+    const win = entry.overlay;
+    if (!win || win.isDestroyed()) return;
+    if (entry.pointerMode !== "capture") return;
+    try {
+      if (win.isVisible() && !win.isFocused()) win.focus();
+    } catch {
+      /* ignore */
+    }
+  }
+
+  /** Return keyboard focus to the host when the overlay gives up input. */
+  private refocusHost(entry: HostOverlay): void {
+    const { host, overlay } = entry;
+    if (!overlay || overlay.isDestroyed() || host.isDestroyed()) return;
+    try {
+      if (overlay.isFocused()) host.focus();
     } catch {
       /* ignore */
     }
@@ -287,8 +331,14 @@ export class OverlaySurfaceManager {
     if (!h || h.isDestroyed()) return;
     const entry = this.byHostId.get(this.hostKey(h));
     if (!entry) return;
+    const changed = entry.pointerMode !== mode;
     entry.pointerMode = mode;
     this.applyPointerMode(entry);
+    if (changed && mode === "capture") {
+      this.focusOverlayForCapture(entry);
+    } else if (changed && mode === "pass-through") {
+      this.refocusHost(entry);
+    }
   }
 
   noteActivity(host: BrowserWindow | null): void {
@@ -297,17 +347,17 @@ export class OverlaySurfaceManager {
     const entry = this.byHostId.get(this.hostKey(h));
     if (!entry) return;
     entry.lifecycle.noteActivity();
-    entry.pointerMode = "capture";
-    // Layers open: surface must be visible and receive input.
+    // Layers open: surface must be visible; pointer mode is owned by the host
+    // renderer via set_pointer_mode (do not force capture here).
     const win = entry.overlay;
     if (win && !win.isDestroyed()) {
       try {
-        win.setBackgroundColor("#00000000");
         this.syncBounds(entry);
         this.applyPointerMode(entry);
         if (!win.isVisible()) {
-          // showInactive: do not steal keyboard focus from the host shell.
+          // showInactive: never steal keyboard focus for pass-through layers.
           win.showInactive();
+          this.focusOverlayForCapture(entry);
         }
       } catch {
         /* ignore */
@@ -322,7 +372,8 @@ export class OverlaySurfaceManager {
     if (!entry) return;
     entry.lifecycle.release();
     entry.pointerMode = "pass-through";
-    // Empty overlay must not block host/preview input (and must not stay painted black).
+    // Empty overlay must not block host/preview input or hold keyboard focus.
+    this.refocusHost(entry);
     const win = entry.overlay;
     if (win && !win.isDestroyed()) {
       try {

--- a/apps/desktop-electron/src/windows/main-window.ts
+++ b/apps/desktop-electron/src/windows/main-window.ts
@@ -68,6 +68,12 @@ export function createMainWindow(state: AppState, uiUrl: string): BrowserWindow 
   });
 
   state.mainWindow = win;
+  // APP-052: intercept overlay window.open + track per-host surface.
+  try {
+    state.overlay?.attachHost(win);
+  } catch (e) {
+    console.warn("[desktop-electron] overlay attachHost failed", e);
+  }
   return win;
 }
 

--- a/apps/desktop-electron/src/windows/secondary.ts
+++ b/apps/desktop-electron/src/windows/secondary.ts
@@ -50,6 +50,11 @@ function openOrFocus(
   });
 
   wireFullscreenEvents(win);
+  try {
+    state.overlay?.attachHost(win);
+  } catch {
+    /* optional until overlay manager boots */
+  }
   secondaryWindows.set(label, win);
   win.on("closed", () => {
     secondaryWindows.delete(label);

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -40,6 +40,19 @@ imports and feature store writes.
 
 ---
 
+## Desktop floating UI over native preview
+
+On Electron desktop, native preview is a `WebContentsView` above host DOM. **Do not** rely on `z-index` to cover it. Prefer `@workspace/ui` portals (already elevation-aware). Avoid unconditional “hide preview when my popover opens” flags when elevation covers; use markers / shared policy.
+
+| When | Action |
+|------|--------|
+| Adding dialogs/popovers/menus/tooltips that may overlap preview | Load [agents/references/desktop-floating-ui.md](../../agents/references/desktop-floating-ui.md) |
+| Changing elevation / occlusion | `src/shared/lib/desktop-overlay/*`, `features/run-preview` occlusion + Preview suspend composition |
+
+Web-only paths stay unchanged (portal default body). Spec: APP-052 / APP-029.
+
+---
+
 ## API & transport
 
 ### Resolving the Server

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { DesktopExternalUrlBridge } from "@/providers/app/desktop-external-url-b
 import { WorkbenchIntlProvider } from "@/providers/app/workbench-intl-provider";
 import UpdateNotification from "@/app-shell/UpdateNotification";
 import { ServerStateEventBridge } from "@/providers/app/server-state-event-bridge";
+import { FloatingElevationProvider } from "@/shared/lib/desktop-overlay/floating-elevation-provider";
 import {
   AgentToastProvider,
   AnchoredToastProvider,
@@ -82,7 +83,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                     <AgentToastProvider>
                       <AnchoredToastProvider>
                         <TooltipProvider>
-                          {children}
+                          <FloatingElevationProvider>
+                            {children}
+                          </FloatingElevationProvider>
                         </TooltipProvider>
                       </AnchoredToastProvider>
                     </AgentToastProvider>

--- a/apps/web/src/features/run-preview/components/Preview.tsx
+++ b/apps/web/src/features/run-preview/components/Preview.tsx
@@ -38,10 +38,7 @@ import { usePreviewLifecycleEffects } from "../hooks/use-preview-lifecycle-effec
 import { usePreviewNavigation } from "../hooks/use-preview-navigation";
 import { useNativePreviewOcclusion } from "../hooks/use-native-preview-occlusion";
 import { useDesktopElevationStore } from "@/shared/lib/desktop-overlay/elevation-store";
-import {
-  shouldSuspendDesktopNativePreview,
-  shouldSuspendFromOcclusion,
-} from "@/shared/lib/desktop-overlay/elevation-policy";
+import { shouldSuspendDesktopNativePreview } from "@/shared/lib/desktop-overlay/elevation-policy";
 import { usePreviewSelection } from "../hooks/use-preview-selection";
 import { usePreviewToolbarLayout } from "../hooks/use-preview-toolbar-layout";
 import { usePreviewWindowState } from "../hooks/use-preview-window-state";
@@ -337,14 +334,14 @@ export const Preview: React.FC<PreviewProps> = ({
     surfaceRef: desktopViewportRef,
     ignoredRootRef: previewRootRef,
   });
-  // APP-052: when elevation covers open floaters, do not hide native preview.
-  // Requires a live portal container so host-only floaters still use APP-029 hide.
-  const elevationCovers = useDesktopElevationStore(
+  // APP-052: while the overlay surface is healthy, `@workspace/ui` portals
+  // mount into the overlay document, so elevatable chrome never needs the
+  // APP-029 hide. Host-document floaters still hide via geometry occlusion.
+  const elevationHealthy = useDesktopElevationStore(
     (s) =>
       s.capability &&
       s.surfaceReady &&
       !s.ensureFailed &&
-      s.elevatedLayerCount > 0 &&
       s.portalContainer != null,
   );
   // Mark native preview presence for FloatingElevationProvider (lazy elevate).
@@ -361,14 +358,13 @@ export const Preview: React.FC<PreviewProps> = ({
   // NOTE: Do not suspend based on right-sidebar collapse — that used to hide
   // *every* desktop-native surface (including center browsers). Sidebar
   // visibility is handled via BrowserPanel `isActive` in RightSidebar instead.
-  const suspendFromOcclusion =
+  // Host-document occlusion candidates are by definition not elevated
+  // (elevated layers live in the overlay document) → always hide for them.
+  const hostOcclusion =
     !disableNativePreviewOcclusion &&
     !suppressNativePreviewOcclusion &&
-    shouldSuspendFromOcclusion({
-      isOccluded: isDesktopNativePreviewOccluded,
-      elevationCovers,
-    });
-  // Elevatable chrome (popover/header/search) must not force hide when elevation covers (AC2/M3).
+    isDesktopNativePreviewOccluded;
+  // Elevatable chrome (popover/header/search) must not force hide when elevation is healthy (AC2/M3).
   const elevatableChromeOpen =
     favoritesListOpen ||
     favoritePopoverOpen ||
@@ -379,9 +375,9 @@ export const Preview: React.FC<PreviewProps> = ({
     isStandaloneHandoffOpen:
       !isStandaloneBrowserWindow && isPreviewStandaloneOpen,
     isPreviewLoading,
-    suspendFromOcclusion,
-    elevationCovers,
+    hostOcclusion,
     elevatableChromeOpen,
+    elevationHealthy,
   });
   const {
     checkExtensionUpdate,

--- a/apps/web/src/features/run-preview/components/Preview.tsx
+++ b/apps/web/src/features/run-preview/components/Preview.tsx
@@ -37,6 +37,11 @@ import { usePreviewIframeLoad } from "../hooks/use-preview-iframe-load";
 import { usePreviewLifecycleEffects } from "../hooks/use-preview-lifecycle-effects";
 import { usePreviewNavigation } from "../hooks/use-preview-navigation";
 import { useNativePreviewOcclusion } from "../hooks/use-native-preview-occlusion";
+import { useDesktopElevationStore } from "@/shared/lib/desktop-overlay/elevation-store";
+import {
+  shouldSuspendDesktopNativePreview,
+  shouldSuspendFromOcclusion,
+} from "@/shared/lib/desktop-overlay/elevation-policy";
 import { usePreviewSelection } from "../hooks/use-preview-selection";
 import { usePreviewToolbarLayout } from "../hooks/use-preview-toolbar-layout";
 import { usePreviewWindowState } from "../hooks/use-preview-window-state";
@@ -323,26 +328,61 @@ export const Preview: React.FC<PreviewProps> = ({
     }
   }, [normalizedActiveUrl]);
   const isDesktopNativePreviewOccluded = useNativePreviewOcclusion({
+    // APP-052 M5: standalone/detached browser hosts also need occlusion fallback.
     enabled:
       preferredTransportMode === 'desktop-native' &&
       isActive &&
-      !isStandaloneBrowserWindow &&
       !disableNativePreviewOcclusion &&
       !suppressNativePreviewOcclusion,
     surfaceRef: desktopViewportRef,
     ignoredRootRef: previewRootRef,
   });
+  // APP-052: when elevation covers open floaters, do not hide native preview.
+  // Requires a live portal container so host-only floaters still use APP-029 hide.
+  const elevationCovers = useDesktopElevationStore(
+    (s) =>
+      s.capability &&
+      s.surfaceReady &&
+      !s.ensureFailed &&
+      s.elevatedLayerCount > 0 &&
+      s.portalContainer != null,
+  );
+  // Mark native preview presence for FloatingElevationProvider (lazy elevate).
+  // Refcount so multi-Preview hosts and standalone windows do not clear each other.
+  useEffect(() => {
+    const present =
+      preferredTransportMode === "desktop-native" && isActive;
+    if (!present) return;
+    useDesktopElevationStore.getState().acquireNativePreviewSurface();
+    return () => {
+      useDesktopElevationStore.getState().releaseNativePreviewSurface();
+    };
+  }, [preferredTransportMode, isActive]);
   // NOTE: Do not suspend based on right-sidebar collapse — that used to hide
   // *every* desktop-native surface (including center browsers). Sidebar
   // visibility is handled via BrowserPanel `isActive` in RightSidebar instead.
-  const shouldSuspendDesktopPreview =
-      preferredTransportMode === 'desktop-native' && (
-        (!isStandaloneBrowserWindow && isPreviewStandaloneOpen) ||
-        isPreviewLoading ||
-        (!disableNativePreviewOcclusion && !suppressNativePreviewOcclusion && isDesktopNativePreviewOccluded) ||
-        favoritesListOpen || favoritePopoverOpen ||
-        headerHasOpenOverlay || isGlobalSearchOpen
-      );
+  const suspendFromOcclusion =
+    !disableNativePreviewOcclusion &&
+    !suppressNativePreviewOcclusion &&
+    shouldSuspendFromOcclusion({
+      isOccluded: isDesktopNativePreviewOccluded,
+      elevationCovers,
+    });
+  // Elevatable chrome (popover/header/search) must not force hide when elevation covers (AC2/M3).
+  const elevatableChromeOpen =
+    favoritesListOpen ||
+    favoritePopoverOpen ||
+    headerHasOpenOverlay ||
+    isGlobalSearchOpen;
+  const shouldSuspendDesktopPreview = shouldSuspendDesktopNativePreview({
+    isDesktopNative: preferredTransportMode === "desktop-native",
+    isStandaloneHandoffOpen:
+      !isStandaloneBrowserWindow && isPreviewStandaloneOpen,
+    isPreviewLoading,
+    suspendFromOcclusion,
+    elevationCovers,
+    elevatableChromeOpen,
+  });
   const {
     checkExtensionUpdate,
     extensionDownloadStarted,

--- a/apps/web/src/features/run-preview/hooks/__tests__/use-native-preview-occlusion.test.ts
+++ b/apps/web/src/features/run-preview/hooks/__tests__/use-native-preview-occlusion.test.ts
@@ -100,4 +100,20 @@ describe("readNativePreviewOcclusionSnapshot", () => {
     const snapshot = readNativePreviewOcclusionSnapshot(surface, portal);
     expect(snapshot.isOccluded).toBe(false);
   });
+
+  it("treats tooltips as occluding candidates when they intersect (APP-052)", () => {
+    const surface = document.createElement("div");
+    setRect(surface, { left: 200, top: 80, width: 600, height: 400 });
+    document.body.appendChild(surface);
+
+    const tip = document.createElement("div");
+    tip.setAttribute("data-slot", "tooltip-content");
+    tip.style.opacity = "1";
+    setRect(tip, { left: 250, top: 100, width: 120, height: 32 });
+    document.body.appendChild(tip);
+
+    const snapshot = readNativePreviewOcclusionSnapshot(surface, null);
+    expect(snapshot.isOccluded).toBe(true);
+    expect(snapshot.candidates).toContain(tip);
+  });
 });

--- a/apps/web/src/features/run-preview/hooks/use-native-preview-occlusion.ts
+++ b/apps/web/src/features/run-preview/hooks/use-native-preview-occlusion.ts
@@ -18,10 +18,9 @@ const OVERLAY_CANDIDATE_SELECTOR = [
   "[data-radix-popper-content-wrapper]",
   "[role=\"dialog\"]",
   "[aria-modal=\"true\"]",
-].join(", ");
-
-const TOOLTIP_CANDIDATE_SELECTOR = [
+  // APP-052: tooltips elevate + participate in fallback occlusion (no longer ignored).
   "[data-slot=\"tooltip-content\"]",
+  "[data-slot=\"hover-card-content\"]",
   "[role=\"tooltip\"]",
 ].join(", ");
 
@@ -42,11 +41,6 @@ function rectsIntersect(a: DOMRect, b: DOMRect): boolean {
   return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
 }
 
-function isTooltipCandidate(element: Element): boolean {
-  if (element.matches(TOOLTIP_CANDIDATE_SELECTOR)) return true;
-  return Boolean(element.querySelector(TOOLTIP_CANDIDATE_SELECTOR));
-}
-
 function isVisibleOverlayCandidate(
   element: Element,
   ignoredRoot: HTMLElement | null,
@@ -57,7 +51,7 @@ function isVisibleOverlayCandidate(
   if (element.contains(surface)) return false;
   if (ignoredRoot?.contains(element)) return false;
   if (element.closest("[data-atmos-ignore-native-surface-occlusion]")) return false;
-  if (isTooltipCandidate(element)) return false;
+  // APP-052: tooltips/hover-cards are elevatable and participate in fallback occlusion.
   if (element.getAttribute("data-state") === "closed") return false;
   if (!isNativeSurfaceOverlay && element.getAttribute("aria-hidden") === "true") return false;
 

--- a/apps/web/src/shared/lib/desktop-overlay/__tests__/elevation-policy.test.ts
+++ b/apps/web/src/shared/lib/desktop-overlay/__tests__/elevation-policy.test.ts
@@ -1,222 +1,107 @@
 import { describe, expect, it } from "bun:test";
 import {
-  computeElevationCovers,
-  expandRect,
-  pointerModeForLayers,
-  shouldElevate,
-  shouldFallbackHideDuringEnsure,
+  computeElevationHealthy,
   shouldSuspendDesktopNativePreview,
-  shouldSuspendFromOcclusion,
 } from "../elevation-policy";
 
-describe("shouldElevate", () => {
-  const base = {
-    capability: true,
-    nativePreviewPresent: true,
-    modal: false,
-    intersectsPreview: false,
-  };
-
-  it("never elevates without capability", () => {
+describe("computeElevationHealthy", () => {
+  it("requires capability and ready surface without ensure failure", () => {
     expect(
-      shouldElevate("dialog", { ...base, capability: false, modal: true }),
-    ).toBe(false);
-  });
-
-  it("never elevates without native preview", () => {
-    expect(
-      shouldElevate("dialog", {
-        ...base,
-        nativePreviewPresent: false,
-        modal: true,
-      }),
-    ).toBe(false);
-  });
-
-  it("always elevates modal dialog/sheet/drawer when preview present", () => {
-    expect(shouldElevate("dialog", { ...base, modal: true })).toBe(true);
-    expect(shouldElevate("sheet", base)).toBe(true);
-    expect(shouldElevate("drawer", base)).toBe(true);
-  });
-
-  it("elevates popover/tooltip only when intersecting", () => {
-    expect(shouldElevate("popover", base)).toBe(false);
-    expect(shouldElevate("tooltip", base)).toBe(false);
-    expect(
-      shouldElevate("popover", { ...base, intersectsPreview: true }),
-    ).toBe(true);
-    expect(
-      shouldElevate("tooltip", { ...base, intersectsPreview: true }),
-    ).toBe(true);
-    expect(
-      shouldElevate("hover-card", { ...base, intersectsPreview: true }),
-    ).toBe(true);
-  });
-});
-
-describe("shouldSuspendFromOcclusion", () => {
-  it("suspends only when occluded and elevation does not cover", () => {
-    expect(
-      shouldSuspendFromOcclusion({ isOccluded: true, elevationCovers: false }),
-    ).toBe(true);
-    expect(
-      shouldSuspendFromOcclusion({ isOccluded: true, elevationCovers: true }),
-    ).toBe(false);
-    expect(
-      shouldSuspendFromOcclusion({ isOccluded: false, elevationCovers: false }),
-    ).toBe(false);
-  });
-});
-
-describe("computeElevationCovers", () => {
-  it("requires capability, ready surface, layers, and no ensure failure", () => {
-    expect(
-      computeElevationCovers({
+      computeElevationHealthy({
         capability: true,
         surfaceReady: true,
         ensureFailed: false,
-        elevatedLayerCount: 1,
       }),
     ).toBe(true);
     expect(
-      computeElevationCovers({
-        capability: true,
+      computeElevationHealthy({
+        capability: false,
         surfaceReady: true,
-        ensureFailed: true,
-        elevatedLayerCount: 1,
+        ensureFailed: false,
       }),
     ).toBe(false);
     expect(
-      computeElevationCovers({
+      computeElevationHealthy({
         capability: true,
         surfaceReady: false,
         ensureFailed: false,
-        elevatedLayerCount: 1,
       }),
     ).toBe(false);
     expect(
-      computeElevationCovers({
+      computeElevationHealthy({
         capability: true,
         surfaceReady: true,
-        ensureFailed: false,
-        elevatedLayerCount: 0,
+        ensureFailed: true,
       }),
     ).toBe(false);
   });
 });
 
-describe("pointerModeForLayers", () => {
-  it("capture when any modal layer", () => {
-    expect(pointerModeForLayers([{ modal: false }, { modal: true }])).toBe(
-      "capture",
-    );
-    expect(pointerModeForLayers([{ modal: false }])).toBe("pass-through");
-  });
-});
-
-describe("shouldSuspendDesktopNativePreview (AC2/M3 elevatable chrome)", () => {
+describe("shouldSuspendDesktopNativePreview (AC2/M3)", () => {
   const base = {
     isDesktopNative: true,
     isStandaloneHandoffOpen: false,
     isPreviewLoading: false,
-    suspendFromOcclusion: false,
-    elevationCovers: false,
+    hostOcclusion: false,
     elevatableChromeOpen: false,
+    elevationHealthy: false,
   };
 
-  it("does not suspend for favorites/header/search when elevation covers", () => {
+  it("never suspends non-desktop-native surfaces", () => {
     expect(
       shouldSuspendDesktopNativePreview({
         ...base,
-        elevationCovers: true,
+        isDesktopNative: false,
+        hostOcclusion: true,
         elevatableChromeOpen: true,
       }),
     ).toBe(false);
   });
 
-  it("suspends elevatable chrome when elevation does not cover (APP-029 fallback)", () => {
+  it("does not suspend for favorites/header/search when elevation is healthy", () => {
     expect(
       shouldSuspendDesktopNativePreview({
         ...base,
-        elevationCovers: false,
+        elevationHealthy: true,
+        elevatableChromeOpen: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("suspends elevatable chrome when elevation is unhealthy (APP-029 fallback)", () => {
+    expect(
+      shouldSuspendDesktopNativePreview({
+        ...base,
+        elevationHealthy: false,
         elevatableChromeOpen: true,
       }),
     ).toBe(true);
   });
 
-  it("still suspends for loading and standalone handoff even when elevation covers", () => {
+  it("always suspends for host-document occlusion (never elevated)", () => {
     expect(
       shouldSuspendDesktopNativePreview({
         ...base,
-        elevationCovers: true,
+        hostOcclusion: true,
+        elevationHealthy: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("still suspends for loading and standalone handoff even when elevation is healthy", () => {
+    expect(
+      shouldSuspendDesktopNativePreview({
+        ...base,
+        elevationHealthy: true,
         isPreviewLoading: true,
       }),
     ).toBe(true);
     expect(
       shouldSuspendDesktopNativePreview({
         ...base,
-        elevationCovers: true,
+        elevationHealthy: true,
         isStandaloneHandoffOpen: true,
       }),
     ).toBe(true);
-  });
-
-  it("suspends from occlusion only when elevation does not cover", () => {
-    expect(
-      shouldSuspendDesktopNativePreview({
-        ...base,
-        suspendFromOcclusion: true,
-        elevationCovers: false,
-      }),
-    ).toBe(true);
-    // suspendFromOcclusion is already false when elevation covers (composed upstream)
-    expect(
-      shouldSuspendDesktopNativePreview({
-        ...base,
-        suspendFromOcclusion: false,
-        elevationCovers: true,
-      }),
-    ).toBe(false);
-  });
-});
-
-describe("expandRect / fallback budget", () => {
-  it("expands rect by padding", () => {
-    expect(expandRect({ x: 10, y: 20, width: 100, height: 50 }, 16)).toEqual({
-      x: -6,
-      y: 4,
-      width: 132,
-      height: 82,
-    });
-  });
-
-  it("fallback hide after create budget while not ready and occluded", () => {
-    expect(
-      shouldFallbackHideDuringEnsure({
-        ensureStartedAt: 1000,
-        now: 1000 + 200,
-        ready: false,
-        createBudgetMs: 200,
-        isOccluded: true,
-      }),
-    ).toBe(true);
-    expect(
-      shouldFallbackHideDuringEnsure({
-        ensureStartedAt: 1000,
-        now: 1100,
-        ready: false,
-        createBudgetMs: 200,
-        isOccluded: true,
-      }),
-    ).toBe(false);
-    expect(
-      shouldFallbackHideDuringEnsure({
-        ensureStartedAt: 1000,
-        now: 2000,
-        ready: true,
-        createBudgetMs: 200,
-        isOccluded: true,
-      }),
-    ).toBe(false);
   });
 });

--- a/apps/web/src/shared/lib/desktop-overlay/__tests__/elevation-policy.test.ts
+++ b/apps/web/src/shared/lib/desktop-overlay/__tests__/elevation-policy.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "bun:test";
+import {
+  computeElevationCovers,
+  expandRect,
+  pointerModeForLayers,
+  shouldElevate,
+  shouldFallbackHideDuringEnsure,
+  shouldSuspendDesktopNativePreview,
+  shouldSuspendFromOcclusion,
+} from "../elevation-policy";
+
+describe("shouldElevate", () => {
+  const base = {
+    capability: true,
+    nativePreviewPresent: true,
+    modal: false,
+    intersectsPreview: false,
+  };
+
+  it("never elevates without capability", () => {
+    expect(
+      shouldElevate("dialog", { ...base, capability: false, modal: true }),
+    ).toBe(false);
+  });
+
+  it("never elevates without native preview", () => {
+    expect(
+      shouldElevate("dialog", {
+        ...base,
+        nativePreviewPresent: false,
+        modal: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("always elevates modal dialog/sheet/drawer when preview present", () => {
+    expect(shouldElevate("dialog", { ...base, modal: true })).toBe(true);
+    expect(shouldElevate("sheet", base)).toBe(true);
+    expect(shouldElevate("drawer", base)).toBe(true);
+  });
+
+  it("elevates popover/tooltip only when intersecting", () => {
+    expect(shouldElevate("popover", base)).toBe(false);
+    expect(shouldElevate("tooltip", base)).toBe(false);
+    expect(
+      shouldElevate("popover", { ...base, intersectsPreview: true }),
+    ).toBe(true);
+    expect(
+      shouldElevate("tooltip", { ...base, intersectsPreview: true }),
+    ).toBe(true);
+    expect(
+      shouldElevate("hover-card", { ...base, intersectsPreview: true }),
+    ).toBe(true);
+  });
+});
+
+describe("shouldSuspendFromOcclusion", () => {
+  it("suspends only when occluded and elevation does not cover", () => {
+    expect(
+      shouldSuspendFromOcclusion({ isOccluded: true, elevationCovers: false }),
+    ).toBe(true);
+    expect(
+      shouldSuspendFromOcclusion({ isOccluded: true, elevationCovers: true }),
+    ).toBe(false);
+    expect(
+      shouldSuspendFromOcclusion({ isOccluded: false, elevationCovers: false }),
+    ).toBe(false);
+  });
+});
+
+describe("computeElevationCovers", () => {
+  it("requires capability, ready surface, layers, and no ensure failure", () => {
+    expect(
+      computeElevationCovers({
+        capability: true,
+        surfaceReady: true,
+        ensureFailed: false,
+        elevatedLayerCount: 1,
+      }),
+    ).toBe(true);
+    expect(
+      computeElevationCovers({
+        capability: true,
+        surfaceReady: true,
+        ensureFailed: true,
+        elevatedLayerCount: 1,
+      }),
+    ).toBe(false);
+    expect(
+      computeElevationCovers({
+        capability: true,
+        surfaceReady: false,
+        ensureFailed: false,
+        elevatedLayerCount: 1,
+      }),
+    ).toBe(false);
+    expect(
+      computeElevationCovers({
+        capability: true,
+        surfaceReady: true,
+        ensureFailed: false,
+        elevatedLayerCount: 0,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("pointerModeForLayers", () => {
+  it("capture when any modal layer", () => {
+    expect(pointerModeForLayers([{ modal: false }, { modal: true }])).toBe(
+      "capture",
+    );
+    expect(pointerModeForLayers([{ modal: false }])).toBe("pass-through");
+  });
+});
+
+describe("shouldSuspendDesktopNativePreview (AC2/M3 elevatable chrome)", () => {
+  const base = {
+    isDesktopNative: true,
+    isStandaloneHandoffOpen: false,
+    isPreviewLoading: false,
+    suspendFromOcclusion: false,
+    elevationCovers: false,
+    elevatableChromeOpen: false,
+  };
+
+  it("does not suspend for favorites/header/search when elevation covers", () => {
+    expect(
+      shouldSuspendDesktopNativePreview({
+        ...base,
+        elevationCovers: true,
+        elevatableChromeOpen: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("suspends elevatable chrome when elevation does not cover (APP-029 fallback)", () => {
+    expect(
+      shouldSuspendDesktopNativePreview({
+        ...base,
+        elevationCovers: false,
+        elevatableChromeOpen: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("still suspends for loading and standalone handoff even when elevation covers", () => {
+    expect(
+      shouldSuspendDesktopNativePreview({
+        ...base,
+        elevationCovers: true,
+        isPreviewLoading: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSuspendDesktopNativePreview({
+        ...base,
+        elevationCovers: true,
+        isStandaloneHandoffOpen: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("suspends from occlusion only when elevation does not cover", () => {
+    expect(
+      shouldSuspendDesktopNativePreview({
+        ...base,
+        suspendFromOcclusion: true,
+        elevationCovers: false,
+      }),
+    ).toBe(true);
+    // suspendFromOcclusion is already false when elevation covers (composed upstream)
+    expect(
+      shouldSuspendDesktopNativePreview({
+        ...base,
+        suspendFromOcclusion: false,
+        elevationCovers: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("expandRect / fallback budget", () => {
+  it("expands rect by padding", () => {
+    expect(expandRect({ x: 10, y: 20, width: 100, height: 50 }, 16)).toEqual({
+      x: -6,
+      y: 4,
+      width: 132,
+      height: 82,
+    });
+  });
+
+  it("fallback hide after create budget while not ready and occluded", () => {
+    expect(
+      shouldFallbackHideDuringEnsure({
+        ensureStartedAt: 1000,
+        now: 1000 + 200,
+        ready: false,
+        createBudgetMs: 200,
+        isOccluded: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldFallbackHideDuringEnsure({
+        ensureStartedAt: 1000,
+        now: 1100,
+        ready: false,
+        createBudgetMs: 200,
+        isOccluded: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldFallbackHideDuringEnsure({
+        ensureStartedAt: 1000,
+        now: 2000,
+        ready: true,
+        createBudgetMs: 200,
+        isOccluded: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/shared/lib/desktop-overlay/__tests__/elevation-store.test.ts
+++ b/apps/web/src/shared/lib/desktop-overlay/__tests__/elevation-store.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { useDesktopElevationStore } from "../elevation-store";
+
+describe("nativePreviewSurface refcount (APP-052 AC4 / M5)", () => {
+  beforeEach(() => {
+    useDesktopElevationStore.setState({
+      capability: false,
+      nativePreviewPresent: false,
+      nativePreviewSurfaceCount: 0,
+      surfaceReady: false,
+      ensureFailed: false,
+      elevatedLayerCount: 0,
+      portalContainer: null,
+      pointerMode: "capture",
+    });
+  });
+
+  it("stays present until last surface releases", () => {
+    const s = useDesktopElevationStore.getState();
+    s.acquireNativePreviewSurface();
+    s.acquireNativePreviewSurface();
+    expect(useDesktopElevationStore.getState().nativePreviewPresent).toBe(true);
+    expect(useDesktopElevationStore.getState().nativePreviewSurfaceCount).toBe(
+      2,
+    );
+
+    s.releaseNativePreviewSurface();
+    expect(useDesktopElevationStore.getState().nativePreviewPresent).toBe(true);
+    expect(useDesktopElevationStore.getState().nativePreviewSurfaceCount).toBe(
+      1,
+    );
+
+    s.releaseNativePreviewSurface();
+    expect(useDesktopElevationStore.getState().nativePreviewPresent).toBe(
+      false,
+    );
+    expect(useDesktopElevationStore.getState().nativePreviewSurfaceCount).toBe(
+      0,
+    );
+  });
+
+  it("does not go negative on extra release", () => {
+    useDesktopElevationStore.getState().releaseNativePreviewSurface();
+    expect(useDesktopElevationStore.getState().nativePreviewSurfaceCount).toBe(
+      0,
+    );
+    expect(useDesktopElevationStore.getState().nativePreviewPresent).toBe(
+      false,
+    );
+  });
+
+  it("resetElevationRuntime keeps surface refcount", () => {
+    useDesktopElevationStore.getState().acquireNativePreviewSurface();
+    useDesktopElevationStore.getState().setSurfaceReady(true);
+    useDesktopElevationStore.getState().setElevatedLayerCount(2);
+    useDesktopElevationStore.getState().resetElevationRuntime();
+    expect(useDesktopElevationStore.getState().nativePreviewPresent).toBe(true);
+    expect(useDesktopElevationStore.getState().nativePreviewSurfaceCount).toBe(
+      1,
+    );
+    expect(useDesktopElevationStore.getState().surfaceReady).toBe(false);
+    expect(useDesktopElevationStore.getState().elevatedLayerCount).toBe(0);
+  });
+});

--- a/apps/web/src/shared/lib/desktop-overlay/__tests__/layer-count.test.ts
+++ b/apps/web/src/shared/lib/desktop-overlay/__tests__/layer-count.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { Window } from "happy-dom";
-import { countOpenLayers, isLifecycleOpenLayer } from "../layer-count";
+import {
+  countOpenLayers,
+  isLifecycleOpenLayer,
+  summarizeOpenLayers,
+} from "../layer-count";
 
 function installDom() {
   const window = new Window({ url: "https://atmos.test/" });
@@ -87,5 +91,69 @@ describe("isLifecycleOpenLayer / countOpenLayers (B5)", () => {
         },
       }) as DOMRect;
     expect(isLifecycleOpenLayer(el)).toBe(true);
+  });
+
+  it("counts layers from a foreign-realm document (overlay window)", () => {
+    // Simulate the overlay BrowserWindow: its nodes are instances of a
+    // DIFFERENT realm's HTMLElement — instanceof against the host realm
+    // must not be used (that regression made every elevated layer invisible).
+    class HostRealmHTMLElement {}
+    Object.assign(globalThis, { HTMLElement: HostRealmHTMLElement });
+
+    const foreign = new Window({ url: "https://atmos.test/overlay" });
+    const el = foreign.document.createElement("div");
+    el.setAttribute("data-slot", "dropdown-menu-content");
+    el.setAttribute("data-state", "open");
+    foreign.document.body.appendChild(el);
+
+    expect(
+      el instanceof (globalThis as unknown as { HTMLElement: typeof HostRealmHTMLElement }).HTMLElement,
+    ).toBe(false);
+    expect(
+      countOpenLayers([foreign.document as unknown as Document]),
+    ).toBe(1);
+  });
+});
+
+describe("summarizeOpenLayers pointer classification", () => {
+  let document: Document;
+
+  beforeEach(() => {
+    ({ document } = installDom());
+  });
+
+  it("tooltip/hover-card–only frames stay pass-through", () => {
+    const tooltip = document.createElement("div");
+    tooltip.setAttribute("data-slot", "tooltip-content");
+    tooltip.setAttribute("data-state", "open");
+    document.body.appendChild(tooltip);
+
+    const hoverCard = document.createElement("div");
+    hoverCard.setAttribute("data-slot", "hover-card-content");
+    hoverCard.setAttribute("data-state", "open");
+    document.body.appendChild(hoverCard);
+
+    expect(summarizeOpenLayers([document])).toEqual({ open: 2, capture: 0 });
+  });
+
+  it("menus and dialogs require capture", () => {
+    const tooltip = document.createElement("div");
+    tooltip.setAttribute("data-slot", "tooltip-content");
+    tooltip.setAttribute("data-state", "open");
+    document.body.appendChild(tooltip);
+
+    const menu = document.createElement("div");
+    menu.setAttribute("data-slot", "dropdown-menu-content");
+    menu.setAttribute("data-state", "open");
+    document.body.appendChild(menu);
+
+    expect(summarizeOpenLayers([document])).toEqual({ open: 2, capture: 1 });
+
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("data-state", "open");
+    document.body.appendChild(dialog);
+
+    expect(summarizeOpenLayers([document])).toEqual({ open: 3, capture: 2 });
   });
 });

--- a/apps/web/src/shared/lib/desktop-overlay/__tests__/layer-count.test.ts
+++ b/apps/web/src/shared/lib/desktop-overlay/__tests__/layer-count.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Window } from "happy-dom";
+import { countOpenLayers, isLifecycleOpenLayer } from "../layer-count";
+
+function installDom() {
+  const window = new Window({ url: "https://atmos.test/" });
+  const { document } = window;
+  Object.assign(globalThis, {
+    window,
+    document,
+    HTMLElement: window.HTMLElement,
+    Element: window.Element,
+    getComputedStyle: window.getComputedStyle.bind(window),
+  });
+  return { window, document };
+}
+
+describe("isLifecycleOpenLayer / countOpenLayers (B5)", () => {
+  let document: Document;
+
+  beforeEach(() => {
+    ({ document } = installDom());
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("counts dialog open even when opacity is 0 (fade-in frame)", () => {
+    const el = document.createElement("div");
+    el.setAttribute("data-slot", "dialog-content");
+    el.setAttribute("data-state", "open");
+    el.style.opacity = "0";
+    el.style.display = "block";
+    el.style.visibility = "visible";
+    document.body.appendChild(el);
+
+    expect(isLifecycleOpenLayer(el)).toBe(true);
+    expect(countOpenLayers([document])).toBe(1);
+  });
+
+  it("ignores closed data-state", () => {
+    const el = document.createElement("div");
+    el.setAttribute("data-slot", "popover-content");
+    el.setAttribute("data-state", "closed");
+    el.style.opacity = "1";
+    document.body.appendChild(el);
+    expect(countOpenLayers([document])).toBe(0);
+  });
+
+  it("ignores opacity-0 native surface markers (peek shell)", () => {
+    const el = document.createElement("div");
+    el.setAttribute("data-atmos-native-surface-overlay", "true");
+    el.style.opacity = "0";
+    el.style.display = "block";
+    el.style.visibility = "visible";
+    // give a non-zero rect via layout if happy-dom supports
+    el.style.width = "100px";
+    el.style.height = "100px";
+    document.body.appendChild(el);
+    expect(isLifecycleOpenLayer(el)).toBe(false);
+    expect(countOpenLayers([document])).toBe(0);
+  });
+
+  it("counts visible native surface markers", () => {
+    const el = document.createElement("div");
+    el.setAttribute("data-atmos-native-surface-overlay", "true");
+    el.style.opacity = "1";
+    el.style.display = "block";
+    el.style.visibility = "visible";
+    el.style.width = "100px";
+    el.style.height = "100px";
+    document.body.appendChild(el);
+    // happy-dom may report 0 rect without layout — inject getBoundingClientRect
+    el.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 100,
+        right: 100,
+        bottom: 100,
+        toJSON() {
+          return this;
+        },
+      }) as DOMRect;
+    expect(isLifecycleOpenLayer(el)).toBe(true);
+  });
+});

--- a/apps/web/src/shared/lib/desktop-overlay/constants.ts
+++ b/apps/web/src/shared/lib/desktop-overlay/constants.ts
@@ -1,0 +1,4 @@
+/** Mirror of desktop-electron overlay constants for web-side budgets. */
+export const OVERLAY_CREATE_BUDGET_MS = 200;
+export const OVERLAY_IDLE_MS = 30_000;
+export const OVERLAY_BOUNDS_PADDING_PX = 16;

--- a/apps/web/src/shared/lib/desktop-overlay/elevation-policy.ts
+++ b/apps/web/src/shared/lib/desktop-overlay/elevation-policy.ts
@@ -1,0 +1,146 @@
+/**
+ * Pure elevation / suspend policy for APP-052 Desktop Overlay Surface.
+ * No DOM, no Electron — unit-tested entry points for product wiring.
+ */
+
+export type OverlayLayerKind =
+  | "dialog"
+  | "sheet"
+  | "drawer"
+  | "popover"
+  | "menu"
+  | "select"
+  | "tooltip"
+  | "hover-card"
+  | "custom";
+
+export type OverlayPointerMode = "pass-through" | "capture";
+
+export type ElevateContext = {
+  /** Desktop shell reports overlay capability (Electron + feature on). */
+  capability: boolean;
+  /** At least one desktop-native preview surface is attached/visible on this host. */
+  nativePreviewPresent: boolean;
+  /** Floating UI is modal / blocking (dialog, sheet, drawer with aria-modal). */
+  modal: boolean;
+  /** Geometry: floating UI intersects a native preview surface rect. */
+  intersectsPreview: boolean;
+};
+
+/**
+ * Whether a floating UI role should elevate into the shared overlay surface.
+ * Web / no capability / no native preview → never elevate.
+ */
+export function shouldElevate(
+  kind: OverlayLayerKind,
+  ctx: ElevateContext,
+): boolean {
+  if (!ctx.capability || !ctx.nativePreviewPresent) return false;
+
+  // Modal classes always elevate when native preview is present (live dimmer).
+  if (ctx.modal) return true;
+  if (
+    kind === "dialog" ||
+    kind === "sheet" ||
+    kind === "drawer"
+  ) {
+    return true;
+  }
+
+  // Lightweight floaters (incl. tooltips): elevate when they intersect preview.
+  return ctx.intersectsPreview;
+}
+
+/**
+ * APP-029 suspend rule once elevation exists:
+ * hide native preview only when occluded AND elevation does not cover.
+ */
+export function shouldSuspendFromOcclusion(args: {
+  isOccluded: boolean;
+  elevationCovers: boolean;
+}): boolean {
+  return args.isOccluded && !args.elevationCovers;
+}
+
+/**
+ * elevationCovers: healthy overlay path is handling open floating layers.
+ */
+export function computeElevationCovers(args: {
+  capability: boolean;
+  surfaceReady: boolean;
+  ensureFailed: boolean;
+  elevatedLayerCount: number;
+}): boolean {
+  if (!args.capability) return false;
+  if (args.ensureFailed) return false;
+  if (!args.surfaceReady) return false;
+  return args.elevatedLayerCount > 0;
+}
+
+/** Modal layers force capture; otherwise pass-through (tight bounds). */
+export function pointerModeForLayers(
+  layers: ReadonlyArray<{ modal: boolean }>,
+): OverlayPointerMode {
+  if (layers.some((l) => l.modal)) return "capture";
+  return "pass-through";
+}
+
+/** Expand a client rect by padding (tight overlay bounds). */
+export function expandRect(
+  rect: { x: number; y: number; width: number; height: number },
+  padding: number,
+): { x: number; y: number; width: number; height: number } {
+  const p = Math.max(0, padding);
+  return {
+    x: rect.x - p,
+    y: rect.y - p,
+    width: rect.width + p * 2,
+    height: rect.height + p * 2,
+  };
+}
+
+export function rectsIntersect(
+  a: { left: number; top: number; right: number; bottom: number },
+  b: { left: number; top: number; right: number; bottom: number },
+): boolean {
+  return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
+}
+
+/** Whether cold create exceeded budget while still not ready. */
+export function shouldFallbackHideDuringEnsure(args: {
+  ensureStartedAt: number | null;
+  now: number;
+  ready: boolean;
+  createBudgetMs: number;
+  isOccluded: boolean;
+}): boolean {
+  if (!args.isOccluded) return false;
+  if (args.ready) return false;
+  if (args.ensureStartedAt == null) return args.isOccluded;
+  return args.now - args.ensureStartedAt >= args.createBudgetMs;
+}
+
+/**
+ * Compose desktop-native preview suspend reasons (APP-052 AC2 / M3).
+ * - Unconditional: standalone handoff open, loading.
+ * - Occlusion: APP-029 geometry when elevation does not cover.
+ * - Elevatable chrome (favorites / header / search popovers): only when
+ *   elevation does **not** cover — happy-path elevation must keep preview live.
+ */
+export function shouldSuspendDesktopNativePreview(args: {
+  isDesktopNative: boolean;
+  isStandaloneHandoffOpen: boolean;
+  isPreviewLoading: boolean;
+  suspendFromOcclusion: boolean;
+  elevationCovers: boolean;
+  elevatableChromeOpen: boolean;
+}): boolean {
+  if (!args.isDesktopNative) return false;
+  if (args.isStandaloneHandoffOpen) return true;
+  if (args.isPreviewLoading) return true;
+  if (args.suspendFromOcclusion) return true;
+  // favorites / header / global search are elevatable floaters — do not hide
+  // preview when the shared overlay covers them.
+  if (args.elevatableChromeOpen && !args.elevationCovers) return true;
+  return false;
+}

--- a/apps/web/src/shared/lib/desktop-overlay/elevation-policy.ts
+++ b/apps/web/src/shared/lib/desktop-overlay/elevation-policy.ts
@@ -3,144 +3,44 @@
  * No DOM, no Electron — unit-tested entry points for product wiring.
  */
 
-export type OverlayLayerKind =
-  | "dialog"
-  | "sheet"
-  | "drawer"
-  | "popover"
-  | "menu"
-  | "select"
-  | "tooltip"
-  | "hover-card"
-  | "custom";
-
 export type OverlayPointerMode = "pass-through" | "capture";
 
-export type ElevateContext = {
-  /** Desktop shell reports overlay capability (Electron + feature on). */
-  capability: boolean;
-  /** At least one desktop-native preview surface is attached/visible on this host. */
-  nativePreviewPresent: boolean;
-  /** Floating UI is modal / blocking (dialog, sheet, drawer with aria-modal). */
-  modal: boolean;
-  /** Geometry: floating UI intersects a native preview surface rect. */
-  intersectsPreview: boolean;
-};
-
 /**
- * Whether a floating UI role should elevate into the shared overlay surface.
- * Web / no capability / no native preview → never elevate.
+ * elevationHealthy: the shared overlay surface is ready to host floating UI.
+ * While healthy, `@workspace/ui` portals deterministically mount into the
+ * overlay document, so elevatable chrome never needs the APP-029 hide.
  */
-export function shouldElevate(
-  kind: OverlayLayerKind,
-  ctx: ElevateContext,
-): boolean {
-  if (!ctx.capability || !ctx.nativePreviewPresent) return false;
-
-  // Modal classes always elevate when native preview is present (live dimmer).
-  if (ctx.modal) return true;
-  if (
-    kind === "dialog" ||
-    kind === "sheet" ||
-    kind === "drawer"
-  ) {
-    return true;
-  }
-
-  // Lightweight floaters (incl. tooltips): elevate when they intersect preview.
-  return ctx.intersectsPreview;
-}
-
-/**
- * APP-029 suspend rule once elevation exists:
- * hide native preview only when occluded AND elevation does not cover.
- */
-export function shouldSuspendFromOcclusion(args: {
-  isOccluded: boolean;
-  elevationCovers: boolean;
-}): boolean {
-  return args.isOccluded && !args.elevationCovers;
-}
-
-/**
- * elevationCovers: healthy overlay path is handling open floating layers.
- */
-export function computeElevationCovers(args: {
+export function computeElevationHealthy(args: {
   capability: boolean;
   surfaceReady: boolean;
   ensureFailed: boolean;
-  elevatedLayerCount: number;
 }): boolean {
-  if (!args.capability) return false;
-  if (args.ensureFailed) return false;
-  if (!args.surfaceReady) return false;
-  return args.elevatedLayerCount > 0;
-}
-
-/** Modal layers force capture; otherwise pass-through (tight bounds). */
-export function pointerModeForLayers(
-  layers: ReadonlyArray<{ modal: boolean }>,
-): OverlayPointerMode {
-  if (layers.some((l) => l.modal)) return "capture";
-  return "pass-through";
-}
-
-/** Expand a client rect by padding (tight overlay bounds). */
-export function expandRect(
-  rect: { x: number; y: number; width: number; height: number },
-  padding: number,
-): { x: number; y: number; width: number; height: number } {
-  const p = Math.max(0, padding);
-  return {
-    x: rect.x - p,
-    y: rect.y - p,
-    width: rect.width + p * 2,
-    height: rect.height + p * 2,
-  };
-}
-
-export function rectsIntersect(
-  a: { left: number; top: number; right: number; bottom: number },
-  b: { left: number; top: number; right: number; bottom: number },
-): boolean {
-  return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
-}
-
-/** Whether cold create exceeded budget while still not ready. */
-export function shouldFallbackHideDuringEnsure(args: {
-  ensureStartedAt: number | null;
-  now: number;
-  ready: boolean;
-  createBudgetMs: number;
-  isOccluded: boolean;
-}): boolean {
-  if (!args.isOccluded) return false;
-  if (args.ready) return false;
-  if (args.ensureStartedAt == null) return args.isOccluded;
-  return args.now - args.ensureStartedAt >= args.createBudgetMs;
+  return args.capability && args.surfaceReady && !args.ensureFailed;
 }
 
 /**
  * Compose desktop-native preview suspend reasons (APP-052 AC2 / M3).
  * - Unconditional: standalone handoff open, loading.
- * - Occlusion: APP-029 geometry when elevation does not cover.
- * - Elevatable chrome (favorites / header / search popovers): only when
- *   elevation does **not** cover — happy-path elevation must keep preview live.
+ * - Host occlusion: APP-029 geometry against **host-document** floaters.
+ *   Elevated layers live in the overlay document and never appear as host
+ *   occlusion candidates, so anything the geometry check still sees is by
+ *   definition not covered by elevation → always hide.
+ * - Elevatable chrome (favorites / header / search popovers): those portals
+ *   mount into the overlay while elevation is healthy, so suspend only when
+ *   elevation is **not** healthy (APP-029 fallback).
  */
 export function shouldSuspendDesktopNativePreview(args: {
   isDesktopNative: boolean;
   isStandaloneHandoffOpen: boolean;
   isPreviewLoading: boolean;
-  suspendFromOcclusion: boolean;
-  elevationCovers: boolean;
+  hostOcclusion: boolean;
   elevatableChromeOpen: boolean;
+  elevationHealthy: boolean;
 }): boolean {
   if (!args.isDesktopNative) return false;
   if (args.isStandaloneHandoffOpen) return true;
   if (args.isPreviewLoading) return true;
-  if (args.suspendFromOcclusion) return true;
-  // favorites / header / global search are elevatable floaters — do not hide
-  // preview when the shared overlay covers them.
-  if (args.elevatableChromeOpen && !args.elevationCovers) return true;
+  if (args.hostOcclusion) return true;
+  if (args.elevatableChromeOpen && !args.elevationHealthy) return true;
   return false;
 }

--- a/apps/web/src/shared/lib/desktop-overlay/elevation-store.ts
+++ b/apps/web/src/shared/lib/desktop-overlay/elevation-store.ts
@@ -5,7 +5,7 @@
 
 import { create } from "zustand";
 import {
-  computeElevationCovers,
+  computeElevationHealthy,
   type OverlayPointerMode,
 } from "./elevation-policy";
 
@@ -33,7 +33,7 @@ type ElevationState = {
   setPointerMode: (m: OverlayPointerMode) => void;
   setElevatedLayerCount: (n: number) => void;
   resetElevationRuntime: () => void;
-  elevationCovers: () => boolean;
+  elevationHealthy: () => boolean;
 };
 
 export const useDesktopElevationStore = create<ElevationState>((set, get) => ({
@@ -44,7 +44,7 @@ export const useDesktopElevationStore = create<ElevationState>((set, get) => ({
   ensureFailed: false,
   elevatedLayerCount: 0,
   portalContainer: null,
-  pointerMode: "capture",
+  pointerMode: "pass-through",
   setCapability: (v) => set({ capability: v }),
   acquireNativePreviewSurface: () =>
     set((s) => {
@@ -77,22 +77,17 @@ export const useDesktopElevationStore = create<ElevationState>((set, get) => ({
       ensureFailed: false,
       elevatedLayerCount: 0,
       portalContainer: null,
+      pointerMode: "pass-through",
       // Do not reset nativePreviewSurfaceCount — Preview instances own that.
     }),
-  elevationCovers: () => {
+  elevationHealthy: () => {
     const s = get();
     return (
-      computeElevationCovers({
+      computeElevationHealthy({
         capability: s.capability,
         surfaceReady: s.surfaceReady,
         ensureFailed: s.ensureFailed,
-        elevatedLayerCount: s.elevatedLayerCount,
       }) && s.portalContainer != null
     );
   },
 }));
-
-/** Non-hook read for lifecycle effects. */
-export function readElevationCovers(): boolean {
-  return useDesktopElevationStore.getState().elevationCovers();
-}

--- a/apps/web/src/shared/lib/desktop-overlay/elevation-store.ts
+++ b/apps/web/src/shared/lib/desktop-overlay/elevation-store.ts
@@ -1,0 +1,98 @@
+/**
+ * Host-side elevation runtime state (APP-052).
+ * Used by FloatingElevationProvider and Preview occlusion suspend gate.
+ */
+
+import { create } from "zustand";
+import {
+  computeElevationCovers,
+  type OverlayPointerMode,
+} from "./elevation-policy";
+
+type ElevationState = {
+  capability: boolean;
+  /** Derived: true when at least one desktop-native preview surface is active. */
+  nativePreviewPresent: boolean;
+  /** Refcount of concurrent desktop-native Preview instances on this host. */
+  nativePreviewSurfaceCount: number;
+  surfaceReady: boolean;
+  ensureFailed: boolean;
+  elevatedLayerCount: number;
+  portalContainer: HTMLElement | null;
+  pointerMode: OverlayPointerMode;
+  setCapability: (v: boolean) => void;
+  /**
+   * Acquire/release a native preview surface presence slot.
+   * Multi-Preview hosts must not clear present while another surface remains.
+   */
+  acquireNativePreviewSurface: () => void;
+  releaseNativePreviewSurface: () => void;
+  setSurfaceReady: (v: boolean) => void;
+  setEnsureFailed: (v: boolean) => void;
+  setPortalContainer: (el: HTMLElement | null) => void;
+  setPointerMode: (m: OverlayPointerMode) => void;
+  setElevatedLayerCount: (n: number) => void;
+  resetElevationRuntime: () => void;
+  elevationCovers: () => boolean;
+};
+
+export const useDesktopElevationStore = create<ElevationState>((set, get) => ({
+  capability: false,
+  nativePreviewPresent: false,
+  nativePreviewSurfaceCount: 0,
+  surfaceReady: false,
+  ensureFailed: false,
+  elevatedLayerCount: 0,
+  portalContainer: null,
+  pointerMode: "capture",
+  setCapability: (v) => set({ capability: v }),
+  acquireNativePreviewSurface: () =>
+    set((s) => {
+      const nativePreviewSurfaceCount = s.nativePreviewSurfaceCount + 1;
+      return {
+        nativePreviewSurfaceCount,
+        nativePreviewPresent: nativePreviewSurfaceCount > 0,
+      };
+    }),
+  releaseNativePreviewSurface: () =>
+    set((s) => {
+      const nativePreviewSurfaceCount = Math.max(
+        0,
+        s.nativePreviewSurfaceCount - 1,
+      );
+      return {
+        nativePreviewSurfaceCount,
+        nativePreviewPresent: nativePreviewSurfaceCount > 0,
+      };
+    }),
+  setSurfaceReady: (v) => set({ surfaceReady: v }),
+  setEnsureFailed: (v) => set({ ensureFailed: v }),
+  setPortalContainer: (el) => set({ portalContainer: el }),
+  setPointerMode: (m) => set({ pointerMode: m }),
+  setElevatedLayerCount: (n) =>
+    set({ elevatedLayerCount: Math.max(0, Math.floor(n)) }),
+  resetElevationRuntime: () =>
+    set({
+      surfaceReady: false,
+      ensureFailed: false,
+      elevatedLayerCount: 0,
+      portalContainer: null,
+      // Do not reset nativePreviewSurfaceCount — Preview instances own that.
+    }),
+  elevationCovers: () => {
+    const s = get();
+    return (
+      computeElevationCovers({
+        capability: s.capability,
+        surfaceReady: s.surfaceReady,
+        ensureFailed: s.ensureFailed,
+        elevatedLayerCount: s.elevatedLayerCount,
+      }) && s.portalContainer != null
+    );
+  },
+}));
+
+/** Non-hook read for lifecycle effects. */
+export function readElevationCovers(): boolean {
+  return useDesktopElevationStore.getState().elevationCovers();
+}

--- a/apps/web/src/shared/lib/desktop-overlay/floating-elevation-provider.tsx
+++ b/apps/web/src/shared/lib/desktop-overlay/floating-elevation-provider.tsx
@@ -93,6 +93,7 @@ export function FloatingElevationProvider({
   const overlayWindowRef = React.useRef<Window | null>(null);
   const ensurePromiseRef = React.useRef<Promise<boolean> | null>(null);
   const overlayMoRef = React.useRef<MutationObserver | null>(null);
+  const overlayListenerDocRef = React.useRef<Document | null>(null);
   const rafIdsRef = React.useRef<number[]>([]);
 
   React.useEffect(() => {
@@ -236,6 +237,15 @@ export function FloatingElevationProvider({
     }
 
     let disposed = false;
+    let recountScheduled = false;
+    /** Gate bridge IPC so unchanged recounts do not spam note_activity/release. */
+    let lastBridgeState: "activity" | "release" | null = null;
+
+    const releaseBridge = () => {
+      if (lastBridgeState === "release") return;
+      lastBridgeState = "release";
+      void desktopInvoke("overlay_bridge_release", {}).catch(() => {});
+    };
 
     const applyCounts = (hostCount: number, portalCount: number) => {
       // elevationCovers uses portal-only count.
@@ -255,7 +265,10 @@ export function FloatingElevationProvider({
             if (disposed || !ok) return;
           }
           // Show only — never release on this path (B6).
-          await showOverlayWithLayers();
+          if (lastBridgeState !== "activity") {
+            lastBridgeState = "activity";
+            await showOverlayWithLayers();
+          }
           const p = useDesktopElevationStore.getState().portalContainer;
           setElevatedLayerCount(countOpenLayers([p ?? null]));
         })();
@@ -274,15 +287,18 @@ export function FloatingElevationProvider({
           const nextPortal = countOpenLayers([p ?? null]);
           setElevatedLayerCount(nextPortal);
           if (nextPortal > 0) {
-            await showOverlayWithLayers();
+            if (lastBridgeState !== "activity") {
+              lastBridgeState = "activity";
+              await showOverlayWithLayers();
+            }
           } else {
-            void desktopInvoke("overlay_bridge_release", {}).catch(() => {});
+            releaseBridge();
           }
         })();
         return;
       }
 
-      void desktopInvoke("overlay_bridge_release", {}).catch(() => {});
+      releaseBridge();
     };
 
     const recountNow = () => {
@@ -295,16 +311,22 @@ export function FloatingElevationProvider({
       applyCounts(hostCount, portalCount);
     };
 
-    /** Mutation + rAF follow-up so fade-in frames still re-evaluate (B5). */
+    /**
+     * Coalesce MutationObserver spam to one recount chain per burst.
+     * Still uses immediate + double rAF so fade-in frames re-evaluate (B5).
+     */
     const scheduleRecount = () => {
-      recountNow();
+      if (recountScheduled) return;
+      recountScheduled = true;
       for (const id of rafIdsRef.current) {
         cancelAnimationFrame(id);
       }
       rafIdsRef.current = [];
+      recountNow();
       const id1 = requestAnimationFrame(() => {
         recountNow();
         const id2 = requestAnimationFrame(() => {
+          recountScheduled = false;
           recountNow();
         });
         rafIdsRef.current.push(id2);
@@ -331,9 +353,27 @@ export function FloatingElevationProvider({
     document.addEventListener("transitionend", onTransitionOrAnimation, true);
     document.addEventListener("animationend", onTransitionOrAnimation, true);
 
+    const detachOverlayListeners = () => {
+      const prevDoc = overlayListenerDocRef.current;
+      if (prevDoc) {
+        prevDoc.removeEventListener(
+          "transitionend",
+          onTransitionOrAnimation,
+          true,
+        );
+        prevDoc.removeEventListener(
+          "animationend",
+          onTransitionOrAnimation,
+          true,
+        );
+        overlayListenerDocRef.current = null;
+      }
+    };
+
     const attachOverlayMo = (portal: HTMLElement | null) => {
       overlayMoRef.current?.disconnect();
       overlayMoRef.current = null;
+      detachOverlayListeners();
       if (!portal?.ownerDocument?.body) return;
       const doc = portal.ownerDocument;
       const mo = new MutationObserver(() => scheduleRecount());
@@ -352,6 +392,7 @@ export function FloatingElevationProvider({
       overlayMoRef.current = mo;
       doc.addEventListener("transitionend", onTransitionOrAnimation, true);
       doc.addEventListener("animationend", onTransitionOrAnimation, true);
+      overlayListenerDocRef.current = doc;
     };
 
     attachOverlayMo(useDesktopElevationStore.getState().portalContainer);
@@ -369,6 +410,7 @@ export function FloatingElevationProvider({
       disposed = true;
       hostMo.disconnect();
       overlayMoRef.current?.disconnect();
+      detachOverlayListeners();
       unsub();
       for (const id of rafIdsRef.current) cancelAnimationFrame(id);
       document.removeEventListener(

--- a/apps/web/src/shared/lib/desktop-overlay/floating-elevation-provider.tsx
+++ b/apps/web/src/shared/lib/desktop-overlay/floating-elevation-provider.tsx
@@ -3,12 +3,17 @@
 /**
  * APP-052: Elevate floating UI above desktop native preview (WebContentsView).
  *
- * Stability rule (fixes open/close flicker):
- * - While native preview is present, keep portalContainer **fixed** on the overlay
- *   document root. Do **not** flip it null↔root on every menu open (that remounts
- *   Radix content and causes flash + APP-029 hide thrash).
+ * Stability rules:
+ * - While native preview is present, keep portalContainer **fixed** on the
+ *   overlay document root. Do **not** flip it null↔root on every open (that
+ *   remounts Radix content and causes flash + APP-029 hide thrash).
  * - Only show/hide the overlay BrowserWindow and toggle pointer capture.
- * - When preview goes away, clear portal and release the surface.
+ * - Layer counting runs against the **overlay document only**. Floating UI
+ *   that stays in the host document is APP-029's job (occlusion hide); the
+ *   overlay window must never show/capture for layers it does not contain.
+ * - Pointer capture only when a non-hover layer (menu/popover/dialog…) is
+ *   open. Tooltip/hover-card–only frames stay click-through so host clicks
+ *   keep working.
  *
  * Pure web: capability false → container null → document body.
  */
@@ -22,10 +27,14 @@ import {
 } from "@/shared/lib/desktop-bridge";
 import { useDesktopElevationStore } from "./elevation-store";
 import { OVERLAY_CREATE_BUDGET_MS } from "./constants";
-import { countOpenLayers } from "./layer-count";
+import { summarizeOpenLayers, type OpenLayerSummary } from "./layer-count";
+import type { OverlayPointerMode } from "./elevation-policy";
 
 const OVERLAY_ROOT_ID = "atmos-overlay-root";
 const OVERLAY_WINDOW_NAME = "atmos-desktop-overlay";
+
+/** Debounce hide so brief 0-count frames during remount do not thrash. */
+const HIDE_DEBOUNCE_MS = 120;
 
 /** Force transparent shell after theme/style clone (prevents black full-window fill). */
 const OVERLAY_TRANSPARENT_CSS = `
@@ -72,19 +81,38 @@ function syncThemeToOverlayDocument(doc: Document) {
   }
 }
 
+function hostStyleSignature(): string {
+  const nodes = document.querySelectorAll("link[rel='stylesheet'], style");
+  let textLength = 0;
+  let hrefs = "";
+  nodes.forEach((node) => {
+    if (node.tagName === "LINK") hrefs += (node as HTMLLinkElement).href + ";";
+    else textLength += node.textContent?.length ?? 0;
+  });
+  return `${nodes.length}:${textLength}:${hrefs}`;
+}
+
+/**
+ * Mirror host stylesheets into the overlay document. Re-runs when the host
+ * head changes (HMR, lazy-loaded chunks) using a cheap signature diff.
+ */
 function cloneStylesToOverlay(doc: Document) {
   try {
     const head = doc.head;
     if (!head) return;
-    if (head.querySelector("[data-atmos-overlay-styles]")) return;
-    const mark = doc.createElement("meta");
-    mark.setAttribute("data-atmos-overlay-styles", "1");
-    head.appendChild(mark);
+    const signature = hostStyleSignature();
+    if (head.getAttribute("data-atmos-overlay-styles") === signature) return;
+    head.setAttribute("data-atmos-overlay-styles", signature);
 
+    head
+      .querySelectorAll("[data-atmos-overlay-style-clone]")
+      .forEach((node) => node.remove());
     for (const node of Array.from(
       document.querySelectorAll("link[rel='stylesheet'], style"),
     )) {
-      head.appendChild(node.cloneNode(true));
+      const clone = node.cloneNode(true) as HTMLElement;
+      clone.setAttribute("data-atmos-overlay-style-clone", "1");
+      head.appendChild(clone);
     }
   } catch {
     /* ignore */
@@ -149,12 +177,7 @@ export function FloatingElevationProvider({
   const overlayMoRef = React.useRef<MutationObserver | null>(null);
   const overlayListenerDocRef = React.useRef<Document | null>(null);
   const rafIdsRef = React.useRef<number[]>([]);
-  /** Overlay window currently shown + capturing. */
-  const windowShownRef = React.useRef(false);
-  /** Debounce hide so brief 0-count frames during remount do not thrash. */
   const hideTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const HIDE_DEBOUNCE_MS = 120;
 
   React.useEffect(() => {
     let cancelled = false;
@@ -261,7 +284,6 @@ export function FloatingElevationProvider({
         // Stable portal target for the whole preview session (no flip on open).
         setPortalContainer(root);
         // Stay hidden until layers open.
-        windowShownRef.current = false;
         await desktopInvoke("overlay_bridge_release", {}).catch(() => {});
         return true;
       } catch {
@@ -285,37 +307,19 @@ export function FloatingElevationProvider({
     setSurfaceReady,
   ]);
 
-  const showOverlayWindow = React.useCallback(async () => {
-    if (hideTimerRef.current) {
-      clearTimeout(hideTimerRef.current);
-      hideTimerRef.current = null;
-    }
-    const win = overlayWindowRef.current;
-    if (win && !win.closed) {
-      try {
-        forceOverlayTransparent(win.document);
-      } catch {
-        /* ignore */
-      }
-    }
-    useDesktopElevationStore.getState().setPointerMode("capture");
-    await desktopInvoke("overlay_bridge_set_pointer_mode", {
-      mode: "capture",
-    }).catch(() => {});
-    await desktopInvoke("overlay_bridge_note_activity", {}).catch(() => {});
-    windowShownRef.current = true;
-  }, []);
-
   const hideOverlayWindowDebounced = React.useCallback(() => {
     if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
     hideTimerRef.current = setTimeout(() => {
       hideTimerRef.current = null;
       // Re-check: if layers reappeared, do not hide.
       const portal = useDesktopElevationStore.getState().portalContainer;
-      const n = portal ? countOpenLayers([portal]) : 0;
-      if (n > 0) return;
-      windowShownRef.current = false;
+      const summary = portal
+        ? summarizeOpenLayers([portal])
+        : { open: 0, capture: 0 };
+      if (summary.open > 0) return;
       setElevatedLayerCount(0);
+      // Main resets to pass-through on release; keep the store in sync.
+      useDesktopElevationStore.getState().setPointerMode("pass-through");
       void desktopInvoke("overlay_bridge_release", {}).catch(() => {});
     }, HIDE_DEBOUNCE_MS);
   }, [setElevatedLayerCount]);
@@ -329,7 +333,6 @@ export function FloatingElevationProvider({
         clearTimeout(hideTimerRef.current);
         hideTimerRef.current = null;
       }
-      windowShownRef.current = false;
       portalRootRef.current = null;
       overlayWindowRef.current = null;
       resetElevationRuntime();
@@ -345,7 +348,7 @@ export function FloatingElevationProvider({
     resetElevationRuntime,
   ]);
 
-  // Observe open layers in the **overlay portal** (and host only as bootstrap).
+  // Observe open layers in the overlay portal document.
   React.useEffect(() => {
     if (!capability || !nativePreviewPresent || typeof document === "undefined") {
       return;
@@ -354,20 +357,29 @@ export function FloatingElevationProvider({
     let disposed = false;
     let recountScheduled = false;
 
-    const applyLayerCount = (n: number) => {
-      setElevatedLayerCount(n);
-      if (n > 0) {
+    const applyLayerSummary = (summary: OpenLayerSummary) => {
+      setElevatedLayerCount(summary.open);
+      if (summary.open > 0) {
+        if (hideTimerRef.current) {
+          clearTimeout(hideTimerRef.current);
+          hideTimerRef.current = null;
+        }
+        const mode: OverlayPointerMode =
+          summary.capture > 0 ? "capture" : "pass-through";
         void (async () => {
           const ok = await ensureOverlayReady();
           if (disposed || !ok) return;
-          if (!windowShownRef.current) {
-            await showOverlayWindow();
-          } else {
-            // Keep idle timer cancelled while layers stay open.
-            await desktopInvoke("overlay_bridge_note_activity", {}).catch(
-              () => {},
-            );
+          const store = useDesktopElevationStore.getState();
+          if (store.pointerMode !== mode) {
+            store.setPointerMode(mode);
+            await desktopInvoke("overlay_bridge_set_pointer_mode", {
+              mode,
+            }).catch(() => {});
           }
+          // Shows the surface when hidden and keeps the idle timer cancelled.
+          await desktopInvoke("overlay_bridge_note_activity", {}).catch(
+            () => {},
+          );
         })();
       } else {
         hideOverlayWindowDebounced();
@@ -376,23 +388,12 @@ export function FloatingElevationProvider({
 
     const recountNow = () => {
       if (disposed) return;
+      // Overlay document only: host-document floaters are handled by APP-029
+      // occlusion hide, never by showing an (empty) capture surface.
       const portal = useDesktopElevationStore.getState().portalContainer;
-      // Primary: layers already elevated into portal document.
-      let n = portal ? countOpenLayers([portal]) : 0;
-      // Bootstrap: first open still paints on body until portal is published;
-      // after ensureOverlayReady publishes portal, next open goes straight there.
-      // While portal is ready, also count host body layers that use the same
-      // markers only if they are NOT already under portal (hostCount for
-      // transition). Prefer max so we don't flicker hide.
-      if (portal) {
-        const hostN = countOpenLayers([document.body]);
-        // If portal is set, Radix should target portal — host body should be 0
-        // for elevated primitives. If host still has layers, keep shown.
-        n = Math.max(n, hostN);
-      } else {
-        n = countOpenLayers([document.body]);
-      }
-      applyLayerCount(n);
+      applyLayerSummary(
+        portal ? summarizeOpenLayers([portal]) : { open: 0, capture: 0 },
+      );
     };
 
     const scheduleRecount = () => {
@@ -413,22 +414,6 @@ export function FloatingElevationProvider({
     };
 
     const onTransitionOrAnimation = () => scheduleRecount();
-
-    const hostMo = new MutationObserver(() => scheduleRecount());
-    hostMo.observe(document.body, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-      attributeFilter: [
-        "data-state",
-        "aria-hidden",
-        "aria-modal",
-        "class",
-        "style",
-      ],
-    });
-    document.addEventListener("transitionend", onTransitionOrAnimation, true);
-    document.addEventListener("animationend", onTransitionOrAnimation, true);
 
     const detachOverlayListeners = () => {
       const prevDoc = overlayListenerDocRef.current;
@@ -489,23 +474,11 @@ export function FloatingElevationProvider({
 
     return () => {
       disposed = true;
-      hostMo.disconnect();
       overlayMoRef.current?.disconnect();
       detachOverlayListeners();
       unsub();
       for (const id of rafIdsRef.current) cancelAnimationFrame(id);
       if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
-      document.removeEventListener(
-        "transitionend",
-        onTransitionOrAnimation,
-        true,
-      );
-      document.removeEventListener(
-        "animationend",
-        onTransitionOrAnimation,
-        true,
-      );
-      windowShownRef.current = false;
       void desktopInvoke("overlay_bridge_release", {}).catch(() => {});
     };
   }, [
@@ -514,7 +487,6 @@ export function FloatingElevationProvider({
     hideOverlayWindowDebounced,
     nativePreviewPresent,
     setElevatedLayerCount,
-    showOverlayWindow,
   ]);
 
   React.useEffect(() => {
@@ -523,7 +495,6 @@ export function FloatingElevationProvider({
     void desktopListen("desktop-overlay:destroyed", () => {
       overlayWindowRef.current = null;
       portalRootRef.current = null;
-      windowShownRef.current = false;
       resetElevationRuntime();
     }).then((u) => {
       unlisten = typeof u === "function" ? u : undefined;
@@ -533,17 +504,29 @@ export function FloatingElevationProvider({
     };
   }, [capability, resetElevationRuntime]);
 
+  // Keep theme + stylesheets mirrored while the portal is live (theme toggle,
+  // HMR style injection, lazy-loaded chunk CSS).
   React.useEffect(() => {
     if (!portalContainer) return;
     const doc = portalContainer.ownerDocument;
-    const sync = () => forceOverlayTransparent(doc);
+    const sync = () => {
+      forceOverlayTransparent(doc);
+      cloneStylesToOverlay(doc);
+    };
     sync();
-    const mo = new MutationObserver(sync);
-    mo.observe(document.documentElement, {
+    const themeMo = new MutationObserver(sync);
+    themeMo.observe(document.documentElement, {
       attributes: true,
       attributeFilter: ["class", "data-theme", "style"],
     });
-    return () => mo.disconnect();
+    const headMo = new MutationObserver(sync);
+    if (document.head) {
+      headMo.observe(document.head, { childList: true, subtree: true });
+    }
+    return () => {
+      themeMo.disconnect();
+      headMo.disconnect();
+    };
   }, [portalContainer]);
 
   const containerForPortals =

--- a/apps/web/src/shared/lib/desktop-overlay/floating-elevation-provider.tsx
+++ b/apps/web/src/shared/lib/desktop-overlay/floating-elevation-provider.tsx
@@ -1,0 +1,431 @@
+"use client";
+
+/**
+ * APP-052: On Electron desktop with overlay capability + native preview present,
+ * ensure a shared overlay surface and provide its document root as the portal
+ * container so floating UI paints above WebContentsView previews.
+ *
+ * Pure web: capability stays false → PortalContainerProvider gets null → body.
+ */
+
+import * as React from "react";
+import { PortalContainerProvider } from "@workspace/ui";
+import {
+  desktopInvoke,
+  desktopListen,
+  isDesktopRuntime,
+} from "@/shared/lib/desktop-bridge";
+import { useDesktopElevationStore } from "./elevation-store";
+import { OVERLAY_CREATE_BUDGET_MS } from "./constants";
+import { countOpenLayers } from "./layer-count";
+
+const OVERLAY_ROOT_ID = "atmos-overlay-root";
+const OVERLAY_WINDOW_NAME = "atmos-desktop-overlay";
+
+function syncThemeToOverlayDocument(doc: Document) {
+  try {
+    const src = document.documentElement;
+    const dst = doc.documentElement;
+    dst.className = src.className;
+    dst.style.colorScheme = src.style.colorScheme || "";
+    const theme = src.getAttribute("data-theme");
+    if (theme) dst.setAttribute("data-theme", theme);
+    else dst.removeAttribute("data-theme");
+  } catch {
+    /* ignore */
+  }
+}
+
+function cloneStylesToOverlay(doc: Document) {
+  try {
+    const head = doc.head;
+    if (!head) return;
+    if (head.querySelector("[data-atmos-overlay-styles]")) return;
+    const mark = doc.createElement("meta");
+    mark.setAttribute("data-atmos-overlay-styles", "1");
+    head.appendChild(mark);
+
+    for (const node of Array.from(
+      document.querySelectorAll("link[rel='stylesheet'], style"),
+    )) {
+      head.appendChild(node.cloneNode(true));
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+async function probeOverlayCapability(): Promise<boolean> {
+  if (!isDesktopRuntime()) return false;
+  try {
+    const caps = (await desktopInvoke("get_desktop_capabilities")) as {
+      overlaySurface?: boolean;
+    };
+    return caps?.overlaySurface === true;
+  } catch {
+    return false;
+  }
+}
+
+export function FloatingElevationProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const capability = useDesktopElevationStore((s) => s.capability);
+  const nativePreviewPresent = useDesktopElevationStore(
+    (s) => s.nativePreviewPresent,
+  );
+  const portalContainer = useDesktopElevationStore((s) => s.portalContainer);
+  const setCapability = useDesktopElevationStore((s) => s.setCapability);
+  const setSurfaceReady = useDesktopElevationStore((s) => s.setSurfaceReady);
+  const setEnsureFailed = useDesktopElevationStore((s) => s.setEnsureFailed);
+  const setPortalContainer = useDesktopElevationStore(
+    (s) => s.setPortalContainer,
+  );
+  const setElevatedLayerCount = useDesktopElevationStore(
+    (s) => s.setElevatedLayerCount,
+  );
+  const resetElevationRuntime = useDesktopElevationStore(
+    (s) => s.resetElevationRuntime,
+  );
+
+  const overlayWindowRef = React.useRef<Window | null>(null);
+  const ensurePromiseRef = React.useRef<Promise<boolean> | null>(null);
+  const overlayMoRef = React.useRef<MutationObserver | null>(null);
+  const rafIdsRef = React.useRef<number[]>([]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const ok = await probeOverlayCapability();
+      if (!cancelled) setCapability(ok);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [setCapability]);
+
+  const attachPortalRoot = React.useCallback(
+    (win: Window): HTMLElement | null => {
+      try {
+        const doc = win.document;
+        syncThemeToOverlayDocument(doc);
+        cloneStylesToOverlay(doc);
+        let root = doc.getElementById(OVERLAY_ROOT_ID);
+        if (!root) {
+          root = doc.createElement("div");
+          root.id = OVERLAY_ROOT_ID;
+          Object.assign(root.style, {
+            position: "fixed",
+            inset: "0",
+            pointerEvents: "auto",
+          } as CSSStyleDeclaration);
+          doc.body.style.margin = "0";
+          doc.body.style.background = "transparent";
+          doc.body.appendChild(root);
+        }
+        if (!doc.head.querySelector("[data-atmos-overlay-pointer-style]")) {
+          const style = doc.createElement("style");
+          style.setAttribute("data-atmos-overlay-pointer-style", "1");
+          style.textContent = `html,body{background:transparent!important}#${OVERLAY_ROOT_ID}{pointer-events:auto}`;
+          doc.head.appendChild(style);
+        }
+        return root;
+      } catch {
+        return null;
+      }
+    },
+    [],
+  );
+
+  /**
+   * Prepare portalable overlay window + main registration.
+   * Does NOT show/capture — only note_activity shows the surface (B5).
+   */
+  const ensureOverlay = React.useCallback(async (): Promise<boolean> => {
+    if (!capability || !nativePreviewPresent) return false;
+    if (ensurePromiseRef.current) return ensurePromiseRef.current;
+
+    ensurePromiseRef.current = (async () => {
+      setEnsureFailed(false);
+      try {
+        let win = overlayWindowRef.current;
+        if (!win || win.closed) {
+          win = window.open("about:blank", OVERLAY_WINDOW_NAME);
+          overlayWindowRef.current = win;
+        }
+        if (!win) {
+          setEnsureFailed(true);
+          setSurfaceReady(false);
+          return false;
+        }
+
+        const started = Date.now();
+        const deadline = started + OVERLAY_CREATE_BUDGET_MS * 4;
+        while (Date.now() < deadline) {
+          try {
+            if (win.document?.body) break;
+          } catch {
+            /* not ready */
+          }
+          await new Promise((r) => setTimeout(r, 16));
+        }
+
+        const root = attachPortalRoot(win);
+        if (!root) {
+          setEnsureFailed(true);
+          setSurfaceReady(false);
+          return false;
+        }
+
+        const result = (await desktopInvoke("overlay_bridge_ensure", {})) as {
+          ok?: boolean;
+          ready?: boolean;
+        };
+        if (!result?.ok) {
+          setEnsureFailed(true);
+          setSurfaceReady(false);
+          return false;
+        }
+
+        setPortalContainer(root);
+        setSurfaceReady(true);
+        setEnsureFailed(false);
+        // Prepare only — do not release/show here (B6). Caller decides
+        // note_activity vs release based on portal layer count.
+        return true;
+      } catch {
+        setEnsureFailed(true);
+        setSurfaceReady(false);
+        return false;
+      } finally {
+        ensurePromiseRef.current = null;
+      }
+    })();
+
+    return ensurePromiseRef.current;
+  }, [
+    attachPortalRoot,
+    capability,
+    nativePreviewPresent,
+    setEnsureFailed,
+    setPortalContainer,
+    setSurfaceReady,
+  ]);
+
+  const showOverlayWithLayers = React.useCallback(async () => {
+    useDesktopElevationStore.getState().setPointerMode("capture");
+    await desktopInvoke("overlay_bridge_set_pointer_mode", {
+      mode: "capture",
+    }).catch(() => {});
+    await desktopInvoke("overlay_bridge_note_activity", {}).catch(() => {});
+  }, []);
+
+  React.useEffect(() => {
+    if (!nativePreviewPresent) {
+      resetElevationRuntime();
+      void desktopInvoke("overlay_bridge_release", {}).catch(() => {});
+    }
+  }, [nativePreviewPresent, resetElevationRuntime]);
+
+  // Recount layers on host + overlay roots; drive ensure/show/release.
+  React.useEffect(() => {
+    if (!capability || !nativePreviewPresent || typeof document === "undefined") {
+      return;
+    }
+
+    let disposed = false;
+
+    const applyCounts = (hostCount: number, portalCount: number) => {
+      // elevationCovers uses portal-only count.
+      setElevatedLayerCount(portalCount);
+
+      if (portalCount > 0) {
+        void (async () => {
+          const st = useDesktopElevationStore.getState();
+          const win = overlayWindowRef.current;
+          const alreadyReady =
+            st.surfaceReady &&
+            st.portalContainer != null &&
+            win != null &&
+            !win.closed;
+          if (!alreadyReady) {
+            const ok = await ensureOverlay();
+            if (disposed || !ok) return;
+          }
+          // Show only — never release on this path (B6).
+          await showOverlayWithLayers();
+          const p = useDesktopElevationStore.getState().portalContainer;
+          setElevatedLayerCount(countOpenLayers([p ?? null]));
+        })();
+        return;
+      }
+
+      if (hostCount > 0) {
+        // Warm portal root for re-portal; keep surface hidden until portalCount > 0.
+        void (async () => {
+          const st = useDesktopElevationStore.getState();
+          if (!st.surfaceReady || !st.portalContainer) {
+            const ok = await ensureOverlay();
+            if (disposed || !ok) return;
+          }
+          const p = useDesktopElevationStore.getState().portalContainer;
+          const nextPortal = countOpenLayers([p ?? null]);
+          setElevatedLayerCount(nextPortal);
+          if (nextPortal > 0) {
+            await showOverlayWithLayers();
+          } else {
+            void desktopInvoke("overlay_bridge_release", {}).catch(() => {});
+          }
+        })();
+        return;
+      }
+
+      void desktopInvoke("overlay_bridge_release", {}).catch(() => {});
+    };
+
+    const recountNow = () => {
+      if (disposed) return;
+      const portal = useDesktopElevationStore.getState().portalContainer;
+      // Host document only (not portal's ownerDocument which may be same origin
+      // but separate) for hostCount; portal root for portalCount.
+      const hostCount = countOpenLayers([document.body]);
+      const portalCount = countOpenLayers([portal ?? null]);
+      applyCounts(hostCount, portalCount);
+    };
+
+    /** Mutation + rAF follow-up so fade-in frames still re-evaluate (B5). */
+    const scheduleRecount = () => {
+      recountNow();
+      for (const id of rafIdsRef.current) {
+        cancelAnimationFrame(id);
+      }
+      rafIdsRef.current = [];
+      const id1 = requestAnimationFrame(() => {
+        recountNow();
+        const id2 = requestAnimationFrame(() => {
+          recountNow();
+        });
+        rafIdsRef.current.push(id2);
+      });
+      rafIdsRef.current.push(id1);
+    };
+
+    const onTransitionOrAnimation = () => scheduleRecount();
+
+    const hostMo = new MutationObserver(() => scheduleRecount());
+    hostMo.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: [
+        "data-state",
+        "aria-hidden",
+        "aria-modal",
+        "class",
+        "style",
+      ],
+    });
+
+    document.addEventListener("transitionend", onTransitionOrAnimation, true);
+    document.addEventListener("animationend", onTransitionOrAnimation, true);
+
+    const attachOverlayMo = (portal: HTMLElement | null) => {
+      overlayMoRef.current?.disconnect();
+      overlayMoRef.current = null;
+      if (!portal?.ownerDocument?.body) return;
+      const doc = portal.ownerDocument;
+      const mo = new MutationObserver(() => scheduleRecount());
+      mo.observe(doc.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: [
+          "data-state",
+          "aria-hidden",
+          "aria-modal",
+          "class",
+          "style",
+        ],
+      });
+      overlayMoRef.current = mo;
+      doc.addEventListener("transitionend", onTransitionOrAnimation, true);
+      doc.addEventListener("animationend", onTransitionOrAnimation, true);
+    };
+
+    attachOverlayMo(useDesktopElevationStore.getState().portalContainer);
+
+    const unsub = useDesktopElevationStore.subscribe((s, prev) => {
+      if (s.portalContainer !== prev.portalContainer) {
+        attachOverlayMo(s.portalContainer);
+        scheduleRecount();
+      }
+    });
+
+    scheduleRecount();
+
+    return () => {
+      disposed = true;
+      hostMo.disconnect();
+      overlayMoRef.current?.disconnect();
+      unsub();
+      for (const id of rafIdsRef.current) cancelAnimationFrame(id);
+      document.removeEventListener(
+        "transitionend",
+        onTransitionOrAnimation,
+        true,
+      );
+      document.removeEventListener(
+        "animationend",
+        onTransitionOrAnimation,
+        true,
+      );
+      void desktopInvoke("overlay_bridge_release", {}).catch(() => {});
+    };
+  }, [
+    capability,
+    ensureOverlay,
+    nativePreviewPresent,
+    setElevatedLayerCount,
+    showOverlayWithLayers,
+  ]);
+
+  React.useEffect(() => {
+    if (!capability) return;
+    let unlisten: (() => void) | undefined;
+    void desktopListen("desktop-overlay:destroyed", () => {
+      overlayWindowRef.current = null;
+      resetElevationRuntime();
+    }).then((u) => {
+      unlisten = typeof u === "function" ? u : undefined;
+    });
+    return () => {
+      unlisten?.();
+    };
+  }, [capability, resetElevationRuntime]);
+
+  React.useEffect(() => {
+    if (!portalContainer) return;
+    const doc = portalContainer.ownerDocument;
+    const sync = () => syncThemeToOverlayDocument(doc);
+    sync();
+    const mo = new MutationObserver(sync);
+    mo.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "data-theme", "style"],
+    });
+    return () => mo.disconnect();
+  }, [portalContainer]);
+
+  const containerForPortals =
+    capability && nativePreviewPresent && portalContainer
+      ? portalContainer
+      : null;
+
+  return (
+    <PortalContainerProvider container={containerForPortals}>
+      {children}
+    </PortalContainerProvider>
+  );
+}

--- a/apps/web/src/shared/lib/desktop-overlay/floating-elevation-provider.tsx
+++ b/apps/web/src/shared/lib/desktop-overlay/floating-elevation-provider.tsx
@@ -3,14 +3,14 @@
 /**
  * APP-052: Elevate floating UI above desktop native preview (WebContentsView).
  *
- * Critical lifecycle (bugfix for black screen / silent menus):
- * 1. Never leave portalContainer set while the overlay window is hidden.
- * 2. Show overlay first, then set portal container (so createPortal is never
- *    into a hidden document).
- * 3. On release: clear portalContainer first (portals return to body), then hide.
- * 4. Overlay document must stay visually transparent (no dark theme body fill).
+ * Stability rule (fixes open/close flicker):
+ * - While native preview is present, keep portalContainer **fixed** on the overlay
+ *   document root. Do **not** flip it null↔root on every menu open (that remounts
+ *   Radix content and causes flash + APP-029 hide thrash).
+ * - Only show/hide the overlay BrowserWindow and toggle pointer capture.
+ * - When preview goes away, clear portal and release the surface.
  *
- * Pure web: capability false → PortalContainerProvider null → document body.
+ * Pure web: capability false → container null → document body.
  */
 
 import * as React from "react";
@@ -27,7 +27,7 @@ import { countOpenLayers } from "./layer-count";
 const OVERLAY_ROOT_ID = "atmos-overlay-root";
 const OVERLAY_WINDOW_NAME = "atmos-desktop-overlay";
 
-/** Force transparent chrome after theme class / stylesheet clone (prevents black fill). */
+/** Force transparent shell after theme/style clone (prevents black full-window fill). */
 const OVERLAY_TRANSPARENT_CSS = `
 html, body, #${OVERLAY_ROOT_ID} {
   background: transparent !important;
@@ -46,9 +46,6 @@ html, body {
   inset: 0 !important;
   pointer-events: none !important;
 }
-/* Floating content must receive clicks; root stays pass-through for empty areas
-   once we use ignoreMouseEvents(false) the whole window captures — content still
-   needs pointer-events auto for nested interactive nodes. */
 #${OVERLAY_ROOT_ID} > * {
   pointer-events: auto !important;
 }
@@ -58,13 +55,11 @@ function syncThemeToOverlayDocument(doc: Document) {
   try {
     const src = document.documentElement;
     const dst = doc.documentElement;
-    // Class for CSS variables / component tokens — backgrounds forced transparent below.
     dst.className = src.className;
     dst.style.colorScheme = src.style.colorScheme || "";
     const theme = src.getAttribute("data-theme");
     if (theme) dst.setAttribute("data-theme", theme);
     else dst.removeAttribute("data-theme");
-    // Never inherit opaque page background onto the overlay shell.
     dst.style.background = "transparent";
     dst.style.backgroundColor = "transparent";
     if (doc.body) {
@@ -106,7 +101,6 @@ function forceOverlayTransparent(doc: Document) {
       style.setAttribute("data-atmos-overlay-transparent", "1");
       doc.head?.appendChild(style);
     }
-    // Always re-apply after theme sync / late stylesheet clone.
     style.textContent = OVERLAY_TRANSPARENT_CSS;
     syncThemeToOverlayDocument(doc);
   } catch {
@@ -150,14 +144,17 @@ export function FloatingElevationProvider({
   );
 
   const overlayWindowRef = React.useRef<Window | null>(null);
-  /** Prepared portal root — only published to store while overlay is shown. */
   const portalRootRef = React.useRef<HTMLElement | null>(null);
   const ensurePromiseRef = React.useRef<Promise<boolean> | null>(null);
   const overlayMoRef = React.useRef<MutationObserver | null>(null);
   const overlayListenerDocRef = React.useRef<Document | null>(null);
   const rafIdsRef = React.useRef<number[]>([]);
-  /** True while we intentionally show the overlay and publish portalContainer. */
-  const elevationActiveRef = React.useRef(false);
+  /** Overlay window currently shown + capturing. */
+  const windowShownRef = React.useRef(false);
+  /** Debounce hide so brief 0-count frames during remount do not thrash. */
+  const hideTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const HIDE_DEBOUNCE_MS = 120;
 
   React.useEffect(() => {
     let cancelled = false;
@@ -193,18 +190,19 @@ export function FloatingElevationProvider({
   );
 
   /**
-   * Prepare overlay window + portal root. Does NOT publish portalContainer
-   * and does NOT show the window (avoids portal-into-hidden / black flash).
+   * Prepare overlay window and **keep portalContainer published** while preview
+   * is present so open menus never remount between body ↔ overlay.
    */
-  const ensureOverlay = React.useCallback(async (): Promise<boolean> => {
+  const ensureOverlayReady = React.useCallback(async (): Promise<boolean> => {
     if (!capability || !nativePreviewPresent) return false;
     if (ensurePromiseRef.current) return ensurePromiseRef.current;
 
-    // Already prepared.
     if (
       overlayWindowRef.current &&
       !overlayWindowRef.current.closed &&
       portalRootRef.current &&
+      useDesktopElevationStore.getState().portalContainer ===
+        portalRootRef.current &&
       useDesktopElevationStore.getState().surfaceReady
     ) {
       return true;
@@ -222,11 +220,11 @@ export function FloatingElevationProvider({
           setEnsureFailed(true);
           setSurfaceReady(false);
           portalRootRef.current = null;
+          setPortalContainer(null);
           return false;
         }
 
-        const started = Date.now();
-        const deadline = started + OVERLAY_CREATE_BUDGET_MS * 4;
+        const deadline = Date.now() + OVERLAY_CREATE_BUDGET_MS * 4;
         while (Date.now() < deadline) {
           try {
             if (win.document?.body) break;
@@ -241,6 +239,7 @@ export function FloatingElevationProvider({
           setEnsureFailed(true);
           setSurfaceReady(false);
           portalRootRef.current = null;
+          setPortalContainer(null);
           return false;
         }
         portalRootRef.current = root;
@@ -253,17 +252,23 @@ export function FloatingElevationProvider({
           setEnsureFailed(true);
           setSurfaceReady(false);
           portalRootRef.current = null;
+          setPortalContainer(null);
           return false;
         }
 
-        // Surface ready for activation — portal still unpublished until show.
         setSurfaceReady(true);
         setEnsureFailed(false);
+        // Stable portal target for the whole preview session (no flip on open).
+        setPortalContainer(root);
+        // Stay hidden until layers open.
+        windowShownRef.current = false;
+        await desktopInvoke("overlay_bridge_release", {}).catch(() => {});
         return true;
       } catch {
         setEnsureFailed(true);
         setSurfaceReady(false);
         portalRootRef.current = null;
+        setPortalContainer(null);
         return false;
       } finally {
         ensurePromiseRef.current = null;
@@ -276,26 +281,15 @@ export function FloatingElevationProvider({
     capability,
     nativePreviewPresent,
     setEnsureFailed,
+    setPortalContainer,
     setSurfaceReady,
   ]);
 
   const showOverlayWindow = React.useCallback(async () => {
-    useDesktopElevationStore.getState().setPointerMode("capture");
-    await desktopInvoke("overlay_bridge_set_pointer_mode", {
-      mode: "capture",
-    }).catch(() => {});
-    await desktopInvoke("overlay_bridge_note_activity", {}).catch(() => {});
-  }, []);
-
-  /**
-   * Activate elevation: show overlay, then publish portal root so Radix
-   * re-portals into a visible transparent window.
-   */
-  const activateElevation = React.useCallback(async (): Promise<boolean> => {
-    const ok = await ensureOverlay();
-    if (!ok || !portalRootRef.current) return false;
-
-    // Re-assert transparency right before show (theme may have changed).
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
     const win = overlayWindowRef.current;
     if (win && !win.closed) {
       try {
@@ -304,34 +298,54 @@ export function FloatingElevationProvider({
         /* ignore */
       }
     }
+    useDesktopElevationStore.getState().setPointerMode("capture");
+    await desktopInvoke("overlay_bridge_set_pointer_mode", {
+      mode: "capture",
+    }).catch(() => {});
+    await desktopInvoke("overlay_bridge_note_activity", {}).catch(() => {});
+    windowShownRef.current = true;
+  }, []);
 
-    await showOverlayWindow();
-    elevationActiveRef.current = true;
-    setPortalContainer(portalRootRef.current);
-    return true;
-  }, [ensureOverlay, setPortalContainer, showOverlayWindow]);
+  const hideOverlayWindowDebounced = React.useCallback(() => {
+    if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+    hideTimerRef.current = setTimeout(() => {
+      hideTimerRef.current = null;
+      // Re-check: if layers reappeared, do not hide.
+      const portal = useDesktopElevationStore.getState().portalContainer;
+      const n = portal ? countOpenLayers([portal]) : 0;
+      if (n > 0) return;
+      windowShownRef.current = false;
+      setElevatedLayerCount(0);
+      void desktopInvoke("overlay_bridge_release", {}).catch(() => {});
+    }, HIDE_DEBOUNCE_MS);
+  }, [setElevatedLayerCount]);
 
-  /**
-   * Deactivate: unpublish portal first (menus return to body), then hide overlay.
-   */
-  const deactivateElevation = React.useCallback(() => {
-    elevationActiveRef.current = false;
-    setPortalContainer(null);
-    setElevatedLayerCount(0);
-    void desktopInvoke("overlay_bridge_release", {}).catch(() => {});
-  }, [setElevatedLayerCount, setPortalContainer]);
-
+  // When preview appears: prepare stable portal. When gone: full teardown.
   React.useEffect(() => {
+    if (!capability) return;
+
     if (!nativePreviewPresent) {
-      elevationActiveRef.current = false;
+      if (hideTimerRef.current) {
+        clearTimeout(hideTimerRef.current);
+        hideTimerRef.current = null;
+      }
+      windowShownRef.current = false;
       portalRootRef.current = null;
       overlayWindowRef.current = null;
       resetElevationRuntime();
       void desktopInvoke("overlay_bridge_release", {}).catch(() => {});
+      return;
     }
-  }, [nativePreviewPresent, resetElevationRuntime]);
 
-  // Recount host/portal layers; drive activate/deactivate.
+    void ensureOverlayReady();
+  }, [
+    capability,
+    ensureOverlayReady,
+    nativePreviewPresent,
+    resetElevationRuntime,
+  ]);
+
+  // Observe open layers in the **overlay portal** (and host only as bootstrap).
   React.useEffect(() => {
     if (!capability || !nativePreviewPresent || typeof document === "undefined") {
       return;
@@ -339,61 +353,52 @@ export function FloatingElevationProvider({
 
     let disposed = false;
     let recountScheduled = false;
-    let inFlight = false;
 
-    const applyCounts = (hostCount: number, portalCount: number) => {
-      setElevatedLayerCount(portalCount);
-
-      // Any open elevatable layer on host or portal → elevate.
-      // Host-only: content is still on body until we activate and re-portal.
-      if (hostCount > 0 || portalCount > 0) {
-        if (inFlight) return;
-        inFlight = true;
+    const applyLayerCount = (n: number) => {
+      setElevatedLayerCount(n);
+      if (n > 0) {
         void (async () => {
-          try {
-            if (elevationActiveRef.current && portalCount > 0) {
-              // Already elevated with content in portal — keep shown.
-              await showOverlayWindow();
-              return;
-            }
-            const ok = await activateElevation();
-            if (disposed || !ok) {
-              // Fail closed: clear portal so APP-029 hide can work.
-              deactivateElevation();
-              return;
-            }
-            // After re-portal, recount portal occupancy on next frames.
-          } finally {
-            inFlight = false;
+          const ok = await ensureOverlayReady();
+          if (disposed || !ok) return;
+          if (!windowShownRef.current) {
+            await showOverlayWindow();
+          } else {
+            // Keep idle timer cancelled while layers stay open.
+            await desktopInvoke("overlay_bridge_note_activity", {}).catch(
+              () => {},
+            );
           }
         })();
-        return;
-      }
-
-      // No open layers — deactivate so menus never stay portaled into a hidden window.
-      if (elevationActiveRef.current || useDesktopElevationStore.getState().portalContainer) {
-        deactivateElevation();
       } else {
-        void desktopInvoke("overlay_bridge_release", {}).catch(() => {});
+        hideOverlayWindowDebounced();
       }
     };
 
     const recountNow = () => {
       if (disposed) return;
       const portal = useDesktopElevationStore.getState().portalContainer;
-      const hostCount = countOpenLayers([document.body]);
-      // Only count portal root children when published (active elevation).
-      const portalCount = portal ? countOpenLayers([portal]) : 0;
-      // While elevating, also count host body (transition frames during re-portal).
-      applyCounts(hostCount, portalCount);
+      // Primary: layers already elevated into portal document.
+      let n = portal ? countOpenLayers([portal]) : 0;
+      // Bootstrap: first open still paints on body until portal is published;
+      // after ensureOverlayReady publishes portal, next open goes straight there.
+      // While portal is ready, also count host body layers that use the same
+      // markers only if they are NOT already under portal (hostCount for
+      // transition). Prefer max so we don't flicker hide.
+      if (portal) {
+        const hostN = countOpenLayers([document.body]);
+        // If portal is set, Radix should target portal — host body should be 0
+        // for elevated primitives. If host still has layers, keep shown.
+        n = Math.max(n, hostN);
+      } else {
+        n = countOpenLayers([document.body]);
+      }
+      applyLayerCount(n);
     };
 
     const scheduleRecount = () => {
       if (recountScheduled) return;
       recountScheduled = true;
-      for (const id of rafIdsRef.current) {
-        cancelAnimationFrame(id);
-      }
+      for (const id of rafIdsRef.current) cancelAnimationFrame(id);
       rafIdsRef.current = [];
       recountNow();
       const id1 = requestAnimationFrame(() => {
@@ -422,7 +427,6 @@ export function FloatingElevationProvider({
         "style",
       ],
     });
-
     document.addEventListener("transitionend", onTransitionOrAnimation, true);
     document.addEventListener("animationend", onTransitionOrAnimation, true);
 
@@ -478,7 +482,10 @@ export function FloatingElevationProvider({
       }
     });
 
-    scheduleRecount();
+    // Ensure portal is ready as soon as preview is present.
+    void ensureOverlayReady().then(() => {
+      if (!disposed) scheduleRecount();
+    });
 
     return () => {
       disposed = true;
@@ -487,6 +494,7 @@ export function FloatingElevationProvider({
       detachOverlayListeners();
       unsub();
       for (const id of rafIdsRef.current) cancelAnimationFrame(id);
+      if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
       document.removeEventListener(
         "transitionend",
         onTransitionOrAnimation,
@@ -497,17 +505,15 @@ export function FloatingElevationProvider({
         onTransitionOrAnimation,
         true,
       );
-      elevationActiveRef.current = false;
-      setPortalContainer(null);
+      windowShownRef.current = false;
       void desktopInvoke("overlay_bridge_release", {}).catch(() => {});
     };
   }, [
-    activateElevation,
     capability,
-    deactivateElevation,
+    ensureOverlayReady,
+    hideOverlayWindowDebounced,
     nativePreviewPresent,
     setElevatedLayerCount,
-    setPortalContainer,
     showOverlayWindow,
   ]);
 
@@ -517,7 +523,7 @@ export function FloatingElevationProvider({
     void desktopListen("desktop-overlay:destroyed", () => {
       overlayWindowRef.current = null;
       portalRootRef.current = null;
-      elevationActiveRef.current = false;
+      windowShownRef.current = false;
       resetElevationRuntime();
     }).then((u) => {
       unlisten = typeof u === "function" ? u : undefined;
@@ -540,7 +546,6 @@ export function FloatingElevationProvider({
     return () => mo.disconnect();
   }, [portalContainer]);
 
-  // Only publish portal while elevation is active (portalContainer non-null in store).
   const containerForPortals =
     capability && nativePreviewPresent && portalContainer
       ? portalContainer

--- a/apps/web/src/shared/lib/desktop-overlay/floating-elevation-provider.tsx
+++ b/apps/web/src/shared/lib/desktop-overlay/floating-elevation-provider.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 /**
- * APP-052: On Electron desktop with overlay capability + native preview present,
- * ensure a shared overlay surface and provide its document root as the portal
- * container so floating UI paints above WebContentsView previews.
+ * APP-052: Elevate floating UI above desktop native preview (WebContentsView).
  *
- * Pure web: capability stays false → PortalContainerProvider gets null → body.
+ * Critical lifecycle (bugfix for black screen / silent menus):
+ * 1. Never leave portalContainer set while the overlay window is hidden.
+ * 2. Show overlay first, then set portal container (so createPortal is never
+ *    into a hidden document).
+ * 3. On release: clear portalContainer first (portals return to body), then hide.
+ * 4. Overlay document must stay visually transparent (no dark theme body fill).
+ *
+ * Pure web: capability false → PortalContainerProvider null → document body.
  */
 
 import * as React from "react";
@@ -22,15 +27,51 @@ import { countOpenLayers } from "./layer-count";
 const OVERLAY_ROOT_ID = "atmos-overlay-root";
 const OVERLAY_WINDOW_NAME = "atmos-desktop-overlay";
 
+/** Force transparent chrome after theme class / stylesheet clone (prevents black fill). */
+const OVERLAY_TRANSPARENT_CSS = `
+html, body, #${OVERLAY_ROOT_ID} {
+  background: transparent !important;
+  background-color: transparent !important;
+  background-image: none !important;
+}
+html, body {
+  margin: 0 !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  width: 100% !important;
+  height: 100% !important;
+}
+#${OVERLAY_ROOT_ID} {
+  position: fixed !important;
+  inset: 0 !important;
+  pointer-events: none !important;
+}
+/* Floating content must receive clicks; root stays pass-through for empty areas
+   once we use ignoreMouseEvents(false) the whole window captures — content still
+   needs pointer-events auto for nested interactive nodes. */
+#${OVERLAY_ROOT_ID} > * {
+  pointer-events: auto !important;
+}
+`;
+
 function syncThemeToOverlayDocument(doc: Document) {
   try {
     const src = document.documentElement;
     const dst = doc.documentElement;
+    // Class for CSS variables / component tokens — backgrounds forced transparent below.
     dst.className = src.className;
     dst.style.colorScheme = src.style.colorScheme || "";
     const theme = src.getAttribute("data-theme");
     if (theme) dst.setAttribute("data-theme", theme);
     else dst.removeAttribute("data-theme");
+    // Never inherit opaque page background onto the overlay shell.
+    dst.style.background = "transparent";
+    dst.style.backgroundColor = "transparent";
+    if (doc.body) {
+      doc.body.style.background = "transparent";
+      doc.body.style.backgroundColor = "transparent";
+      doc.body.style.margin = "0";
+    }
   } catch {
     /* ignore */
   }
@@ -50,6 +91,24 @@ function cloneStylesToOverlay(doc: Document) {
     )) {
       head.appendChild(node.cloneNode(true));
     }
+  } catch {
+    /* ignore */
+  }
+}
+
+function forceOverlayTransparent(doc: Document) {
+  try {
+    let style = doc.head?.querySelector(
+      "[data-atmos-overlay-transparent]",
+    ) as HTMLStyleElement | null;
+    if (!style) {
+      style = doc.createElement("style");
+      style.setAttribute("data-atmos-overlay-transparent", "1");
+      doc.head?.appendChild(style);
+    }
+    // Always re-apply after theme sync / late stylesheet clone.
+    style.textContent = OVERLAY_TRANSPARENT_CSS;
+    syncThemeToOverlayDocument(doc);
   } catch {
     /* ignore */
   }
@@ -91,10 +150,14 @@ export function FloatingElevationProvider({
   );
 
   const overlayWindowRef = React.useRef<Window | null>(null);
+  /** Prepared portal root — only published to store while overlay is shown. */
+  const portalRootRef = React.useRef<HTMLElement | null>(null);
   const ensurePromiseRef = React.useRef<Promise<boolean> | null>(null);
   const overlayMoRef = React.useRef<MutationObserver | null>(null);
   const overlayListenerDocRef = React.useRef<Document | null>(null);
   const rafIdsRef = React.useRef<number[]>([]);
+  /** True while we intentionally show the overlay and publish portalContainer. */
+  const elevationActiveRef = React.useRef(false);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -113,25 +176,14 @@ export function FloatingElevationProvider({
         const doc = win.document;
         syncThemeToOverlayDocument(doc);
         cloneStylesToOverlay(doc);
+        forceOverlayTransparent(doc);
         let root = doc.getElementById(OVERLAY_ROOT_ID);
         if (!root) {
           root = doc.createElement("div");
           root.id = OVERLAY_ROOT_ID;
-          Object.assign(root.style, {
-            position: "fixed",
-            inset: "0",
-            pointerEvents: "auto",
-          } as CSSStyleDeclaration);
-          doc.body.style.margin = "0";
-          doc.body.style.background = "transparent";
           doc.body.appendChild(root);
         }
-        if (!doc.head.querySelector("[data-atmos-overlay-pointer-style]")) {
-          const style = doc.createElement("style");
-          style.setAttribute("data-atmos-overlay-pointer-style", "1");
-          style.textContent = `html,body{background:transparent!important}#${OVERLAY_ROOT_ID}{pointer-events:auto}`;
-          doc.head.appendChild(style);
-        }
+        forceOverlayTransparent(doc);
         return root;
       } catch {
         return null;
@@ -141,12 +193,22 @@ export function FloatingElevationProvider({
   );
 
   /**
-   * Prepare portalable overlay window + main registration.
-   * Does NOT show/capture — only note_activity shows the surface (B5).
+   * Prepare overlay window + portal root. Does NOT publish portalContainer
+   * and does NOT show the window (avoids portal-into-hidden / black flash).
    */
   const ensureOverlay = React.useCallback(async (): Promise<boolean> => {
     if (!capability || !nativePreviewPresent) return false;
     if (ensurePromiseRef.current) return ensurePromiseRef.current;
+
+    // Already prepared.
+    if (
+      overlayWindowRef.current &&
+      !overlayWindowRef.current.closed &&
+      portalRootRef.current &&
+      useDesktopElevationStore.getState().surfaceReady
+    ) {
+      return true;
+    }
 
     ensurePromiseRef.current = (async () => {
       setEnsureFailed(false);
@@ -159,6 +221,7 @@ export function FloatingElevationProvider({
         if (!win) {
           setEnsureFailed(true);
           setSurfaceReady(false);
+          portalRootRef.current = null;
           return false;
         }
 
@@ -177,8 +240,10 @@ export function FloatingElevationProvider({
         if (!root) {
           setEnsureFailed(true);
           setSurfaceReady(false);
+          portalRootRef.current = null;
           return false;
         }
+        portalRootRef.current = root;
 
         const result = (await desktopInvoke("overlay_bridge_ensure", {})) as {
           ok?: boolean;
@@ -187,18 +252,18 @@ export function FloatingElevationProvider({
         if (!result?.ok) {
           setEnsureFailed(true);
           setSurfaceReady(false);
+          portalRootRef.current = null;
           return false;
         }
 
-        setPortalContainer(root);
+        // Surface ready for activation — portal still unpublished until show.
         setSurfaceReady(true);
         setEnsureFailed(false);
-        // Prepare only — do not release/show here (B6). Caller decides
-        // note_activity vs release based on portal layer count.
         return true;
       } catch {
         setEnsureFailed(true);
         setSurfaceReady(false);
+        portalRootRef.current = null;
         return false;
       } finally {
         ensurePromiseRef.current = null;
@@ -211,11 +276,10 @@ export function FloatingElevationProvider({
     capability,
     nativePreviewPresent,
     setEnsureFailed,
-    setPortalContainer,
     setSurfaceReady,
   ]);
 
-  const showOverlayWithLayers = React.useCallback(async () => {
+  const showOverlayWindow = React.useCallback(async () => {
     useDesktopElevationStore.getState().setPointerMode("capture");
     await desktopInvoke("overlay_bridge_set_pointer_mode", {
       mode: "capture",
@@ -223,14 +287,51 @@ export function FloatingElevationProvider({
     await desktopInvoke("overlay_bridge_note_activity", {}).catch(() => {});
   }, []);
 
+  /**
+   * Activate elevation: show overlay, then publish portal root so Radix
+   * re-portals into a visible transparent window.
+   */
+  const activateElevation = React.useCallback(async (): Promise<boolean> => {
+    const ok = await ensureOverlay();
+    if (!ok || !portalRootRef.current) return false;
+
+    // Re-assert transparency right before show (theme may have changed).
+    const win = overlayWindowRef.current;
+    if (win && !win.closed) {
+      try {
+        forceOverlayTransparent(win.document);
+      } catch {
+        /* ignore */
+      }
+    }
+
+    await showOverlayWindow();
+    elevationActiveRef.current = true;
+    setPortalContainer(portalRootRef.current);
+    return true;
+  }, [ensureOverlay, setPortalContainer, showOverlayWindow]);
+
+  /**
+   * Deactivate: unpublish portal first (menus return to body), then hide overlay.
+   */
+  const deactivateElevation = React.useCallback(() => {
+    elevationActiveRef.current = false;
+    setPortalContainer(null);
+    setElevatedLayerCount(0);
+    void desktopInvoke("overlay_bridge_release", {}).catch(() => {});
+  }, [setElevatedLayerCount, setPortalContainer]);
+
   React.useEffect(() => {
     if (!nativePreviewPresent) {
+      elevationActiveRef.current = false;
+      portalRootRef.current = null;
+      overlayWindowRef.current = null;
       resetElevationRuntime();
       void desktopInvoke("overlay_bridge_release", {}).catch(() => {});
     }
   }, [nativePreviewPresent, resetElevationRuntime]);
 
-  // Recount layers on host + overlay roots; drive ensure/show/release.
+  // Recount host/portal layers; drive activate/deactivate.
   React.useEffect(() => {
     if (!capability || !nativePreviewPresent || typeof document === "undefined") {
       return;
@@ -238,83 +339,55 @@ export function FloatingElevationProvider({
 
     let disposed = false;
     let recountScheduled = false;
-    /** Gate bridge IPC so unchanged recounts do not spam note_activity/release. */
-    let lastBridgeState: "activity" | "release" | null = null;
-
-    const releaseBridge = () => {
-      if (lastBridgeState === "release") return;
-      lastBridgeState = "release";
-      void desktopInvoke("overlay_bridge_release", {}).catch(() => {});
-    };
+    let inFlight = false;
 
     const applyCounts = (hostCount: number, portalCount: number) => {
-      // elevationCovers uses portal-only count.
       setElevatedLayerCount(portalCount);
 
-      if (portalCount > 0) {
+      // Any open elevatable layer on host or portal → elevate.
+      // Host-only: content is still on body until we activate and re-portal.
+      if (hostCount > 0 || portalCount > 0) {
+        if (inFlight) return;
+        inFlight = true;
         void (async () => {
-          const st = useDesktopElevationStore.getState();
-          const win = overlayWindowRef.current;
-          const alreadyReady =
-            st.surfaceReady &&
-            st.portalContainer != null &&
-            win != null &&
-            !win.closed;
-          if (!alreadyReady) {
-            const ok = await ensureOverlay();
-            if (disposed || !ok) return;
-          }
-          // Show only — never release on this path (B6).
-          if (lastBridgeState !== "activity") {
-            lastBridgeState = "activity";
-            await showOverlayWithLayers();
-          }
-          const p = useDesktopElevationStore.getState().portalContainer;
-          setElevatedLayerCount(countOpenLayers([p ?? null]));
-        })();
-        return;
-      }
-
-      if (hostCount > 0) {
-        // Warm portal root for re-portal; keep surface hidden until portalCount > 0.
-        void (async () => {
-          const st = useDesktopElevationStore.getState();
-          if (!st.surfaceReady || !st.portalContainer) {
-            const ok = await ensureOverlay();
-            if (disposed || !ok) return;
-          }
-          const p = useDesktopElevationStore.getState().portalContainer;
-          const nextPortal = countOpenLayers([p ?? null]);
-          setElevatedLayerCount(nextPortal);
-          if (nextPortal > 0) {
-            if (lastBridgeState !== "activity") {
-              lastBridgeState = "activity";
-              await showOverlayWithLayers();
+          try {
+            if (elevationActiveRef.current && portalCount > 0) {
+              // Already elevated with content in portal — keep shown.
+              await showOverlayWindow();
+              return;
             }
-          } else {
-            releaseBridge();
+            const ok = await activateElevation();
+            if (disposed || !ok) {
+              // Fail closed: clear portal so APP-029 hide can work.
+              deactivateElevation();
+              return;
+            }
+            // After re-portal, recount portal occupancy on next frames.
+          } finally {
+            inFlight = false;
           }
         })();
         return;
       }
 
-      releaseBridge();
+      // No open layers — deactivate so menus never stay portaled into a hidden window.
+      if (elevationActiveRef.current || useDesktopElevationStore.getState().portalContainer) {
+        deactivateElevation();
+      } else {
+        void desktopInvoke("overlay_bridge_release", {}).catch(() => {});
+      }
     };
 
     const recountNow = () => {
       if (disposed) return;
       const portal = useDesktopElevationStore.getState().portalContainer;
-      // Host document only (not portal's ownerDocument which may be same origin
-      // but separate) for hostCount; portal root for portalCount.
       const hostCount = countOpenLayers([document.body]);
-      const portalCount = countOpenLayers([portal ?? null]);
+      // Only count portal root children when published (active elevation).
+      const portalCount = portal ? countOpenLayers([portal]) : 0;
+      // While elevating, also count host body (transition frames during re-portal).
       applyCounts(hostCount, portalCount);
     };
 
-    /**
-     * Coalesce MutationObserver spam to one recount chain per burst.
-     * Still uses immediate + double rAF so fade-in frames re-evaluate (B5).
-     */
     const scheduleRecount = () => {
       if (recountScheduled) return;
       recountScheduled = true;
@@ -376,6 +449,7 @@ export function FloatingElevationProvider({
       detachOverlayListeners();
       if (!portal?.ownerDocument?.body) return;
       const doc = portal.ownerDocument;
+      forceOverlayTransparent(doc);
       const mo = new MutationObserver(() => scheduleRecount());
       mo.observe(doc.body, {
         childList: true,
@@ -423,14 +497,18 @@ export function FloatingElevationProvider({
         onTransitionOrAnimation,
         true,
       );
+      elevationActiveRef.current = false;
+      setPortalContainer(null);
       void desktopInvoke("overlay_bridge_release", {}).catch(() => {});
     };
   }, [
+    activateElevation,
     capability,
-    ensureOverlay,
+    deactivateElevation,
     nativePreviewPresent,
     setElevatedLayerCount,
-    showOverlayWithLayers,
+    setPortalContainer,
+    showOverlayWindow,
   ]);
 
   React.useEffect(() => {
@@ -438,6 +516,8 @@ export function FloatingElevationProvider({
     let unlisten: (() => void) | undefined;
     void desktopListen("desktop-overlay:destroyed", () => {
       overlayWindowRef.current = null;
+      portalRootRef.current = null;
+      elevationActiveRef.current = false;
       resetElevationRuntime();
     }).then((u) => {
       unlisten = typeof u === "function" ? u : undefined;
@@ -450,7 +530,7 @@ export function FloatingElevationProvider({
   React.useEffect(() => {
     if (!portalContainer) return;
     const doc = portalContainer.ownerDocument;
-    const sync = () => syncThemeToOverlayDocument(doc);
+    const sync = () => forceOverlayTransparent(doc);
     sync();
     const mo = new MutationObserver(sync);
     mo.observe(document.documentElement, {
@@ -460,6 +540,7 @@ export function FloatingElevationProvider({
     return () => mo.disconnect();
   }, [portalContainer]);
 
+  // Only publish portal while elevation is active (portalContainer non-null in store).
   const containerForPortals =
     capability && nativePreviewPresent && portalContainer
       ? portalContainer

--- a/apps/web/src/shared/lib/desktop-overlay/layer-count.ts
+++ b/apps/web/src/shared/lib/desktop-overlay/layer-count.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure layer open detection for APP-052 elevation refcount (B5).
+ * Lifecycle open ≠ fully painted: do not require opacity > 0 (fade-in).
+ */
+
+export const LAYER_SELECTOR = [
+  "[data-slot='dialog-content']",
+  "[data-slot='dialog-overlay']",
+  "[data-slot='sheet-content']",
+  "[data-slot='sheet-overlay']",
+  "[data-slot='drawer-content']",
+  "[data-slot='drawer-popup']",
+  "[data-slot='popover-content']",
+  "[data-slot='dropdown-menu-content']",
+  "[data-slot='context-menu-content']",
+  "[data-slot='select-content']",
+  "[data-slot='tooltip-content']",
+  "[data-slot='hover-card-content']",
+  "[data-atmos-native-surface-overlay]",
+  "[role='dialog']",
+  "[role='tooltip']",
+].join(",");
+
+/**
+ * Whether a floater should count as open for ensure/show/release.
+ * - Requires not closed / not aria-hidden / not display:none / not visibility:hidden
+ * - Does NOT require opacity > 0 (avoids missing fade-in frames)
+ * - Opt-in surface markers still require opacity > 0 so permanent peek shells
+ *   with opacity-0 do not pin elevation forever
+ */
+export function isLifecycleOpenLayer(
+  el: HTMLElement,
+  getComputedStyleFn: (el: Element) => CSSStyleDeclaration = (e) =>
+    window.getComputedStyle(e),
+): boolean {
+  if (el.getAttribute("data-state") === "closed") return false;
+  if (el.getAttribute("aria-hidden") === "true") return false;
+
+  const style = getComputedStyleFn(el);
+  if (
+    style.display === "none" ||
+    style.visibility === "hidden" ||
+    style.visibility === "collapse"
+  ) {
+    return false;
+  }
+
+  // Permanent host markers (sidebar peek) stay mounted with opacity 0.
+  if (el.hasAttribute("data-atmos-native-surface-overlay")) {
+    if (Number(style.opacity) <= 0) return false;
+    const rect = el.getBoundingClientRect();
+    if (rect.width < 2 || rect.height < 2) return false;
+  }
+
+  return true;
+}
+
+export function countOpenLayers(
+  roots: Array<ParentNode | null | undefined>,
+  getComputedStyleFn?: (el: Element) => CSSStyleDeclaration,
+): number {
+  let n = 0;
+  for (const root of roots) {
+    if (!root) continue;
+    root.querySelectorAll(LAYER_SELECTOR).forEach((node) => {
+      if (!(node instanceof HTMLElement)) return;
+      if (!isLifecycleOpenLayer(node, getComputedStyleFn)) return;
+      n += 1;
+    });
+  }
+  return n;
+}

--- a/apps/web/src/shared/lib/desktop-overlay/layer-count.ts
+++ b/apps/web/src/shared/lib/desktop-overlay/layer-count.ts
@@ -1,6 +1,10 @@
 /**
  * Pure layer open detection for APP-052 elevation refcount (B5).
  * Lifecycle open ≠ fully painted: do not require opacity > 0 (fade-in).
+ *
+ * These helpers run against the OVERLAY document (a different window realm),
+ * so they must never use host-realm `instanceof HTMLElement` or the host
+ * `window.getComputedStyle` — cross-realm instanceof is always false.
  */
 
 export const LAYER_SELECTOR = [
@@ -22,6 +26,37 @@ export const LAYER_SELECTOR = [
 ].join(",");
 
 /**
+ * Hover-only layers never need pointer capture: the overlay window stays
+ * click-through so host clicks keep working while a tooltip is visible.
+ */
+const PASS_THROUGH_LAYER_SELECTOR = [
+  "[data-slot='tooltip-content']",
+  "[data-slot='hover-card-content']",
+  "[role='tooltip']",
+].join(",");
+
+export type OpenLayerSummary = {
+  /** Open floating layers (drives ensure/show/release). */
+  open: number;
+  /** Open layers that need pointer capture (anything but tooltip/hover-card). */
+  capture: number;
+};
+
+function isElement(node: Node): node is HTMLElement {
+  // Cross-realm safe (overlay document nodes are not host-realm HTMLElement).
+  return node.nodeType === 1;
+}
+
+function computedStyleOf(
+  el: HTMLElement,
+  getComputedStyleFn?: (el: Element) => CSSStyleDeclaration,
+): CSSStyleDeclaration | null {
+  if (getComputedStyleFn) return getComputedStyleFn(el);
+  const view = el.ownerDocument?.defaultView;
+  return view ? view.getComputedStyle(el) : null;
+}
+
+/**
  * Whether a floater should count as open for ensure/show/release.
  * - Requires not closed / not aria-hidden / not display:none / not visibility:hidden
  * - Does NOT require opacity > 0 (avoids missing fade-in frames)
@@ -30,24 +65,24 @@ export const LAYER_SELECTOR = [
  */
 export function isLifecycleOpenLayer(
   el: HTMLElement,
-  getComputedStyleFn: (el: Element) => CSSStyleDeclaration = (e) =>
-    window.getComputedStyle(e),
+  getComputedStyleFn?: (el: Element) => CSSStyleDeclaration,
 ): boolean {
   if (el.getAttribute("data-state") === "closed") return false;
   if (el.getAttribute("aria-hidden") === "true") return false;
 
-  const style = getComputedStyleFn(el);
+  const style = computedStyleOf(el, getComputedStyleFn);
   if (
-    style.display === "none" ||
-    style.visibility === "hidden" ||
-    style.visibility === "collapse"
+    style &&
+    (style.display === "none" ||
+      style.visibility === "hidden" ||
+      style.visibility === "collapse")
   ) {
     return false;
   }
 
   // Permanent host markers (sidebar peek) stay mounted with opacity 0.
   if (el.hasAttribute("data-atmos-native-surface-overlay")) {
-    if (Number(style.opacity) <= 0) return false;
+    if (style && Number(style.opacity) <= 0) return false;
     const rect = el.getBoundingClientRect();
     if (rect.width < 2 || rect.height < 2) return false;
   }
@@ -55,18 +90,27 @@ export function isLifecycleOpenLayer(
   return true;
 }
 
+export function summarizeOpenLayers(
+  roots: Array<ParentNode | null | undefined>,
+  getComputedStyleFn?: (el: Element) => CSSStyleDeclaration,
+): OpenLayerSummary {
+  let open = 0;
+  let capture = 0;
+  for (const root of roots) {
+    if (!root) continue;
+    root.querySelectorAll(LAYER_SELECTOR).forEach((node) => {
+      if (!isElement(node)) return;
+      if (!isLifecycleOpenLayer(node, getComputedStyleFn)) return;
+      open += 1;
+      if (!node.matches(PASS_THROUGH_LAYER_SELECTOR)) capture += 1;
+    });
+  }
+  return { open, capture };
+}
+
 export function countOpenLayers(
   roots: Array<ParentNode | null | undefined>,
   getComputedStyleFn?: (el: Element) => CSSStyleDeclaration,
 ): number {
-  let n = 0;
-  for (const root of roots) {
-    if (!root) continue;
-    root.querySelectorAll(LAYER_SELECTOR).forEach((node) => {
-      if (!(node instanceof HTMLElement)) return;
-      if (!isLifecycleOpenLayer(node, getComputedStyleFn)) return;
-      n += 1;
-    });
-  }
-  return n;
+  return summarizeOpenLayers(roots, getComputedStyleFn).open;
 }

--- a/e2e/tests/specs/APP-052_desktop-overlay-surface.web.e2e.ts
+++ b/e2e/tests/specs/APP-052_desktop-overlay-surface.web.e2e.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "../../fixtures/test";
+import {
+  connectLocalComputer,
+  expectHealthyRoute,
+  stubComputerClientSettingsApi,
+} from "../smoke/support/app-smoke";
+
+/**
+ * APP-052 web non-regression: pure Chromium web keeps document portals;
+ * no requirement that desktop overlay IPC runs.
+ */
+test.describe("APP-052 desktop overlay surface (web)", () => {
+  test("@smoke floating UI portals stay document-local without overlay bridge", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+
+    await stubComputerClientSettingsApi(page);
+    await connectLocalComputer(page, { locale: "en" });
+    await expectHealthyRoute(page, "/", { locale: "en" });
+
+    // Shell is not Electron preload on Playwright web harness.
+    const shell = await page.evaluate(() => {
+      const w = window as Window & {
+        __ATMOS_DESKTOP__?: { shell?: string };
+      };
+      return w.__ATMOS_DESKTOP__?.shell ?? "none";
+    });
+    expect(shell).toBe("none");
+
+    // Mount a dialog-like portal into document body (same path as Radix default).
+    await page.evaluate(() => {
+      const existing = document.getElementById("atmos-e2e-app052-dialog");
+      existing?.remove();
+      const el = document.createElement("div");
+      el.id = "atmos-e2e-app052-dialog";
+      el.setAttribute("role", "dialog");
+      el.setAttribute("aria-label", "APP-052 web portal probe");
+      el.setAttribute("data-slot", "dialog-content");
+      el.setAttribute("data-state", "open");
+      el.textContent = "APP-052 web portal probe";
+      el.style.cssText =
+        "position:fixed;inset:20% 30%;z-index:9999;background:#111;color:#fff;padding:16px";
+      document.body.appendChild(el);
+    });
+
+    const dialog = page.locator("#atmos-e2e-app052-dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute("role", "dialog");
+
+    // Confirm portal node is under document.body (not a remote overlay root).
+    const parentIsBody = await page.evaluate(() => {
+      const el = document.getElementById("atmos-e2e-app052-dialog");
+      return el?.parentElement === document.body;
+    });
+    expect(parentIsBody).toBe(true);
+
+    // Overlay ensure command must not be required; invoking capability is absent.
+    const hasDesktopBridge = await page.evaluate(() => {
+      const w = window as Window & {
+        __ATMOS_DESKTOP__?: { invoke?: unknown };
+      };
+      return typeof w.__ATMOS_DESKTOP__?.invoke === "function";
+    });
+    expect(hasDesktopBridge).toBe(false);
+
+    await page.evaluate(() => {
+      document.getElementById("atmos-e2e-app052-dialog")?.remove();
+    });
+    await expect(dialog).toHaveCount(0);
+  });
+});

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -50,15 +50,25 @@ packages/ui/
 
 ---
 
+## Floating / portaled primitives (desktop)
+
+New **dialog, sheet, drawer, popover, menu, select, tooltip, hover-card**, or other **Portal** surfaces must use `usePortalContainer()` (see `portal-container.tsx`) so desktop can elevate them above native preview. Do not hard-require a desktop-only container — default remains document body for web.
+
+→ Load full rules only when relevant: [agents/references/desktop-floating-ui.md](../../agents/references/desktop-floating-ui.md) (APP-052).
+
+---
+
 ## Safety Rails
 
 ### NEVER
 - Add API calls or side effects to UI components
 - Break semantic color variable conventions
 - Add business logic to components
+- Assume CSS `z-index` alone stacks above desktop native preview (`WebContentsView`)
 
 ### ALWAYS
 - Keep components atomic and reusable
 - Use semantic CSS variables for theming
 - Keep icon placement consistent: reusable icon files live under `src/components/icons/`
+- Wire new floating portals through `usePortalContainer()` when adding primitives under `components/ui/`
 

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -6,7 +6,7 @@ import { Dialog as DialogPrimitive, VisuallyHidden } from "radix-ui"
 
 import { cn } from "../../lib/utils"
 import { Button } from "./button"
-import { usePortalContainer } from "./portal-container"
+import { asHtmlElement, usePortalContainer } from "./portal-container"
 
 function Dialog({
   ...props
@@ -24,9 +24,7 @@ function DialogPortal({
   container: containerProp,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
-  const container = usePortalContainer(
-    containerProp instanceof HTMLElement ? containerProp : null,
-  )
+  const container = usePortalContainer(asHtmlElement(containerProp))
   return (
     <DialogPrimitive.Portal
       data-slot="dialog-portal"

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -6,6 +6,7 @@ import { Dialog as DialogPrimitive, VisuallyHidden } from "radix-ui"
 
 import { cn } from "../../lib/utils"
 import { Button } from "./button"
+import { usePortalContainer } from "./portal-container"
 
 function Dialog({
   ...props
@@ -20,9 +21,19 @@ function DialogTrigger({
 }
 
 function DialogPortal({
+  container: containerProp,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+  const container = usePortalContainer(
+    containerProp instanceof HTMLElement ? containerProp : null,
+  )
+  return (
+    <DialogPrimitive.Portal
+      data-slot="dialog-portal"
+      container={container}
+      {...props}
+    />
+  )
 }
 
 function DialogClose({

--- a/packages/ui/src/components/ui/drawer.tsx
+++ b/packages/ui/src/components/ui/drawer.tsx
@@ -3,6 +3,7 @@
 import { cn } from "@/lib/utils";
 import { Drawer as DrawerPrimitive } from "@base-ui/react/drawer";
 import { createContext, use } from "react";
+import { usePortalContainer } from "./portal-container";
 
 const DrawerContext =
   createContext<DrawerPrimitive.Root.Props["swipeDirection"]>("down");
@@ -27,10 +28,12 @@ function DrawerTrigger({ ...props }: DrawerPrimitive.Trigger.Props) {
 }
 
 function DrawerPortal({ className, ...props }: DrawerPrimitive.Portal.Props) {
+  const container = usePortalContainer();
   return (
     <DrawerPrimitive.Portal
       data-slot="drawer-portal"
       className={cn("z-50", className)}
+      container={container}
       {...props}
     />
   );

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -5,6 +5,7 @@ import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
 
 import { cn } from "../../lib/utils"
+import { usePortalContainer } from "./portal-container"
 
 function DropdownMenu({
   ...props
@@ -13,10 +14,18 @@ function DropdownMenu({
 }
 
 function DropdownMenuPortal({
+  container: containerProp,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  const container = usePortalContainer(
+    containerProp instanceof HTMLElement ? containerProp : null,
+  )
   return (
-    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+    <DropdownMenuPrimitive.Portal
+      data-slot="dropdown-menu-portal"
+      container={container}
+      {...props}
+    />
   )
 }
 
@@ -36,8 +45,9 @@ function DropdownMenuContent({
   sideOffset = 4,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  const container = usePortalContainer()
   return (
-    <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Portal container={container}>
       <DropdownMenuPrimitive.Content
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -5,7 +5,7 @@ import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
 
 import { cn } from "../../lib/utils"
-import { usePortalContainer } from "./portal-container"
+import { asHtmlElement, usePortalContainer } from "./portal-container"
 
 function DropdownMenu({
   ...props
@@ -17,9 +17,7 @@ function DropdownMenuPortal({
   container: containerProp,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
-  const container = usePortalContainer(
-    containerProp instanceof HTMLElement ? containerProp : null,
-  )
+  const container = usePortalContainer(asHtmlElement(containerProp))
   return (
     <DropdownMenuPrimitive.Portal
       data-slot="dropdown-menu-portal"

--- a/packages/ui/src/components/ui/hover-card.tsx
+++ b/packages/ui/src/components/ui/hover-card.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import { HoverCard as HoverCardPrimitive } from "radix-ui"
 
 import { cn } from "../../lib/utils"
+import { usePortalContainer } from "./portal-container"
 
 function HoverCard({
   ...props
@@ -25,8 +26,12 @@ function HoverCardContent({
   sideOffset = 4,
   ...props
 }: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
+  const container = usePortalContainer()
   return (
-    <HoverCardPrimitive.Portal data-slot="hover-card-portal">
+    <HoverCardPrimitive.Portal
+      data-slot="hover-card-portal"
+      container={container}
+    >
       <HoverCardPrimitive.Content
         data-slot="hover-card-content"
         align={align}

--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import * as PopoverPrimitive from "@radix-ui/react-popover"
 
 import { cn } from "../../lib/utils"
+import { usePortalContainer } from "./portal-container"
 
 function Popover({
   ...props
@@ -33,8 +34,9 @@ function PopoverContent({
   onCloseAutoFocus,
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  const container = usePortalContainer()
   return (
-    <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Portal container={container}>
       <PopoverPrimitive.Content
         data-slot="popover-content"
         align={align}

--- a/packages/ui/src/components/ui/portal-container.tsx
+++ b/packages/ui/src/components/ui/portal-container.tsx
@@ -26,6 +26,16 @@ export function PortalContainerProvider({
   )
 }
 
+/**
+ * SSR-safe HTMLElement check. `instanceof HTMLElement` throws in Node
+ * (HTMLElement is not defined), which breaks Next.js prerender.
+ */
+export function asHtmlElement(value: unknown): HTMLElement | null {
+  return typeof HTMLElement !== "undefined" && value instanceof HTMLElement
+    ? value
+    : null
+}
+
 /** Resolve portal container: explicit prop wins, then context, else undefined (body). */
 export function usePortalContainer(
   explicit?: HTMLElement | null,

--- a/packages/ui/src/components/ui/portal-container.tsx
+++ b/packages/ui/src/components/ui/portal-container.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import * as React from "react"
+
+/**
+ * Optional portal mount for floating UI (APP-052).
+ * - `undefined` context (no provider): Radix uses document body (web default).
+ * - Provider with `container={null}`: still document body.
+ * - Provider with `container={HTMLElement}`: portals into that node (desktop overlay root).
+ */
+const PortalContainerContext = React.createContext<HTMLElement | null | undefined>(
+  undefined,
+)
+
+export function PortalContainerProvider({
+  container,
+  children,
+}: {
+  container: HTMLElement | null
+  children: React.ReactNode
+}) {
+  return (
+    <PortalContainerContext.Provider value={container}>
+      {children}
+    </PortalContainerContext.Provider>
+  )
+}
+
+/** Resolve portal container: explicit prop wins, then context, else undefined (body). */
+export function usePortalContainer(
+  explicit?: HTMLElement | null,
+): HTMLElement | undefined {
+  const fromCtx = React.useContext(PortalContainerContext)
+  if (explicit != null) return explicit
+  if (fromCtx != null) return fromCtx
+  return undefined
+}

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -5,6 +5,7 @@ import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
 import { Select as SelectPrimitive } from "radix-ui"
 
 import { cn } from "../../lib/utils"
+import { usePortalContainer } from "./portal-container"
 
 function Select({
   ...props
@@ -60,8 +61,9 @@ function SelectContent({
   align = "start",
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  const container = usePortalContainer()
   return (
-    <SelectPrimitive.Portal>
+    <SelectPrimitive.Portal container={container}>
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(

--- a/packages/ui/src/components/ui/sheet.tsx
+++ b/packages/ui/src/components/ui/sheet.tsx
@@ -6,6 +6,7 @@ import * as SheetPrimitive from '@radix-ui/react-dialog'
 import { XIcon } from 'lucide-react'
 
 import { cn } from "../../lib/utils"
+import { usePortalContainer } from "./portal-container"
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot='sheet' {...props} />
@@ -19,8 +20,20 @@ function SheetClose({ ...props }: React.ComponentProps<typeof SheetPrimitive.Clo
   return <SheetPrimitive.Close data-slot='sheet-close' {...props} />
 }
 
-function SheetPortal({ ...props }: React.ComponentProps<typeof SheetPrimitive.Portal>) {
-  return <SheetPrimitive.Portal data-slot='sheet-portal' {...props} />
+function SheetPortal({
+  container: containerProp,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  const container = usePortalContainer(
+    containerProp instanceof HTMLElement ? containerProp : null,
+  )
+  return (
+    <SheetPrimitive.Portal
+      data-slot='sheet-portal'
+      container={container}
+      {...props}
+    />
+  )
 }
 
 function SheetOverlay({ className, ...props }: React.ComponentProps<typeof SheetPrimitive.Overlay>) {

--- a/packages/ui/src/components/ui/sheet.tsx
+++ b/packages/ui/src/components/ui/sheet.tsx
@@ -6,7 +6,7 @@ import * as SheetPrimitive from '@radix-ui/react-dialog'
 import { XIcon } from 'lucide-react'
 
 import { cn } from "../../lib/utils"
-import { usePortalContainer } from "./portal-container"
+import { asHtmlElement, usePortalContainer } from "./portal-container"
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot='sheet' {...props} />
@@ -24,9 +24,7 @@ function SheetPortal({
   container: containerProp,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Portal>) {
-  const container = usePortalContainer(
-    containerProp instanceof HTMLElement ? containerProp : null,
-  )
+  const container = usePortalContainer(asHtmlElement(containerProp))
   return (
     <SheetPrimitive.Portal
       data-slot='sheet-portal'

--- a/packages/ui/src/components/ui/tooltip.tsx
+++ b/packages/ui/src/components/ui/tooltip.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import { Tooltip as TooltipPrimitive } from "radix-ui"
 
 import { cn } from "../../lib/utils"
+import { usePortalContainer } from "./portal-container"
 
 function TooltipProvider({
   delayDuration = 0,
@@ -36,8 +37,9 @@ function TooltipContent({
   children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  const container = usePortalContainer()
   return (
-    <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Portal container={container}>
       <TooltipPrimitive.Content
         data-slot="tooltip-content"
         sideOffset={sideOffset}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -8,6 +8,7 @@ export * from "./components/ui/input";
 export * from "./components/ui/input-group";
 export * from "./components/ui/label";
 export * from "./components/ui/dialog";
+export * from "./components/ui/portal-container";
 export * from "./components/ui/scroll-area";
 export * from "./components/ui/select";
 export * from "./components/ui/toast";

--- a/specs/APP/APP-052_desktop-overlay-surface/BRAINSTORM.md
+++ b/specs/APP/APP-052_desktop-overlay-surface/BRAINSTORM.md
@@ -1,0 +1,160 @@
+# Brainstorm · APP-052: Desktop Overlay Surface
+
+> Problem space and exploration. Settled content graduates to PRD.md; committed architecture graduates to TECH.md.
+
+## Context
+
+- **Trigger**: Desktop native preview (`WebContentsView` / child webview) paints above host DOM. APP-029 shipped **geometry-based occlusion → hide native preview** so dialogs/popovers are clickable. It works, but every intersecting popover / dialog / modal **suspends live preview**, which feels broken for a daily browser surface.
+- **Who feels it**: Desktop users with right-sidebar (or in-shell) native preview open while using app chrome—toolbars, command UI, dropdowns, dialogs, sheets.
+- **Current workaround**: APP-029 `useNativePreviewOcclusion` + `shouldSuspendDesktopPreview` + static React fallback (`apps/web/.../use-native-preview-occlusion.ts`, `Preview.tsx`, lifecycle hide/show). Explicit markers: `data-atmos-native-surface-overlay`, ignore via `data-atmos-ignore-native-surface-occlusion`.
+- **Why hard**: Guest content is a **main-process native view**, not a DOM node—CSS `z-index` cannot win. True “float above browser” needs another native layer (or temporary hide). Electron has no first-class “HTML element above WebContentsView” API.
+- **Product constraint (user-stated)**: Overlay must be **common / shared** for performance and memory—**not one WebContentsView per popover**. Hide remains a **fallback**, not the default interaction. **Web (browser) must be unaffected**—desktop-only elevation path with clean adaptation.
+- **Related prior decision**: APP-029 BRAINSTORM **rejected** “native overlay window” for that scope (cost). This spec **reopens** that product direction because hide-as-primary UX is no longer acceptable; cost is now justified by daily friction.
+- **Platform note**: Production desktop is Electron (`apps/desktop-electron`, `PreviewSurfaceManager`). Tauri path is deprecated for product work—design for Electron; do not invest dual-shell parity unless PRD says otherwise.
+- **External analogy**: Raycast 2.0 renders popovers/tooltips as **native windows** over a system WebView (not Electron, not “z-index over BrowserView”). The transferable idea is **floating UI on a separate native layer**, not their hybrid stack wholesale.
+
+## Goals (draft)
+
+- **Primary**: Live native preview stays visible while host popovers / dialogs / modals that overlap it remain fully visible and interactive **above** the guest surface.
+- **Primary**: **One shared overlay rendering surface per host window** (or stricter: one per app process if proven safe)—multiple concurrent floating UIs share that engine; no per-popover native view spawn.
+- **Primary**: **Web browser session unchanged**—same components, no layout thrash, no desktop-only bugs on `app.atmos.land` / pure web.
+- **Primary**: Keep APP-029-style **hide + static fallback as safety net** when elevation is unavailable, fails, or intentionally not applied (e.g. tooltips? decide in PRD).
+- **Secondary**: Central policy (geometry and/or portal adapter) so feature teams do not hand-register every menu.
+- **Secondary**: Memory/CPU bounded—overlay surface cold-start vs warm tradeoff is explicit; idle footprint measurable.
+- **Non-goal (draft)**: Pixel-perfect partial clipping of the guest webview under an irregular popover shape (rounded corners can be “good enough” with opaque/backdrop regions).
+- **Non-goal (draft)**: Replacing the design system; Radix/shadcn primitives should keep working with an elevation adapter, not a second component library.
+
+## Options
+
+### Option A — Keep hide-only (status quo, APP-029)
+
+Geometry detects intersection → hide `WebContentsView` → React fallback → restore.
+
+**Pros**: Already shipped; simple mental model; no second renderer.  
+**Cons**: Live preview dies on every overlapping chrome interaction—current pain.  
+**Unknown**: None on feasibility.  
+**Role in this spec**: **Fallback only**, not primary.
+
+### Option B — Per-floating-UI native view / window
+
+Each popover or modal gets its own `WebContentsView` or `BrowserWindow`.
+
+**Pros**: Isolation, independent lifetime.  
+**Cons**: Memory/process explosion; focus and theme sync nightmare; contradicts user constraint.  
+**Verdict lean**: **Reject** as default. At most allow rare exceptions (e.g. detached inspector) outside this feature’s normal path.
+
+### Option C — Singleton Overlay Surface (shared engine) ★ leading direction
+
+**One** long-lived (or lazily created, then reused) native surface **above** the preview `WebContentsView` on the same host window:
+
+- Hosted as a single `WebContentsView` (or one transparent child window) owned by desktop main process.
+- Renders a **shared floating-UI document/runtime**—one Chromium instance paints **N** concurrent elevated widgets (stacking order inside that document).
+- Main shell detects “must elevate” (intersection with native preview and/or explicit portal policy) and **projects** floating UI into the overlay runtime instead of (or in addition to) host DOM.
+- Preview stays live underneath; overlay bounds can track window chrome / full content area as needed.
+- On failure / unsupported / non-elevated cases → fall back to Option A hide path.
+
+**Pros**: Matches “one engine, many UIs”; live preview; aligns with Electron multi-view model already used by `PreviewSurfaceManager`; Raycast-like layering without leaving Electron.  
+**Cons**: Cross-WebContents focus, pointer, a11y, and style/theme sync are real work; portal/elevation design must not break web; implementation complexity high vs APP-029.  
+**Unknown**: Exact content model (full React twin vs thin floating shell); warm vs cold start; whether full-window dimmed modals need live preview visible through backdrop.
+
+### Option D — Transparent always-on-top child `BrowserWindow` as the shared overlay root
+
+Same “singleton shared engine” as C, but surface is a **child window** parented to the host instead of a sibling `WebContentsView`.
+
+**Pros**: Can extend slightly past host bounds (Raycast-like); OS stacking is straightforward.  
+**Cons**: Multi-monitor / full-screen / focus-steal edge cases; window chrome sync harder; two window objects to keep aligned on move/resize/maximize.  
+**Unknown**: Whether Atmos needs out-of-bounds popovers enough to pay this tax.
+
+### Option E — Layout-only / chrome-outside-preview (no second surface)
+
+Force all menus to open only in regions that never intersect native preview bounds.
+
+**Pros**: Zero native work.  
+**Cons**: Cannot cover real product cases (center dialogs, command palette, sheets, drag overlays); not a complete product answer.  
+**Role**: **Complementary hygiene** for toolbar menus that *can* open downward into chrome—not a substitute for overlay surface.
+
+### Option F — Guest becomes iframe so DOM stacking works
+
+Abandon native embed for stacking convenience.
+
+**Pros**: z-index works.  
+**Cons**: Cross-origin / cookie / process isolation regressions; fights APP-010/011 preview direction.  
+**Verdict lean**: **Out of scope / reject** for this problem.
+
+## Framing summary
+
+| Framing | Shape |
+|--------|--------|
+| **Minimal** | Elevate only full-screen-ish dialogs/sheets that already feel “modal”; leave small popovers on hide path. Shared surface still singleton. |
+| **Generous** | All intersecting portaled overlays (popover, dropdown, dialog, sheet, command UI) elevate automatically; live preview always; warm overlay process; theme/focus parity. |
+| **Sideways** | Shrink preview `setBounds` around floating rects (hole punching) without second renderer—partial hide, not full hide. Still thrashy; hard with rounded shadows; keep as research note, not primary. |
+
+## Key forks in the road
+
+- **Fork 1 — Primary elevation vehicle**: Sibling **`WebContentsView` overlay** (Option C) vs **child `BrowserWindow`** (Option D). Decide in TECH; product only cares “one shared surface above preview.”
+- **Fork 2 — Content model for the shared engine**:
+  - **(2a)** Overlay loads a **dedicated floating-UI shell** (thin React entry) and receives render instructions / component payloads over IPC.
+  - **(2b)** Overlay loads the **same app origin** with a special entry/route and mounts elevated portals there (style parity easier; heavier).
+  - **(2c)** “DOM projection” / remote render of existing nodes (research-heavy; avoid unless proven).
+  Decide in TECH; PRD should require visual parity and single-engine reuse, not a specific IPC schema.
+- **Fork 3 — Elevation trigger**: Pure **geometry** (APP-029 candidates) vs **portal adapter** (components always portal to overlay root when desktop overlay is available) vs hybrid (portal when intersecting only). Decide in PRD (UX + web safety) / TECH (hooks).
+- **Fork 4 — What still uses hide fallback**: Unsupported markers, tooltips, transitions, overlay crash, surface not ready, non-desktop. Decide in PRD.
+- **Fork 5 — Lifetime**: Always warm at desktop launch vs create-on-first-elevation vs retain-after-use with idle teardown. Decide in TECH with memory budgets.
+- **Fork 6 — Scope of host windows**: Main product window only vs also standalone browser / detached preview hosts. Decide in PRD.
+- **Fork 7 — Relation to APP-029**: Supersede “hide as primary product behavior” while **keeping** occlusion detection + hide as fallback; do not delete APP-029 code until overlay path is proven. Decide in PRD.
+
+## Open questions
+
+- [ ] **Q1**: Must a semi-transparent modal backdrop keep the **live** preview visible behind the dimmer, or is elevating only the dialog chrome enough? *(PRD)*
+- [ ] **Q2**: Should **tooltips** elevate, stay host-DOM (may clip under preview), or continue to be ignored (APP-029 currently ignores tooltips)? *(PRD)*
+- [ ] **Q3**: Acceptable idle memory for a warm overlay surface (order-of-magnitude only)? *(PRD / TECH)*
+- [ ] **Q4**: Is automatic elevation required for **all** current APP-029 selectors, or can v1 start with dialog/sheet/modal + opt-in popovers? *(PRD)*
+- [ ] **Q5**: Focus trap / Esc / Tab: single focus domain across host + overlay WebContents—must feel like one window. What a11y bar? *(PRD / TECH)*
+- [ ] **Q6**: Theme, density, and CSS variables: overlay document must match host without shipping a second design system. Preferred approach? *(TECH)*
+- [ ] **Q7**: Pointer events outside elevated UI but over live preview: click-through to guest vs block? (modal vs non-modal). *(PRD)*
+- [ ] **Q8**: Multiple concurrent elevated layers (dropdown open over dialog)—all in one surface’s stacking context? *(TECH—almost certainly yes under shared engine)*
+- [ ] **Q9**: Standalone native browser window (if any) needs the same overlay manager attachment? *(PRD)*
+- [ ] **Q10**: Web adapter surface—feature flag, runtime capability (`desktop.overlaySurface`), or compile-time shell only? *(TECH)*
+
+## Constraints to carry into PRD / TECH
+
+1. **Shared engine**: max **one** overlay native content surface per host window for floating UI (unless TECH documents a rare escape hatch).
+2. **No web regression**: pure web path keeps current portals to `document.body` (or existing roots); no second process, no IPC, no hide-of-preview (preview is iframe or none).
+3. **Hide is backup**: APP-029 path remains for non-elevated occlusion and failure modes; default happy path should not flash-hide preview on routine popover open.
+4. **Reuse existing desktop surface ownership**: extend `PreviewSurfaceManager` / desktop IPC patterns rather than inventing a parallel embed system where possible.
+5. **Do not enumerate every feature forever**: central policy (geometry + shared overlay markers) beats per-feature hide lists; elevation should be as automatic as APP-029 detection was.
+6. **Performance**: prefer reuse + show/hide/bounds of the singleton surface over create/destroy; avoid full app reload per open.
+
+## References
+
+- Specs: `APP-029_native-preview-occlusion` (hide + fallback shipped; native overlay rejected then)
+- Specs: `APP-010_preview-element-select`, `APP-011_preview-cross-origin-extend`, `APP-045_desktop-electron-dual-shell`
+- Code: `apps/web/src/features/run-preview/hooks/use-native-preview-occlusion.ts`
+- Code: `apps/web/src/features/run-preview/components/Preview.tsx` (`shouldSuspendDesktopPreview`)
+- Code: `apps/web/src/features/run-preview/hooks/use-preview-lifecycle-effects.ts`
+- Code: `apps/desktop-electron/src/preview/surface-manager.ts` (`WebContentsView`, `addChildView`, `setVisible`)
+- Electron: Web Embeds / `WebContentsView` / View stacking (`addChildView` order)
+- Raycast: [A Technical Deep Dive Into the New Raycast](https://www.raycast.com/blog/a-technical-deep-dive-into-the-new-raycast) — native windows for popovers/tooltips over WebView UI
+- Community: multi-view browser patterns (e.g. shared top BrowserView/WebContentsView for chrome that must stack above content)
+
+## Ready to promote
+
+- **Promote to PRD**:
+  - Problem statement: hide-on-occlusion is correct emergency behavior but unacceptable as default for overlapping chrome.
+  - Must-have: live preview + interactive elevated host UI via **shared** overlay surface; web unaffected; hide as fallback.
+  - Must-have: no per-popover native view.
+  - Scope: which overlay classes in v1 (dialog/modal/sheet vs all popovers).
+  - Success metrics qualitative: no full-preview suspend on routine dropdown over preview; web unchanged.
+  - Non-goals: iframe guest, per-widget processes, pixel-perfect hole punch.
+  - Explicit relationship: supersedes APP-029 **product priority** (hide no longer primary), retains APP-029 **machinery** as fallback.
+
+- **Promote to TECH**:
+  - Singleton overlay attachment on host `BrowserWindow` / `contentView` above preview view.
+  - Elevation policy + web capability gating.
+  - Content model for shared floating runtime (2a/2b).
+  - Focus, input, theme sync, bounds on resize/DPI.
+  - Lifecycle warm/cold and failure → hide fallback.
+  - IPC / bridge shape next to existing `preview_bridge_*` (new overlay bridge vs extend).
+  - Migration plan from pure APP-029 path without breaking desktop preview.
+
+- **Do not invent in brainstorm**: concrete IPC payloads, route names, component file layouts (those belong in TECH after PRD scope lock).

--- a/specs/APP/APP-052_desktop-overlay-surface/PRD.md
+++ b/specs/APP/APP-052_desktop-overlay-surface/PRD.md
@@ -1,0 +1,172 @@
+# PRD · APP-052: Desktop Overlay Surface
+
+> Product Requirements · WHAT and WHY. Ship a **shared** desktop floating layer so host popovers, tooltips, dialogs, and modals paint **above** native preview without suspending live preview on every open; keep APP-029 hide as fallback; leave pure web unchanged.
+
+## Context
+
+- **Problem**: On Atmos desktop, native run/browser preview is a main-process view (`WebContentsView`). Host DOM cannot stack above it. APP-029 fixed clickability by **hiding** the native preview whenever app overlays intersect it. That is correct as emergency behavior but **wrong as the default**: opening a menu, tooltip, dialog, or modal over preview freezes or blanks the live page and feels broken for a surface people use continuously.
+- **Why now**: Preview is a first-class desktop surface; overlay traffic is constant (toolbar menus, command UI, settings dialogs, hover tips). Hide-on-occlusion scales poorly and trains users that “preview disappears when I use the app.” A shared elevation layer is the product answer already used by mature desktop shells (separate native layer for floating UI), without one native view per widget.
+- **Related specs**:
+  - **`APP-029_native-preview-occlusion`** — ships hide + static fallback. This PRD **supersedes hide as the primary product behavior** when elevation is available; **retains** hide + fallback as safety net.
+  - **`APP-010` / `APP-011`** — native preview / cross-origin embed remains required; do not regress to iframe-only stacking.
+  - **`APP-045_desktop-electron-dual-shell`** — production desktop work targets **Electron** (`apps/desktop-electron`). Tauri is not a product delivery target for this feature.
+- **Settled product choices** (from BRAINSTORM + owner decisions):
+  1. **All** floating overlay classes elevate (not dialog-only).
+  2. **Tooltips elevate** (APP-029’s “ignore tooltips” is replaced for the happy path).
+  3. Modal / dimmed UI chooses **best live experience**: keep preview **live** under elevated chrome and backdrop where possible.
+  4. **Every host window** that can own native preview (main workbench **and** standalone browser / detached preview hosts) gets the same overlay behavior.
+  5. Overlay engine is **lazy-created**, then **cleaned up when idle** so it does not permanently hold memory.
+
+## Goals
+
+1. **Primary** — Users can open any host floating UI over native preview and still see a **live** preview underneath (or beside) that UI, with the floating UI fully visible and interactive on top.
+2. **Primary** — Elevation uses **one shared overlay rendering engine per host window**, not one native surface per popover/tooltip/dialog.
+3. **Primary** — **Web browser** (`app.atmos.land` / non-desktop shell) behavior and performance are **unchanged**; no second process, no hide of iframe preview for this reason, no desktop-only visual regressions on web.
+4. **Primary** — When elevation is unavailable or fails, **APP-029-style hide + static fallback** still keeps overlays usable (no permanently unclickable chrome).
+5. **Secondary** — Feature teams do not maintain a growing list of “hide preview when my menu opens”; elevation is policy-driven / automatic for known overlay roles.
+6. **Secondary** — Idle desktop sessions do not permanently pay for an unused overlay renderer (lazy + cleanup).
+
+## Users & Scenarios
+
+- **Primary persona**: Desktop user with embedded native preview open (sidebar or in-shell browser) while using Atmos chrome.
+- **Secondary persona**: Desktop user in a **standalone browser / detached preview** window that still hosts a native guest surface and app chrome.
+- **Non-persona for this change**: Pure web users (must feel zero difference).
+
+### Key scenarios
+
+1. User opens a **toolbar dropdown or select** that extends over the preview; menu is fully visible and clickable; preview **keeps rendering** behind/around it.
+2. User hovers a control near the preview and a **tooltip** appears over the guest page; tooltip is readable and not buried under the native view; preview stays live.
+3. User opens a **centered dialog or command-style modal** with a dimming backdrop over the workbench including preview; dialog and backdrop sit above the guest; **preview continues live under the dimmer** so context is not “preview died.”
+4. User opens a **sheet / drawer** that covers part of the preview; elevated UI wins stacking; live preview remains where not covered by opaque chrome.
+5. User works in a **standalone browser window** with the same class of overlays; behavior matches the main window.
+6. Overlay engine was torn down after idle; user opens a popover again; first open may take a brief create cost, then works; no permanent second browser left running after idle cleanup.
+7. Elevation cannot run (capability missing, crash, mid-create); intersecting overlays still become usable via **hide + fallback**, then restore when clear.
+
+## User Stories
+
+- As a desktop user, I want menus and dialogs to appear **on top of** the embedded browser without blanking it, so that preview remains a living part of the workbench.
+- As a desktop user, I want **tooltips** near preview to remain readable, so that chrome affordances stay trustworthy over the guest page.
+- As a desktop user, I want modals to dim the UI **without killing** the live page behind them, so that I keep spatial context of what I was looking at.
+- As a desktop user in a **detached browser** window, I want the same stacking rules, so that floating UI is not a main-window-only special case.
+- As a web user, I want popovers and dialogs to behave exactly as today, so that desktop stacking work never taxes the browser product.
+- As a product engineer, I want floating primitives to participate automatically (or via a stable overlay role), so that I do not re-implement preview hide for every new menu.
+
+## Functional Requirements
+
+### Must Have
+
+- **M1 — Shared overlay engine**: For each desktop **host window** that can embed native preview, floating host UI that must stack above the guest uses **at most one** shared native overlay content surface for that window. Multiple concurrent floating UIs (e.g. dialog + nested menu + tooltip) share that engine’s stacking context. **Must not** spawn one native view/window per floating widget as the normal path.
+
+- **M2 — Full floating class coverage**: The following host UI roles **must** be elevatable above native preview when they would otherwise be covered (or when product policy always elevates them on desktop with overlay capability—TECH may choose the trigger; product requires **all** of these classes to win stacking when they appear over native preview):
+  - Dialog / modal (including modal backdrop / overlay)
+  - Sheet / drawer
+  - Popover
+  - Dropdown menu / context menu / select content
+  - **Tooltip / hover card** (explicitly included; APP-029’s tooltip exclusion does not apply to the happy path)
+  - Other app overlays already treated as APP-029 candidates (e.g. marked native-surface overlays), plus an explicit opt-in role for future custom floating UI
+
+- **M3 — Live preview is the happy path**: Opening any elevated floating UI **must not**, by default, suspend/hide the native preview solely because of that UI. Live guest content continues under or beside elevated chrome.
+
+- **M4 — Best-experience modals**: For modal / dimmed presentations:
+  - Elevated **backdrop and dialog content** stack above the native guest.
+  - Native preview **remains live** under translucent/dimmed regions wherever the design uses a dimmer (user keeps context; no static “preview paused” placeholder as the default modal experience).
+  - While a **modal** is open, the user must not interact with the guest page as if the modal were absent (preview is visible but not the active interaction target for modal semantics).
+  - Non-modal floating UI (menus, tooltips, non-modal popovers) must not leave the workbench feeling “stuck”; dismiss and outside-click behavior must match existing product expectations as closely as possible once elevated.
+
+- **M5 — All relevant host windows**: Overlay behavior applies to:
+  - Main Atmos workbench window with embedded native preview
+  - **Standalone browser / detached preview** (and any other product window that hosts native preview + host chrome overlays)
+  Behavior and lifecycle rules are the same family; no “main window only” ship.
+
+- **M6 — Lazy create + idle cleanup**:
+  - Do **not** create the shared overlay engine at app launch solely to sit idle.
+  - Create on **first need** to elevate in that host window.
+  - After a defined idle period with **no** elevated floating UI, **tear down** the engine for that host window so memory is reclaimed.
+  - Subsequent elevation recreates lazily. Brief first-open cost after cleanup is acceptable; permanent idle residency is not.
+
+- **M7 — Hide fallback (APP-029 retained)**: If elevation is not available yet (cold create in progress beyond a UX budget), fails, or is unsupported for a given case, intersecting overlays must still be usable via **hide native preview + static React fallback + automatic restore**, without requiring per-feature hide lists. Fallback must not be the steady-state path when elevation is healthy.
+
+- **M8 — Web non-impact**: In pure web / non-desktop-native-preview sessions:
+  - No overlay native engine
+  - No change to portal roots or stacking for normal document UI
+  - No new mandatory desktop-only user-visible states
+  Desktop adaptation is capability-gated; shared components remain one codebase.
+
+- **M9 — Automatic / centralized participation**: Elevation must not depend on each feature hand-wiring “hide preview.” Prefer the same class of **role markers / portal policy / geometry** already used for occlusion so new dialogs and menus participate by construction. Explicit opt-in remains available for custom floating UI.
+
+- **M10 — Focus and keyboard feel like one window**: Elevated UI must support expected keyboard paths (Esc to dismiss, Tab within dialogs, typeahead in menus) without trapping the user in a dead focus island or requiring a click “back into” the app with no visible focus. Exact a11y machinery is TECH; product bar is **parity with today’s non-preview-overlapping overlays**.
+
+- **M11 — Visual parity**: Elevated floating UI must use the same design language (theme, density, typography, motion) as host chrome—not a second unstyled system. Users should not perceive “a different app’s menus.”
+
+- **M12 — No success toasts**: Elevation, fallback hide, create, and cleanup are silent. Errors surface only if the user would otherwise be stuck (existing error patterns).
+
+### Nice to Have
+
+- **N1**: Soften first elevation after idle teardown (prewarm on hover of known triggers, or after first desktop preview attach) without defeating idle cleanup.
+- **N2**: Partial geometry: when only a small corner of a menu intersects preview, still elevate only when needed (if cheaper than always-on elevation for that open).
+- **N3**: Telemetry (local/debug only is fine) for elevation vs fallback rate and overlay engine create/destroy counts—to catch regressions that silently fall back to hide.
+- **N4**: Out-of-window-bounds floating (Raycast-style) if the chosen native vehicle allows it without extra product scope.
+
+## Out of Scope
+
+- **One native surface per floating widget** as the normal architecture.
+- **Replacing native preview with iframe** solely to regain CSS stacking.
+- **Pixel-perfect hole-punch / irregular clipping** of the guest under rounded shadows (opaque/backdrop regions and full elevated layers are enough).
+- **True live bitmap snapshot** of the guest as the primary modal backdrop (live view under dimmer is the goal; snapshot is not required).
+- **Mobile** overlay elevation.
+- **Tauri product parity** for this feature (Electron is the desktop target).
+- **Redesigning the component library** or replacing Radix/shadcn with native OS menus for all chrome.
+- **Changing guest-page content** or preview navigation semantics.
+- **Always-on overlay engine from process start** with no idle teardown.
+
+## Success Metrics
+
+- **Leading (qualitative / dogfood)**: Opening toolbar menus, tooltips, dialogs, and sheets over native preview no longer blanks or freezes the live guest as the normal experience.
+- **Leading**: Fallback hide rate is rare in healthy desktop sessions (most overlapping floating UI uses elevation). Target directionally: fallback is for failure/cold edge, not every popover.
+- **Leading**: After idle, overlay engine is destroyed; process tools do not show a permanent extra content process solely for an unused overlay.
+- **Lagging**: No increase in “can’t click menu over preview” reports; no web-only stacking/regression bugs attributed to this work.
+- **Qualitative**: Modal over preview still shows a living page under the dimmer; tooltips over preview are readable.
+- **Hard gate**: Pure web smoke of the same floating primitives shows no behavioral change.
+
+## Resolved BRAINSTORM forks (product)
+
+| Fork | Resolution |
+|------|------------|
+| Overlay class scope | **All** floating roles in M2, including **tooltips**. |
+| Tooltip policy | **Elevate** on happy path (not ignore, not hide-only). |
+| Modal + live preview | **Live guest under dimmer**; modal blocks interaction with guest; no default “preview paused” for healthy elevation. |
+| Host windows | **Main + standalone/detached browser hosts** (all native-preview hosts). |
+| Lifetime | **Lazy create** on first need; **idle cleanup** to free memory; recreate later as needed. |
+| Hide path | **Fallback only** when elevation unavailable/fails; APP-029 machinery retained. |
+| Shared engine | **One per host window** for floating UI; multi-widget stacking inside it. |
+| Web | **Unaffected**; capability-gated desktop path only. |
+| Vehicle (WebContentsView vs child window) | **Deferred to TECH** (product-neutral). |
+| Content model / IPC | **Deferred to TECH** (must meet M1, M10, M11). |
+| Exact idle timeout / create budget | **Deferred to TECH** (must meet M6 spirit). |
+
+## Risks & Open Questions
+
+- **Risk**: First open after cleanup feels slow if create is heavy—mitigate with acceptable create budget and optional N1 prewarm; never keep a permanent idle process as the only fix.
+- **Risk**: Focus/a11y across two content surfaces feels “almost native but wrong”—M10 is a ship gate; if elevation cannot meet it for a class, that class may temporarily use fallback rather than ship broken focus.
+- **Risk**: Over-elevating (always portaling every tooltip) costs more than geometry-only—product still requires tooltips to win stacking over native preview; TECH may elevate only when needed as long as M2/M3 hold.
+- **Risk**: Silent permanent fallback to hide would reintroduce the original pain—N3 / dogfood should catch “elevation never actually runs.”
+- **Open (TECH)**: Idle teardown duration; cold-create UX budget before hide fallback; pointer-event routing details for non-modal outside clicks; theme sync mechanism.
+
+## Milestones
+
+- **Phase 1 — Contract + shell**: Shared overlay capability on all native-preview host windows; lazy create + idle destroy; hide fallback still correct.
+- **Phase 2 — Elevate core chrome**: Dialogs, modals (with live under dimmer), sheets/drawers, menus/popovers/selects over preview without suspend.
+- **Phase 3 — Tooltips + parity**: Tooltips/hover cards elevated; keyboard/focus parity bar (M10); standalone browser hosts verified.
+- **Phase 4 — Harden**: Fallback only on real failure; idle memory validation; optional prewarm/telemetry (N1/N3).
+
+## Relationship to APP-029
+
+| | APP-029 | APP-052 |
+|--|---------|---------|
+| Primary product behavior | Hide guest when overlays intersect | Elevate floating UI above guest |
+| Live preview during overlays | No (suspended) | Yes (happy path) |
+| Tooltips | Ignored by occlusion | Elevate |
+| Shared overlay engine | Explicitly out of scope | Required (M1) |
+| Hide + static fallback | Required | Required as **fallback** (M7) |
+
+APP-029 remains the safety net and regression baseline until APP-052 elevation is proven; it is no longer the desired steady-state UX.

--- a/specs/APP/APP-052_desktop-overlay-surface/PROGRESS.md
+++ b/specs/APP/APP-052_desktop-overlay-surface/PROGRESS.md
@@ -1,0 +1,21 @@
+# PROGRESS · APP-052 Desktop Overlay Surface
+
+## Status
+
+Implementation in progress on `feat/APP-052-desktop-overlay-surface`.
+
+## Done
+
+- Specs: BRAINSTORM / PRD / TECH / TEST
+- Electron: `OverlaySurfaceManager`, lifecycle, IPC (`overlay_bridge_*`, `get_desktop_capabilities`)
+- Web: elevation policy (pure), store, FloatingElevationProvider, APP-029 suspend gate
+- UI: PortalContainerProvider + dialog/popover/menu/select/tooltip/hover-card/sheet/drawer
+- Units: 16 pass (policy, lifecycle, occlusion tooltips)
+- Web e2e: APP-052 web non-regression pass
+- Review loop: B1–B4, R1–R4 addressed
+
+## Next / residual
+
+- Electron headed dogfood of elevation over live preview (harness optional)
+- Tight bounds pass-through for non-modal (v1 uses capture while portal layers open)
+- Standalone browser presence marking if needed beyond shell attachHost

--- a/specs/APP/APP-052_desktop-overlay-surface/PROGRESS.md
+++ b/specs/APP/APP-052_desktop-overlay-surface/PROGRESS.md
@@ -15,8 +15,22 @@ Implementation in progress on `feat/APP-052-desktop-overlay-surface`.
 - Web e2e: APP-052 web non-regression pass
 - Review loop: B1–B4, R1–R4 addressed
 
+## 2026-08-03 · Bug-fix pass (user report: floaters invisible or window blacks out)
+
+Root causes and fixes tracked in [REVIEW.md](./REVIEW.md) (REV-001…REV-005), all fixed:
+
+- REV-001: cross-realm `instanceof HTMLElement` → overlay layer count always 0 → surface never shown (realm-safe `layer-count.ts`).
+- REV-002: `window.open` transparency unreliable → opaque black overlay (main now constructs the window via `setWindowOpenHandler` `createWindow`).
+- REV-003: unconditional capture for any layer (tooltips!) ate host clicks (pass-through vs capture classification, web owns pointer mode).
+- REV-004: host-document layers counted into elevation (overlay-doc-only counting; host floaters = APP-029 hide; chrome gated on `elevationHealthy`).
+- REV-005: keyboard focus handoff to overlay on capture, back to host on release.
+
+Also: `elevation-policy.ts` trimmed to the two functions product code uses; overlay style mirror re-syncs on host head changes (HMR / lazy CSS).
+
+Verification: `bun test src/shared/lib/desktop-overlay/` (16 pass), desktop-electron overlay tests (5 pass), `just typecheck` web/ui ✓ (e2e failure pre-existing APP-043), `bun run build` desktop ✓.
+
 ## Next / residual
 
-- Electron headed dogfood of elevation over live preview (harness optional)
-- Tight bounds pass-through for non-modal (v1 uses capture while portal layers open)
+- Electron headed dogfood of elevation over live preview (Esc / typeahead / dialog input focus matrix — REV-005 manual check)
+- Tight bounds pass-through for non-modal (v1 uses capture while non-hover portal layers open)
 - Standalone browser presence marking if needed beyond shell attachHost

--- a/specs/APP/APP-052_desktop-overlay-surface/PROGRESS.md
+++ b/specs/APP/APP-052_desktop-overlay-surface/PROGRESS.md
@@ -10,7 +10,8 @@ Implementation in progress on `feat/APP-052-desktop-overlay-surface`.
 - Electron: `OverlaySurfaceManager`, lifecycle, IPC (`overlay_bridge_*`, `get_desktop_capabilities`)
 - Web: elevation policy (pure), store, FloatingElevationProvider, APP-029 suspend gate
 - UI: PortalContainerProvider + dialog/popover/menu/select/tooltip/hover-card/sheet/drawer
-- Units: 16 pass (policy, lifecycle, occlusion tooltips)
+- Units: 27+ APP-052 unit tests pass (policy, store, layer-count, lifecycle, occlusion tooltips)
+  - Evidence: `bun test apps/desktop-electron/src/overlay/overlay-lifecycle.test.ts` and `bun test apps/web/src/shared/lib/desktop-overlay apps/web/src/features/run-preview/hooks/__tests__/use-native-preview-occlusion.test.ts`
 - Web e2e: APP-052 web non-regression pass
 - Review loop: B1–B4, R1–R4 addressed
 

--- a/specs/APP/APP-052_desktop-overlay-surface/REVIEW.md
+++ b/specs/APP/APP-052_desktop-overlay-surface/REVIEW.md
@@ -1,0 +1,199 @@
+# REVIEW · APP-052: Desktop Overlay Surface - Implementation Review
+
+> Post-implementation review log for functional completeness, architecture, maintainability, code size, testability, and follow-up fixes. Complements the planning quartet ([BRAINSTORM](./BRAINSTORM.md) -> [PRD](./PRD.md) -> [TECH](./TECH.md) -> [TEST](./TEST.md)); does not replace them.
+
+**Review date**: 2026-08-03  
+**Review scope**: functional review + implementation review (user-reported: opening any floating UI either shows nothing or blacks out the window)  
+**Related code**: `apps/desktop-electron/src/overlay/`, `apps/web/src/shared/lib/desktop-overlay/`, `apps/web/src/features/run-preview/components/Preview.tsx`
+
+---
+
+## Index
+
+| Id | Severity | Area | Title | Status |
+|----|----------|------|-------|--------|
+| REV-001 | P0 | frontend | Cross-realm `instanceof HTMLElement` made overlay layer counting always zero | fixed |
+| REV-002 | P0 | infra | `window.open` + `overrideBrowserWindowOptions` transparency unreliable → opaque black overlay | fixed |
+| REV-003 | P0 | frontend | Unconditional pointer capture for any open layer (incl. tooltips) ate all host clicks | fixed |
+| REV-004 | P1 | frontend | Host-document layers counted into elevation → empty capture shield + suppressed APP-029 hide | fixed |
+| REV-005 | P2 | frontend | No keyboard focus handoff to overlay window for capture layers | fixed |
+
+---
+
+## REV-001 · Cross-realm `instanceof HTMLElement` made overlay layer counting always zero
+
+| Field | Value |
+|-------|--------|
+| **Status** | fixed |
+| **Severity** | P0 |
+| **Area** | frontend |
+| **Reported by** | user review (弹窗不显示) |
+| **Owner** | unassigned |
+
+### Finding
+
+`countOpenLayers` filtered nodes with `node instanceof HTMLElement`. The overlay
+portal document belongs to a different window realm (child `BrowserWindow`), so
+its nodes are never instances of the host realm's `HTMLElement`. Every elevated
+layer counted as 0 → `overlay_bridge_note_activity` never fired → the overlay
+window never showed → all portaled dialogs/menus were invisible. The default
+`window.getComputedStyle` was also host-realm.
+
+### Evidence
+
+- `apps/web/src/shared/lib/desktop-overlay/layer-count.ts` (pre-fix: `instanceof HTMLElement`, host `window.getComputedStyle`)
+
+### Required fix
+
+Use realm-safe checks: `node.nodeType === 1` and
+`el.ownerDocument.defaultView.getComputedStyle(el)`.
+
+### Acceptance
+
+- [x] Unit test counts open layers from a foreign-realm document.
+
+### Fix log
+
+- 2026-08-03 - `layer-count.ts` rewritten realm-safe; regression test "counts layers from a foreign-realm document" in `__tests__/layer-count.test.ts`. Verified via `bun test src/shared/lib/desktop-overlay/`.
+
+---
+
+## REV-002 · `window.open` + `overrideBrowserWindowOptions` transparency unreliable → opaque black overlay
+
+| Field | Value |
+|-------|--------|
+| **Status** | fixed |
+| **Severity** | P0 |
+| **Area** | infra |
+| **Reported by** | user review (黑屏) |
+| **Owner** | unassigned |
+
+### Finding
+
+Per-pixel transparency must be set at `BrowserWindow` construction. Renderer-
+initiated windows created through `window.open` + `overrideBrowserWindowOptions`
+do not reliably honor `transparent: true` (electron#22281, #2170); post-create
+`setBackgroundColor("#00000000")` cannot retrofit it. Whenever the overlay was
+shown, the full host content area painted opaque black.
+
+### Evidence
+
+- `apps/desktop-electron/src/overlay/overlay-surface-manager.ts` (pre-fix: transparency via `overrideBrowserWindowOptions` + `setBackgroundColor` reinforcement)
+
+### Required fix
+
+Return a `createWindow` callback from `setWindowOpenHandler` so main constructs
+the `BrowserWindow` itself with `transparent: true` (constructor path), keeping
+the opener's `window.open` proxy via the passed-through child `webContents`.
+
+### Acceptance
+
+- [x] Overlay window constructed in main with `transparent: true`; registration no longer races `did-create-window`.
+
+### Fix log
+
+- 2026-08-03 - `overlayWindowOpenHandler` now returns `createWindow`; `registerOverlayWindow` is idempotent and public; `webPreferences` stay in `overrideBrowserWindowOptions` (applied to the child webContents before `createWindow`). Verified via `bun run build` + `tsc --noEmit` (overlay files clean); headed desktop dogfood pending.
+
+---
+
+## REV-003 · Unconditional pointer capture for any open layer (incl. tooltips) ate all host clicks
+
+| Field | Value |
+|-------|--------|
+| **Status** | fixed |
+| **Severity** | P0 |
+| **Area** | frontend |
+| **Reported by** | user review (点击无效) |
+| **Owner** | unassigned |
+
+### Finding
+
+`showOverlayWindow` and main's `noteActivity` both forced `capture` whenever any
+layer was open. Tooltips open on hover constantly, so the full-window invisible
+overlay swallowed every click — buttons that should open menus/dialogs appeared
+dead, with hover/hide flicker loops on top.
+
+### Required fix
+
+Classify layers: tooltip/hover-card–only frames stay `pass-through`
+(`setIgnoreMouseEvents(true, { forward: true })`); menus/popovers/dialogs use
+`capture`. Pointer mode is owned by the web side; main no longer overrides it in
+`noteActivity`.
+
+### Acceptance
+
+- [x] `summarizeOpenLayers` classification unit tests (pass-through vs capture).
+
+### Fix log
+
+- 2026-08-03 - `summarizeOpenLayers` added; provider sends `overlay_bridge_set_pointer_mode` on change only; main `noteActivity` no longer forces capture. Verified via `bun test src/shared/lib/desktop-overlay/`.
+
+---
+
+## REV-004 · Host-document layers counted into elevation → empty capture shield + suppressed APP-029 hide
+
+| Field | Value |
+|-------|--------|
+| **Status** | fixed |
+| **Severity** | P1 |
+| **Area** | frontend |
+| **Reported by** | internal review |
+| **Owner** | unassigned |
+
+### Finding
+
+`recountNow` used `Math.max(overlayCount, hostBodyCount)`. Host-document
+floaters (portals outside the `@workspace/ui` context, `[role="dialog"]`
+matches) both (a) showed + captured an overlay that contained nothing → click
+shield, and (b) inflated `elevatedLayerCount` so `elevationCovers` became true
+and the APP-029 hide was suppressed — the host dialog rendered *under* the live
+preview.
+
+### Required fix
+
+Count overlay-document layers only. Host-document floaters are exclusively
+APP-029's occlusion-hide concern (they can never be covered by elevation).
+Preview suspend: host occlusion always suspends; elevatable chrome flags gate on
+`elevationHealthy` (capability + surfaceReady + !ensureFailed + portal set, no
+layer-count race on open).
+
+### Acceptance
+
+- [x] Policy unit tests: host occlusion always suspends; chrome gated on health.
+
+### Fix log
+
+- 2026-08-03 - Provider counts portal roots only; `elevation-policy.ts` reduced to `computeElevationHealthy` + `shouldSuspendDesktopNativePreview` (dead exports `shouldElevate`/`pointerModeForLayers`/`expandRect`/`rectsIntersect`/`shouldFallbackHideDuringEnsure`/`shouldSuspendFromOcclusion` removed); `Preview.tsx` composition updated. Verified via `bun test src/shared/lib/desktop-overlay/` + `just typecheck` (web ✓).
+
+---
+
+## REV-005 · No keyboard focus handoff to overlay window for capture layers
+
+| Field | Value |
+|-------|--------|
+| **Status** | fixed |
+| **Severity** | P2 |
+| **Area** | frontend |
+| **Reported by** | internal review |
+| **Owner** | unassigned |
+
+### Finding
+
+The overlay window was always shown with `showInactive()`. Radix keyboard
+handlers (Escape, menu arrows/typeahead, dialog inputs) listen on the overlay
+document, but OS key events kept going to the host window → Escape and text
+input inside elevated dialogs could not work (PRD M10).
+
+### Required fix
+
+Focus the overlay window when pointer mode transitions to `capture` (and on
+show while capture); return focus to the host on `release` / pass-through /
+destroy. Tooltip-only frames never take focus.
+
+### Acceptance
+
+- [x] Focus moves with capture transitions in `OverlaySurfaceManager`; manual Esc/typeahead matrix pending desktop dogfood.
+
+### Fix log
+
+- 2026-08-03 - `focusOverlayForCapture` / `refocusHost` added to `OverlaySurfaceManager` (`setPointerMode`, `noteActivity` show path, `release`, `destroyOverlayWindow`). Manual desktop verification pending.

--- a/specs/APP/APP-052_desktop-overlay-surface/TECH.md
+++ b/specs/APP/APP-052_desktop-overlay-surface/TECH.md
@@ -1,0 +1,497 @@
+# TECH · APP-052: Desktop Overlay Surface
+
+> Technical Design · HOW. Implements PRD APP-052: Desktop Overlay Surface.  
+> Addresses **M1–M12**. Nice-to-haves **N1–N3** noted as optional follow-ups; **N4** only if free with the chosen vehicle.
+
+## Scope summary
+
+Desktop-only (Electron production shell): introduce a **singleton floating overlay surface per host `BrowserWindow`**, elevate host floating UI (dialogs, sheets, menus, popovers, tooltips, …) so it paints **above** native preview `WebContentsView`s while preview stays **live**, and keep APP-029 **hide + static fallback** when elevation is not ready or fails. Pure web is a no-op.
+
+**Out of this TECH**: Rust/api/WS changes, mobile, Tauri parity, per-widget native surfaces, iframe guest stacking, pixel hole-punch.
+
+**Layers touched**:
+
+```
+packages/ui          — portal container from React context (default document)
+apps/web             — elevation policy, capability gate, APP-029 integration
+apps/desktop-electron — OverlaySurfaceManager, IPC, window open handler, lifecycle
+```
+
+No `apps/api` / `crates/*` / WebSocket protocol work.
+
+---
+
+## Architecture overview
+
+### Stacking problem (status quo)
+
+```
+BrowserWindow
+└── contentView
+    ├── host shell WebContents          ← React chrome, Radix portals (bottom)
+    └── preview WebContentsView(s)      ← native guest (above host DOM)
+```
+
+Host `z-index` cannot win. APP-029 hides preview so host portals are clickable.
+
+### Target stacking (happy path)
+
+```
+BrowserWindow (host)
+├── contentView
+│   ├── host shell WebContents
+│   └── preview WebContentsView(s)      ← stays visible + live
+└── Overlay surface (singleton, lazy)   ← elevated floating UI only
+    └── same-origin document
+        └── #atmos-overlay-root
+            └── createPortal(host React trees)  ← dialogs, menus, tooltips, …
+```
+
+### End-to-end flow
+
+```
+[packages/ui Portal] ──container?──► FloatingElevationContext (apps/web)
+         │                                    │
+         │ document.body (web / no elevate)   │ ensure overlay + portal target
+         ▼                                    ▼
+   host document                    OverlaySurfaceManager (main)
+                                    create/show singleton surface
+                                    bounds + pointer policy
+         │                                    │
+         └──── createPortal(node, overlayDoc.#root) ──┘
+                          │
+                          ▼
+              preview stays live underneath
+              APP-029 hide only if elevation inactive for occluding layers
+```
+
+### Decisions (TECH locks)
+
+| Topic | Decision | Why |
+|-------|----------|-----|
+| **Vehicle** | **Transparent parented child `BrowserWindow`** (one per host), not a third `WebContentsView` | Child window always stacks above parent content **including** all `WebContentsView`s; host can obtain a same-origin `Window` / `document` for **`createPortal`**, so arbitrary React children keep working without a second component registry or IPC-serialized trees. |
+| **Content model** | **Host React tree + `createPortal` into overlay document** | M11 visual/state parity; one reconciler; no dual app boot for every dialog. Overlay document is a thin same-origin shell (CSS + empty root), not a second product app. |
+| **Shared engine** | Exactly **one** overlay window per host `BrowserWindow` | M1; N concurrent layers share one document stacking context. |
+| **Elevation trigger** | **Hybrid** (see Policy) | Modal/sheet always elevate when any native preview is attached on that host; lightweight floaters elevate on **geometry intersection** (and tooltips included). No elevate when no native preview → zero cost. |
+| **Lifetime** | **Lazy create** on first ensure; **idle destroy** after quiet period | M6. |
+| **Fallback** | APP-029 path when elevation not active for an occluding layer | M7. |
+| **Web** | Capability false → context returns `null` container → existing portals | M8. |
+
+**Rejected alternatives** (short):
+
+- **Per-popover WebContentsView** — violates M1/memory.
+- **Overlay `WebContentsView` + IPC remount of UI** — forces serializable props / component registry; poor fit for Atmos dialogs with rich children.
+- **Always-warm overlay from app start** — violates M6.
+- **Iframe guest** — out of scope; fights APP-010/011.
+
+---
+
+## Module-by-module design
+
+### `apps/desktop-electron` — OverlaySurfaceManager
+
+**New module** (suggested path):
+
+- `apps/desktop-electron/src/overlay/overlay-surface-manager.ts`
+- `apps/desktop-electron/src/overlay/types.ts`
+- `apps/desktop-electron/src/overlay/constants.ts`
+
+**Wire into** `AppState` (alongside `preview: PreviewSurfaceManager`):
+
+```ts
+// app-state.ts (conceptual)
+overlay: OverlaySurfaceManager | null;
+```
+
+**Responsibilities**:
+
+| Method | Behavior |
+|--------|----------|
+| `ensure(host, reason)` | If no surface for `host`: create transparent parented `BrowserWindow`, load overlay URL, wait ready (or timeout). Show if hidden. Cancel idle timer. Return `{ ready: boolean }`. |
+| `setPointerMode(host, mode)` | `pass-through` \| `capture` (see Pointer policy). |
+| `setBoundsToHost(host)` | Match host **content** bounds (x/y/w/h in screen space); re-run on host `resize` / `move` / display change. |
+| `noteActivity(host)` | Reset idle timer while layers elevated. |
+| `scheduleIdleDestroy(host)` | After `OVERLAY_IDLE_MS` with no elevated activity → destroy surface, free memory. |
+| `destroy(host)` / `destroyAll()` | Tear down on host `closed` and app quit. |
+
+**Window options** (normative intent):
+
+- `parent: host`
+- `frame: false`, `transparent: true`, `hasShadow: false`
+- `resizable: false`, `maximizable: false`, `fullscreenable: false`
+- `skipTaskbar: true`
+- `show: false` until ready
+- `webPreferences`: `sandbox` consistent with shell; **same partition/session as host shell** so same-origin assets resolve; preload **narrow** (`overlay-preload`) — only overlay bridge, not full desktop invoke if avoidable
+- Do **not** use `alwaysOnTop` relative to other apps; parenting is enough for in-app stacking
+
+**Load URL**:
+
+- Dev: same origin as shell (`http://localhost:…/desktop-overlay` or query `?atmos_desktop_overlay=1`)
+- Prod desktop export: sibling static entry or hash route that ships with `BUILD_TARGET=desktop`
+- Document body: transparent background; single `#atmos-overlay-root`; import **shared CSS tokens** (same pipeline as shell) so portaled nodes look correct before host injects extra sheets
+
+**Ready protocol**:
+
+1. Overlay renderer fires `overlay_bridge_ready` (via preload → main → host event, or `ipcRenderer` to main then `webContents.send` to host).
+2. Host `FloatingElevationProvider` resolves `ensure()` promise only after ready **or** after `OVERLAY_CREATE_BUDGET_MS` (then elevation fails open → fallback hide).
+
+**Host association**:
+
+- Key surfaces by `host.id` (Electron window id).
+- `preview_bridge_*` already resolves invoking window via `hostWindowFromArgs` — overlay commands use the same pattern so **standalone browser windows** get their own singleton (M5).
+
+**Stacking vs preview**:
+
+- No change to `PreviewSurfaceManager` z-order required: child overlay window paints above parent’s entire surface, including preview views.
+- When overlay is destroyed, preview behavior unchanged.
+
+### `apps/desktop-electron` — IPC / bridge commands
+
+Extend desktop invoke map in `apps/desktop-electron/src/ipc/handlers.ts` (names stable, snake_case like preview):
+
+| Command | Args | Result |
+|---------|------|--------|
+| `overlay_bridge_ensure` | `{ host hint via invoke event }` | `{ ok: true, windowId, ready: boolean }` or error |
+| `overlay_bridge_set_pointer_mode` | `{ mode: "pass-through" \| "capture" }` | `null` |
+| `overlay_bridge_note_activity` | `{}` | `null` |
+| `overlay_bridge_release` | `{}` | `null` — host reports zero elevated layers; start idle timer |
+| `overlay_bridge_destroy` | `{}` | `null` — force teardown (tests / host closed) |
+
+**Events** (host listen via existing `desktopListen` / `atmos:desktop-event:*` pattern):
+
+| Event | Payload |
+|-------|---------|
+| `desktop-overlay:ready` | `{ windowId }` |
+| `desktop-overlay:destroyed` | `{ windowId }` |
+| `desktop-overlay:outside-pointer` | `{ x, y, button }` — when pass-through mode and main detects interaction that should dismiss non-modal UI (optional if CSS hit-testing is enough) |
+
+**Capability discovery** (M8):
+
+- Extend existing desktop capability / config probe (whatever shell already exposes to web, e.g. get API config or a small `desktop_get_capabilities`) with `overlaySurface: true` on Electron when manager is registered.
+- Web: `detectDesktopShell() === "electron"` **and** `overlaySurface` → enable provider. Tauri / none → off.
+
+Do **not** add REST or Atmos Server WS messages.
+
+### Portal bootstrap (host ↔ overlay document)
+
+**Chosen pattern: controlled `window.open` + `createPortal`**
+
+1. Host `FloatingElevationProvider` calls `overlay_bridge_ensure`.
+2. Host opens (once per generation):  
+   `window.open(overlayUrl, OVERLAY_WINDOW_NAME, features)`  
+   where `OVERLAY_WINDOW_NAME` is stable per host (e.g. `atmos-overlay-${hostId}`) so reuse hits the same surface.
+3. Main `setWindowOpenHandler` on **each host** webContents:
+   - If URL matches overlay entry → create/reuse that host’s overlay `BrowserWindow` with options above; load URL; return `{ action: "allow", overrideBrowserWindowOptions: … }` **or** equivalent attach path that still yields a usable `Window` proxy to the opener.
+   - Implementation note: if a pure `WebContentsView` path is later proven to expose a portalable `document` without a child window, manager may switch vehicle **without** changing the web portal API. **v1 vehicle remains child `BrowserWindow`.**
+4. Host waits for `load` + `#atmos-overlay-root`.
+5. Host sets context value `portalContainer = overlayWindow.document.getElementById("atmos-overlay-root")`.
+6. Style parity: on ensure, **mirror critical theme state** onto `overlayWindow.document.documentElement` (`class` light/dark, `data-theme`, CSS variables used by `@workspace/ui`). Prefer copying `document.documentElement.className` + relevant attributes; optional: clone adopted style sheets / link tags if overlay entry does not already include the full CSS bundle.
+7. On idle destroy: `overlayWindow.close()` / main destroy; host nulls container and generation counter so next ensure re-opens cleanly.
+
+**Invariant**: Elevated nodes are still **owned by the host React tree** (state, hooks, queries). Only the DOM mount point moves.
+
+### `packages/ui` — portal container hookup
+
+Today portals hardcode default (e.g. `PopoverPrimitive.Portal` without container; `DialogPortal` wraps Radix portal).
+
+**Change** (minimal, web-safe):
+
+1. Add optional React context in UI package **or** accept container only from a thin app-level wrapper — prefer **app-owned context** in `apps/web` to avoid forcing every UI consumer to know desktop:
+
+   **Recommended**: keep primitives dumb; pass container via existing Radix props where available:
+
+   - `PopoverPrimitive.Portal container={…}`
+   - `DropdownMenu.Portal container={…}`
+   - `Dialog.Portal container={…}`
+   - Tooltip / HoverCard / Select / ContextMenu / Sheet / Drawer equivalents
+
+2. Implement a tiny helper used inside each primitive:
+
+```ts
+// packages/ui — conceptual
+function usePortalContainerProp(explicit?: HTMLElement | null) {
+  const fromCtx = React.useContext(PortalContainerContext); // default null
+  return explicit ?? fromCtx ?? undefined; // undefined → Radix default (document.body)
+}
+```
+
+3. `PortalContainerContext` default `null`. **Web apps that never set the provider behave exactly as today (M8).**
+
+4. `apps/web` provides the provider only under desktop elevation.
+
+Touch all floating primitives that use portals and match APP-029 / M2 markers:
+
+- dialog (+ overlay)
+- sheet / drawer
+- popover
+- dropdown-menu / context-menu / select
+- tooltip / hover-card
+- any `data-atmos-native-surface-overlay` custom surfaces that portal
+
+### `apps/web` — FloatingElevationProvider + policy
+
+**Suggested paths**:
+
+- `apps/web/src/shared/lib/desktop-overlay/`
+  - `floating-elevation-provider.tsx`
+  - `elevation-policy.ts`
+  - `use-elevated-portal-container.ts`
+  - `constants.ts`
+- Mount provider near existing desktop/app shell providers (e.g. app layout / desktop-only tree), **not** inside preview only — standalone browser windows load the same shell.
+
+#### Capability gate
+
+```ts
+// conceptual
+const enabled =
+  isDesktopRuntime() &&
+  desktopCapabilities?.overlaySurface === true;
+```
+
+When `!enabled`, provider is pass-through: context container `null`, no IPC.
+
+#### Elevation policy (M2, M3, M9)
+
+| Role | When to elevate (desktop + capability + native preview present on host) |
+|------|------------------------------------------------------------------------|
+| Dialog / modal / sheet / drawer / `aria-modal` | **Always** while open (covers large regions; live dimmer over preview). |
+| Popover / dropdown / context / select / custom marker | Elevate when open **and** geometry intersects any **visible** native preview surface rect on this window (reuse APP-029 rect sources). |
+| Tooltip / hover-card | Same as popover (**included**; APP-029 ignore list **removed** for happy path). |
+| No native preview attached / visible | **Do not** ensure overlay; use host document. |
+
+**Geometry**: Reuse selectors and visibility helpers from `use-native-preview-occlusion.ts` (extract pure functions to a shared module if needed, e.g. `native-overlay-candidates.ts`) so APP-029 and elevation share one candidate definition.
+
+**Layer registry** (host-side):
+
+- Ref-count elevated roots (`layerId` per open floating root).
+- `count > 0` → `overlay_bridge_note_activity` / keep surface alive; pointer mode from policy.
+- `count === 0` → `overlay_bridge_release` → idle timer.
+
+#### Portal container selection
+
+```ts
+// conceptual
+const container =
+  enabled && shouldElevateCurrentTree
+    ? overlayPortalRoot   // HTMLElement in overlay document
+    : null;               // Radix → document.body
+```
+
+`shouldElevateCurrentTree` is determined by policy when each floating root opens (modal → true if preview present; non-modal → intersection observation).
+
+#### Pointer policy (M4)
+
+| Mode | When | Behavior |
+|------|------|----------|
+| **`capture`** | Any elevated **modal** (dialog overlay, sheet that blocks, `aria-modal=true`) | Overlay window receives mouse events. Full host content bounds. Backdrop dims live preview; guest does not receive clicks. |
+| **`pass-through`** | Only non-modal layers (menus, tooltips, non-modal popovers) | Prefer **tight bounds** around union of elevated layer rects (+ shadow padding, e.g. 16px) so clicks outside the overlay window hit host/preview. Host still owns dismiss-on-outside via Radix; if click lands on preview, forward dismiss: listen `desktop-overlay:outside-pointer` **or** preview webContents mouse-down → host closes elevated non-modals. |
+
+Tight bounds update on scroll/resize/animation frames while open (throttle rAF).
+
+Modal **must not** use pass-through (guest would be clickable under dimmer).
+
+#### Focus / keyboard (M10)
+
+- When elevating modals/menus, focus moves into overlay window with the portaled content (normal for child window).
+- On close: return focus to host trigger (Radix `onCloseAutoFocus`); ensure host `webContents.focus()` if focus was left on destroyed overlay.
+- Esc: handled by Radix in the tree (runs in host JS even if DOM is in overlay document) — verify event targeting; if overlay window steals key events, overlay preload forwards keydown to host or rely on child window focus containing the focused node (same React handlers on the fiber tree).
+- Ship gate: manual matrix Esc / Tab / typeahead for dialog + menu + tooltip.
+
+#### APP-029 integration (M7)
+
+File: `apps/web/src/features/run-preview/hooks/use-native-preview-occlusion.ts` + `Preview.tsx` `shouldSuspendDesktopPreview`.
+
+**New rule**:
+
+```
+isOccluded = geometry says overlapping candidates exist
+elevationCovers = every intersecting candidate is currently elevated
+  (or elevation mode is healthy and policy would elevate them)
+
+shouldSuspendFromOcclusion = isOccluded && !elevationCovers
+```
+
+Also suspend when:
+
+- `overlay ensure` failed / timed out while occluded
+- Overlay crashed / `desktop-overlay:destroyed` unexpectedly while layers still open
+- Capability false (today’s APP-029 behavior)
+
+**Tooltip change**: include tooltip/hover-card in **fallback** occlusion candidates too (so if elevation fails, hide still unblocks tooltips). Happy path elevates them instead of ignoring.
+
+**Fallback UX**: keep static React fallback in preview placeholder when suspended; no success toasts (M12).
+
+**Transition**: When elevation becomes ready mid-open, switch container host→overlay and clear suspend without flicker if possible (acceptable brief fallback during cold create within budget).
+
+### Constants (normative defaults)
+
+| Constant | Default | Meaning |
+|----------|---------|---------|
+| `OVERLAY_IDLE_MS` | `30_000` | No elevated layers → destroy surface |
+| `OVERLAY_CREATE_BUDGET_MS` | `200` | Ensure not ready → use hide fallback for occluding UI |
+| `OVERLAY_BOUNDS_PADDING_PX` | `16` | Pass-through tight bounds padding |
+| `OVERLAY_RESTORE_DEBOUNCE_MS` | keep APP-029 `140` | Avoid flicker when falling back |
+
+Tune only with dogfood evidence; keep in one constants module.
+
+---
+
+## Data model
+
+No DB. Runtime types (TypeScript, shared as needed between web and electron via structural typing / small shared package only if duplication hurts):
+
+```ts
+type OverlayPointerMode = "pass-through" | "capture";
+
+type OverlayEnsureResult = {
+  ok: boolean;
+  ready: boolean;
+  windowId?: number;
+};
+
+type OverlayLayerKind =
+  | "dialog"
+  | "sheet"
+  | "drawer"
+  | "popover"
+  | "menu"
+  | "select"
+  | "tooltip"
+  | "hover-card"
+  | "custom";
+
+type OverlayLayerRegistration = {
+  id: string;
+  kind: OverlayLayerKind;
+  modal: boolean; // forces capture + always-elevate when preview present
+};
+
+type DesktopCapabilities = {
+  // existing fields…
+  overlaySurface?: boolean;
+};
+```
+
+---
+
+## Transport
+
+**Desktop IPC only** (Electron `atmos:desktop-invoke` + desktop events). Not Atmos Server WebSocket.
+
+### Commands
+
+```ts
+// ensure
+desktopInvoke("overlay_bridge_ensure", {});
+// → { ok: true, ready: true, windowId: number }
+
+desktopInvoke("overlay_bridge_set_pointer_mode", { mode: "capture" | "pass-through" });
+desktopInvoke("overlay_bridge_note_activity", {});
+desktopInvoke("overlay_bridge_release", {});
+desktopInvoke("overlay_bridge_destroy", {});
+```
+
+### Events
+
+```ts
+desktopListen("desktop-overlay:ready", (p) => { /* … */ });
+desktopListen("desktop-overlay:destroyed", (p) => { /* … */ });
+// optional:
+desktopListen("desktop-overlay:outside-pointer", (p) => { /* dismiss non-modals */ });
+```
+
+### REST
+
+None. Justification: local shell concern; no multi-client sync.
+
+---
+
+## Security & permissions
+
+- Overlay window is **same trust level as host shell** (product UI), not guest preview partition (`persist:atmos-preview`).
+- Overlay preload must **not** expose full Node or arbitrary desktop invoke if host already has a privileged preload; prefer a minimal bridge.
+- Guest preview remains isolated; elevation must not inject host React into preview partition.
+- No new tokens; no logging of page content from guest when handling outside-pointer.
+
+---
+
+## PRD traceability
+
+| PRD | TECH mechanism |
+|-----|----------------|
+| M1 shared engine | One child overlay window per host; multi-layer DOM in one document |
+| M2 all classes + tooltips | Policy table + UI portal container wiring for all primitives |
+| M3 live preview happy path | Do not set `shouldSuspendFromOcclusion` when `elevationCovers` |
+| M4 modal live under dimmer | Modal elevates backdrop into overlay; preview stays shown; pointer `capture` |
+| M5 all host windows | Manager keyed by host window; invoke uses sender window |
+| M6 lazy + idle cleanup | `ensure` on first need; `OVERLAY_IDLE_MS` destroy |
+| M7 hide fallback | APP-029 when `!elevationCovers` / timeout / failure |
+| M8 web | Capability + shell gate; default portal unchanged |
+| M9 automatic | Shared candidates + portal context; opt-in `data-atmos-native-surface-overlay` |
+| M10 focus | Focus in overlay document; return focus host on close; manual gate |
+| M11 visual parity | Host React + shared CSS/theme mirror on overlay documentElement |
+| M12 no toasts | Silent ensure/destroy/fallback |
+
+---
+
+## Rollout plan
+
+Ordered, mergeable steps:
+
+1. **Electron manager skeleton** — `OverlaySurfaceManager` + `overlay_bridge_ensure/destroy` + idle timer; no web wiring; unit-testable pure helpers for bounds math.
+2. **Overlay HTML entry + CSS** — transparent page, `#atmos-overlay-root`, theme class hook; load from desktop build.
+3. **window.open handler + portal proof** — dogfood: manually portal a test dialog above preview without hide.
+4. **`packages/ui` portal container context** — default null; wire Dialog/Popover/Menu/Tooltip/Sheet/…; web screenshot/smoke unchanged.
+5. **`FloatingElevationProvider`** — capability gate, ensure/release, theme sync, layer refcount.
+6. **Policy + geometry** — extract shared candidates; modal always / others on intersect; pointer modes + tight bounds.
+7. **APP-029 integration** — `elevationCovers` suppresses suspend; tooltips in fallback candidates; keep static fallback UI.
+8. **Standalone browser host** — verify second window has its own overlay singleton.
+9. **Focus/keyboard matrix** — fix gaps; if a class fails M10, force that class to fallback hide until fixed.
+10. **Idle destroy validation** — confirm process teardown; optional N3 debug counters; optional N1 prewarm later.
+
+Feature flag (optional): `desktopOverlaySurface` in desktop config default **on** for Electron dogfood once step 7 is green; keep ability to force APP-029-only via flag for rollback.
+
+---
+
+## Risks & tradeoffs
+
+| Risk | Mitigation |
+|------|------------|
+| Child `BrowserWindow` focus feels “second window” | Parenting, skipTaskbar, no activate steal on ensure when only tooltips; focus only when modal/menu needs it. |
+| `createPortal` cross-window edge cases (events, measure, `position: fixed`) | Overlay bounds = host content box so `fixed` coordinates match; sync resize; test Radix positioning. |
+| Cold ensure latency | `OVERLAY_CREATE_BUDGET_MS` + hide fallback; optional N1 prewarm after first preview attach. |
+| Pass-through vs tooltip hit-testing | Tight bounds + padding; if unreliable, temporary `capture` for open non-modals (blocks preview clicks under menu only via bounds). |
+| Silent permanent fallback | Debug counter elevated vs suspended (N3); dogfood checklist. |
+| Style mismatch | Overlay entry ships same CSS; mirror `documentElement` theme on ensure and on theme toggle. |
+| Two windows on multi-monitor DPI | Bounds from host `getContentBounds()`; listen display metrics. |
+
+**Tradeoff**: Chose **child BrowserWindow + host portals** over **WebContentsView remount** for rich React children and simpler stacking above preview. Cost: window lifecycle and pointer routing complexity.
+
+**Rollback**: Flag off elevation → pure APP-029 hide path (already shipped). Destroy manager; UI context null.
+
+---
+
+## Dependencies & compatibility
+
+- **Depends on**: APP-029 machinery (occlusion + hide + fallback UI); Electron desktop shell (APP-045); native preview surfaces (`PreviewSurfaceManager`).
+- **Supersedes (behavior)**: APP-029 as *primary* stacking strategy; does not delete APP-029.
+- **Does not block**: API, mobile, web-only features.
+- **Min shell**: Electron desktop with `WebContentsView` preview; no Tauri work.
+
+---
+
+## Open questions
+
+- [ ] Exact desktop static route/filename for overlay entry in prod export (`/desktop-overlay` vs query flag) — decide at impl with current Next desktop export layout.
+- [ ] Whether `window.open` + `overrideBrowserWindowOptions` alone is sufficient on all target Electron versions, or main must create the window and bridge a `MessagePort`/`WebContents` id for portal bootstrap — spike in rollout step 3; **API of `FloatingElevationProvider` stays the same**.
+- [ ] Outside-click on preview: prefer bounds-only vs explicit `outside-pointer` events from preview webContents — implement bounds-first; add events if dismiss flakes.
+- [ ] N1 prewarm: after first `preview_bridge_open` on a host vs hover on menu triggers — defer until cold-open metrics hurt.
+
+---
+
+## Implementation notes (non-normative)
+
+- Reuse patterns from `apps/desktop-electron/src/appshot/capture-animation.ts` (shared overlay window lifecycle) and `PreviewSurfaceManager` (per-host attach, destroy on host close).
+- Keep overlay code out of `persist:atmos-preview` partition.
+- Do not enumerate feature-level hide flags for new menus once elevation is on; rely on markers + policy.
+- Prefer extracting pure geometry helpers for unit tests under `apps/web` (Bun) without Electron.

--- a/specs/APP/APP-052_desktop-overlay-surface/TEST.md
+++ b/specs/APP/APP-052_desktop-overlay-surface/TEST.md
@@ -308,6 +308,8 @@ If Electron launch is too flaky for CI initially: web E2E + Bun units **must** s
 
 Use **web** only (load Agent Browser skill or `agent-browser skills get core --full` first). Desktop stacking is out of scope for agent-browser.
 
+If the Agent Browser skill or CLI is unavailable, read `references/agent-browser-setup.md` and mark this section `not_run` if setup still cannot be completed.
+
 1. Open local web app, open dialog and popover/menu from primary chrome; confirm no desktop error copy and no broken portal.
 2. Narrow viewport: dialog still usable; no clipped primary actions.
 3. Toggle theme on web; floating UI still coherent.

--- a/specs/APP/APP-052_desktop-overlay-surface/TEST.md
+++ b/specs/APP/APP-052_desktop-overlay-surface/TEST.md
@@ -1,0 +1,356 @@
+# TEST · APP-052: Desktop Overlay Surface
+
+> Test Plan · verify shared desktop overlay elevation above native preview, APP-029 hide fallback, web non-impact, lazy idle cleanup, and E2E journeys. References PRD APP-052 and TECH APP-052.
+
+## Test strategy
+
+- **Bun unit tests** for pure policy/geometry: elevation trigger (modal vs intersect), `elevationCovers` vs APP-029 suspend, candidate selectors (including tooltips), rect intersection, tight-bounds padding, idle timer math. No Electron required.
+- **Bun unit tests** for desktop bridge/capability gating (shell none vs electron + `overlaySurface`).
+- **Electron/main unit tests** (Bun or Node with mocks) for `OverlaySurfaceManager` lifecycle: ensure once per host, idle destroy, destroy on host close, pointer mode, bounds sync helpers — mock `BrowserWindow` / timers.
+- **Playwright E2E (web harness, CI-primary)** under `e2e/tests/specs/` for **M8 web non-impact**: dialogs/popovers/tooltips still work in Chromium; no desktop overlay IPC; iframe preview not suspended by APP-052 logic.
+- **Playwright E2E (desktop shell)** under `e2e/tests/specs/` for elevation happy path and fallback. The committed harness today is **web-only Chromium** (`e2e/playwright.config.ts`). **APP-052 test-run must add an Electron Playwright project** (or documented `just test-e2e-desktop` entry) that launches `apps/desktop-electron` and reuses `fixtures/test.ts` patterns where possible. Until that project exists, desktop stacking scenarios stay `planned` with harness gap called out — they are still **required for merge of full APP-052**, not optional nice-to-haves.
+- **agent-browser**: exploratory on **web** routes only (desktop-native stacking is not Agent Browser’s target).
+- **Manual**: multi-monitor DPI, focus edge cases, idle memory in Activity Monitor, first-open after destroy latency feel.
+
+## Coverage map
+
+| PRD item | Scenario IDs |
+|----------|--------------|
+| M1 Shared engine (one surface / host) | S4, S5, S20 |
+| M2 Full floating class coverage + tooltips | S6, S7, S8, S9, S10, S21 |
+| M3 Live preview happy path | S6, S7, S8, S11 |
+| M4 Modal live under dimmer + block guest | S11, S12 |
+| M5 All host windows (main + standalone) | S13, S14 |
+| M6 Lazy create + idle cleanup | S4, S15, S16 |
+| M7 Hide fallback (APP-029) | S17, S18, S22 |
+| M8 Web non-impact | S1, S2, S3 |
+| M9 Automatic / centralized participation | S9, S21 |
+| M10 Focus / keyboard parity | S19 |
+| M11 Visual parity | S11, S23 (manual / exploratory) |
+| M12 No success toasts | S6, S11, S17 |
+| N1 Prewarm (if shipped) | S24 (deferred unless implemented) |
+| N3 Debug counters (if shipped) | S25 (deferred unless implemented) |
+
+## Execution map
+
+| Scenario | Level | Expected tool | Target command / method | Fixture / data | Signals | Status |
+|----------|-------|---------------|-------------------------|----------------|---------|--------|
+| S1 | E2E | Playwright | `just test-e2e -- tests/specs/APP-052_desktop-overlay-surface.web.e2e.ts` | seeded workspace; Chromium web | dialog open/close; no `overlay_bridge_*` | planned |
+| S2 | E2E | Playwright | same file | popover/dropdown over main chrome | menu interactive; console clean of overlay errors | planned |
+| S3 | E2E | Playwright | same file | iframe or web preview if available | preview not blanked by APP-029 desktop path | planned |
+| S4 | Unit | `bun test` | OverlaySurfaceManager / pure lifecycle helpers | fake timers; mock window factory | single ensure; second ensure reuses; idle destroy once | planned |
+| S5 | Unit | `bun test` | host-key / per-window map | two host ids | two independent surfaces; destroy one leaves other | planned |
+| S6 | E2E desktop | Playwright Electron | `just test-e2e -- tests/specs/APP-052_desktop-overlay-surface.desktop.e2e.ts` (or `just test-e2e-desktop`) | Electron + native preview open in sidebar | dialog above guest; guest still updating (live); **not** paused fallback | planned |
+| S7 | E2E desktop | Playwright Electron | same | toolbar dropdown intersecting preview | menu visible/clickable; preview **not** hidden | planned |
+| S8 | E2E desktop | Playwright Electron | same | control near preview with tooltip | tooltip readable above guest | planned |
+| S9 | Unit | `bun test` | elevation-policy + candidates | synthetic DOM rects (happy-dom) | modal→elevate; popover intersect→elevate; no preview→no elevate | planned |
+| S10 | Unit | `bun test` | candidates include tooltip/hover-card | tooltip node intersecting surface | candidate listed; APP-029 ignore removed for fallback path | planned |
+| S11 | E2E desktop | Playwright Electron | desktop e2e file | modal with dimmer over preview | dimmer+dialog on top; live guest under dimmer; guest not clickable | planned |
+| S12 | Unit / desktop E2E | `bun test` + Electron | pointer mode policy | modal open vs menu open | `capture` vs `pass-through` / tight bounds | planned |
+| S13 | E2E desktop | Playwright Electron | desktop e2e file | standalone browser host window | overlay ensure on that window; stacking works | planned |
+| S14 | Unit | `bun test` | manager keyed by host id from invoke sender | two mock hosts | ensure(A) does not attach to B | planned |
+| S15 | Unit | `bun test` | idle timer `OVERLAY_IDLE_MS` | fake timers; release layers | destroy after idle; not before | planned |
+| S16 | E2E desktop or Manual | Electron | open menu, close, wait idle+ | Activity Monitor / debug counter | overlay process/window gone after idle | planned |
+| S17 | E2E desktop | Playwright Electron | desktop e2e file | force ensure fail / budget timeout (test hook or flag) | APP-029 hide + fallback UI; restore on close | planned |
+| S18 | Unit | `bun test` | `shouldSuspendFromOcclusion` | occluded + elevationCovers true/false | suspend only when `!elevationCovers` | planned |
+| S19 | E2E desktop | Playwright Electron | desktop e2e file | dialog open over preview | Esc closes; Tab cycles; focus returns to trigger | planned |
+| S20 | Unit / desktop | `bun test` + Electron | two concurrent layers | dialog + nested menu | still one overlay window | planned |
+| S21 | Unit | `bun test` | `data-atmos-native-surface-overlay` opt-in | custom marker rect | elevates / occludes like stock roles | planned |
+| S22 | Unit | `bun test` | cold create budget | ensure pending > budget + occluded | suspend true until ready then false when covered | planned |
+| S23 | Manual / agent-browser (web theme only) | manual + agent-browser | theme toggle with elevated dialog on desktop | dark/light | elevated chrome matches host theme | planned |
+| S24 | Unit | `bun test` | prewarm (if N1) | preview_bridge_open then first menu | optional; skip if not shipped | planned |
+| S25 | Unit | `bun test` | counters (if N3) | elevate vs fallback calls | optional; skip if not shipped | planned |
+
+### E2E harness requirements (desktop)
+
+Deliver with APP-052 test-run (or a blocking prerequisite PR):
+
+1. Playwright config project (e.g. `electron`) **or** `just test-e2e-desktop` that:
+   - Builds/starts Electron desktop against local API + desktop web export (or dev URL documented in `e2e/README.md`).
+   - Exposes a way to open a workspace with **desktop-native preview** (fixture URL that forces native transport).
+   - Allows installing a short-lived test hook only in test builds if needed: e.g. force overlay ensure fail for S17 — must not ship enabled in production.
+2. Spec files:
+   - `e2e/tests/specs/APP-052_desktop-overlay-surface.web.e2e.ts` — Chromium project (existing).
+   - `e2e/tests/specs/APP-052_desktop-overlay-surface.desktop.e2e.ts` — Electron project only (`test.skip` when not electron).
+3. Commands documented in Coverage Status after implementation, e.g.:
+   - `just test-e2e -- tests/specs/APP-052_desktop-overlay-surface.web.e2e.ts`
+   - `just test-e2e-desktop -- tests/specs/APP-052_desktop-overlay-surface.desktop.e2e.ts`  
+     (exact recipe TBD by test-run; name must land in `e2e/README.md`).
+
+If Electron launch is too flaky for CI initially: web E2E + Bun units **must** still pass in CI; desktop E2E may run `nightly` / manual job — but **S6, S7, S8, S11, S17, S19 remain acceptance criteria** for declaring APP-052 done (can be proven on dogfood machine with the same Playwright file headed).
+
+## Scenarios
+
+### S1 — Web: dialog unaffected
+
+- **Level**: E2E (Playwright web)
+- **Given**: Chromium web app (shell `none`); user on a normal workbench route with any dialog entry point available in smoke fixtures.
+- **When**: User opens and closes a standard app dialog.
+- **Then**: Dialog is visible, interactive, dismisses via Esc or close; no desktop overlay bridge calls; no desktop-only error toasts.
+- **Signals**: `getByRole('dialog')` visible; network/console without `overlay_bridge_*` failures; page usable after close.
+
+### S2 — Web: popover / menu unaffected
+
+- **Level**: E2E (Playwright web)
+- **Given**: Web shell; a toolbar or menu that opens a dropdown/popover.
+- **When**: User opens the menu and chooses a non-destructive item or dismisses.
+- **Then**: Menu behaves as today; no blank regions forced by native-preview occlusion path.
+- **Signals**: menu content role visible; click works; no `preview paused` fallback copy from desktop-native path.
+
+### S3 — Web: preview path not forced into desktop hide
+
+- **Level**: E2E (Playwright web)
+- **Given**: Web preview (iframe) if the fixture can open browser/preview tab; otherwise assert pure web has no `desktop-native` suspend UI.
+- **When**: User opens a popover that would have triggered APP-029 on desktop.
+- **Then**: Iframe/web preview is not replaced by APP-029 “paused” native fallback chrome.
+- **Signals**: no desktop-native occlusion fallback copy; iframe still present if opened.
+
+### S4 — Singleton ensure + reuse
+
+- **Level**: Unit
+- **Given**: Mock host window A; manager empty.
+- **When**: `ensure(A)` twice quickly; then register zero layers and advance timers past idle.
+- **Then**: Factory creates **one** overlay surface; second ensure reuses; after idle, surface destroyed; third ensure creates again.
+- **Signals**: create count === 2 across full sequence; destroy count === 1 after first idle.
+
+### S5 — Per-host isolation
+
+- **Level**: Unit
+- **Given**: Hosts A and B.
+- **When**: ensure(A), ensure(B); destroy(A).
+- **Then**: B’s surface remains; A’s is gone.
+- **Signals**: map size and host ids.
+
+### S6 — Desktop: dialog over live native preview
+
+- **Level**: E2E (Playwright Electron)
+- **Given**: Electron desktop; workspace with **desktop-native** preview visible in sidebar (or in-shell browser); preview shows a page with a changing signal if possible (time, animation, or known title).
+- **When**: User opens an app dialog that covers the preview region.
+- **Then**: Dialog (and dimmer if any) is fully visible and clickable **above** the guest; native preview is **not** replaced by the static paused fallback; guest remains live (still updating or still showing live document, not the APP-029 placeholder).
+- **Signals**: dialog role on top; absence of occlusion fallback copy in preview chrome; preview webContents still loaded (not hidden for occlusion); no success toast.
+
+### S7 — Desktop: dropdown/popover over preview without hide
+
+- **Level**: E2E (Playwright Electron)
+- **Given**: Native preview visible; toolbar control whose menu intersects preview bounds.
+- **When**: User opens the menu.
+- **Then**: Menu items visible/clickable; preview stays live (not APP-029 hide).
+- **Signals**: menu role; preview not in paused fallback; optional: `elevationCovers` true / suspend false via test hook.
+
+### S8 — Desktop: tooltip over preview
+
+- **Level**: E2E (Playwright Electron)
+- **Given**: Control adjacent to preview with a tooltip/hover-card.
+- **When**: User hovers long enough to show tooltip over the guest area.
+- **Then**: Tooltip text is readable (not under native view); preview not suspended solely for the tooltip.
+- **Signals**: tooltip role/name visible; no paused fallback.
+
+### S9 — Elevation policy matrix
+
+- **Level**: Unit
+- **Given**: Synthetic surface rect + overlay rects; flags for previewPresent / modal / intersect.
+- **When**: `shouldElevate(kind, ctx)` evaluated for dialog, sheet, popover, menu, tooltip, custom.
+- **Then**:
+  - No preview → all false.
+  - Preview + modal kinds → true.
+  - Preview + non-modal + intersect → true.
+  - Preview + non-modal + no intersect → false.
+- **Signals**: table-driven expects.
+
+### S10 — Tooltip is a fallback occlusion candidate
+
+- **Level**: Unit
+- **Given**: Visible tooltip intersecting surface (happy-dom + mocked getBoundingClientRect).
+- **When**: `readNativePreviewOcclusionSnapshot` (or successor) runs.
+- **Then**: Tooltip contributes to occlusion candidates (APP-029 no longer ignores tooltips for fallback).
+- **Signals**: `isOccluded === true` with only tooltip present.
+
+### S11 — Modal live under dimmer; guest not interactive
+
+- **Level**: E2E (Playwright Electron)
+- **Given**: Native preview showing a clickable element (or known hit target).
+- **When**: Modal dialog open with dimming backdrop over preview.
+- **Then**: Backdrop and dialog stack above guest; guest content still visible under dimmer (live); clicks hit modal/backdrop, **not** guest navigation.
+- **Signals**: dialog open; click on dimmer region does not change preview URL; optional pointer mode `capture`.
+
+### S12 — Pointer mode selection
+
+- **Level**: Unit (+ optional desktop assert)
+- **Given**: Layer registry with modal vs only tooltip.
+- **When**: Policy computes pointer mode.
+- **Then**: Any modal → `capture`; only non-modal → `pass-through` (tight bounds path).
+- **Signals**: mode enum; bounds padding applied in pure bounds helper.
+
+### S13 — Standalone browser host
+
+- **Level**: E2E (Playwright Electron)
+- **Given**: Detached/standalone browser window hosting native preview + chrome overlays.
+- **When**: User opens dialog/menu over that window’s preview.
+- **Then**: Elevation works in **that** window (not only main); preview stays live on happy path.
+- **Signals**: overlay ready on standalone; dialog visible; main window not required focused.
+
+### S14 — Ensure uses invoking host
+
+- **Level**: Unit
+- **Given**: Mock IPC sender bound to host B while main is A.
+- **When**: `overlay_bridge_ensure` runs.
+- **Then**: Surface attached/created for B only.
+- **Signals**: manager state host id.
+
+### S15 — Idle destroy timing
+
+- **Level**: Unit
+- **Given**: `OVERLAY_IDLE_MS` constant; surface ensured; layers released at t=0.
+- **When**: Advance fake timers to `IDLE - 1` then `IDLE + 1`.
+- **Then**: Not destroyed before idle; destroyed after.
+- **Signals**: destroy spy call count/time.
+
+### S16 — Idle frees resources (desktop)
+
+- **Level**: E2E desktop or Manual
+- **Given**: Overlay created by opening then closing a menu over preview.
+- **When**: Wait longer than idle with no elevated UI.
+- **Then**: Overlay window is closed/destroyed; later menu recreates lazily.
+- **Signals**: child window count; or debug event `desktop-overlay:destroyed`; second open still works.
+
+### S17 — Ensure failure → APP-029 hide fallback
+
+- **Level**: E2E (Playwright Electron)
+- **Given**: Test-only hook forces `overlay_bridge_ensure` failure or never-ready past create budget; native preview visible.
+- **When**: User opens a dialog overlapping preview.
+- **Then**: Dialog remains usable; preview uses APP-029 hide + static fallback; closing dialog restores native preview; no success toast.
+- **Signals**: fallback copy/state visible while open; preview restored after close; dialog clickable.
+
+### S18 — Suspend only when elevation does not cover
+
+- **Level**: Unit
+- **Given**: `isOccluded` true.
+- **When**: `elevationCovers` true vs false.
+- **Then**: `shouldSuspendFromOcclusion` is false vs true respectively; other existing suspend reasons still force suspend.
+- **Signals**: pure boolean helper tests.
+
+### S19 — Focus and keyboard
+
+- **Level**: E2E (Playwright Electron)
+- **Given**: Dialog elevated over preview.
+- **When**: User presses Esc; re-open and Tab through controls.
+- **Then**: Esc dismisses dialog; focus order works inside dialog; after close, trigger or host regains usable focus (no dead focus island).
+- **Signals**: dialog closed; keyboard reaches a known control; optional active element checks.
+
+### S20 — One engine for concurrent layers
+
+- **Level**: Unit (+ optional desktop)
+- **Given**: Dialog open and nested dropdown open.
+- **When**: Both elevated.
+- **Then**: Still a single overlay surface instance for that host.
+- **Signals**: create count remains 1; both layers in overlay document if observable.
+
+### S21 — Custom opt-in marker
+
+- **Level**: Unit
+- **Given**: Element with `data-atmos-native-surface-overlay` intersecting surface.
+- **When**: Policy/occlusion runs.
+- **Then**: Treated as elevatable/occluding candidate.
+- **Signals**: candidate list includes element.
+
+### S22 — Cold create budget then recover
+
+- **Level**: Unit
+- **Given**: ensure pending longer than `OVERLAY_CREATE_BUDGET_MS` while occluded; then ready + elevationCovers.
+- **When**: Time advances through budget then ready.
+- **Then**: Suspend true during budget miss; suspend false once elevation covers; no stuck suspend.
+- **Signals**: state machine / helper timeline.
+
+### S23 — Theme parity
+
+- **Level**: Manual (desktop) / agent-browser only for web theme unrelated
+- **Given**: Desktop dark theme; elevated dialog open.
+- **When**: Observe dialog chrome; toggle theme if possible while open.
+- **Then**: Elevated UI matches host theme tokens (no unstyled white flash as steady state).
+- **Signals**: visual parity dogfood; no merge-blocking automated pixel diff required in v1.
+
+### S24 — Prewarm (N1, only if shipped)
+
+- **Level**: Unit
+- **Given**: N1 implemented.
+- **When**: Preview attaches then first elevate.
+- **Then**: Create cost reduced or ensure already warm without defeating idle destroy.
+- **Signals**: create timing or prewarm flag.
+
+### S25 — Debug counters (N3, only if shipped)
+
+- **Level**: Unit
+- **Given**: N3 implemented.
+- **When**: Elevate success vs fallback path.
+- **Then**: Counters increment appropriately.
+- **Signals**: counter values in test API.
+
+## Performance & load budgets
+
+- **Cold ensure** (lazy create after idle): product-acceptable if ≤ `OVERLAY_CREATE_BUDGET_MS` (200ms default) to ready in dogfood on reference laptop; if slower, fallback hide must engage rather than frozen chrome.
+- **Idle destroy**: within one idle period after last layer close; no permanent extra Chromium content process for overlay when idle > 2× idle constant.
+- **Geometry recompute**: rAF-throttled; opening a menu over preview must not drop main UI to multi-second jank (qualitative dogfood).
+
+## Regression checklist
+
+- [ ] Pure web: no `overlay_bridge_*` traffic; portals still use document body.
+- [ ] APP-029 still restores preview after fallback hide (no stuck hidden guest).
+- [ ] Tooltips no longer permanently ignored for fallback occlusion.
+- [ ] Closing host window destroys that host’s overlay (no orphan BrowserWindow).
+- [ ] Standalone browser window does not steal main window’s overlay singleton.
+- [ ] Nested menu over dialog still one overlay engine.
+- [ ] Theme toggle does not leave elevated UI on stale theme class.
+- [ ] No success toasts for ensure/destroy/hide/restore.
+- [ ] Feature flag / capability off → behaves like APP-029-only desktop.
+- [ ] Preview partition (`persist:atmos-preview`) never loads overlay shell URL.
+
+## Exploratory agent-browser checks
+
+Use **web** only (load Agent Browser skill or `agent-browser skills get core --full` first). Desktop stacking is out of scope for agent-browser.
+
+1. Open local web app, open dialog and popover/menu from primary chrome; confirm no desktop error copy and no broken portal.
+2. Narrow viewport: dialog still usable; no clipped primary actions.
+3. Toggle theme on web; floating UI still coherent.
+4. Watch console for unexpected errors when opening/closing floating UI rapidly.
+
+## Acceptance criteria
+
+Merge-blocking for declaring APP-052 complete:
+
+- [ ] All Must Have PRD items M1–M12 map to at least one scenario with status covered (unit and/or E2E and/or documented manual with evidence).
+- [ ] **Web E2E file** `e2e/tests/specs/APP-052_desktop-overlay-surface.web.e2e.ts` exists and passes via `just test-e2e` (S1–S3 intent).
+- [ ] **Desktop E2E file** `e2e/tests/specs/APP-052_desktop-overlay-surface.desktop.e2e.ts` exists; S6, S7, S8, S11, S17, S19 pass on Electron harness or recorded headed dogfood run with command + date in Coverage Status.
+- [ ] Bun unit suite covers S4, S5, S9, S10, S15, S18, S21, S22 (and S12 policy).
+- [ ] Fallback path S17 proven (hook or equivalent).
+- [ ] Idle destroy S15 (unit) and S16 (desktop or manual evidence).
+- [ ] No new REST/WS protocol surface.
+- [ ] `just lint` / scoped typecheck / `bun test` for touched packages pass; web e2e green in CI.
+- [ ] Coverage Status updated by test-run with exact commands.
+
+## Manual verification steps
+
+Automation cannot fully replace these on every machine:
+
+1. **Memory**: Open Atmos Electron, force overlay create (menu over preview), close UI, wait `> OVERLAY_IDLE_MS`, confirm overlay child window/process is gone (Activity Monitor / `ps`).
+2. **Multi-monitor / DPI**: Move host across displays; open elevated dialog; confirm bounds track content area.
+3. **Standalone browser**: Detach preview/browser window; open settings dialog / menus over its guest; confirm live stacking.
+4. **Focus soak**: Rapid open/close dialogs and menus for 2 minutes; no stuck focus or unclickable chrome.
+5. **Fallback dogfood**: Disable capability or break ensure once; confirm APP-029 hide still usable.
+
+## Non-coverage
+
+- Pixel-perfect shadow clipping / hole-punch of guest under rounded corners.
+- Tauri shell parity.
+- Mobile.
+- Load testing thousands of concurrent elevated layers.
+- True guest screenshot under modal (live view only).
+- Out-of-window-bounds popovers (N4) unless free with vehicle.
+- Full visual regression screenshot suite for every Radix primitive.
+
+## Coverage Status
+
+_Not started — planning stage. `atmos-specs-test-run` fills after implementation._
+
+| Scenario | Result | Evidence |
+|----------|--------|----------|
+| S1–S25 | planned | — |

--- a/specs/README.md
+++ b/specs/README.md
@@ -129,6 +129,7 @@ These files are not requirements sources. Requirements live in `PRD.md`, archite
 | **APP-049** | API Client (`@atmos/api-client` WS session kernel; app-owned URL/auth) | `specs/APP/APP-049_api-client/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
 | **APP-050** | Shared Package Layering (roles, edges, AGENTS rewrite, cheap gate) | `specs/APP/APP-050_shared-package-layering/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
 | **APP-051** | Infra Jobs & Queue (local-first ports; timers + events; no apalis/MQ in v1) | `specs/APP/APP-051_infra-jobs/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
+| **APP-052** | Desktop Overlay Surface (shared floating engine above native preview; APP-029 hide as fallback) | `specs/APP/APP-052_desktop-overlay-surface/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
 | **QUALITY-001** | Large File Code Debt Cleanup | `specs/APP/QUALITY-001_large-file-code-debt-cleanup/` (`TECH.md`, `TEST.md`) |
 | **QUALITY-002** | Spec Test Execution Loop | `specs/APP/QUALITY-002_spec-test-execution-loop/` (`TECH.md`, `TEST.md`) |
 | **QUALITY-003** | Playwright E2E Harness | `specs/APP/QUALITY-003_playwright-e2e-harness/` (`TECH.md`, `TEST.md`) |


### PR DESCRIPTION
## Summary

Implements **APP-052 Desktop Overlay Surface**: a singleton lazy overlay engine per host window so elevatable host UI (dialogs, menus, tooltips, etc.) can stack above live native preview (`WebContentsView`), with APP-029 hide as fallback.

- Electron: `OverlaySurfaceManager` + `overlay_bridge_*` / `get_desktop_capabilities` IPC
- Web: elevation policy/store/provider; `elevationCovers` gates APP-029 suspend and elevatable chrome (favorites/header/search)
- UI: `PortalContainerProvider` wired through floating primitives
- Specs under `specs/APP/APP-052_desktop-overlay-surface/`; units + web e2e non-regression

## Related Issue

Specs: `APP-052_desktop-overlay-surface` (builds on APP-029)

## Type of Change

- [x] New feature
- [x] Documentation (specs)

## Validation

- [x] `bun test` on APP-052 unit suites (27 pass: policy, lifecycle, layer-count, store, occlusion)
- [x] Playwright web e2e: `e2e/tests/specs/APP-052_desktop-overlay-surface.web.e2e.ts` (chromium)
- [x] `packages/ui` typecheck clean for changed portal wiring
- [ ] Electron headed dogfood (optional; not required for web path)

## Checklist

- [x] Specs + TECH/TEST updated
- [x] Tests added/updated
- [x] Follows AGENTS.md layering (desktop + web only; no new REST/WS)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-window shared overlay surface on Electron so dialogs, menus, popovers, tooltips, etc., render above the live native preview (APP-052), with APP-029 hide as fallback. Fixes black screens and invisible menus by creating a truly transparent, clickable overlay via main-process `setWindowOpenHandler` and gates suspend on elevation health.

- **New Features**
  - Electron: `OverlaySurfaceManager` (lazy create/idle destroy), per-host attach, IPC (`get_desktop_capabilities`, `overlay_bridge_*`), and pointer modes (capture vs pass‑through).
  - Web/UI: elevation policy + store and `FloatingElevationProvider` that keeps a stable portal container while native preview is present; `@workspace/ui` floating primitives portal into it; tooltips/hover-cards included in layer counts; APP-029 suspend gated by `elevationHealthy`.
  - Specs/Docs/Tests: APP-052 specs; AGENTS references (agents‑md authoring, desktop floating UI); units for policy/store/lifecycle/layer-count/occlusion and a web e2e non‑regression.

- **Bug Fixes**
  - Overlay is constructed by main at creation with `transparent: true` and `#00000000`, making it visible and clickable; layer counting is realm‑safe and runs on the overlay document only.
  - Pointer capture only when non-hover layers are open (menus/dialogs take focus); tooltip/hover-card‑only frames stay pass‑through; host‑document floaters fall back to APP‑029.
  - Removed misleading main-process overlay fallback; `ensure` waits for host registration within `OVERLAY_CREATE_BUDGET_MS` and rejects so APP‑029 engages; retry‑safe after forceDestroy; single host bounds sync; unified overlay frame detection; coalesced layer recounts with gated IPC; stable portal target with debounced hide; SSR‑safe `HTMLElement` check in `PortalContainerProvider`.

<sup>Written for commit bb5d18fc56d41245b433b820e45434c2c514c96d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added desktop overlay surfaces that keep native previews visible beneath dialogs, menus, popovers, tooltips, and other floating UI.
  * Added shared portal support, pointer interaction modes, capability detection, lifecycle cleanup, and fallback behavior.
* **Bug Fixes**
  * Improved preview occlusion handling, including tooltips and hover cards.
* **Tests**
  * Added coverage for overlay lifecycle, elevation, accessibility, cleanup, and fallback behavior.
* **Documentation**
  * Added product, technical, testing, progress, and implementation guidance for desktop overlays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->