### PR TITLE
fix(landing): hide mobile side rails and cap feature sphere height

### DIFF
--- a/apps/landing/src/components/blocks/feature-showcase.tsx
+++ b/apps/landing/src/components/blocks/feature-showcase.tsx
@@ -120,7 +120,10 @@ export default function FeatureShowcase() {
             <FeatureImageSphere
               features={features}
               onFocusChange={setMediaFocused}
-              className="min-h-[min(88vh,860px)] h-[min(88vh,860px)] sm:min-h-[min(90vh,920px)] sm:h-[min(90vh,920px)]"
+              // Cap under the visual viewport (dvh). The sphere uses
+              // touch-action:none for 3D drag — if this block fills the screen,
+              // mobile users cannot page-scroll past it.
+              className="h-[min(68dvh,560px)] max-h-[100dvh] sm:h-[min(78dvh,720px)] md:h-[min(85dvh,860px)] lg:h-[min(88dvh,920px)]"
             />
 
             {/* Soft edge dust — thin, hugs the section rails (fade out while focused) */}

--- a/apps/landing/src/components/layout/header.tsx
+++ b/apps/landing/src/components/layout/header.tsx
@@ -106,13 +106,14 @@ const Header = ({ className }: HeaderProps) => {
       {/* Same 72rem center track as LandingFrame — rails never drift between sections */}
       <div className='mx-auto grid h-full w-full max-w-6xl xl:max-w-none xl:grid-cols-[minmax(0,1fr)_72rem_minmax(0,1fr)]'>
         <div className='hidden xl:block' aria-hidden />
-        <div className='relative flex h-full min-w-0 w-full items-center justify-between gap-2 border-x px-4 sm:gap-4 sm:px-6 lg:px-8'>
+        <div className='relative flex h-full min-w-0 w-full items-center justify-between gap-2 min-[72rem]:border-x px-4 sm:gap-4 sm:px-6 lg:px-8'>
+          {/* Rail progress only when gutters exist (same breakpoint as border-x) */}
           <motion.div
-            className="absolute -left-px top-0 bottom-0 w-px origin-bottom bg-primary"
+            className="absolute -left-px top-0 bottom-0 hidden w-px origin-bottom bg-primary min-[72rem]:block"
             style={{ scaleY: leftScaleY }}
           />
           <motion.div
-            className="absolute -right-px top-0 bottom-0 w-px origin-bottom bg-primary"
+            className="absolute -right-px top-0 bottom-0 hidden w-px origin-bottom bg-primary min-[72rem]:block"
             style={{ scaleY: rightScaleY }}
           />
           {/* Logo */}

--- a/apps/landing/src/components/layout/landing-frame.tsx
+++ b/apps/landing/src/components/layout/landing-frame.tsx
@@ -11,7 +11,9 @@ import { cn } from '@/lib/utils'
  * and a fixed 72rem center — the vertical lines never drift relative to each
  * other as the viewport shrinks within the xl range.
  *
- * Narrower screens: single centered column, still max-w-6xl, same border-x.
+ * Below `max-w-6xl` the column is edge-to-edge — hide border-x so mobile does
+ * not show a pair of vertical “split lines” flush with the screen edges.
+ * Borders appear only once the viewport is wider than the content track.
  */
 export function LandingFrame({
   children,
@@ -43,7 +45,8 @@ export function LandingFrame({
         <div
           className={cn(
             'relative min-w-0 w-full',
-            showBorder && 'border-x',
+            // max-w-6xl = 72rem — only rail when gutters exist outside the column
+            showBorder && 'min-[72rem]:border-x',
             contentClassName
           )}
         >


### PR DESCRIPTION
## Summary

- Hide `LandingFrame` / header `border-x` rails below `min-[72rem]` so mobile full-width viewports no longer show edge split lines
- Hide header scroll-progress rail indicators on the same breakpoint
- Cap the “See Atmos in Action” 3D sphere under the visual viewport (`dvh`) so page scroll is not trapped by `touch-action: none` on the canvas

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] Code review of landing layout height/border breakpoints against mobile scroll trap behavior

## Checklist

- [ ] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the mobile landing layout by hiding side rails on narrow screens and capping the 3D feature sphere height to keep scrolling usable. Prevents edge split lines and mobile scroll traps.

- **Bug Fixes**
  - Hide `border-x` rails and header scroll-progress lines below `min-[72rem]`, so rails only appear when gutters exist.
  - Cap “See Atmos in Action” sphere height using `dvh` across breakpoints to avoid canvas scroll trapping on mobile.

<sup>Written for commit 28f65326a7253bb3410a76334a310889b4b15670. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout behavior on the landing page.
  * Reduced the feature showcase sphere’s height on smaller screens and improved sizing across viewport types.
  * Limited header rails and side borders to wider screen sizes, creating a cleaner mobile and tablet experience.
  * Preserved touch interaction and scroll-progress behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->