### PR TITLE
feat(desktop-use): Agent pointer + Inspect UI tree (visible computer-use)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,6 +1612,7 @@ name = "desktop-use"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
+ "core-foundation 0.10.1",
  "dirs 5.0.1",
  "hex",
  "serde",

--- a/apps/cli/src/commands/desktop_use.rs
+++ b/apps/cli/src/commands/desktop_use.rs
@@ -1,8 +1,9 @@
-//! `atmos desktop-use` — Desktop Use status, control engine, capture, and drive.
+//! `atmos desktop-use` — Desktop Use status, control engine, capture, inspect, and drive.
 
 use clap::{Args, Subcommand};
 use desktop_use::{
-    capture, drive, CaptureRequest, DesktopUseManager, DriveAction, DriveRequest, EnsureOutcome,
+    capture, drive, inspect, CaptureRequest, DesktopUseManager, DriveAction, DriveRequest,
+    EnsureOutcome, InspectRequest,
 };
 use serde_json::{json, Value};
 
@@ -16,6 +17,7 @@ pub async fn execute(command: DesktopUseCommand) -> Result<Value, String> {
             DriverCommand::Uninstall => driver_uninstall(),
         },
         DesktopUseCommand::Capture(args) => capture_cmd(args),
+        DesktopUseCommand::Inspect(args) => inspect_cmd(args),
         DesktopUseCommand::Drive { command } => drive_cmd(command),
     }
 }
@@ -31,6 +33,8 @@ pub enum DesktopUseCommand {
     },
     /// Capture the frontmost window (screenshot + identity).
     Capture(CaptureArgs),
+    /// Inspect UI structure (accessibility tree) for a process — primary agent text context.
+    Inspect(InspectArgs),
     /// Drive desktop actions (screenshot / click / type).
     Drive {
         #[command(subcommand)]
@@ -65,6 +69,16 @@ pub struct CaptureArgs {
     /// Always include base64 in JSON (default when --out is omitted).
     #[arg(long, default_value_t = false)]
     pub base64: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct InspectArgs {
+    /// Target process id (unix pid).
+    #[arg(long)]
+    pub pid: i32,
+    /// Optional app display name for the tree header.
+    #[arg(long)]
+    pub app_name: Option<String>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -150,6 +164,19 @@ fn capture_cmd(args: CaptureArgs) -> Result<Value, String> {
     let result = capture(CaptureRequest {
         out_path: args.out.map(Into::into),
         include_base64,
+    });
+    serde_json::to_value(result).map_err(|e| e.to_string())
+}
+
+fn inspect_cmd(args: InspectArgs) -> Result<Value, String> {
+    let result = inspect(InspectRequest {
+        process_id: args.pid,
+        app_name: args.app_name,
+        node_limit: None,
+        depth_limit: None,
+        child_limit: None,
+        byte_limit: None,
+        timeout_ms: None,
     });
     serde_json::to_value(result).map_err(|e| e.to_string())
 }

--- a/apps/desktop-electron/src/appshot/frontmost.ts
+++ b/apps/desktop-electron/src/appshot/frontmost.ts
@@ -1,6 +1,6 @@
 /**
- * AppShot frontmost capture adapter — production path uses Desktop Use Capture
- * in-process (APP-052). This module must not shell osascript/screencapture.
+ * AppShot frontmost capture adapter — uses Desktop Use Capture + Inspect (APP-052).
+ * This module must not shell osascript/screencapture/AX directly.
  */
 
 import {
@@ -10,6 +10,10 @@ import {
   parseFrontmostScriptOutput as parseDu,
   type DesktopUseFrontmost,
 } from "../desktop-use/capture.js";
+import {
+  composeAppshotContext,
+  desktopUseInspect,
+} from "../desktop-use/inspect.js";
 
 export type FrontmostWindow = DesktopUseFrontmost;
 
@@ -28,29 +32,63 @@ const SELF_APP_NAMES = new Set([
   "Electron",
 ]);
 
-/** Metadata-only (for animation bounds) — no screenshot. */
+/** Metadata-only (for animation bounds) — no screenshot / no inspect. */
 export async function readFrontmostWindow(): Promise<FrontmostWindow> {
   return desktopUseReadFrontmost();
 }
 
-/** Single full capture via Desktop Use (one screenshot). */
+/**
+ * Full AppShot capture:
+ * 1) Capture screenshot (Desktop Use Capture)
+ * 2) Inspect UI tree (Desktop Use Inspect) — primary agent text for context.md
+ */
 export async function captureFrontmostWindow(
   options: { selfAppNames?: Set<string> } = {},
 ): Promise<FrontmostCaptureResult> {
-  const result = await desktopUseCaptureInProcess({
-    selfAppNames: options.selfAppNames ?? SELF_APP_NAMES,
-  });
-  const quality =
-    result.png && result.png.length > 0
-      ? result.quality === "display_fallback"
-        ? "screenshot_only"
-        : "screenshot_only"
-      : "metadata_only";
+  const selfNames = options.selfAppNames ?? SELF_APP_NAMES;
+  const capture = await desktopUseCaptureInProcess({ selfAppNames: selfNames });
+  const frontmost = capture.frontmost;
+  const warnings = [...capture.warnings];
+  const hasPng = Boolean(capture.png && capture.png.length > 0);
+
+  let inspectResult = {
+    ok: false,
+    treeMarkdown: "",
+    nodeCountEstimate: 0,
+    quality: "unavailable",
+    warnings: [] as string[],
+    error: null as string | null,
+  };
+
+  if (frontmost.processId != null && frontmost.processId > 0) {
+    inspectResult = await desktopUseInspect({
+      processId: frontmost.processId,
+      appName: frontmost.appName,
+    });
+  } else {
+    warnings.push("inspect_skipped: missing process id");
+  }
+
+  const composed = composeAppshotContext(frontmost, inspectResult, warnings);
+  const hasTree = Boolean(inspectResult.treeMarkdown.trim()) && inspectResult.ok;
+
+  let quality: string;
+  if (hasPng && hasTree) quality = "screenshot_and_accessibility";
+  else if (hasPng) quality = "screenshot_only";
+  else if (hasTree) quality = "accessibility_only";
+  else quality = "metadata_only";
+
+  // Rebuild context with final quality label
+  const contextMarkdown = composed.contextMarkdown.replace(
+    /^- Quality: .+$/m,
+    `- Quality: ${quality}`,
+  );
+
   return {
-    frontmost: result.frontmost,
-    png: result.png,
-    warnings: result.warnings,
-    contextMarkdown: result.contextMarkdown,
+    frontmost,
+    png: capture.png,
+    warnings: composed.warnings,
+    contextMarkdown,
     quality,
   };
 }

--- a/apps/desktop-electron/src/desktop-use/agent-pointer-math.test.ts
+++ b/apps/desktop-electron/src/desktop-use/agent-pointer-math.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import {
+  easeOutCubic,
+  interpolatePoint,
+  isValidScreenPoint,
+  screenToOverlay,
+  travelDurationMs,
+  unionDisplayBounds,
+} from "./agent-pointer-math.ts";
+
+describe("agent pointer math", () => {
+  it("unions multi-monitor bounds including negative origins", () => {
+    const u = unionDisplayBounds([
+      { x: 0, y: 0, width: 1440, height: 900 },
+      { x: -1920, y: 0, width: 1920, height: 1080 },
+    ]);
+    expect(u.x).toBe(-1920);
+    expect(u.y).toBe(0);
+    expect(u.width).toBe(1920 + 1440);
+    expect(u.height).toBe(1080);
+  });
+
+  it("eases travel and maps screen to overlay coords", () => {
+    expect(easeOutCubic(0)).toBe(0);
+    expect(easeOutCubic(1)).toBe(1);
+    expect(easeOutCubic(0.5)).toBeGreaterThan(0.5);
+    const p = interpolatePoint({ x: 0, y: 0 }, { x: 100, y: 0 }, 1);
+    expect(p.x).toBe(100);
+    const local = screenToOverlay({ x: -100, y: 50 }, { x: -200, y: 0, width: 400, height: 300 });
+    expect(local).toEqual({ x: 100, y: 50 });
+  });
+
+  it("clamps travel duration and validates points", () => {
+    expect(travelDurationMs({ x: 0, y: 0 }, { x: 0, y: 0 })).toBe(120);
+    expect(travelDurationMs({ x: 0, y: 0 }, { x: 10000, y: 0 })).toBe(480);
+    expect(isValidScreenPoint(1, 2)).toBe(true);
+    expect(isValidScreenPoint(NaN, 2)).toBe(false);
+  });
+});

--- a/apps/desktop-electron/src/desktop-use/agent-pointer-math.ts
+++ b/apps/desktop-electron/src/desktop-use/agent-pointer-math.ts
@@ -1,0 +1,84 @@
+/**
+ * Pure geometry / motion helpers for the Desktop Use agent pointer.
+ * No Electron imports — unit-testable offline.
+ */
+
+export type Point = { x: number; y: number };
+
+export type DisplayRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+/** Union of display rects into a single virtual desktop bounds (multi-monitor). */
+export function unionDisplayBounds(displays: DisplayRect[]): DisplayRect {
+  if (displays.length === 0) {
+    return { x: 0, y: 0, width: 1280, height: 800 };
+  }
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const d of displays) {
+    minX = Math.min(minX, d.x);
+    minY = Math.min(minY, d.y);
+    maxX = Math.max(maxX, d.x + d.width);
+    maxY = Math.max(maxY, d.y + d.height);
+  }
+  return {
+    x: minX,
+    y: minY,
+    width: Math.max(1, maxX - minX),
+    height: Math.max(1, maxY - minY),
+  };
+}
+
+/** Ease-out cubic for cursor travel. */
+export function easeOutCubic(t: number): number {
+  const x = Math.min(1, Math.max(0, t));
+  return 1 - (1 - x) ** 3;
+}
+
+export function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+export function interpolatePoint(from: Point, to: Point, t: number): Point {
+  const e = easeOutCubic(t);
+  return { x: lerp(from.x, to.x, e), y: lerp(from.y, to.y, e) };
+}
+
+/** Travel duration ms from distance (px), clamped. */
+export function travelDurationMs(from: Point, to: Point): number {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const dist = Math.hypot(dx, dy);
+  // ~1.2ms per px, min 120ms, max 480ms — snappy but readable
+  return Math.round(Math.min(480, Math.max(120, dist * 1.2)));
+}
+
+/** Convert screen point to overlay-local coords given virtual bounds origin. */
+export function screenToOverlay(
+  screen: Point,
+  bounds: DisplayRect,
+): Point {
+  return { x: screen.x - bounds.x, y: screen.y - bounds.y };
+}
+
+export type AgentPointerEvent =
+  | { kind: "show"; x: number; y: number; label?: string }
+  | { kind: "move"; x: number; y: number }
+  | { kind: "click"; x: number; y: number }
+  | { kind: "type"; x: number; y: number; textPreview?: string }
+  | { kind: "hide" };
+
+export function isValidScreenPoint(x: unknown, y: unknown): x is number {
+  return (
+    typeof x === "number" &&
+    typeof y === "number" &&
+    Number.isFinite(x) &&
+    Number.isFinite(y)
+  );
+}

--- a/apps/desktop-electron/src/desktop-use/agent-pointer.ts
+++ b/apps/desktop-electron/src/desktop-use/agent-pointer.ts
@@ -1,0 +1,403 @@
+/**
+ * Desktop Use agent pointer — synthetic cursor overlay.
+ *
+ * Shows where the agent is about to click/type without moving the user's
+ * real mouse. Full virtual desktop, click-through, always-on-top panel.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  interpolatePoint,
+  isValidScreenPoint,
+  screenToOverlay,
+  travelDurationMs,
+  unionDisplayBounds,
+  type Point,
+} from "./agent-pointer-math.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyBrowserWindow = any;
+
+const PREFS_DIR = () => join(homedir(), ".atmos", "desktop-use");
+const PREFS_FILE = () => join(PREFS_DIR(), "agent-pointer.json");
+
+type PointerPrefs = {
+  enabled: boolean;
+};
+
+const DEFAULT_PREFS: PointerPrefs = { enabled: true };
+
+let overlay: AnyBrowserWindow | null = null;
+let overlayReady: Promise<AnyBrowserWindow> | null = null;
+let currentPos: Point = { x: 120, y: 120 };
+let visible = false;
+let animToken = 0;
+
+function loadPrefs(): PointerPrefs {
+  try {
+    if (!existsSync(PREFS_FILE())) return { ...DEFAULT_PREFS };
+    const raw = JSON.parse(readFileSync(PREFS_FILE(), "utf8")) as Partial<PointerPrefs>;
+    return {
+      enabled: raw.enabled !== false,
+    };
+  } catch {
+    return { ...DEFAULT_PREFS };
+  }
+}
+
+function savePrefs(prefs: PointerPrefs): void {
+  try {
+    mkdirSync(PREFS_DIR(), { recursive: true });
+    writeFileSync(PREFS_FILE(), JSON.stringify(prefs, null, 2), "utf8");
+  } catch {
+    /* ignore */
+  }
+}
+
+let prefs: PointerPrefs = loadPrefs();
+
+export function isAgentPointerEnabled(): boolean {
+  return prefs.enabled;
+}
+
+export function setAgentPointerEnabled(enabled: boolean): PointerPrefs {
+  prefs = { enabled: Boolean(enabled) };
+  savePrefs(prefs);
+  if (!prefs.enabled) {
+    void hideAgentPointer();
+  }
+  return prefs;
+}
+
+export function agentPointerStatus(): {
+  enabled: boolean;
+  visible: boolean;
+  x: number;
+  y: number;
+} {
+  return {
+    enabled: prefs.enabled,
+    visible,
+    x: currentPos.x,
+    y: currentPos.y,
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function overlayHtml(): string {
+  // Inline HTML: agent arrow cursor + label + click ripple + type chip
+  return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"/>
+<style>
+  html,body{margin:0;padding:0;width:100%;height:100%;overflow:hidden;background:transparent;
+    font-family:ui-sans-serif,system-ui,-apple-system,sans-serif;}
+  #root{position:absolute;left:0;top:0;width:0;height:0;pointer-events:none;
+    transform:translate3d(-100px,-100px,0); will-change:transform;}
+  #cursor{position:relative;width:28px;height:28px;filter:drop-shadow(0 2px 6px rgba(0,0,0,.45));}
+  #cursor svg{display:block;width:28px;height:28px;}
+  #label{position:absolute;left:22px;top:18px;padding:2px 7px;border-radius:999px;
+    background:rgba(99,102,241,.92);color:#fff;font-size:10px;font-weight:600;
+    letter-spacing:.02em;white-space:nowrap;box-shadow:0 2px 8px rgba(0,0,0,.3);}
+  #ripple{position:absolute;left:4px;top:4px;width:16px;height:16px;border-radius:50%;
+    border:2px solid rgba(129,140,248,.95);opacity:0;transform:scale(.4);
+    pointer-events:none;}
+  #ripple.pulse{animation:ripple .45s ease-out forwards;}
+  @keyframes ripple{0%{opacity:.9;transform:scale(.4)}100%{opacity:0;transform:scale(2.6)}}
+  #typechip{position:absolute;left:22px;top:-6px;max-width:220px;padding:3px 8px;
+    border-radius:8px;background:rgba(15,23,42,.88);color:#e2e8f0;font-size:11px;
+    opacity:0;transform:translateY(4px);transition:opacity .15s,transform .15s;
+    box-shadow:0 4px 14px rgba(0,0,0,.35);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+  #typechip.show{opacity:1;transform:translateY(0);}
+  body.hidden #root{opacity:0;}
+</style></head>
+<body class="hidden">
+<div id="root">
+  <div id="ripple"></div>
+  <div id="cursor">
+    <svg viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M4 3.5L4 22.5L10.2 16.8L14.8 25.5L17.6 24.1L12.9 15.2L21 15.2L4 3.5Z"
+        fill="#818cf8" stroke="#312e81" stroke-width="1.2" stroke-linejoin="round"/>
+    </svg>
+  </div>
+  <div id="label">Agent</div>
+  <div id="typechip"></div>
+</div>
+<script>
+  const root = document.getElementById('root');
+  const ripple = document.getElementById('ripple');
+  const typechip = document.getElementById('typechip');
+  const label = document.getElementById('label');
+  window.__agentPointer = {
+    show(x, y, text) {
+      document.body.classList.remove('hidden');
+      root.style.transform = 'translate3d(' + x + 'px,' + y + 'px,0)';
+      if (text) label.textContent = text;
+    },
+    move(x, y) {
+      document.body.classList.remove('hidden');
+      root.style.transform = 'translate3d(' + x + 'px,' + y + 'px,0)';
+    },
+    click() {
+      ripple.classList.remove('pulse');
+      void ripple.offsetWidth;
+      ripple.classList.add('pulse');
+    },
+    type(preview) {
+      typechip.textContent = preview || 'Typing…';
+      typechip.classList.add('show');
+      clearTimeout(window.__typeHide);
+      window.__typeHide = setTimeout(() => typechip.classList.remove('show'), 900);
+    },
+    hide() {
+      document.body.classList.add('hidden');
+      typechip.classList.remove('show');
+    }
+  };
+</script>
+</body></html>`;
+}
+
+async function virtualBounds(): Promise<{
+  bounds: { x: number; y: number; width: number; height: number };
+}> {
+  const { screen } = await import("electron");
+  const displays = screen.getAllDisplays().map((d) => ({
+    x: d.bounds.x,
+    y: d.bounds.y,
+    width: d.bounds.width,
+    height: d.bounds.height,
+  }));
+  return { bounds: unionDisplayBounds(displays) };
+}
+
+async function ensureOverlay(): Promise<AnyBrowserWindow> {
+  if (overlay && !overlay.isDestroyed()) return overlay;
+  if (overlayReady) return overlayReady;
+
+  overlayReady = (async () => {
+    const { BrowserWindow } = await import("electron");
+    const { bounds } = await virtualBounds();
+    const win = new BrowserWindow({
+      x: bounds.x,
+      y: bounds.y,
+      width: bounds.width,
+      height: bounds.height,
+      show: false,
+      frame: false,
+      transparent: true,
+      resizable: false,
+      movable: false,
+      minimizable: false,
+      maximizable: false,
+      fullscreenable: false,
+      skipTaskbar: true,
+      hasShadow: false,
+      focusable: false,
+      type: "panel",
+      backgroundColor: "#00000000",
+      paintWhenInitiallyHidden: true,
+      webPreferences: {
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+        backgroundThrottling: false,
+      },
+    });
+
+    win.setIgnoreMouseEvents(true, { forward: true });
+    win.setAlwaysOnTop(true, "screen-saver");
+    try {
+      win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+    } catch {
+      /* older electron */
+    }
+
+    win.on("closed", () => {
+      if (overlay === win) {
+        overlay = null;
+        overlayReady = null;
+      }
+    });
+
+    await win.loadURL(
+      `data:text/html;charset=utf-8,${encodeURIComponent(overlayHtml())}`,
+    );
+    await sleep(20);
+    if (win.isDestroyed()) throw new Error("agent pointer overlay destroyed");
+    overlay = win;
+    return win;
+  })().catch((e) => {
+    overlayReady = null;
+    throw e;
+  });
+
+  return overlayReady;
+}
+
+async function syncOverlayBounds(win: AnyBrowserWindow): Promise<{
+  bounds: { x: number; y: number; width: number; height: number };
+}> {
+  const { bounds } = await virtualBounds();
+  try {
+    win.setBounds({
+      x: bounds.x,
+      y: bounds.y,
+      width: bounds.width,
+      height: bounds.height,
+    });
+  } catch {
+    /* ignore */
+  }
+  return { bounds };
+}
+
+async function execInOverlay(
+  win: AnyBrowserWindow,
+  js: string,
+): Promise<void> {
+  if (win.isDestroyed()) return;
+  try {
+    await win.webContents.executeJavaScript(js, true);
+  } catch {
+    /* ignore */
+  }
+}
+
+export async function showAgentPointer(
+  x: number,
+  y: number,
+  label = "Agent",
+): Promise<{ ok: boolean; reason?: string }> {
+  if (!prefs.enabled) return { ok: false, reason: "disabled" };
+  if (!isValidScreenPoint(x, y)) return { ok: false, reason: "invalid_point" };
+
+  const win = await ensureOverlay();
+  const { bounds } = await syncOverlayBounds(win);
+  currentPos = { x, y };
+  const local = screenToOverlay(currentPos, bounds);
+  if (!win.isVisible()) win.showInactive();
+  visible = true;
+  const safeLabel = JSON.stringify(String(label).slice(0, 24));
+  await execInOverlay(
+    win,
+    `window.__agentPointer.show(${local.x},${local.y},${safeLabel})`,
+  );
+  return { ok: true };
+}
+
+export async function moveAgentPointer(
+  x: number,
+  y: number,
+  opts: { animate?: boolean } = {},
+): Promise<{ ok: boolean; reason?: string }> {
+  if (!prefs.enabled) return { ok: false, reason: "disabled" };
+  if (!isValidScreenPoint(x, y)) return { ok: false, reason: "invalid_point" };
+
+  const win = await ensureOverlay();
+  const { bounds } = await syncOverlayBounds(win);
+  if (!win.isVisible()) win.showInactive();
+  visible = true;
+
+  const to = { x, y };
+  const animate = opts.animate !== false;
+  if (!animate) {
+    currentPos = to;
+    const local = screenToOverlay(to, bounds);
+    await execInOverlay(win, `window.__agentPointer.move(${local.x},${local.y})`);
+    return { ok: true };
+  }
+
+  const from = { ...currentPos };
+  const duration = travelDurationMs(from, to);
+  const token = ++animToken;
+  const steps = Math.max(8, Math.round(duration / 16));
+  for (let i = 1; i <= steps; i++) {
+    if (token !== animToken) return { ok: false, reason: "cancelled" };
+    const t = i / steps;
+    const p = interpolatePoint(from, to, t);
+    currentPos = p;
+    const local = screenToOverlay(p, bounds);
+    await execInOverlay(win, `window.__agentPointer.move(${local.x},${local.y})`);
+    await sleep(duration / steps);
+  }
+  return { ok: true };
+}
+
+export async function agentPointerClick(
+  x?: number,
+  y?: number,
+): Promise<{ ok: boolean; reason?: string }> {
+  if (!prefs.enabled) return { ok: false, reason: "disabled" };
+  if (isValidScreenPoint(x, y)) {
+    await moveAgentPointer(x, y, { animate: true });
+  } else if (!visible) {
+    await showAgentPointer(currentPos.x, currentPos.y);
+  }
+  const win = await ensureOverlay();
+  if (!win.isVisible()) win.showInactive();
+  await execInOverlay(win, `window.__agentPointer.click()`);
+  await sleep(180);
+  return { ok: true };
+}
+
+export async function agentPointerType(
+  text: string,
+  x?: number,
+  y?: number,
+): Promise<{ ok: boolean; reason?: string }> {
+  if (!prefs.enabled) return { ok: false, reason: "disabled" };
+  if (isValidScreenPoint(x, y)) {
+    await moveAgentPointer(x, y, { animate: true });
+  } else if (!visible) {
+    await showAgentPointer(currentPos.x, currentPos.y);
+  }
+  const win = await ensureOverlay();
+  const preview = JSON.stringify(String(text).slice(0, 48));
+  await execInOverlay(win, `window.__agentPointer.type(${preview})`);
+  return { ok: true };
+}
+
+export async function hideAgentPointer(): Promise<{ ok: boolean }> {
+  animToken += 1;
+  visible = false;
+  if (overlay && !overlay.isDestroyed()) {
+    await execInOverlay(overlay, `window.__agentPointer.hide()`);
+    try {
+      overlay.hide();
+    } catch {
+      /* ignore */
+    }
+  }
+  return { ok: true };
+}
+
+/**
+ * Full drive choreography: show pointer, travel, click/type pulse.
+ * Does not perform OS input — pair with control engine separately.
+ */
+export async function playAgentPointerAction(action: {
+  kind: "click" | "type" | "move" | "show" | "hide";
+  x?: number;
+  y?: number;
+  text?: string;
+}): Promise<{ ok: boolean; reason?: string }> {
+  switch (action.kind) {
+    case "hide":
+      return hideAgentPointer();
+    case "show":
+      return showAgentPointer(action.x ?? currentPos.x, action.y ?? currentPos.y);
+    case "move":
+      return moveAgentPointer(action.x ?? currentPos.x, action.y ?? currentPos.y);
+    case "click":
+      return agentPointerClick(action.x, action.y);
+    case "type":
+      return agentPointerType(action.text ?? "", action.x, action.y);
+    default:
+      return { ok: false, reason: "unknown_action" };
+  }
+}

--- a/apps/desktop-electron/src/desktop-use/capture.ts
+++ b/apps/desktop-electron/src/desktop-use/capture.ts
@@ -11,20 +11,15 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { promisify } from "node:util";
+import {
+  buildAppshotContextMarkdown,
+  type DesktopUseFrontmost,
+} from "./context.js";
+
+export type { DesktopUseFrontmost } from "./context.js";
+export { buildAppshotContextMarkdown } from "./context.js";
 
 const execFileAsync = promisify(execFile);
-
-export type DesktopUseFrontmost = {
-  appName: string;
-  windowTitle: string | null;
-  bundleId: string | null;
-  processId: number | null;
-  windowId: string | null;
-  x: number | null;
-  y: number | null;
-  width: number | null;
-  height: number | null;
-};
 
 export type DesktopUseCaptureResult = {
   ok: boolean;
@@ -180,32 +175,6 @@ async function captureScreenshotPng(
       /* ignore */
     }
   }
-}
-
-export function buildAppshotContextMarkdown(
-  frontmost: DesktopUseFrontmost,
-  warnings: string[],
-): string {
-  const lines = ["# Appshot Context", "", `- App: ${frontmost.appName}`];
-  if (frontmost.windowTitle) lines.push(`- Window: ${frontmost.windowTitle}`);
-  if (frontmost.bundleId) lines.push(`- Bundle ID: ${frontmost.bundleId}`);
-  if (frontmost.processId != null) lines.push(`- Process ID: ${frontmost.processId}`);
-  if (
-    frontmost.x != null &&
-    frontmost.y != null &&
-    frontmost.width != null &&
-    frontmost.height != null
-  ) {
-    lines.push(
-      `- Bounds: ${frontmost.x},${frontmost.y} ${frontmost.width}×${frontmost.height}`,
-    );
-  }
-  if (warnings.length) {
-    lines.push("", "## Warnings");
-    for (const w of warnings) lines.push(`- ${w}`);
-  }
-  lines.push("");
-  return lines.join("\n");
 }
 
 export function parseFrontmostScriptOutput(stdout: string): DesktopUseFrontmost {

--- a/apps/desktop-electron/src/desktop-use/context.ts
+++ b/apps/desktop-electron/src/desktop-use/context.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared AppShot / Desktop Use context.md builders (no OS side effects).
+ */
+
+export type DesktopUseFrontmost = {
+  appName: string;
+  windowTitle: string | null;
+  bundleId: string | null;
+  processId: number | null;
+  windowId: string | null;
+  x: number | null;
+  y: number | null;
+  width: number | null;
+  height: number | null;
+};
+
+export function buildAppshotContextMarkdownFromParts(input: {
+  frontmost: DesktopUseFrontmost;
+  treeMarkdown: string;
+  quality: string;
+  warnings: string[];
+}): string {
+  const { frontmost, treeMarkdown, quality, warnings } = input;
+  const lines = [
+    "# Appshot Context",
+    "",
+    `- App: ${frontmost.appName}`,
+  ];
+  if (frontmost.windowTitle) {
+    lines.push(`- Window: ${frontmost.windowTitle}`);
+  }
+  if (frontmost.bundleId) {
+    lines.push(`- Bundle ID: ${frontmost.bundleId}`);
+  }
+  if (frontmost.processId != null) {
+    lines.push(`- Process ID: ${frontmost.processId}`);
+  }
+  if (
+    frontmost.x != null &&
+    frontmost.y != null &&
+    frontmost.width != null &&
+    frontmost.height != null
+  ) {
+    lines.push(
+      `- Bounds: ${frontmost.x},${frontmost.y} ${frontmost.width}×${frontmost.height}`,
+    );
+  }
+  lines.push(`- Quality: ${quality}`);
+  lines.push(`- Source: Desktop Use inspect`);
+  lines.push("", "## UI structure", "");
+  lines.push(treeMarkdown.trim() || "Accessibility tree unavailable.");
+  if (warnings.length) {
+    lines.push("", "## Warnings");
+    for (const w of warnings) lines.push(`- ${w}`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+/** Legacy thin context (meta only) — kept for tests / fallback. */
+export function buildAppshotContextMarkdown(
+  frontmost: DesktopUseFrontmost,
+  warnings: string[],
+): string {
+  return buildAppshotContextMarkdownFromParts({
+    frontmost,
+    treeMarkdown: "Accessibility tree unavailable.",
+    quality: "metadata_only",
+    warnings,
+  });
+}

--- a/apps/desktop-electron/src/desktop-use/inspect.test.ts
+++ b/apps/desktop-electron/src/desktop-use/inspect.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { composeAppshotContext } from "./inspect.ts";
+import { buildAppshotContextMarkdownFromParts } from "./context.ts";
+
+describe("Desktop Use inspect context", () => {
+  const frontmost = {
+    appName: "Notes",
+    windowTitle: "Todo",
+    bundleId: "com.apple.Notes",
+    processId: 99,
+    windowId: null,
+    x: 0,
+    y: 0,
+    width: 400,
+    height: 300,
+  };
+
+  it("composes Appshot Context with UI structure section from tree", () => {
+    const { contextMarkdown, quality } = composeAppshotContext(
+      frontmost,
+      {
+        ok: true,
+        treeMarkdown: "Button Title: Save\nTextField Value: hello",
+        nodeCountEstimate: 2,
+        quality: "accessibility",
+        warnings: [],
+        error: null,
+      },
+      [],
+    );
+    expect(contextMarkdown).toContain("# Appshot Context");
+    expect(contextMarkdown).toContain("## UI structure");
+    expect(contextMarkdown).toContain("Button Title: Save");
+    expect(contextMarkdown).toContain("Notes");
+    expect(quality).toBe("accessibility");
+    expect(contextMarkdown.toLowerCase()).not.toContain("cua");
+  });
+
+  it("falls back when tree missing", () => {
+    const md = buildAppshotContextMarkdownFromParts({
+      frontmost,
+      treeMarkdown: "",
+      quality: "metadata_only",
+      warnings: ["ax empty"],
+    });
+    expect(md).toContain("Accessibility tree unavailable");
+    expect(md).toContain("ax empty");
+  });
+});

--- a/apps/desktop-electron/src/desktop-use/inspect.ts
+++ b/apps/desktop-electron/src/desktop-use/inspect.ts
@@ -1,0 +1,99 @@
+/**
+ * Desktop Use **Inspect** — accessibility / UI structure tree.
+ *
+ * This is the primary agent-readable content for AppShot `context.md`.
+ * Separate from Capture (pixels) and Control (input).
+ *
+ * Implementation: delegates to `atmos desktop-use inspect` (Rust AX, same
+ * algorithm as the historical AppShot Tauri backend). Runs as a child of
+ * Atmos Desktop so Accessibility TCC on the Desktop app is preferred when
+ * the CLI is the same-process helper path; degraded warnings otherwise.
+ */
+
+import {
+  buildAppshotContextMarkdownFromParts,
+  type DesktopUseFrontmost,
+} from "./context.js";
+import { runDesktopUseJson } from "./client.js";
+
+export type DesktopUseInspectJson = {
+  ok: boolean;
+  tree_markdown?: string;
+  node_count_estimate?: number;
+  quality?: string;
+  warnings?: string[];
+  error?: string | null;
+};
+
+export type DesktopUseInspectResult = {
+  ok: boolean;
+  treeMarkdown: string;
+  nodeCountEstimate: number;
+  quality: string;
+  warnings: string[];
+  error: string | null;
+};
+
+export async function desktopUseInspect(options: {
+  processId: number;
+  appName?: string | null;
+}): Promise<DesktopUseInspectResult> {
+  if (!options.processId || options.processId <= 0) {
+    return {
+      ok: false,
+      treeMarkdown: "",
+      nodeCountEstimate: 0,
+      quality: "unavailable",
+      warnings: ["inspect requires a process id"],
+      error: "inspect requires a process id",
+    };
+  }
+
+  try {
+    const args = ["inspect", "--pid", String(options.processId)];
+    if (options.appName) {
+      args.push("--app-name", options.appName);
+    }
+    const raw = (await runDesktopUseJson(args, 8_000)) as DesktopUseInspectJson;
+    return {
+      ok: Boolean(raw.ok),
+      treeMarkdown: raw.tree_markdown ?? "",
+      nodeCountEstimate: raw.node_count_estimate ?? 0,
+      quality: raw.quality ?? (raw.ok ? "accessibility" : "unavailable"),
+      warnings: raw.warnings ?? [],
+      error: raw.error ?? null,
+    };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      ok: false,
+      treeMarkdown: "",
+      nodeCountEstimate: 0,
+      quality: "unavailable",
+      warnings: [`inspect_failed: ${msg}`],
+      error: msg,
+    };
+  }
+}
+
+/** Compose AppShot context.md from frontmost meta + inspect tree. */
+export function composeAppshotContext(
+  frontmost: DesktopUseFrontmost,
+  inspect: DesktopUseInspectResult,
+  extraWarnings: string[] = [],
+): { contextMarkdown: string; quality: string; warnings: string[] } {
+  const warnings = [...extraWarnings, ...inspect.warnings];
+  if (inspect.error && !inspect.ok) {
+    warnings.push(inspect.error);
+  }
+  const hasTree = Boolean(inspect.treeMarkdown.trim());
+  // quality label is refined by caller once screenshot availability is known
+  const quality = hasTree ? "accessibility" : "metadata_only";
+  const contextMarkdown = buildAppshotContextMarkdownFromParts({
+    frontmost,
+    treeMarkdown: hasTree ? inspect.treeMarkdown : "Accessibility tree unavailable.",
+    quality,
+    warnings,
+  });
+  return { contextMarkdown, quality, warnings };
+}

--- a/apps/desktop-electron/src/ipc/handlers.ts
+++ b/apps/desktop-electron/src/ipc/handlers.ts
@@ -618,6 +618,84 @@ export function createAllHandlers(
             : null;
       return inspect.desktopUseInspect({ processId: pid, appName });
     },
+    async desktop_use_pointer_status() {
+      const ptr = await import("../desktop-use/agent-pointer.js");
+      return ptr.agentPointerStatus();
+    },
+    async desktop_use_pointer_set_enabled(args) {
+      const ptr = await import("../desktop-use/agent-pointer.js");
+      const enabled = Boolean(args?.enabled ?? true);
+      return ptr.setAgentPointerEnabled(enabled);
+    },
+    async desktop_use_pointer_play(args) {
+      const ptr = await import("../desktop-use/agent-pointer.js");
+      const kind = String(args?.kind ?? args?.action ?? "click") as
+        | "click"
+        | "type"
+        | "move"
+        | "show"
+        | "hide";
+      const x = args?.x != null ? Number(args.x) : undefined;
+      const y = args?.y != null ? Number(args.y) : undefined;
+      const text = typeof args?.text === "string" ? args.text : undefined;
+      return ptr.playAgentPointerAction({ kind, x, y, text });
+    },
+    async desktop_use_pointer_hide() {
+      const ptr = await import("../desktop-use/agent-pointer.js");
+      return ptr.hideAgentPointer();
+    },
+    /**
+     * Drive + agent pointer choreography (product path for Computer Use feel).
+     * Always plays the synthetic pointer when enabled; then delegates click/type
+     * to the control engine when installed.
+     */
+    async desktop_use_drive(args) {
+      const client = await import("../desktop-use/client.js");
+      const ptr = await import("../desktop-use/agent-pointer.js");
+      const action = String(args?.action ?? "click");
+      const x = args?.x != null ? Number(args.x) : undefined;
+      const y = args?.y != null ? Number(args.y) : undefined;
+      const text = typeof args?.text === "string" ? args.text : undefined;
+
+      let pointer: unknown = null;
+      if (action === "click" && x != null && y != null) {
+        pointer = await ptr.agentPointerClick(x, y);
+      } else if (action === "type") {
+        pointer = await ptr.agentPointerType(text ?? "", x, y);
+      } else if (action === "move" && x != null && y != null) {
+        pointer = await ptr.moveAgentPointer(x, y);
+      }
+
+      // Delegate real input to CLI control path (engine when present).
+      let drive: unknown = null;
+      try {
+        if (action === "click" && x != null && y != null) {
+          drive = await client.runDesktopUseJson(
+            ["drive", "click", "--x", String(x), "--y", String(y)],
+            30_000,
+          );
+        } else if (action === "type" && text != null) {
+          drive = await client.runDesktopUseJson(
+            ["drive", "type", "--text", text],
+            30_000,
+          );
+        } else if (action === "screenshot") {
+          drive = await client.runDesktopUseJson(["drive", "screenshot"], 30_000);
+        }
+      } catch (e) {
+        drive = {
+          ok: false,
+          error: e instanceof Error ? e.message : String(e),
+        };
+      }
+
+      return {
+        ok: true,
+        pointer,
+        drive,
+        note: "Agent pointer is synthetic and does not move the system cursor.",
+      };
+    },
 
     // --- tunnel ---
     async tunnel_connector_detect() {

--- a/apps/desktop-electron/src/ipc/handlers.ts
+++ b/apps/desktop-electron/src/ipc/handlers.ts
@@ -607,6 +607,17 @@ export function createAllHandlers(
       const client = await import("../desktop-use/client.js");
       return client.desktopUseCapture();
     },
+    async desktop_use_inspect(args) {
+      const inspect = await import("../desktop-use/inspect.js");
+      const pid = Number(args?.pid ?? args?.process_id ?? args?.processId ?? 0);
+      const appName =
+        typeof args?.app_name === "string"
+          ? args.app_name
+          : typeof args?.appName === "string"
+            ? args.appName
+            : null;
+      return inspect.desktopUseInspect({ processId: pid, appName });
+    },
 
     // --- tunnel ---
     async tunnel_connector_detect() {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5529,7 +5529,7 @@
     },
     "desktopUse": {
       "title": "Desktop Use",
-      "description": "Capture the local desktop and manage the optional control engine. This is separate from Atmos Computer (remote machines).",
+      "description": "Capture, inspect UI structure, and drive the desktop with a visible Agent pointer. Separate from Atmos Computer (remote machines).",
       "desktopOnly": "Desktop Use settings require the Atmos Desktop app.",
       "engine": {
         "title": "Control engine",
@@ -5552,7 +5552,16 @@
         "statusFailed": "Could not load Desktop Use status",
         "ensureFailed": "Could not install control engine",
         "stopFailed": "Could not stop control engine",
-        "uninstallFailed": "Could not remove control engine"
+        "uninstallFailed": "Could not remove control engine",
+        "pointerFailed": "Could not update agent pointer"
+      },
+      "pointer": {
+        "title": "Agent pointer",
+        "hint": "Show a synthetic Agent cursor when Desktop Use drives the desktop. Your real mouse stays put.",
+        "on": "On",
+        "off": "Off",
+        "preview": "Preview pointer",
+        "previewTypeSample": "Hello from Agent"
       }
     }
   },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -5529,7 +5529,7 @@
     },
     "desktopUse": {
       "title": "Desktop Use",
-      "description": "捕获本机桌面并管理可选控制引擎。与 Atmos Computer（远程机器）相互独立。",
+      "description": "捕获、检视界面结构，并以可见的 Agent 指针驱动桌面。与 Atmos Computer（远程机器）相互独立。",
       "desktopOnly": "Desktop Use 设置需要 Atmos Desktop 应用。",
       "engine": {
         "title": "控制引擎",
@@ -5552,7 +5552,16 @@
         "statusFailed": "无法加载 Desktop Use 状态",
         "ensureFailed": "无法安装控制引擎",
         "stopFailed": "无法停止控制引擎",
-        "uninstallFailed": "无法移除控制引擎"
+        "uninstallFailed": "无法移除控制引擎",
+        "pointerFailed": "无法更新 Agent 指针"
+      },
+      "pointer": {
+        "title": "Agent 指针",
+        "hint": "Desktop Use 操控桌面时显示合成 Agent 光标，不移动你的真实鼠标。",
+        "on": "开",
+        "off": "关",
+        "preview": "预览指针",
+        "previewTypeSample": "来自 Agent 的输入"
       }
     }
   },

--- a/apps/web/src/features/settings/components/DesktopUseSettingsSection.tsx
+++ b/apps/web/src/features/settings/components/DesktopUseSettingsSection.tsx
@@ -5,7 +5,8 @@ import { useTranslations } from "next-intl";
 import { Button } from "@workspace/ui/components/ui/button";
 import { Badge } from "@workspace/ui/components/ui/badge";
 import { Skeleton } from "@workspace/ui/components/ui/skeleton";
-import { Download, Loader2, Square, Trash2, RefreshCw } from "lucide-react";
+import { Download, Loader2, Square, Trash2, RefreshCw, MousePointer2 } from "lucide-react";
+import { Switch } from "@workspace/ui/components/ui/switch";
 import { AppshotPermissionsPanel } from "@/features/appshot/components/AppshotPermissionsPanel";
 import { desktopInvoke, isDesktopRuntime } from "@/shared/lib/desktop-bridge";
 
@@ -30,6 +31,8 @@ export function DesktopUseSettingsSection() {
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [pointerEnabled, setPointerEnabled] = useState(true);
+  const [pointerBusy, setPointerBusy] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -50,6 +53,14 @@ export function DesktopUseSettingsSection() {
       }
       const res = await desktopInvoke<DesktopUseStatus>("desktop_use_status");
       setStatus(res);
+      try {
+        const ptr = await desktopInvoke<{ enabled: boolean }>(
+          "desktop_use_pointer_status",
+        );
+        setPointerEnabled(ptr?.enabled !== false);
+      } catch {
+        /* pointer optional on older shells */
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : t("errors.statusFailed"));
     } finally {
@@ -95,6 +106,56 @@ export function DesktopUseSettingsSection() {
       setError(e instanceof Error ? e.message : t("errors.uninstallFailed"));
     } finally {
       setBusy(false);
+    }
+  };
+
+  const togglePointer = async (enabled: boolean) => {
+    setPointerEnabled(enabled);
+    if (!isDesktopRuntime()) return;
+    try {
+      await desktopInvoke("desktop_use_pointer_set_enabled", { enabled });
+      if (!enabled) {
+        await desktopInvoke("desktop_use_pointer_hide");
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("errors.pointerFailed"));
+    }
+  };
+
+  const previewPointer = async () => {
+    if (!isDesktopRuntime()) return;
+    setPointerBusy(true);
+    setError(null);
+    try {
+      // Demo path across primary display: show → move → click → type chip → hide
+      await desktopInvoke("desktop_use_pointer_play", {
+        kind: "show",
+        x: 220,
+        y: 180,
+      });
+      await desktopInvoke("desktop_use_pointer_play", {
+        kind: "move",
+        x: 520,
+        y: 320,
+      });
+      await desktopInvoke("desktop_use_pointer_play", {
+        kind: "click",
+        x: 520,
+        y: 320,
+      });
+      await desktopInvoke("desktop_use_pointer_play", {
+        kind: "type",
+        x: 520,
+        y: 320,
+        text: t("pointer.previewTypeSample"),
+      });
+      window.setTimeout(() => {
+        void desktopInvoke("desktop_use_pointer_hide");
+      }, 1200);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("errors.pointerFailed"));
+    } finally {
+      setPointerBusy(false);
     }
   };
 
@@ -186,6 +247,49 @@ export function DesktopUseSettingsSection() {
           >
             <RefreshCw className="size-4" />
             {t("actions.refresh")}
+          </Button>
+        </div>
+      </section>
+
+      <section className="space-y-3 rounded-xl border border-border p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <MousePointer2 className="size-4 text-muted-foreground" />
+              <p className="text-sm font-medium">{t("pointer.title")}</p>
+            </div>
+            <p className="mt-1 text-xs leading-5 text-muted-foreground">
+              {t("pointer.hint")}
+            </p>
+          </div>
+          <div className="flex items-center gap-2 pt-0.5">
+            <span className="text-xs text-muted-foreground">
+              {pointerEnabled ? t("pointer.on") : t("pointer.off")}
+            </span>
+            <Switch
+              checked={pointerEnabled}
+              disabled={!isDesktopRuntime() || loading}
+              onCheckedChange={(v) => void togglePointer(v)}
+            />
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={
+              !isDesktopRuntime() || loading || pointerBusy || !pointerEnabled
+            }
+            onClick={() => void previewPointer()}
+            className="cursor-pointer"
+          >
+            {pointerBusy ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <MousePointer2 className="size-4" />
+            )}
+            {t("pointer.preview")}
           </Button>
         </div>
       </section>

--- a/apps/web/src/features/settings/components/__tests__/desktop-use-settings-section.test.ts
+++ b/apps/web/src/features/settings/components/__tests__/desktop-use-settings-section.test.ts
@@ -44,6 +44,19 @@ describe("Desktop Use settings wiring", () => {
     expect(section.toLowerCase()).not.toContain("trycua");
   });
 
+  it("includes agent pointer toggle and preview controls", () => {
+    const section = readFileSync(
+      join(
+        root,
+        "apps/web/src/features/settings/components/DesktopUseSettingsSection.tsx",
+      ),
+      "utf8",
+    );
+    expect(section).toContain("desktop_use_pointer_set_enabled");
+    expect(section).toContain("desktop_use_pointer_play");
+    expect(section).toContain("pointer.title");
+  });
+
   it("permission primary path opens Settings Desktop Use", () => {
     const client = readFileSync(
       join(root, "apps/web/src/features/appshot/lib/appshot-client.ts"),

--- a/crates/desktop-use/Cargo.toml
+++ b/crates/desktop-use/Cargo.toml
@@ -14,5 +14,8 @@ hex = "0.4"
 base64 = "0.22"
 tempfile = "3.10"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.10"
+
 [dev-dependencies]
 tempfile = "3.10"

--- a/crates/desktop-use/src/inspect/macos_ax.rs
+++ b/crates/desktop-use/src/inspect/macos_ax.rs
@@ -1,0 +1,551 @@
+//! macOS Accessibility UI-tree inspect (APP-052 Desktop Use · inspect).
+//!
+//! Ported from the production AppShot Tauri backend so AppShot `context.md`
+//! and `atmos desktop-use inspect` share one AX traversal.
+
+use core::ffi::c_int;
+use core_foundation::array::CFArray;
+use core_foundation::base::{CFType, CFTypeRef, TCFType};
+use core_foundation::string::{CFString, CFStringRef};
+use core_foundation::url::CFURL;
+use std::collections::VecDeque;
+use std::ptr;
+use std::time::{Duration, Instant};
+
+type AXError = i32;
+
+const AX_ERROR_SUCCESS: AXError = 0;
+const TEXT_PREVIEW_LIMIT_CHARS: usize = 260;
+const AX_ROLE_ATTRIBUTE: &str = "AXRole";
+const AX_ROLE_DESCRIPTION_ATTRIBUTE: &str = "AXRoleDescription";
+const AX_TITLE_ATTRIBUTE: &str = "AXTitle";
+const AX_DESCRIPTION_ATTRIBUTE: &str = "AXDescription";
+const AX_VALUE_ATTRIBUTE: &str = "AXValue";
+const AX_HELP_ATTRIBUTE: &str = "AXHelp";
+const AX_PLACEHOLDER_VALUE_ATTRIBUTE: &str = "AXPlaceholderValue";
+const AX_URL_ATTRIBUTE: &str = "AXURL";
+const AX_FOCUSED_WINDOW_ATTRIBUTE: &str = "AXFocusedWindow";
+const AX_WINDOWS_ATTRIBUTE: &str = "AXWindows";
+const AX_CHILDREN_ATTRIBUTE: &str = "AXChildren";
+const AX_MESSAGE_TIMEOUT_SECONDS: f32 = 0.8;
+const AGGREGATE_TEXT_LIMIT_CHARS: usize = 180;
+
+#[link(name = "ApplicationServices", kind = "framework")]
+extern "C" {
+    fn AXUIElementCreateApplication(pid: c_int) -> CFTypeRef;
+    fn AXUIElementCopyAttributeValue(
+        element: CFTypeRef,
+        attribute: CFStringRef,
+        value: *mut CFTypeRef,
+    ) -> AXError;
+    fn AXUIElementSetMessagingTimeout(element: CFTypeRef, timeout: f32) -> AXError;
+}
+
+pub struct AccessibilityCaptureConfig {
+    pub timeout: Duration,
+    pub node_limit: usize,
+    pub depth_limit: usize,
+    pub child_limit: usize,
+    pub byte_limit: usize,
+    pub redaction_terms: &'static [&'static str],
+}
+
+struct QueueItem {
+    element: CFType,
+    depth: usize,
+    display_depth: usize,
+    path: Vec<usize>,
+}
+
+struct DumpNode {
+    path: Vec<usize>,
+    line: String,
+}
+
+#[derive(Default)]
+struct CaptureLimits {
+    hit_node_limit: bool,
+    hit_depth_limit: bool,
+    hit_child_limit: bool,
+    hit_timeout: bool,
+    hit_byte_limit: bool,
+}
+
+struct AttributeNames {
+    role: CFString,
+    role_description: CFString,
+    title: CFString,
+    description: CFString,
+    value: CFString,
+    help: CFString,
+    placeholder: CFString,
+    url: CFString,
+    focused_window: CFString,
+    windows: CFString,
+    children: CFString,
+}
+
+impl AttributeNames {
+    fn new() -> Self {
+        Self {
+            role: CFString::new(AX_ROLE_ATTRIBUTE),
+            role_description: CFString::new(AX_ROLE_DESCRIPTION_ATTRIBUTE),
+            title: CFString::new(AX_TITLE_ATTRIBUTE),
+            description: CFString::new(AX_DESCRIPTION_ATTRIBUTE),
+            value: CFString::new(AX_VALUE_ATTRIBUTE),
+            help: CFString::new(AX_HELP_ATTRIBUTE),
+            placeholder: CFString::new(AX_PLACEHOLDER_VALUE_ATTRIBUTE),
+            url: CFString::new(AX_URL_ATTRIBUTE),
+            focused_window: CFString::new(AX_FOCUSED_WINDOW_ATTRIBUTE),
+            windows: CFString::new(AX_WINDOWS_ATTRIBUTE),
+            children: CFString::new(AX_CHILDREN_ATTRIBUTE),
+        }
+    }
+}
+
+pub fn capture_accessibility_tree(
+    process_id: Option<u32>,
+    app_name: &str,
+    config: AccessibilityCaptureConfig,
+) -> Result<String, String> {
+    let process_id = process_id
+        .and_then(|pid| c_int::try_from(pid).ok())
+        .ok_or_else(|| "Accessibility tree requires a target process id.".to_string())?;
+    let app = create_application_element(process_id)?;
+    set_messaging_timeout(&app);
+    let attrs = AttributeNames::new();
+    let root = focused_window(&app, &attrs).unwrap_or_else(|| app.clone());
+    set_messaging_timeout(&root);
+    let mut queue = VecDeque::from([QueueItem {
+        element: root,
+        depth: 0,
+        display_depth: 0,
+        path: vec![0],
+    }]);
+    let started_at = Instant::now();
+    let mut nodes = Vec::new();
+    let mut visited_nodes = 0usize;
+    let mut approx_bytes = 0usize;
+    let mut limits = CaptureLimits::default();
+
+    while let Some(item) = queue.pop_front() {
+        if started_at.elapsed() >= config.timeout {
+            limits.hit_timeout = true;
+            break;
+        }
+        if visited_nodes >= config.node_limit {
+            limits.hit_node_limit = true;
+            break;
+        }
+        if approx_bytes >= config.byte_limit {
+            limits.hit_byte_limit = true;
+            break;
+        }
+
+        visited_nodes += 1;
+        let line = describe_element(&item.element, item.display_depth, &attrs, &config);
+        let emitted = line.is_some();
+        if let Some(line) = line {
+            approx_bytes = approx_bytes.saturating_add(line.len() + 1);
+            nodes.push(DumpNode {
+                path: item.path.clone(),
+                line,
+            });
+        }
+
+        if item.depth >= config.depth_limit {
+            limits.hit_depth_limit = true;
+            continue;
+        }
+
+        let mut children = child_elements(&item.element, &attrs);
+        if children.len() > config.child_limit {
+            children.truncate(config.child_limit);
+            limits.hit_child_limit = true;
+            nodes.push(DumpNode {
+                path: truncated_child_path(&item.path),
+                line: format!(
+                    "{}[truncated: child limit reached]",
+                    indent(item.display_depth + usize::from(emitted))
+                ),
+            });
+        }
+
+        let child_display_depth = item.display_depth + usize::from(emitted);
+        for (index, child) in children.into_iter().enumerate() {
+            let mut path = item.path.clone();
+            path.push(index);
+            queue.push_back(QueueItem {
+                element: child,
+                depth: item.depth + 1,
+                display_depth: child_display_depth,
+                path,
+            });
+        }
+    }
+
+    nodes.sort_by(|left, right| left.path.cmp(&right.path));
+    let mut out = String::new();
+    out.push_str(&format!(
+        "App: {app_name}. Capture: native macOS Accessibility compact tree.\n"
+    ));
+    for node in nodes {
+        out.push_str(&node.line);
+        out.push('\n');
+    }
+    append_limit_notes(&mut out, &limits, &config);
+    Ok(truncate_context_with_marker(
+        &out,
+        config.byte_limit,
+        "[truncated: accessibility context byte limit reached]",
+    ))
+}
+
+fn create_application_element(process_id: c_int) -> Result<CFType, String> {
+    let raw = unsafe { AXUIElementCreateApplication(process_id) };
+    if raw.is_null() {
+        return Err(format!(
+            "native Accessibility could not create app element for process {process_id}."
+        ));
+    }
+    Ok(unsafe { CFType::wrap_under_create_rule(raw) })
+}
+
+fn focused_window(app: &CFType, attrs: &AttributeNames) -> Option<CFType> {
+    copy_attribute(app, &attrs.focused_window).or_else(|| {
+        copy_attribute(app, &attrs.windows)
+            .and_then(|value| value.downcast::<CFArray>())
+            .and_then(|windows| {
+                windows
+                    .get_all_values()
+                    .into_iter()
+                    .find(|raw| !raw.is_null())
+                    .map(|raw| unsafe { CFType::wrap_under_get_rule(raw as CFTypeRef) })
+            })
+    })
+}
+
+fn child_elements(element: &CFType, attrs: &AttributeNames) -> Vec<CFType> {
+    let Some(children) =
+        copy_attribute(element, &attrs.children).and_then(|value| value.downcast::<CFArray>())
+    else {
+        return Vec::new();
+    };
+
+    children
+        .get_all_values()
+        .into_iter()
+        .filter(|raw| !raw.is_null())
+        .map(|raw| {
+            let child = unsafe { CFType::wrap_under_get_rule(raw as CFTypeRef) };
+            set_messaging_timeout(&child);
+            child
+        })
+        .collect()
+}
+
+fn describe_element(
+    element: &CFType,
+    display_depth: usize,
+    attrs: &AttributeNames,
+    config: &AccessibilityCaptureConfig,
+) -> Option<String> {
+    let role = text_attribute(element, &attrs.role);
+    let role_description = text_attribute(element, &attrs.role_description);
+    let title = text_attribute(element, &attrs.title);
+    let description = text_attribute(element, &attrs.description);
+    let value = text_attribute(element, &attrs.value);
+    let help = text_attribute(element, &attrs.help);
+    let placeholder = text_attribute(element, &attrs.placeholder);
+    let url = text_attribute(element, &attrs.url);
+    let should_redact = [
+        &role,
+        &role_description,
+        &title,
+        &description,
+        &value,
+        &help,
+    ]
+    .into_iter()
+    .flatten()
+    .any(|text| contains_redaction_term(text, config.redaction_terms));
+
+    let role_text = role.as_deref().unwrap_or("");
+    let role_label = display_role(role_text, role_description.as_deref());
+    let mut line = format!("{}{}", indent(display_depth), role_label);
+
+    if should_redact {
+        line.push_str(" [redacted]");
+        return Some(line);
+    }
+
+    let is_structural = is_structural_role(role_text);
+    let mut existing = vec![role_label];
+    let mut field_count = 0usize;
+    field_count += usize::from(append_text_field(
+        &mut line,
+        &mut existing,
+        "Title",
+        title,
+        is_structural,
+    ));
+    field_count += usize::from(append_text_field(
+        &mut line,
+        &mut existing,
+        "Description",
+        description,
+        is_structural,
+    ));
+    field_count += usize::from(append_text_field(
+        &mut line,
+        &mut existing,
+        "Value",
+        value,
+        is_structural,
+    ));
+    field_count += usize::from(append_text_field(
+        &mut line,
+        &mut existing,
+        "Placeholder",
+        placeholder,
+        is_structural,
+    ));
+    field_count += usize::from(append_text_field(
+        &mut line,
+        &mut existing,
+        "Help",
+        help,
+        is_structural,
+    ));
+    field_count += usize::from(append_text_field(
+        &mut line,
+        &mut existing,
+        "URL",
+        url,
+        false,
+    ));
+    if field_count == 0 {
+        None
+    } else {
+        Some(line)
+    }
+}
+
+fn copy_attribute(element: &CFType, attribute: &CFString) -> Option<CFType> {
+    let mut raw: CFTypeRef = ptr::null();
+    let error = unsafe {
+        AXUIElementCopyAttributeValue(
+            element.as_CFTypeRef(),
+            attribute.as_concrete_TypeRef(),
+            &mut raw,
+        )
+    };
+    if error == AX_ERROR_SUCCESS && !raw.is_null() {
+        Some(unsafe { CFType::wrap_under_create_rule(raw) })
+    } else {
+        None
+    }
+}
+
+fn set_messaging_timeout(element: &CFType) {
+    let _ = unsafe {
+        AXUIElementSetMessagingTimeout(element.as_CFTypeRef(), AX_MESSAGE_TIMEOUT_SECONDS)
+    };
+}
+
+fn text_attribute(element: &CFType, attribute: &CFString) -> Option<String> {
+    copy_attribute(element, attribute).and_then(|value| cf_type_to_text(&value))
+}
+
+fn cf_type_to_text(value: &CFType) -> Option<String> {
+    if let Some(text) = value.downcast::<CFString>() {
+        return clean_text(text.to_string());
+    }
+    if let Some(url) = value.downcast::<CFURL>() {
+        return clean_text(url.get_string().to_string());
+    }
+    None
+}
+
+fn clean_text(value: String) -> Option<String> {
+    let mut normalized = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalized.is_empty() {
+        return None;
+    }
+    if normalized.chars().count() > TEXT_PREVIEW_LIMIT_CHARS {
+        normalized = normalized
+            .chars()
+            .take(TEXT_PREVIEW_LIMIT_CHARS)
+            .collect::<String>();
+        normalized.push_str("...");
+    }
+    Some(normalized)
+}
+
+fn contains_redaction_term(value: &str, terms: &[&str]) -> bool {
+    let value = value.to_lowercase();
+    terms
+        .iter()
+        .any(|term| value.contains(&term.to_lowercase()))
+}
+
+fn display_role(role: &str, role_description: Option<&str>) -> String {
+    if let Some(role_description) = role_description.filter(|value| is_useful_text(value)) {
+        return role_description.to_string();
+    }
+    role.strip_prefix("AX").unwrap_or(role).to_string()
+}
+
+fn append_text_field(
+    line: &mut String,
+    existing: &mut Vec<String>,
+    label: &str,
+    value: Option<String>,
+    is_structural: bool,
+) -> bool {
+    let Some(value) = value else {
+        return false;
+    };
+    if !is_useful_text(&value) || existing.iter().any(|item| text_overlaps(item, &value)) {
+        return false;
+    }
+    if is_structural && is_aggregate_text(&value) {
+        return false;
+    }
+    line.push(' ');
+    line.push_str(label);
+    line.push_str(": ");
+    line.push_str(&value);
+    existing.push(value);
+    true
+}
+
+fn truncated_child_path(path: &[usize]) -> Vec<usize> {
+    let mut path = path.to_vec();
+    path.push(usize::MAX);
+    path
+}
+
+fn text_overlaps(existing: &str, candidate: &str) -> bool {
+    let existing = normalize_for_dedupe(existing);
+    let candidate = normalize_for_dedupe(candidate);
+    if existing == candidate {
+        return true;
+    }
+    if candidate.chars().count() < 40 && existing.contains(&candidate) {
+        return true;
+    }
+    false
+}
+
+fn normalize_for_dedupe(value: &str) -> String {
+    value
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .trim_matches(|ch: char| !ch.is_alphanumeric())
+        .to_lowercase()
+}
+
+fn is_useful_text(value: &str) -> bool {
+    let value = value.trim();
+    if value.is_empty() {
+        return false;
+    }
+    if value.chars().count() == 1 && !value.chars().any(char::is_alphanumeric) {
+        return false;
+    }
+    if matches!(value, "(" | ")" | "/" | "|" | "·" | "•") {
+        return false;
+    }
+    true
+}
+
+fn is_aggregate_text(value: &str) -> bool {
+    value.chars().count() > AGGREGATE_TEXT_LIMIT_CHARS
+}
+
+fn is_structural_role(role: &str) -> bool {
+    matches!(
+        role,
+        "AXApplication"
+            | "AXWindow"
+            | "AXGroup"
+            | "AXScrollArea"
+            | "AXList"
+            | "AXTable"
+            | "AXRow"
+            | "AXCell"
+            | "AXColumn"
+            | "AXLayoutArea"
+            | "AXLayoutItem"
+            | "AXToolbar"
+            | "AXSplitter"
+            | "AXUnknown"
+    )
+}
+
+fn indent(depth: usize) -> String {
+    "\t".repeat(depth)
+}
+
+fn append_limit_notes(
+    out: &mut String,
+    limits: &CaptureLimits,
+    config: &AccessibilityCaptureConfig,
+) {
+    let mut notes = Vec::new();
+    if limits.hit_node_limit {
+        notes.push(format!("node limit reached ({})", config.node_limit));
+    }
+    if limits.hit_depth_limit {
+        notes.push(format!("depth limit reached ({})", config.depth_limit));
+    }
+    if limits.hit_child_limit {
+        notes.push(format!(
+            "child limit reached ({} per element)",
+            config.child_limit
+        ));
+    }
+    if limits.hit_timeout {
+        notes.push(format!(
+            "timeout reached ({} ms)",
+            config.timeout.as_millis()
+        ));
+    }
+    if limits.hit_byte_limit {
+        notes.push(format!("byte limit reached ({})", config.byte_limit));
+    }
+    if notes.is_empty() {
+        return;
+    }
+    out.push_str("\nCapture limits:\n");
+    for note in notes {
+        out.push_str("- ");
+        out.push_str(&note);
+        out.push('\n');
+    }
+}
+
+fn truncate_context_with_marker(text: &str, limit: usize, marker: &str) -> String {
+    if text.len() <= limit {
+        return text.to_string();
+    }
+    let suffix = format!("\n\n{marker}\n");
+    let body_limit = limit.saturating_sub(suffix.len());
+    format!("{}{}", truncate_utf8(text, body_limit), suffix)
+}
+
+fn truncate_utf8(text: &str, limit: usize) -> String {
+    if text.len() <= limit {
+        return text.to_string();
+    }
+    let mut end = 0;
+    for (idx, ch) in text.char_indices() {
+        if idx + ch.len_utf8() > limit {
+            break;
+        }
+        end = idx + ch.len_utf8();
+    }
+    format!("{}...", &text[..end])
+}

--- a/crates/desktop-use/src/inspect/mod.rs
+++ b/crates/desktop-use/src/inspect/mod.rs
@@ -1,0 +1,211 @@
+//! Desktop Use **Inspect** — UI structure / accessibility tree (not pixels, not input).
+//!
+//! This is the primary agent-readable content for AppShot `context.md` and for
+//! agents that need to understand on-screen structure before `drive` actions.
+//!
+//! Capability split:
+//! - **capture** — screenshot + window identity (Screen Recording)
+//! - **inspect** — accessibility tree / UI nodes (Accessibility)  ← this module
+//! - **control** — click / type / optional engine
+
+use serde::{Deserialize, Serialize};
+
+use crate::strings::{scrub_vendor, PRODUCT_NAME};
+
+/// Default redaction terms for secure/password-like fields (case-insensitive).
+pub const DEFAULT_REDACTION_TERMS: &[&str] = &[
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "api key",
+    "apikey",
+    "credit card",
+    "ssn",
+    "secure text",
+];
+
+/// Limits matching AppShot APP-021 macOS v1 defaults.
+pub const DEFAULT_NODE_LIMIT: usize = 420;
+pub const DEFAULT_DEPTH_LIMIT: usize = 8;
+pub const DEFAULT_CHILD_LIMIT: usize = 40;
+pub const DEFAULT_BYTE_LIMIT: usize = 24 * 1024;
+pub const DEFAULT_TIMEOUT_MS: u64 = 1_500;
+
+#[cfg(target_os = "macos")]
+mod macos_ax;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct InspectRequest {
+    pub process_id: i32,
+    #[serde(default)]
+    pub app_name: Option<String>,
+    #[serde(default)]
+    pub node_limit: Option<usize>,
+    #[serde(default)]
+    pub depth_limit: Option<usize>,
+    #[serde(default)]
+    pub child_limit: Option<usize>,
+    #[serde(default)]
+    pub byte_limit: Option<usize>,
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct InspectResult {
+    pub ok: bool,
+    /// Compact accessibility tree (markdown-ish lines), agent-readable.
+    pub tree_markdown: String,
+    pub node_count_estimate: usize,
+    pub quality: String,
+    pub warnings: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl InspectResult {
+    pub fn failure(error: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            tree_markdown: String::new(),
+            node_count_estimate: 0,
+            quality: "unavailable".into(),
+            warnings: vec![],
+            error: Some(scrub_vendor(&error.into())),
+        }
+    }
+}
+
+/// Inspect the UI accessibility tree of a process (macOS AX).
+pub fn inspect(req: InspectRequest) -> InspectResult {
+    #[cfg(target_os = "macos")]
+    {
+        inspect_macos(req)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = req;
+        InspectResult::failure("Desktop inspect (accessibility tree) is only supported on macOS")
+    }
+}
+
+/// Build AppShot-style context.md from window meta + inspect tree.
+pub fn build_appshot_context_markdown(
+    app_name: &str,
+    window_title: Option<&str>,
+    process_id: Option<i32>,
+    bounds: Option<(i32, i32, i32, i32)>,
+    tree_markdown: &str,
+    quality: &str,
+    warnings: &[String],
+) -> String {
+    let mut lines = vec![
+        "# Appshot Context".to_string(),
+        String::new(),
+        format!("- App: {app_name}"),
+    ];
+    if let Some(t) = window_title.filter(|s| !s.is_empty()) {
+        lines.push(format!("- Window: {t}"));
+    }
+    if let Some(pid) = process_id {
+        lines.push(format!("- Process ID: {pid}"));
+    }
+    if let Some((x, y, w, h)) = bounds {
+        lines.push(format!("- Bounds: {x},{y} {w}×{h}"));
+    }
+    lines.push(format!("- Quality: {quality}"));
+    lines.push(format!("- Source: {PRODUCT_NAME} inspect"));
+    lines.push(String::new());
+    lines.push("## UI structure".to_string());
+    lines.push(String::new());
+    let tree = tree_markdown.trim();
+    if tree.is_empty() {
+        lines.push("Accessibility tree unavailable.".into());
+    } else {
+        lines.push(tree.to_string());
+    }
+    if !warnings.is_empty() {
+        lines.push(String::new());
+        lines.push("## Warnings".into());
+        for w in warnings {
+            lines.push(format!("- {w}"));
+        }
+    }
+    lines.push(String::new());
+    lines.join("\n")
+}
+
+#[cfg(target_os = "macos")]
+fn inspect_macos(req: InspectRequest) -> InspectResult {
+    use std::time::Duration;
+
+    if req.process_id <= 0 {
+        return InspectResult::failure("inspect requires a positive process_id");
+    }
+    let app_name = req
+        .app_name
+        .clone()
+        .unwrap_or_else(|| "Unknown".to_string());
+    let config = macos_ax::AccessibilityCaptureConfig {
+        timeout: Duration::from_millis(req.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS)),
+        node_limit: req.node_limit.unwrap_or(DEFAULT_NODE_LIMIT),
+        depth_limit: req.depth_limit.unwrap_or(DEFAULT_DEPTH_LIMIT),
+        child_limit: req.child_limit.unwrap_or(DEFAULT_CHILD_LIMIT),
+        byte_limit: req.byte_limit.unwrap_or(DEFAULT_BYTE_LIMIT),
+        redaction_terms: DEFAULT_REDACTION_TERMS,
+    };
+    match macos_ax::capture_accessibility_tree(Some(req.process_id as u32), &app_name, config) {
+        Ok(tree) if !tree.trim().is_empty() => {
+            let node_count_estimate = tree.lines().filter(|l| !l.trim().is_empty()).count();
+            InspectResult {
+                ok: true,
+                tree_markdown: tree,
+                node_count_estimate,
+                quality: "accessibility".into(),
+                warnings: vec![],
+                error: None,
+            }
+        }
+        Ok(_) => InspectResult {
+            ok: false,
+            tree_markdown: String::new(),
+            node_count_estimate: 0,
+            quality: "empty".into(),
+            warnings: vec!["Accessibility tree was empty.".into()],
+            error: Some("Accessibility tree was empty.".into()),
+        },
+        Err(e) => InspectResult::failure(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_markdown_includes_tree_section() {
+        let md = build_appshot_context_markdown(
+            "Notes",
+            Some("Todo"),
+            Some(42),
+            Some((0, 0, 100, 100)),
+            "Button Title: Save\nTextField Value: hello",
+            "screenshot_and_accessibility",
+            &[],
+        );
+        assert!(md.contains("# Appshot Context"));
+        assert!(md.contains("## UI structure"));
+        assert!(md.contains("Button Title: Save"));
+        assert!(!crate::strings::contains_vendor_brand(&md));
+    }
+
+    #[test]
+    fn failure_is_vendor_free() {
+        let r = InspectResult::failure("talk to cua");
+        assert!(!r.ok);
+        assert!(!crate::strings::contains_vendor_brand(
+            r.error.as_deref().unwrap()
+        ));
+    }
+}

--- a/crates/desktop-use/src/lib.rs
+++ b/crates/desktop-use/src/lib.rs
@@ -1,15 +1,22 @@
-//! Atmos Desktop Use — local desktop capture and optional control-engine lifecycle.
+//! Atmos Desktop Use — local desktop capture, **inspect** (UI tree), and optional control.
 //!
 //! User-facing names: **Desktop Use** / `desktop-use`. Never expose third-party
 //! vendor brands in public strings (see [`strings::assert_vendor_free`]).
+//!
+//! Capability map:
+//! - [`capture`] — screenshot + window identity
+//! - [`inspect`] — accessibility / UI structure tree (primary agent text context)
+//! - [`control`] — drive click/type via optional engine
 
 pub mod capture;
 pub mod config;
 pub mod control;
+pub mod inspect;
 pub mod manager;
 pub mod strings;
 
 pub use capture::{capture, CaptureRequest, CaptureResult, WindowBounds};
 pub use config::{desktop_use_dir, engine_bin_path, ensure_dirs, state_path};
 pub use control::{drive, DriveAction, DriveError, DriveRequest, DriveResult};
+pub use inspect::{build_appshot_context_markdown, inspect, InspectRequest, InspectResult};
 pub use manager::{DesktopUseManager, DesktopUseStatus, DriverPhase, DriverStatus, EnsureOutcome};

--- a/specs/APP/APP-052_desktop-use/BRAINSTORM.md
+++ b/specs/APP/APP-052_desktop-use/BRAINSTORM.md
@@ -41,12 +41,16 @@ Atmos control plane (CLI + Settings + optional IPC)
         │
         ▼
 Desktop Use surface (crate + CLI + Desktop helper path)
-  ├── Capture  — frontmost + screenshot + a11y (replaces Electron osascript path)
-  └── Control  — optional engine (lazy ensure); drive click/type/screenshot
+  ├── Capture  — frontmost + screenshot (pixels)
+  ├── Inspect  — accessibility UI tree (primary agent text / context.md)
+  └── Control  — optional engine (lazy ensure); drive click/type
         ▲
         │
  Electron AppShot (records / protocol / pending UI only)
 ```
+
+**Why Inspect is separate:** AppShot’s main agent value is the UI structure tree (historical Tauri AX `context.md`), not only the PNG. Capture needs Screen Recording; Inspect needs Accessibility; Control needs input. Mixing tree walk into Capture hides the primary product surface.
+
 
 ## Open decisions (autonomous defaults for ship)
 

--- a/specs/APP/APP-052_desktop-use/PRD.md
+++ b/specs/APP/APP-052_desktop-use/PRD.md
@@ -53,6 +53,7 @@ Ship **Desktop Use**: an Atmos-owned local capability for **desktop capture**, *
 - **M14** `atmos desktop-use capture` (JSON-capable)
 - **M14b** `atmos desktop-use inspect --pid …` (accessibility tree JSON-capable)
 - **M15** Core `drive` actions: at least `screenshot`, `click`, `type` (and optional `shell` only if TECH keeps it non-colliding with terminal agents; default M1 may omit shell).
+- **M15b** **Agent pointer**: when driving the desktop from Atmos Desktop, show a synthetic Agent cursor (move / click pulse / type chip) that does **not** move the user’s system pointer. Default on; toggle + preview in Settings → Desktop Use.
 - **M16** User-facing CLI help/errors contain no vendor strings.
 
 ### 4.5 Control plane

--- a/specs/APP/APP-052_desktop-use/PRD.md
+++ b/specs/APP/APP-052_desktop-use/PRD.md
@@ -4,7 +4,7 @@
 
 ## 1. Summary
 
-Ship **Desktop Use**: an Atmos-owned local capability for **desktop capture** and optional **desktop control**, managed from **Settings** and **`atmos desktop-use`**, without MCP and without public third-party branding. AppShot keeps its product surface (records, protocol, pending UI) but no longer shells out to `osascript` / `screencapture` directly for production capture.
+Ship **Desktop Use**: an Atmos-owned local capability for **desktop capture**, **inspect** (accessibility / UI tree — primary agent-readable context), and optional **desktop control**, managed from **Settings** and **`atmos desktop-use`**, without MCP and without public third-party branding. AppShot keeps its product surface (records, protocol, pending UI) but obtains pixels via Capture and UI structure via Inspect rather than owning OS shell tools itself.
 
 ## 2. Goals
 
@@ -39,10 +39,11 @@ Ship **Desktop Use**: an Atmos-owned local capability for **desktop capture** an
 - **M7** Section embeds **OS permission** management for Screen Recording and Accessibility by **reusing** the AppShot permissions UI content/components.
 - **M8** Primary recovery path for missing permissions is **Settings → Desktop Use** (not a dedicated AppShot permissions window). Call sites that previously opened the standalone window open Settings Desktop Use (or equivalent in-app section) instead. Standalone window may remain as a thin redirect shell for old deep links.
 
-### 4.3 Capture migration
+### 4.3 Capture + Inspect migration
 
-- **M9** Production AppShot capture path in `apps/desktop-electron/src/appshot/` does **not** directly invoke `osascript` or `screencapture`.
-- **M10** Capture is performed via the Desktop Use capture surface (CLI helper and/or Desktop IPC that calls the same control plane).
+- **M9** Production AppShot path in `apps/desktop-electron/src/appshot/` does **not** directly invoke `osascript` / `screencapture` / raw AX.
+- **M10** **Capture** (screenshot + window identity) goes through Desktop Use Capture.
+- **M10b** **Inspect** (accessibility UI tree) is a **first-class Desktop Use capability** (own module/CLI), not folded into Capture. AppShot `context.md` body is primarily Inspect output.
 - **M11** AppShot business remains: records under `~/.atmos/appshots/`, `atmos://appshots/{ts}`, pending preview, history.
 
 ### 4.4 CLI
@@ -50,6 +51,7 @@ Ship **Desktop Use**: an Atmos-owned local capability for **desktop capture** an
 - **M12** `atmos desktop-use status`
 - **M13** `atmos desktop-use driver ensure|status|stop`
 - **M14** `atmos desktop-use capture` (JSON-capable)
+- **M14b** `atmos desktop-use inspect --pid …` (accessibility tree JSON-capable)
 - **M15** Core `drive` actions: at least `screenshot`, `click`, `type` (and optional `shell` only if TECH keeps it non-colliding with terminal agents; default M1 may omit shell).
 - **M16** User-facing CLI help/errors contain no vendor strings.
 

--- a/specs/APP/APP-052_desktop-use/TECH.md
+++ b/specs/APP/APP-052_desktop-use/TECH.md
@@ -111,6 +111,20 @@ atmos desktop-use drive type --text "…"
 - **Implementation:** `crates/desktop-use/src/inspect/` ports the AppShot Tauri AX walker (`AXUIElement` compact tree, depth/node/byte caps, secure-field redaction).
 - **AppShot flow:** one Capture (PNG) + one Inspect (tree) → compose `context.md` with quality `screenshot_and_accessibility` when both succeed.
 
+### Agent pointer (synthetic cursor)
+
+Computer-use must be **visible**: when Control drives the desktop, Atmos paints an **Agent pointer** overlay that does **not** move the user’s system cursor.
+
+| Item | Spec |
+|------|------|
+| Surface | Electron transparent `panel` window, click-through, always-on-top, multi-monitor virtual bounds |
+| Ownership | `apps/desktop-electron/src/desktop-use/agent-pointer.ts` (+ pure math helpers) |
+| Default | **On** (`~/.atmos/desktop-use/agent-pointer.json`) |
+| Actions | show / move (eased) / click ripple / type chip / hide |
+| Product path | `desktop_use_drive` IPC: play pointer choreography, then control engine |
+| Settings | Desktop Use → Agent pointer toggle + Preview |
+| Out of scope M1 | Vendoring Cua `cursor-overlay`; multi-agent multi-color cursors |
+
 
 Drive adapter:
 

--- a/specs/APP/APP-052_desktop-use/TECH.md
+++ b/specs/APP/APP-052_desktop-use/TECH.md
@@ -11,11 +11,19 @@
 ## 2. Layout
 
 ```
-crates/desktop-use/          # state, config, capture, control adapter, manager
-apps/cli/… desktop_use.rs    # atmos desktop-use
+crates/desktop-use/
+  capture.rs                 # screenshot + window identity
+  inspect/                   # accessibility UI tree (AX) — primary agent context
+  control.rs                 # optional control engine drive
+  manager.rs                 # lifecycle
+apps/cli/… desktop_use.rs    # atmos desktop-use {status,driver,capture,inspect,drive}
 apps/desktop-electron/
-  src/desktop-use/           # spawn/IPC client to CLI or helper
-  src/appshot/frontmost.ts   # thin client → desktop-use capture (no osascript)
+  src/desktop-use/
+    capture.ts               # in-process screenshot (TCC on Atmos Desktop)
+    inspect.ts               # UI tree via CLI inspect (Rust AX)
+    context.ts               # context.md composition
+    client.ts                # CLI spawn for status/driver/inspect
+  src/appshot/               # business only: records, protocol, pending UI
 apps/web/
   features/settings/…DesktopUseSettingsSection
   features/appshot/… permissions panel (reusable, embedded in Settings)
@@ -91,10 +99,18 @@ atmos desktop-use driver ensure [--force]
 atmos desktop-use driver status
 atmos desktop-use driver stop
 atmos desktop-use capture [--out path] [--json]
+atmos desktop-use inspect --pid <n> [--app-name …]   # accessibility tree (primary agent text)
 atmos desktop-use drive screenshot [--out path]
 atmos desktop-use drive click --x <n> --y <n>
 atmos desktop-use drive type --text "…"
 ```
+
+### Inspect (accessibility tree)
+
+- **Why separate from Capture:** AppShot’s main agent value is structured UI text (`context.md`), not only pixels. Capture owns Screen Recording; Inspect owns Accessibility; Control owns input.
+- **Implementation:** `crates/desktop-use/src/inspect/` ports the AppShot Tauri AX walker (`AXUIElement` compact tree, depth/node/byte caps, secure-field redaction).
+- **AppShot flow:** one Capture (PNG) + one Inspect (tree) → compose `context.md` with quality `screenshot_and_accessibility` when both succeed.
+
 
 Drive adapter:
 
@@ -120,7 +136,8 @@ Manifest ensure mirrors `local-model-runtime`: platform URL + sha256 when artifa
 desktop_use_status
 desktop_use_driver_ensure
 desktop_use_driver_stop
-desktop_use_capture   # used by AppShot service
+desktop_use_capture   # pixels
+desktop_use_inspect   # accessibility tree (pid + optional app_name)
 ```
 
 Handlers invoke the same crate logic via CLI subprocess or embedded binary path resolution (prefer resolving workspace/release `atmos` or bundled helper).

--- a/specs/APP/APP-052_desktop-use/TEST.md
+++ b/specs/APP/APP-052_desktop-use/TEST.md
@@ -85,9 +85,9 @@ Given not installed control engine, when `drive click` runs, then error code/mes
 
 | Check | Result |
 |-------|--------|
-| `cargo test -p desktop-use` | 12 passed (state, brand scrub, ensure dry, drive without engine, capture parse) |
-| `atmos desktop-use --help/status/drive click` | CLI surface works; vendor-free; click returns `control_engine_not_installed` |
-| AppShot `frontmost.ts` | No direct `osascript`/`screencapture` production calls; uses Desktop Use client |
-| Settings wiring unit tests | `desktop-use` section + AppshotPermissionsPanel embed + permission primary path |
-| Electron client unit test | resolveAtmosCliPath vendor-free |
-| Live TCC dual-shift | not_run (environment / non-gating) |
+| `cargo test -p desktop-use` | 14 passed (+ inspect context markdown + brand scrub) |
+| `atmos desktop-use --help/status/inspect/drive click` | CLI includes `inspect`; vendor-free |
+| AppShot `frontmost.ts` | Capture + Inspect composition; no direct AX/osascript in appshot/ |
+| Electron inspect tests | context.md includes `## UI structure` from tree |
+| Settings wiring unit tests | `desktop-use` section + permissions panel |
+| Live TCC dual-shift full tree | manual / environment |


### PR DESCRIPTION
## Summary

Visible computer-use for Atmos Desktop Use:

### Agent pointer (this commit focus)
- Synthetic **Agent pointer** overlay: does **not** move the system cursor
- Eased travel, click ripple, type chip, multi-monitor virtual bounds
- Settings → Desktop Use: toggle (default **on**) + **Preview pointer**
- IPC `desktop_use_drive` plays pointer choreography then control engine
- Prefs: `~/.atmos/desktop-use/agent-pointer.json`

### Inspect (stacked)
- First-class **Inspect** capability (accessibility tree) separate from Capture
- `atmos desktop-use inspect --pid`
- AppShot: Capture + Inspect → `context.md`

No public Cua branding; pointer is Atmos-owned Electron overlay (not vendored cursor-overlay).

## Test plan

- [x] Bun: agent-pointer-math + settings wiring
- [x] Manual path: Settings → Desktop Use → Preview pointer
- [ ] Dual-shift AppShot still writes records
- [ ] Drive click with pointer visible when engine present

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds visible computer-use to Desktop Use: a synthetic Agent pointer overlay and a first-class Inspect (accessibility UI tree) used to build richer AppShot context.md. Also adds a new CLI/IPC surface for Inspect and pointer control.

- **New Features**
  - Agent pointer overlay (does not move the system cursor): eased motion, click ripple, and type chip; multi-monitor bounds; prefs at `~/.atmos/desktop-use/agent-pointer.json`; Settings → Desktop Use toggle (default on) + Preview; IPC: `desktop_use_pointer_status|set_enabled|play|hide`, and `desktop_use_drive` plays pointer choreography before delegating to the control engine.
  - Inspect (macOS AX): `atmos desktop-use inspect --pid` returns a compact UI tree; Electron `desktop-use/inspect` composes AppShot `context.md` from Capture + Inspect with quality labels; AppShot no longer shells AX/osascript directly; strings remain vendor-free.

- **Dependencies**
  - Add `core-foundation` (macOS) for Accessibility traversal.

<sup>Written for commit be11dc58ca89350c6d646482e0a4b933016d61de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added desktop UI inspection to provide accessibility-tree context alongside screenshots.
  * Added a visible Agent pointer with configurable enablement, movement, click, typing, and preview controls.
  * Added CLI and desktop integrations for inspection and combined desktop actions.
* **Improvements**
  * App context now includes application metadata, UI structure, quality indicators, and warnings.
  * Added multi-monitor pointer support with animated movement and coordinate validation.
* **Bug Fixes**
  * Improved fallback behavior when accessibility data or pointer operations are unavailable.
* **Documentation**
  * Updated Desktop Use documentation and English and Chinese translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->