### PR TITLE
refactor: address daily quality findings for 2026-08-06

### DIFF
--- a/apps/web/src/features/diff/components/ChangesCodeView.tsx
+++ b/apps/web/src/features/diff/components/ChangesCodeView.tsx
@@ -7,20 +7,17 @@ import {
   type CodeViewHandle,
   type CreateEditor,
 } from '@pierre/diffs/react';
-import type { CodeViewItem, FileContents, SelectedLineRange } from '@pierre/diffs';
+import type { CodeViewItem, SelectedLineRange } from '@pierre/diffs';
 import { parseDiffFromFile } from '@pierre/diffs';
 import { Editor } from '@pierre/diffs/edit';
 import { useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
-import { Loader2, RotateCcw, Save, SquarePen } from 'lucide-react';
-import { AnimatePresence, motion } from 'motion/react';
-import { toastManager } from '@workspace/ui';
-import { fsApi, gitApi } from '@/api/ws-api';
+import { Loader2 } from 'lucide-react';
+import { gitApi } from '@/api/ws-api';
 import { useGitStore } from '@/features/git/store/use-git-store';
 import {
   useGitChangedFilesQuery,
   GIT_WORKTREE_PARAMS,
-  invalidateGitQueries,
 } from '@/features/git/hooks/use-git-changed-files-query';
 import { useGitStatusQuery } from '@/features/git/hooks/use-git-status-query';
 import { computeCompareParams, selectCompareChangedFiles, isCompareQueryEnabled, EMPTY_CHANGED_FILES } from '@/features/git/lib/git-query-options';
@@ -40,13 +37,13 @@ import {
   useDiffPromptStash,
   type LoadedDiffContents,
 } from '@/features/diff/components/useDiffPromptStash';
+import { DiffWorktreeEditToolbar } from '@/features/diff/components/DiffWorktreeEditToolbar';
+import { useDiffWorktreeEdit } from '@/features/diff/components/useDiffWorktreeEdit';
 import type { AgentFixContextRef } from '@/features/agent-fix/types';
 import { sortByDiffTreePath } from '@/features/diff/lib/diff-file-order';
 import {
   applyCollapseModeToItems,
   diffSideCacheKey,
-  getNextItemVersion,
-  isBinaryAnnotation,
   type DiffListAnnotationMeta,
 } from '@/features/diff/lib/diff-code-view-shared';
 import {
@@ -66,17 +63,9 @@ import {
   renderDiffHeaderPrefix,
   scrollCodeViewToItem,
 } from '@/features/diff/lib/code-view-ui';
-import { cn } from '@/shared/lib/utils';
 
 const CODE_VIEW_BATCH_SIZE = 25;
 const FULL_COMMIT_HASH_RE = /^[0-9a-f]{40}$/i;
-
-/** Worktree change groups whose new side maps to a local file we can write. */
-function isEditableWorktreeGroup(
-  kind: DiffChangeGroupKind | null,
-): kind is 'staged' | 'unstaged' | 'untracked' {
-  return kind === 'staged' || kind === 'unstaged' || kind === 'untracked';
-}
 
 function yieldToBrowser(): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, 0));
@@ -84,42 +73,6 @@ function yieldToBrowser(): Promise<void> {
 
 function formatCommitRefLabel(ref: string): string {
   return FULL_COMMIT_HASH_RE.test(ref) ? ref.slice(0, 7) : ref;
-}
-
-function toAbsolutePath(repoPath: string, relativePath: string): string {
-  if (relativePath.startsWith('/')) {
-    return relativePath;
-  }
-  const normalizedRepo = repoPath.endsWith('/') ? repoPath.slice(0, -1) : repoPath;
-  return `${normalizedRepo}/${relativePath}`;
-}
-
-function rebuildDiffItem(
-  path: string,
-  contents: LoadedDiffContents,
-  base: CodeViewItem<DiffListAnnotationMeta>,
-  edit: boolean,
-): CodeViewItem<DiffListAnnotationMeta> {
-  if (base.type !== 'diff') return base;
-  const fileDiff = parseDiffFromFile(
-    {
-      name: path,
-      contents: contents.oldContent,
-      cacheKey: diffSideCacheKey(path, contents.oldContent),
-    },
-    {
-      name: path,
-      contents: contents.newContent,
-      cacheKey: diffSideCacheKey(path, contents.newContent),
-    },
-  );
-  return {
-    ...base,
-    fileDiff,
-    edit,
-    version: getNextItemVersion(base),
-    collapsed: false,
-  };
 }
 
 interface ChangesCodeViewProps {
@@ -211,10 +164,6 @@ export function ChangesCodeView({
   const [collapseMode, setCollapseMode] = useState<'expanded' | 'collapsed'>(
     'expanded',
   );
-  const [editingPath, setEditingPath] = useState<string | null>(null);
-  const [isEditDirty, setIsEditDirty] = useState(false);
-  const [isSavingEdit, setIsSavingEdit] = useState(false);
-
   const codeViewRef = useRef<CodeViewHandle<DiffListAnnotationMeta>>(null);
   const lastHandledNavRef = useRef<string | null>(null);
   const itemIdsRef = useRef<string[]>([]);
@@ -222,11 +171,6 @@ export function ChangesCodeView({
   const scrollActiveIdRef = useRef<string | null>(null);
   const loadedContentsRef = useRef<Map<string, LoadedDiffContents>>(new Map());
   const collapseModeRef = useRef(collapseMode);
-  const draftContentsRef = useRef<Map<string, string>>(new Map());
-  const editingPathRef = useRef<string | null>(null);
-  const isEditDirtyRef = useRef(false);
-  const isSavingEditRef = useRef(false);
-  const stageFiles = useGitStore((s) => s.stageFiles);
   const { openCopyAnnotation, renderAnnotation, stashedPromptChip } =
     useDiffPromptStash({
       agentFixContext,
@@ -248,190 +192,27 @@ export function ChangesCodeView({
     collapseModeRef.current = collapseMode;
   }, [collapseMode]);
 
-  useEffect(() => {
-    editingPathRef.current = editingPath;
-  }, [editingPath]);
-
-  useEffect(() => {
-    isEditDirtyRef.current = isEditDirty;
-  }, [isEditDirty]);
-
-  const canEditWorktree = isEditableWorktreeGroup(effectiveGroupKind);
-
   const createDiffEditor = useCallback<CreateEditor<DiffListAnnotationMeta>>(
     (options) => new Editor(options),
     [],
   );
 
-  const isBinaryItem = useCallback((item: CodeViewItem<DiffListAnnotationMeta> | undefined) => {
-    if (item == null || item.type !== 'diff') return true;
-    return item.annotations?.some((annotation) => isBinaryAnnotation(annotation)) ?? false;
-  }, []);
-
-  const setItemEditMode = useCallback((path: string, edit: boolean) => {
-    const viewer = codeViewRef.current;
-    const item = viewer?.getItem(path);
-    if (viewer == null || item == null || item.type !== 'diff') return false;
-    if (isBinaryItem(item)) return false;
-    item.edit = edit;
-    item.collapsed = false;
-    item.version = getNextItemVersion(item);
-    viewer.updateItem(item);
-    return true;
-  }, [isBinaryItem]);
-
-  const handleEnterEdit = useCallback((path: string) => {
-    if (!canEditWorktree) return;
-    const currentEditing = editingPathRef.current;
-    if (currentEditing && currentEditing !== path) {
-      if (isEditDirtyRef.current) {
-        toastManager.add({
-          title: t('edit.unsavedTitle'),
-          description: t('edit.unsavedDescription'),
-          type: 'error',
-        });
-        return;
-      }
-      setItemEditMode(currentEditing, false);
-      draftContentsRef.current.delete(currentEditing);
-    }
-    if (!setItemEditMode(path, true)) return;
-    const original = loadedContentsRef.current.get(path)?.newContent ?? '';
-    draftContentsRef.current.set(path, original);
-    setEditingPath(path);
-    setIsEditDirty(false);
-  }, [canEditWorktree, setItemEditMode, t]);
-
-  const handleExitEdit = useCallback((path: string) => {
-    setItemEditMode(path, false);
-    draftContentsRef.current.delete(path);
-    if (editingPathRef.current === path) {
-      setEditingPath(null);
-      setIsEditDirty(false);
-    }
-  }, [setItemEditMode]);
-
-  const handleResetEdit = useCallback(() => {
-    const path = editingPathRef.current;
-    if (path == null) return;
-    const viewer = codeViewRef.current;
-    const item = viewer?.getItem(path);
-    const original = loadedContentsRef.current.get(path);
-    if (viewer == null || item == null || item.type !== 'diff' || original == null) {
-      return;
-    }
-    // End the session then re-open so the editor document is rebuilt from the
-    // original new-side contents (pierre owns the live document while edit is on).
-    const closed = rebuildDiffItem(path, original, item, false);
-    viewer.updateItem(closed);
-    const reopenedBase = viewer.getItem(path) ?? closed;
-    const reopened = rebuildDiffItem(path, original, reopenedBase, true);
-    viewer.updateItem(reopened);
-    draftContentsRef.current.set(path, original.newContent);
-    setIsEditDirty(false);
-  }, []);
-
-  const handleSaveEdit = useCallback(async () => {
-    const path = editingPathRef.current;
-    if (path == null || isSavingEditRef.current) return;
-    const draft =
-      draftContentsRef.current.get(path) ??
-      loadedContentsRef.current.get(path)?.newContent;
-    if (draft == null) return;
-
-    isSavingEditRef.current = true;
-    setIsSavingEdit(true);
-    try {
-      const absolutePath = toAbsolutePath(repoPath, path);
-      await fsApi.writeFile(absolutePath, draft);
-      if (effectiveGroupKind === 'staged') {
-        await stageFiles([path]);
-      }
-      const previous = loadedContentsRef.current.get(path);
-      loadedContentsRef.current.set(path, {
-        oldContent: previous?.oldContent ?? '',
-        newContent: draft,
-      });
-      draftContentsRef.current.set(path, draft);
-
-      const viewer = codeViewRef.current;
-      const item = viewer?.getItem(path);
-      const contents = loadedContentsRef.current.get(path);
-      if (viewer != null && item != null && item.type === 'diff' && contents != null) {
-        viewer.updateItem(rebuildDiffItem(path, contents, item, false));
-      }
-
-      setEditingPath(null);
-      setIsEditDirty(false);
-      draftContentsRef.current.delete(path);
-      await invalidateGitQueries(repoPath);
-    } catch (error) {
-      toastManager.add({
-        title: t('edit.saveFailedTitle'),
-        description:
-          error instanceof Error ? error.message : t('edit.saveFailedFallback'),
-        type: 'error',
-      });
-    } finally {
-      isSavingEditRef.current = false;
-      setIsSavingEdit(false);
-    }
-  }, [effectiveGroupKind, repoPath, stageFiles, t]);
-
-  const handleEditButtonClick = useCallback(() => {
-    if (editingPath != null) {
-      if (isEditDirty) {
-        void handleSaveEdit();
-        return;
-      }
-      handleExitEdit(editingPath);
-      return;
-    }
-    if (selectedPath) {
-      handleEnterEdit(selectedPath);
-    }
-  }, [
+  const {
+    canEditWorktree,
     editingPath,
-    handleEnterEdit,
-    handleExitEdit,
-    handleSaveEdit,
     isEditDirty,
+    isSavingEdit,
+    handleResetEdit,
+    handleEditButtonClick,
+    handleItemEditChange,
+  } = useDiffWorktreeEdit({
+    repoPath,
+    effectiveGroupKind,
     selectedPath,
-  ]);
-
-  const handleItemEditChange = useCallback(
-    (item: CodeViewItem<DiffListAnnotationMeta>, file: FileContents) => {
-      const original = loadedContentsRef.current.get(item.id)?.newContent ?? '';
-      draftContentsRef.current.set(item.id, file.contents);
-      if (editingPathRef.current === item.id) {
-        setIsEditDirty(file.contents !== original);
-      }
-    },
-    [],
-  );
-
-  // Cmd/Ctrl+S saves while a worktree diff is being edited.
-  useEffect(() => {
-    if (!canEditWorktree || editingPath == null) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== 's') {
-        return;
-      }
-      event.preventDefault();
-      event.stopPropagation();
-      if (!isEditDirtyRef.current) return;
-      void handleSaveEdit();
-    };
-    window.addEventListener('keydown', onKeyDown, true);
-    return () => window.removeEventListener('keydown', onKeyDown, true);
-  }, [canEditWorktree, editingPath, handleSaveEdit]);
-
-  // Drop edit session when the group reloads or leaves worktree mode.
-  useEffect(() => {
-    setEditingPath(null);
-    setIsEditDirty(false);
-    draftContentsRef.current.clear();
-  }, [groupPath, viewerKey, canEditWorktree]);
+    codeViewRef,
+    loadedContentsRef,
+    resetKey: `${groupPath}:${viewerKey}`,
+  });
 
   const groupFiles = useMemo(() => {
     if (!groupKind) return [];
@@ -962,13 +743,6 @@ export function ChangesCodeView({
   const canStartOrToggleEdit =
     canEditWorktree && editTargetPath != null && !editTargetIsBinary;
   const showEditControls = canEditWorktree && editTargetPath != null;
-  const showResetButton = Boolean(editingPath && isEditDirty);
-  // Clean → Edit icon. Dirty → Save icon + Reset icon peels out to the right.
-  const primaryEditLabel = showResetButton ? t('edit.save') : t('edit.edit');
-  const primaryEditTitle = showResetButton
-    ? t('edit.saveShortcut')
-    : primaryEditLabel;
-
   const toolbar = (
     <div className="flex items-center gap-2">
       <div className="flex min-w-0 flex-1 items-center gap-3">
@@ -990,87 +764,14 @@ export function ChangesCodeView({
         </div>
       )}
       {showEditControls ? (
-        // Width-only expand/collapse for the reset control. Do not put `layout` on
-        // this group or the primary button — layout projection fights the exit
-        // width animation and causes a settle-then-snap when 2 buttons → 1.
-        <div className="flex shrink-0 items-center overflow-hidden">
-          <button
-            type="button"
-            className={cn(
-              'relative flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors disabled:pointer-events-none disabled:opacity-50',
-              showResetButton
-                ? 'bg-primary text-primary-foreground hover:bg-primary/90'
-                : editingPath
-                  ? 'bg-muted text-foreground hover:bg-muted/80'
-                  : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
-            )}
-            disabled={isSavingEdit || (!editingPath && !canStartOrToggleEdit)}
-            onClick={handleEditButtonClick}
-            title={primaryEditTitle}
-            aria-label={primaryEditLabel}
-            aria-pressed={editingPath != null && !isEditDirty ? true : undefined}
-          >
-            <AnimatePresence initial={false}>
-              {isSavingEdit ? (
-                <motion.span
-                  key="saving"
-                  initial={{ opacity: 0, scale: 0.7, rotate: -20 }}
-                  animate={{ opacity: 1, scale: 1, rotate: 0 }}
-                  exit={{ opacity: 0, scale: 0.7, rotate: 20 }}
-                  transition={{ duration: 0.16, ease: 'easeOut' }}
-                  className="absolute inset-0 flex items-center justify-center"
-                >
-                  <Loader2 className="size-3.5 animate-spin" />
-                </motion.span>
-              ) : showResetButton ? (
-                <motion.span
-                  key="save"
-                  initial={{ opacity: 0, scale: 0.7, y: 4 }}
-                  animate={{ opacity: 1, scale: 1, y: 0 }}
-                  exit={{ opacity: 0, scale: 0.7, y: -4 }}
-                  transition={{ duration: 0.16, ease: 'easeOut' }}
-                  className="absolute inset-0 flex items-center justify-center"
-                >
-                  <Save className="size-3.5" />
-                </motion.span>
-              ) : (
-                <motion.span
-                  key="edit"
-                  initial={{ opacity: 0, scale: 0.7, y: -4 }}
-                  animate={{ opacity: 1, scale: 1, y: 0 }}
-                  exit={{ opacity: 0, scale: 0.7, y: 4 }}
-                  transition={{ duration: 0.16, ease: 'easeOut' }}
-                  className="absolute inset-0 flex items-center justify-center"
-                >
-                  <SquarePen className="size-3.5" />
-                </motion.span>
-              )}
-            </AnimatePresence>
-          </button>
-          <AnimatePresence initial={false}>
-            {showResetButton ? (
-              <motion.div
-                key="reset"
-                initial={{ width: 0, opacity: 0 }}
-                animate={{ width: 30, opacity: 1 }}
-                exit={{ width: 0, opacity: 0 }}
-                transition={{ type: 'spring', stiffness: 500, damping: 38, mass: 0.7 }}
-                className="overflow-hidden"
-              >
-                <button
-                  type="button"
-                  className="ml-0.5 flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
-                  disabled={isSavingEdit}
-                  onClick={handleResetEdit}
-                  title={t('edit.reset')}
-                  aria-label={t('edit.reset')}
-                >
-                  <RotateCcw className="size-3.5" />
-                </button>
-              </motion.div>
-            ) : null}
-          </AnimatePresence>
-        </div>
+        <DiffWorktreeEditToolbar
+          editingPath={editingPath}
+          isEditDirty={isEditDirty}
+          isSavingEdit={isSavingEdit}
+          canStartOrToggleEdit={canStartOrToggleEdit}
+          onPrimaryClick={handleEditButtonClick}
+          onResetClick={handleResetEdit}
+        />
       ) : null}
       <DiffCodeViewSettingsMenu
         diffStyle={diffStyle}

--- a/apps/web/src/features/diff/components/DiffWorktreeEditToolbar.tsx
+++ b/apps/web/src/features/diff/components/DiffWorktreeEditToolbar.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { Loader2, RotateCcw, Save, SquarePen } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/shared/lib/utils';
+
+type DiffWorktreeEditToolbarProps = {
+  editingPath: string | null;
+  isEditDirty: boolean;
+  isSavingEdit: boolean;
+  canStartOrToggleEdit: boolean;
+  onPrimaryClick: () => void;
+  onResetClick: () => void;
+};
+
+/**
+ * Compact edit / save / reset control used by the Changes code-view toolbar.
+ */
+export function DiffWorktreeEditToolbar({
+  editingPath,
+  isEditDirty,
+  isSavingEdit,
+  canStartOrToggleEdit,
+  onPrimaryClick,
+  onResetClick,
+}: DiffWorktreeEditToolbarProps) {
+  const t = useTranslations('diff.codeView');
+  const showResetButton = Boolean(editingPath && isEditDirty);
+  // Clean → Edit icon. Dirty → Save icon + Reset icon peels out to the right.
+  const primaryEditLabel = showResetButton ? t('edit.save') : t('edit.edit');
+  const primaryEditTitle = showResetButton
+    ? t('edit.saveShortcut')
+    : primaryEditLabel;
+
+  return (
+    // Width-only expand/collapse for the reset control. Do not put `layout` on
+    // this group or the primary button — layout projection fights the exit
+    // width animation and causes a settle-then-snap when 2 buttons → 1.
+    <div className="flex shrink-0 items-center overflow-hidden">
+      <button
+        type="button"
+        className={cn(
+          'relative flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors disabled:pointer-events-none disabled:opacity-50',
+          showResetButton
+            ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+            : editingPath
+              ? 'bg-muted text-foreground hover:bg-muted/80'
+              : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+        )}
+        disabled={isSavingEdit || (!editingPath && !canStartOrToggleEdit)}
+        onClick={onPrimaryClick}
+        title={primaryEditTitle}
+        aria-label={primaryEditLabel}
+        aria-pressed={editingPath != null && !isEditDirty ? true : undefined}
+      >
+        <AnimatePresence initial={false}>
+          {isSavingEdit ? (
+            <motion.span
+              key="saving"
+              initial={{ opacity: 0, scale: 0.7, rotate: -20 }}
+              animate={{ opacity: 1, scale: 1, rotate: 0 }}
+              exit={{ opacity: 0, scale: 0.7, rotate: 20 }}
+              transition={{ duration: 0.16, ease: 'easeOut' }}
+              className="absolute inset-0 flex items-center justify-center"
+            >
+              <Loader2 className="size-3.5 animate-spin" />
+            </motion.span>
+          ) : showResetButton ? (
+            <motion.span
+              key="save"
+              initial={{ opacity: 0, scale: 0.7, y: 4 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.7, y: -4 }}
+              transition={{ duration: 0.16, ease: 'easeOut' }}
+              className="absolute inset-0 flex items-center justify-center"
+            >
+              <Save className="size-3.5" />
+            </motion.span>
+          ) : (
+            <motion.span
+              key="edit"
+              initial={{ opacity: 0, scale: 0.7, y: -4 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.7, y: 4 }}
+              transition={{ duration: 0.16, ease: 'easeOut' }}
+              className="absolute inset-0 flex items-center justify-center"
+            >
+              <SquarePen className="size-3.5" />
+            </motion.span>
+          )}
+        </AnimatePresence>
+      </button>
+      <AnimatePresence initial={false}>
+        {showResetButton ? (
+          <motion.div
+            key="reset"
+            initial={{ width: 0, opacity: 0 }}
+            animate={{ width: 30, opacity: 1 }}
+            exit={{ width: 0, opacity: 0 }}
+            transition={{ type: 'spring', stiffness: 500, damping: 38, mass: 0.7 }}
+            className="overflow-hidden"
+          >
+            <button
+              type="button"
+              className="ml-0.5 flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+              disabled={isSavingEdit}
+              onClick={onResetClick}
+              title={t('edit.reset')}
+              aria-label={t('edit.reset')}
+            >
+              <RotateCcw className="size-3.5" />
+            </button>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/apps/web/src/features/diff/components/useDiffWorktreeEdit.tsx
+++ b/apps/web/src/features/diff/components/useDiffWorktreeEdit.tsx
@@ -1,0 +1,317 @@
+'use client';
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MutableRefObject,
+} from 'react';
+import { parseDiffFromFile } from '@pierre/diffs';
+import type { CodeViewItem, FileContents } from '@pierre/diffs';
+import type { CodeViewHandle } from '@pierre/diffs/react';
+import { useTranslations } from 'next-intl';
+import { toastManager } from '@workspace/ui';
+import { fsApi } from '@/api/ws-api';
+import { invalidateGitQueries } from '@/features/git/hooks/use-git-changed-files-query';
+import { useGitStore } from '@/features/git/store/use-git-store';
+import type { DiffChangeGroupKind } from '@/features/diff/lib/diff-editor-paths';
+import {
+  diffSideCacheKey,
+  getNextItemVersion,
+  isBinaryAnnotation,
+  type DiffListAnnotationMeta,
+} from '@/features/diff/lib/diff-code-view-shared';
+import type { LoadedDiffContents } from '@/features/diff/components/useDiffPromptStash';
+
+/** Worktree change groups whose new side maps to a local file we can write. */
+export function isEditableWorktreeGroup(
+  kind: DiffChangeGroupKind | null,
+): kind is 'staged' | 'unstaged' | 'untracked' {
+  return kind === 'staged' || kind === 'unstaged' || kind === 'untracked';
+}
+
+export function toAbsoluteRepoPath(repoPath: string, relativePath: string): string {
+  if (relativePath.startsWith('/')) {
+    return relativePath;
+  }
+  const normalizedRepo = repoPath.endsWith('/') ? repoPath.slice(0, -1) : repoPath;
+  return `${normalizedRepo}/${relativePath}`;
+}
+
+export function rebuildDiffItem(
+  path: string,
+  contents: LoadedDiffContents,
+  base: CodeViewItem<DiffListAnnotationMeta>,
+  edit: boolean,
+): CodeViewItem<DiffListAnnotationMeta> {
+  if (base.type !== 'diff') return base;
+  const fileDiff = parseDiffFromFile(
+    {
+      name: path,
+      contents: contents.oldContent,
+      cacheKey: diffSideCacheKey(path, contents.oldContent),
+    },
+    {
+      name: path,
+      contents: contents.newContent,
+      cacheKey: diffSideCacheKey(path, contents.newContent),
+    },
+  );
+  return {
+    ...base,
+    fileDiff,
+    edit,
+    version: getNextItemVersion(base),
+    collapsed: false,
+  };
+}
+
+type UseDiffWorktreeEditArgs = {
+  repoPath: string;
+  /** Effective group kind after compare remapping. */
+  effectiveGroupKind: DiffChangeGroupKind | null;
+  selectedPath: string | undefined;
+  codeViewRef: MutableRefObject<CodeViewHandle<DiffListAnnotationMeta> | null>;
+  loadedContentsRef: MutableRefObject<Map<string, LoadedDiffContents>>;
+  /** Reset session when the viewer identity changes. */
+  resetKey: string | number | boolean;
+};
+
+/**
+ * Inline edit session for worktree diffs (enter / draft / save / reset / Cmd-S).
+ * Keeps pierre viewer item.edit flags and disk write orchestration out of the
+ * main ChangesCodeView render path.
+ */
+export function useDiffWorktreeEdit({
+  repoPath,
+  effectiveGroupKind,
+  selectedPath,
+  codeViewRef,
+  loadedContentsRef,
+  resetKey,
+}: UseDiffWorktreeEditArgs) {
+  const t = useTranslations('diff.codeView');
+  const stageFiles = useGitStore((s) => s.stageFiles);
+
+  const [editingPath, setEditingPath] = useState<string | null>(null);
+  const [isEditDirty, setIsEditDirty] = useState(false);
+  const [isSavingEdit, setIsSavingEdit] = useState(false);
+
+  const draftContentsRef = useRef<Map<string, string>>(new Map());
+  const editingPathRef = useRef<string | null>(null);
+  const isEditDirtyRef = useRef(false);
+  const isSavingEditRef = useRef(false);
+
+  useEffect(() => {
+    editingPathRef.current = editingPath;
+  }, [editingPath]);
+
+  useEffect(() => {
+    isEditDirtyRef.current = isEditDirty;
+  }, [isEditDirty]);
+
+  const canEditWorktree = isEditableWorktreeGroup(effectiveGroupKind);
+
+  const isBinaryItem = useCallback(
+    (item: CodeViewItem<DiffListAnnotationMeta> | undefined) => {
+      if (item == null || item.type !== 'diff') return true;
+      return item.annotations?.some((annotation) => isBinaryAnnotation(annotation)) ?? false;
+    },
+    [],
+  );
+
+  const setItemEditMode = useCallback(
+    (path: string, edit: boolean) => {
+      const viewer = codeViewRef.current;
+      const item = viewer?.getItem(path);
+      if (viewer == null || item == null || item.type !== 'diff') return false;
+      if (isBinaryItem(item)) return false;
+      item.edit = edit;
+      item.collapsed = false;
+      item.version = getNextItemVersion(item);
+      viewer.updateItem(item);
+      return true;
+    },
+    [codeViewRef, isBinaryItem],
+  );
+
+  const handleEnterEdit = useCallback(
+    (path: string) => {
+      if (!canEditWorktree) return;
+      const currentEditing = editingPathRef.current;
+      if (currentEditing && currentEditing !== path) {
+        if (isEditDirtyRef.current) {
+          toastManager.add({
+            title: t('edit.unsavedTitle'),
+            description: t('edit.unsavedDescription'),
+            type: 'error',
+          });
+          return;
+        }
+        setItemEditMode(currentEditing, false);
+        draftContentsRef.current.delete(currentEditing);
+      }
+      if (!setItemEditMode(path, true)) return;
+      const original = loadedContentsRef.current.get(path)?.newContent ?? '';
+      draftContentsRef.current.set(path, original);
+      setEditingPath(path);
+      setIsEditDirty(false);
+    },
+    [canEditWorktree, loadedContentsRef, setItemEditMode, t],
+  );
+
+  const handleExitEdit = useCallback(
+    (path: string) => {
+      setItemEditMode(path, false);
+      draftContentsRef.current.delete(path);
+      if (editingPathRef.current === path) {
+        setEditingPath(null);
+        setIsEditDirty(false);
+      }
+    },
+    [setItemEditMode],
+  );
+
+  const handleResetEdit = useCallback(() => {
+    const path = editingPathRef.current;
+    if (path == null) return;
+    const viewer = codeViewRef.current;
+    const item = viewer?.getItem(path);
+    const original = loadedContentsRef.current.get(path);
+    if (viewer == null || item == null || item.type !== 'diff' || original == null) {
+      return;
+    }
+    // End the session then re-open so the editor document is rebuilt from the
+    // original new-side contents (pierre owns the live document while edit is on).
+    const closed = rebuildDiffItem(path, original, item, false);
+    viewer.updateItem(closed);
+    const reopenedBase = viewer.getItem(path) ?? closed;
+    const reopened = rebuildDiffItem(path, original, reopenedBase, true);
+    viewer.updateItem(reopened);
+    draftContentsRef.current.set(path, original.newContent);
+    setIsEditDirty(false);
+  }, [codeViewRef, loadedContentsRef]);
+
+  const handleSaveEdit = useCallback(async () => {
+    const path = editingPathRef.current;
+    if (path == null || isSavingEditRef.current) return;
+    const draft =
+      draftContentsRef.current.get(path) ??
+      loadedContentsRef.current.get(path)?.newContent;
+    if (draft == null) return;
+
+    isSavingEditRef.current = true;
+    setIsSavingEdit(true);
+    try {
+      const absolutePath = toAbsoluteRepoPath(repoPath, path);
+      await fsApi.writeFile(absolutePath, draft);
+      if (effectiveGroupKind === 'staged') {
+        await stageFiles([path]);
+      }
+      const previous = loadedContentsRef.current.get(path);
+      loadedContentsRef.current.set(path, {
+        oldContent: previous?.oldContent ?? '',
+        newContent: draft,
+      });
+      draftContentsRef.current.set(path, draft);
+
+      const viewer = codeViewRef.current;
+      const item = viewer?.getItem(path);
+      const contents = loadedContentsRef.current.get(path);
+      if (viewer != null && item != null && item.type === 'diff' && contents != null) {
+        viewer.updateItem(rebuildDiffItem(path, contents, item, false));
+      }
+
+      setEditingPath(null);
+      setIsEditDirty(false);
+      draftContentsRef.current.delete(path);
+      await invalidateGitQueries(repoPath);
+    } catch (error) {
+      toastManager.add({
+        title: t('edit.saveFailedTitle'),
+        description:
+          error instanceof Error ? error.message : t('edit.saveFailedFallback'),
+        type: 'error',
+      });
+    } finally {
+      isSavingEditRef.current = false;
+      setIsSavingEdit(false);
+    }
+  }, [
+    codeViewRef,
+    effectiveGroupKind,
+    loadedContentsRef,
+    repoPath,
+    stageFiles,
+    t,
+  ]);
+
+  const handleEditButtonClick = useCallback(() => {
+    if (editingPath != null) {
+      if (isEditDirty) {
+        void handleSaveEdit();
+        return;
+      }
+      handleExitEdit(editingPath);
+      return;
+    }
+    if (selectedPath) {
+      handleEnterEdit(selectedPath);
+    }
+  }, [
+    editingPath,
+    handleEnterEdit,
+    handleExitEdit,
+    handleSaveEdit,
+    isEditDirty,
+    selectedPath,
+  ]);
+
+  const handleItemEditChange = useCallback(
+    (item: CodeViewItem<DiffListAnnotationMeta>, file: FileContents) => {
+      const original = loadedContentsRef.current.get(item.id)?.newContent ?? '';
+      draftContentsRef.current.set(item.id, file.contents);
+      if (editingPathRef.current === item.id) {
+        setIsEditDirty(file.contents !== original);
+      }
+    },
+    [loadedContentsRef],
+  );
+
+  // Cmd/Ctrl+S saves while a worktree diff is being edited.
+  useEffect(() => {
+    if (!canEditWorktree || editingPath == null) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== 's') {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      if (!isEditDirtyRef.current) return;
+      void handleSaveEdit();
+    };
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
+  }, [canEditWorktree, editingPath, handleSaveEdit]);
+
+  // Drop edit session when the group reloads or leaves worktree mode.
+  useEffect(() => {
+    setEditingPath(null);
+    setIsEditDirty(false);
+    draftContentsRef.current.clear();
+  }, [resetKey, canEditWorktree]);
+
+  return {
+    canEditWorktree,
+    editingPath,
+    isEditDirty,
+    isSavingEdit,
+    handleEnterEdit,
+    handleExitEdit,
+    handleResetEdit,
+    handleSaveEdit,
+    handleEditButtonClick,
+    handleItemEditChange,
+  };
+}

--- a/apps/web/src/features/settings/components/TerminalCursorAppearanceSettings.tsx
+++ b/apps/web/src/features/settings/components/TerminalCursorAppearanceSettings.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import * as React from 'react';
+import { useTranslations } from 'next-intl';
+import { Switch, TabsSubtle, TabsSubtleItem, cn } from '@workspace/ui';
+import { Palette } from 'lucide-react';
+import {
+  TERMINAL_CURSOR_STYLES,
+  type TerminalCursorStyle,
+  useTerminalAppearanceSettingsStore,
+} from '@/features/settings/store/terminal-appearance-settings-store';
+import {
+  SettingsGroupCard,
+  SettingsGroupRow,
+} from '@/features/settings/components/settings/SettingsGroupCard';
+
+/** Mini caret glyph used as TabsSubtle icons + live blink preview. */
+function CursorStylePreviewIcon({
+  style,
+  blink,
+  active,
+  className,
+  size = 16,
+}: {
+  style: TerminalCursorStyle;
+  blink: boolean;
+  active: boolean;
+  className?: string;
+  size?: number;
+}) {
+  const shouldBlink = active && blink;
+  return (
+    <span
+      className={cn(
+        'relative inline-flex shrink-0 items-end justify-center text-current',
+        className,
+      )}
+      style={{
+        width: size,
+        height: size,
+        animation: shouldBlink
+          ? 'atmos-cursor-blink 1.06s step-end infinite'
+          : undefined,
+      }}
+      aria-hidden
+    >
+      {style === 'block' ? (
+        <span className="mb-0.5 h-[70%] w-[55%] rounded-[1px] bg-current" />
+      ) : null}
+      {style === 'underline' ? (
+        <span className="mb-0.5 h-[12%] w-[70%] rounded-[1px] bg-current" />
+      ) : null}
+      {style === 'bar' ? (
+        <span className="mb-0.5 h-[75%] w-[12%] rounded-[1px] bg-current" />
+      ) : null}
+    </span>
+  );
+}
+
+function makeCursorStyleTabIcon(
+  style: TerminalCursorStyle,
+  blink: boolean,
+  active: boolean,
+): React.ComponentType<{ className?: string; size?: number }> {
+  return function CursorStyleTabIcon({ className, size }) {
+    return (
+      <CursorStylePreviewIcon
+        style={style}
+        blink={blink}
+        active={active}
+        className={className}
+        size={size}
+      />
+    );
+  };
+}
+
+/**
+ * Terminal appearance settings group (cursor style + blink).
+ * Owns its store load and expand state so TerminalSettingsSection stays thinner.
+ */
+export function TerminalCursorAppearanceSettings() {
+  const t = useTranslations('settings.terminalSection');
+  const {
+    cursorStyle,
+    cursorBlink,
+    loadSettings: loadTerminalAppearanceSettings,
+    setCursorStyle,
+    setCursorBlink,
+  } = useTerminalAppearanceSettingsStore();
+  const [appearanceExpanded, setAppearanceExpanded] = React.useState(true);
+
+  React.useEffect(() => {
+    void loadTerminalAppearanceSettings();
+  }, [loadTerminalAppearanceSettings]);
+
+  const cursorStyleIndex = Math.max(0, TERMINAL_CURSOR_STYLES.indexOf(cursorStyle));
+  const cursorStyleOptions = React.useMemo(
+    () =>
+      TERMINAL_CURSOR_STYLES.map((style) => ({
+        style,
+        label: t(`cursorStyle.options.${style}`),
+        icon: makeCursorStyleTabIcon(style, cursorBlink, style === cursorStyle),
+      })),
+    [cursorBlink, cursorStyle, t],
+  );
+
+  return (
+    <>
+      <style>
+        {`@keyframes atmos-cursor-blink{0%,49%{opacity:1}50%,100%{opacity:0}}`}
+      </style>
+      <SettingsGroupCard
+        open={appearanceExpanded}
+        onOpenChange={setAppearanceExpanded}
+        icon={Palette}
+        title={t('groups.appearance.title')}
+        description={t('groups.appearance.description')}
+      >
+        <SettingsGroupRow
+          title={t('cursorStyle.title')}
+          description={t('cursorStyle.description')}
+          wide
+        >
+          <TabsSubtle
+            idPrefix="terminal-cursor-style"
+            activeLabel
+            selectedIndex={cursorStyleIndex}
+            onSelect={(index) => {
+              const next = TERMINAL_CURSOR_STYLES[index];
+              if (next) void setCursorStyle(next);
+            }}
+            className="justify-end"
+          >
+            {cursorStyleOptions.map((option, index) => (
+              <TabsSubtleItem
+                key={option.style}
+                index={index}
+                label={option.label}
+                icon={option.icon}
+              />
+            ))}
+          </TabsSubtle>
+        </SettingsGroupRow>
+        <SettingsGroupRow
+          title={t('cursorBlink.title')}
+          description={t('cursorBlink.description')}
+        >
+          <Switch
+            checked={cursorBlink}
+            onCheckedChange={(value) => void setCursorBlink(!!value)}
+            aria-label={t('cursorBlink.title')}
+          />
+        </SettingsGroupRow>
+      </SettingsGroupCard>
+    </>
+  );
+}

--- a/apps/web/src/features/settings/components/TerminalSettingsSection.tsx
+++ b/apps/web/src/features/settings/components/TerminalSettingsSection.tsx
@@ -10,9 +10,6 @@ import {
   DropdownMenuTrigger,
   Input,
   Switch,
-  TabsSubtle,
-  TabsSubtleItem,
-  cn,
 } from '@workspace/ui';
 import {
   Check,
@@ -21,7 +18,6 @@ import {
   Keyboard,
   Link2,
   MessageSquareText,
-  Palette,
 } from 'lucide-react';
 import type { TerminalFileLinkOpenMode } from '@/features/settings/store/terminal-link-settings-store';
 import {
@@ -30,11 +26,6 @@ import {
   TERMINAL_SIDE_CONTEXT_PROMPT_BUDGET_STEP_BYTES,
   normalizeTerminalSideContextPromptBudgetBytes,
 } from '@/features/settings/store/terminal-side-chat-settings-store';
-import {
-  TERMINAL_CURSOR_STYLES,
-  type TerminalCursorStyle,
-  useTerminalAppearanceSettingsStore,
-} from '@/features/settings/store/terminal-appearance-settings-store';
 import {
   QUICK_OPEN_APP_MAP,
   QUICK_OPEN_APP_OPTIONS,
@@ -47,67 +38,7 @@ import {
 } from '@/features/settings/components/settings/SettingsGroupCard';
 import { AgentSelect, AGENT_OPTIONS } from '@/features/wiki/components/AgentSelect';
 import { useTerminalSplitPrefsStore } from '@/features/settings/store/terminal-split-prefs-store';
-
-/** Mini caret glyph used as TabsSubtle icons + live blink preview. */
-function CursorStylePreviewIcon({
-  style,
-  blink,
-  active,
-  className,
-  size = 16,
-}: {
-  style: TerminalCursorStyle;
-  blink: boolean;
-  active: boolean;
-  className?: string;
-  size?: number;
-}) {
-  const shouldBlink = active && blink;
-  return (
-    <span
-      className={cn(
-        'relative inline-flex shrink-0 items-end justify-center text-current',
-        className,
-      )}
-      style={{
-        width: size,
-        height: size,
-        animation: shouldBlink
-          ? 'atmos-cursor-blink 1.06s step-end infinite'
-          : undefined,
-      }}
-      aria-hidden
-    >
-      {style === 'block' ? (
-        <span className="mb-0.5 h-[70%] w-[55%] rounded-[1px] bg-current" />
-      ) : null}
-      {style === 'underline' ? (
-        <span className="mb-0.5 h-[12%] w-[70%] rounded-[1px] bg-current" />
-      ) : null}
-      {style === 'bar' ? (
-        <span className="mb-0.5 h-[75%] w-[12%] rounded-[1px] bg-current" />
-      ) : null}
-    </span>
-  );
-}
-
-function makeCursorStyleTabIcon(
-  style: TerminalCursorStyle,
-  blink: boolean,
-  active: boolean,
-): React.ComponentType<{ className?: string; size?: number }> {
-  return function CursorStyleTabIcon({ className, size }) {
-    return (
-      <CursorStylePreviewIcon
-        style={style}
-        blink={blink}
-        active={active}
-        className={className}
-        size={size}
-      />
-    );
-  };
-}
+import { TerminalCursorAppearanceSettings } from '@/features/settings/components/TerminalCursorAppearanceSettings';
 
 export function TerminalSettingsSection({
   fileLinkOpenMode,
@@ -153,14 +84,6 @@ export function TerminalSettingsSection({
     setRunConfig: setDefaultSplitAgentRunConfig,
     setApplyToNewTerminalTab,
   } = useTerminalSplitPrefsStore();
-  const {
-    cursorStyle,
-    cursorBlink,
-    loadSettings: loadTerminalAppearanceSettings,
-    setCursorStyle,
-    setCursorBlink,
-  } = useTerminalAppearanceSettingsStore();
-  const [appearanceExpanded, setAppearanceExpanded] = React.useState(true);
   const [behaviorExpanded, setBehaviorExpanded] = React.useState(true);
   const [richInputExpanded, setRichInputExpanded] = React.useState(true);
   const [sideChatExpanded, setSideChatExpanded] = React.useState(true);
@@ -198,19 +121,7 @@ export function TerminalSettingsSection({
 
   React.useEffect(() => {
     void loadTerminalSplitPrefs();
-    void loadTerminalAppearanceSettings();
-  }, [loadTerminalAppearanceSettings, loadTerminalSplitPrefs]);
-
-  const cursorStyleIndex = Math.max(0, TERMINAL_CURSOR_STYLES.indexOf(cursorStyle));
-  const cursorStyleOptions = React.useMemo(
-    () =>
-      TERMINAL_CURSOR_STYLES.map((style) => ({
-        style,
-        label: t(`cursorStyle.options.${style}`),
-        icon: makeCursorStyleTabIcon(style, cursorBlink, style === cursorStyle),
-      })),
-    [cursorBlink, cursorStyle, t],
-  );
+  }, [loadTerminalSplitPrefs]);
 
   React.useEffect(() => {
     setLocalSideContextBudget(sideContextPromptBudgetBytes.toString());
@@ -284,52 +195,7 @@ export function TerminalSettingsSection({
 
   return (
     <div className="space-y-4">
-      <style>
-        {`@keyframes atmos-cursor-blink{0%,49%{opacity:1}50%,100%{opacity:0}}`}
-      </style>
-      <SettingsGroupCard
-        open={appearanceExpanded}
-        onOpenChange={setAppearanceExpanded}
-        icon={Palette}
-        title={t('groups.appearance.title')}
-        description={t('groups.appearance.description')}
-      >
-        <SettingsGroupRow
-          title={t('cursorStyle.title')}
-          description={t('cursorStyle.description')}
-          wide
-        >
-          <TabsSubtle
-            idPrefix="terminal-cursor-style"
-            activeLabel
-            selectedIndex={cursorStyleIndex}
-            onSelect={(index) => {
-              const next = TERMINAL_CURSOR_STYLES[index];
-              if (next) void setCursorStyle(next);
-            }}
-            className="justify-end"
-          >
-            {cursorStyleOptions.map((option, index) => (
-              <TabsSubtleItem
-                key={option.style}
-                index={index}
-                label={option.label}
-                icon={option.icon}
-              />
-            ))}
-          </TabsSubtle>
-        </SettingsGroupRow>
-        <SettingsGroupRow
-          title={t('cursorBlink.title')}
-          description={t('cursorBlink.description')}
-        >
-          <Switch
-            checked={cursorBlink}
-            onCheckedChange={(value) => void setCursorBlink(!!value)}
-            aria-label={t('cursorBlink.title')}
-          />
-        </SettingsGroupRow>
-      </SettingsGroupCard>
+      <TerminalCursorAppearanceSettings />
 
       <SettingsGroupCard
         open={behaviorExpanded}

--- a/automations/review/quality/result/2026-08/08-06_score-78_RESULT.md
+++ b/automations/review/quality/result/2026-08/08-06_score-78_RESULT.md
@@ -1,0 +1,170 @@
+# Atmos main 每日代码质量评分（2026-08-06）
+
+## 1. 审查范围
+
+- 昨日时间窗口：2026-08-06 00:00:00 到 2026-08-06 23:59:59（UTC+8 / Asia/Shanghai）。
+- 分支：`main`（日终 tip `dd75f5f11`；窗口前 tip `bdd1b2474` 所在 first-parent 之前另有 08-05 晚间提交，审查以 **提交时间戳落在窗口内** 的 origin/main 可达提交为准）。
+- 排除：窗口内无「只改 `automations/review/quality/result/`」的 automation 归档提交。
+- 审查方式：以窗口内 27 个非 merge + 2 个 merge 提交为主，重点覆盖 worktree diff 内联编辑、agent attention latch、terminal center-tab / cursor、sidebar agent+PR 状态、Desktop Use grant overlay、Desktop packaging。
+- 本地用户工作区在无关 feature 分支；审查与修复在独立 worktree `grokbuild/quality-fix/2026-08-06` 完成，未覆盖用户改动。
+
+被审查提交（含 merge，按时间）：
+
+| Hash | Author | Message |
+| --- | --- | --- |
+| `8842c9654` | AarynLu | feat(desktop-use): native highlight binary and Electron grant overlay |
+| `c3649a2d1` | AarynLu | feat(agent): sticky attention latches and idle/dismiss hooks |
+| `10c15826e` | AarynLu | feat(terminal): center-tab presentation and agent name titles |
+| `e47016efc` | AarynLu | feat(web): configurable agent activity indicators |
+| `96f1e5958` | AarynLu | refactor(ui): use border-beam package and dialog polish |
+| `9f61c7f26` | AarynLu | fix(web): shell chrome, surface policies, and i18n polish |
+| `d75b7aeb2` | AarynLu | feat(shared/terminal): stabilize center-tab OSC session titles |
+| `ccce0d50b` | AarynLu | feat(web): add terminal cursor appearance settings |
+| `611232cf8` | AarynLu | fix(terminal): zero scrollback only for inline mouse TUIs |
+| `3696f107b` | AarynLu | fix(web): keep warm terminal chrome from painting over light surfaces |
+| `b3490bd70` | AarynLu | feat(web): show workspace agent and PR status on sidebar rows |
+| `8a4207efa` | AarynLu | feat(web): polish agent activity indicator picker |
+| `a5ffb7eb0` | AarynLu | feat(web): improve Appshots history popover UX |
+| `c01090a67` | AarynLu | fix(web): polish Desktop Use readiness and permissions UX |
+| `d90667882` | AarynLu | chore(desktop): unify host and notification icons with legacy regen |
+| `c8ed993b0` | AarynLu | fix(web): stabilize commit message field and refresh tab chrome |
+| `963563e55` | AarynLu | docs: English UI casing rule and icon regen notes |
+| `000b8b68a` | AarynLu | feat(release): inject desktop Download section and Contributors mentions |
+| `dd4ef818b` | AarynLu | chore(deps): bump Next.js to 16.3.0 and @pierre/diffs to 1.3.4 |
+| `81aed8489` | AarynLu | feat(web): allow inline edit of worktree diffs in Changes view |
+| `6f72615e4` | AarynLu | fix(diff): smooth edit-toolbar collapse and use SquarePen icon |
+| `125490723` | AarynLu | fix(editor): refresh git gutter live while typing and after save |
+| `9bf93d587` | AarynLu | Merge remote-tracking branch 'origin/main' into feat/app-053-browser-use-embedded |
+| `6293ccc1c` | AruNi_Lu | Merge pull request #204 from AruNi-01/feat/app-053-browser-use-embedded |
+| `89a6dccfc` | AarynLu | chore(desktop-electron): release 2026.8.6-beta.1 |
+| `bab1dd2e5` | AarynLu | fix(web): add scrollMargin to MockIntersectionObserver for Next 16.3 types |
+| `0d3ed7b17` | AarynLu | chore(desktop-electron): release 2026.8.6-beta.2 |
+| `df43c9707` | AarynLu | fix(desktop): use webpack for desktop web static export on all platforms |
+| `dd75f5f11` | AarynLu | chore(desktop-electron): release 2026.8.6-beta.3 |
+
+## 2. 一份好代码应该是什么样
+
+本次标准看「新能力是否把状态机、纯规则和 UI 编排拆开」。worktree 内联编辑应把 draft/save/stage 会话与 pierre 视图编排隔离；sticky attention 应是可导航的子域，而不是继续塞进已超千行的 `agent_hooks` 主文件；sidebar 的 agent/PR 展示应像已做的那样沉淀纯 presentation + hook；设置页新增外观块应自包含，而不是把 `TerminalSettingsSection` 继续拉长。
+
+## 3. 评分方法
+
+- 100 分制：设计与分层 30、可读性与复杂度 25、体量与内聚 20、可维护性与复用 15、工程卫生 10。
+- 高/中/低严重度分别约扣 8–15 / 3–7 / 1–2 分；同一根因不重复计数。
+- 体量阈值作信号：服务文件 800+、UI/hook 400+、单函数 80+ 且职责混杂时才明确扣分。
+- 不把历史债务整包算到当日；只计当日引入、放大或固化的结构问题。正向拆分（pure lib + tests）计入观察，不机械抵消。
+
+## 4. 总分
+
+总分：78/100。总体判断：良好。
+
+当日交付面广且多项能力抽出了纯模块与单测，但 Changes 内联编辑把已偏大的 `ChangesCodeView` 推到 1100+ 行枢纽，attention latch 又把 `agent_hooks.rs` 从 ~1109 抬到 ~1409，terminal 枢纽与设置页也继续长大。结构方向总体正确，枢纽膨胀需要尽快收口。
+
+## 5. 分项评分
+
+| 维度 | 得分 | 扣分原因 |
+| --- | ---: | --- |
+| 设计与分层 | 24/30 | 正向：`terminal-center-tab-presentation`、`workspace-pr-status`、`workspace-agent-status`、`agent-activity-indicator-styles`、`AgentRunningGlyph`、grant-overlay 自成模块。扣分：worktree 编辑会话嵌在 Changes 视图总编排里；attention latch 逻辑落在已巨大的 hooks service 而非子模块。 |
+| 可读性与复杂度 | 20/25 | 编辑路径依赖多份 state+ref 镜像与 pierre item 重建时序；`Terminal.tsx` 在既有超长组件上继续叠 TUI/cursor/title 行为。 |
+| 体量与内聚 | 13/20 | 日终：`ChangesCodeView` ~1117（+353）、`Terminal.tsx` ~1634、`agent_hooks.rs` ~1409（+300）、`TerminalAgentInputOverlay` ~1383、`TerminalSettingsSection` ~577、`WorkspaceKanbanCard` ~601。 |
+| 可维护性与复用 | 12/15 | 正向：PR/agent status 与 center-tab 规则可单测复用。扣分：编辑逻辑未抽 hook，后续若 commit/review 视图也要编辑会复制；cursor 外观 UI 与其它设置组仍耦在同一文件。 |
+| 工程卫生 | 9/10 | 大量 structural/unit 测试、NOTICE/orbs 归属、release notes 脚本拆分、webpack 平台注释清晰；编辑状态双写（state + ref）偏啰嗦，轻微扣分。 |
+
+## 6. 主要问题清单
+
+### 中：`ChangesCodeView` 吸收完整 worktree 内联编辑会话，体量突破高风险区
+
+- 提交：`81aed8489`、`6f72615e4`
+- 文件：`apps/web/src/features/diff/components/ChangesCodeView.tsx`（~764 → ~1117）
+- 问题：enter/exit/save/reset、Cmd/Ctrl+S、staged 写回 `stageFiles`、draft Map、编辑态 state/ref 同步、工具栏动画按钮全部堆进同一组件；`export function ChangesCodeView` 本体约 980+ 行。
+- 为什么是质量问题：后续改 diff 加载批处理或改编辑协议必须通读整份枢纽；编辑状态机与视图编排耦合，回归面过大。
+- 优化建议：抽出 `useDiffWorktreeEdit`（会话状态 + save/stage + 快捷键）与 `DiffWorktreeEditToolbar`（按钮呈现）；纯函数 `rebuildDiffItem` / 路径拼接放进 hook 或 `lib/`。
+
+### 中：`agent_hooks.rs` 再增 sticky attention latch，服务文件继续膨胀
+
+- 提交：`c3649a2d1`
+- 文件：`crates/core-service/src/service/agent_hooks.rs`（~1109 → ~1409）
+- 问题：`AgentAttentionLatch` 类型、`maybe_raise_attention` / `clear_attention_matching_ids` / broadcast 与 4 个单测直接写在主文件；与既有 session/child lifecycle 编排混读。
+- 为什么是质量问题：目录下已有 `agent_hooks/child_lifecycle.rs` 拆分先例，attention 作为独立子域却未跟进，导航与冲突合并成本上升。
+- 优化建议：新增 `agent_hooks/attention.rs`，用 `impl AgentHooksService` 承载 latch API 与测试（与 `child_lifecycle` 同模式），主文件只保留字段与 `update_state` 调用点。
+
+### 中：`Terminal.tsx` / `TerminalAgentInputOverlay` 枢纽继续放大
+
+- 提交：`10c15826e`、`611232cf8`、`3696f107b`
+- 文件：`apps/web/src/features/terminal/components/Terminal.tsx`（~1506 → ~1634）、`TerminalAgentInputOverlay.tsx`（~1383）
+- 问题：center-tab presentation 已正确抽到 pure lib，但 TUI scrollback 策略、cursor appearance 接线、warm chrome 仍改在超大组件内。
+- 为什么是质量问题：历史枢纽未减负，当日改动继续抬高阅读成本。
+- 优化建议：后续把 xterm option 同步（cursor style/blink）与 mouse/scrollback policy 接线收到 `useTerminalXtermAppearance` / 既有 `tui-mouse-*` 边界；overlay 的 surface 可见性策略保持策略表 + 小组件。
+
+### 低：`TerminalSettingsSection` 因 cursor 外观再增约 140 行
+
+- 提交：`ccce0d50b`
+- 文件：`apps/web/src/features/settings/components/TerminalSettingsSection.tsx`（~440 → ~577）
+- 问题：预览 icon、TabsSubtle 选项与 blink Switch 与行为/性能设置同文件。
+- 为什么是质量问题：设置组本可自包含，继续堆叠会让下一次外观迭代更难定位。
+- 优化建议：`TerminalCursorAppearanceSettings` 组件拥有 store load 与 expand 状态，主 section 只挂载。
+
+### 低：`WorkspaceKanbanCard` / `AppshotsHistoryPopover` 接近或超过 UI 中风险阈值
+
+- 提交：`b3490bd70`、`a5ffb7eb0`
+- 文件：`WorkspaceKanbanCard.tsx` ~601、`AppshotsHistoryPopover.tsx` ~585
+- 问题：PR 状态接线与 history UX 完善合理，且已抽 pure lib/hook；卡片/弹层 JSX 仍偏长。
+- 为什么是质量问题：中期若继续加 status chrome 会再次混职责。
+- 优化建议：Kanban 卡内 PR 行可下沉为 `WorkspacePrLeadingSlot`；Appshots 列表项抽 `AppshotHistoryRow`。
+
+## 7. 正向观察
+
+- **纯规则模块 + 测试**：`terminal-center-tab-presentation`、`workspace-pr-status`、`workspace-agent-status`、`agent-activity-indicator-styles` 边界清晰，便于无 UI 回归。
+- **Agent 指示器拆分**：`AgentRunningGlyph` + settings picker 预览 mock 分离良好；Orbs 带 NOTICE/归属注释。
+- **Desktop Use grant overlay**：独立 `grant-overlay.ts` + structural test + preload，HTML 面板自包含。
+- **Release 管线**：`append-desktop-download-section.mjs` 与 electron release notes 测试增强，平台 webpack 路径有明确注释。
+- **merge #204 后** surface-manager / BrowserSession 体量相对前日略降（历史债有收敛迹象，不归当日新债）。
+
+## 8. Review 建议
+
+人工 review 优先盯：
+
+1. Changes 内联编辑：未保存切换文件、staged 写回、Cmd-S 与 pierre `item.edit` 重建时序。
+2. Attention latch：refresh 恢复、focus 清除、QuietIdle 不抬 task-complete、与 child lifecycle 的交叉。
+3. Terminal center-tab sticky OSC 与 cursor appearance 是否只在该接线层改动。
+4. 是否还有新的 800+ 枢纽在当日被继续堆功能（尤其 Terminal / Changes）。
+
+## 9. 自动修复与 PR
+
+总分 78 < 90，已触发自动修复。
+
+### 修复摘要
+
+1. **Changes 内联编辑拆分**  
+   - 新增 `useDiffWorktreeEdit.tsx`（会话状态、save/stage、快捷键、`rebuildDiffItem`）  
+   - 新增 `DiffWorktreeEditToolbar.tsx`（Edit/Save/Reset 控件）  
+   - `ChangesCodeView.tsx` 约 1117 → ~818 行
+
+2. **Agent attention 子模块**  
+   - 新增 `crates/core-service/src/service/agent_hooks/attention.rs`  
+   - 类型、API、broadcast 与 4 个单测迁出；`agent_hooks.rs` 约 1409 → ~1129 行，并 `pub use` 保持对外类型路径
+
+3. **Terminal cursor 设置自包含**  
+   - 新增 `TerminalCursorAppearanceSettings.tsx`  
+   - `TerminalSettingsSection.tsx` 约 577 → ~443 行
+
+### 验证
+
+- `cargo test -p core-service --lib agent_hooks`：68 passed
+- `bun --filter web typecheck`：通过
+- pre-commit `cargo fmt`：通过
+- 未跑全量 `just test` / E2E（与改动无关的历史成本过高）；编辑行为需人工点验
+
+### 剩余风险
+
+- `Terminal.tsx` / `TerminalAgentInputOverlay` 枢纽未在本次大幅拆分（风险高、行为面宽，避免无测试大挪）。
+- 编辑流程依赖 pierre 运行时，建议在 PR 上手工验证 staged/unstaged 保存与未保存切换 toast。
+
+## 10. 结果文件
+
+- `automations/review/quality/result/2026-08/08-06_score-78_RESULT.md`
+
+## 11. 结果提交与推送
+
+- 修复分支：`grokbuild/quality-fix/2026-08-06`
+- 修复提交：`2df44a0af`（结果文件随后续提交纳入同一 PR）
+- PR URL：见创建后回填

--- a/automations/review/quality/result/2026-08/08-06_score-78_RESULT.md
+++ b/automations/review/quality/result/2026-08/08-06_score-78_RESULT.md
@@ -167,4 +167,4 @@
 
 - 修复分支：`grokbuild/quality-fix/2026-08-06`
 - 修复提交：`2df44a0af`（结果文件随后续提交纳入同一 PR）
-- PR URL：见创建后回填
+- PR URL：https://github.com/AruNi-01/atmos/pull/208

--- a/crates/core-service/src/service/agent_hooks.rs
+++ b/crates/core-service/src/service/agent_hooks.rs
@@ -1,5 +1,6 @@
 mod ampcode;
 mod antigravity;
+mod attention;
 mod child_agent;
 mod child_lifecycle;
 mod claude_code;
@@ -26,6 +27,7 @@ use tracing::{debug, info, warn};
 
 use super::notification::NotificationService;
 
+pub use attention::{AgentAttentionLatch, AgentAttentionReason};
 pub(super) use child_agent::{extract_child_agent_id, is_child_start_event, is_child_stop_event};
 
 /// How long late mid-turn progress events are ignored after a terminal idle /
@@ -160,37 +162,6 @@ pub struct AgentHookStateUpdate {
     pub hook_version: Option<u32>,
 }
 
-/// Sticky "needs attention" reason (mirrors the web client latch).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum AgentAttentionReason {
-    PermissionRequest,
-    TaskComplete,
-}
-
-impl AgentAttentionReason {
-    fn priority(self) -> u8 {
-        match self {
-            Self::PermissionRequest => 2,
-            Self::TaskComplete => 1,
-        }
-    }
-}
-
-/// In-memory sticky attention latch for a terminal pane.
-/// Survives browser refresh until the user acknowledges the pane.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AgentAttentionLatch {
-    pub stable_pane_id: String,
-    pub context_id: String,
-    pub reason: AgentAttentionReason,
-    pub session_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tool: Option<AgentToolType>,
-    /// RFC3339 timestamp when the latch was raised (or last upgraded).
-    pub raised_at: String,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AgentHookEvent {
@@ -274,10 +245,6 @@ impl AgentHooksService {
 
     pub fn get_all_sessions(&self) -> Vec<AgentHookSession> {
         self.sessions.read().values().cloned().collect()
-    }
-
-    pub fn get_all_attention(&self) -> Vec<AgentAttentionLatch> {
-        self.attention.read().values().cloned().collect()
     }
 
     pub fn remove_session(&self, session_id: &str) -> bool {
@@ -660,140 +627,6 @@ impl AgentHooksService {
         }
     }
 
-    fn context_id_from_stable_pane_id(stable_pane_id: &str) -> String {
-        match stable_pane_id.split_once(':') {
-            Some((ctx, _)) if !ctx.is_empty() => ctx.to_string(),
-            _ => stable_pane_id.to_string(),
-        }
-    }
-
-    fn resolve_stable_pane_id(update: &AgentHookStateUpdate) -> String {
-        update
-            .pane_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .unwrap_or(update.session_id.as_str())
-            .to_string()
-    }
-
-    /// Raise a sticky attention latch when the agent needs the user (permission
-    /// or task complete). Survives browser refresh until acknowledged.
-    fn maybe_raise_attention(
-        &self,
-        previous_state: Option<AgentHookState>,
-        update: &AgentHookStateUpdate,
-        kind: StateUpdateKind,
-    ) {
-        // QuietIdle settles child-only work without a new task-complete signal.
-        if kind == StateUpdateKind::QuietIdle {
-            return;
-        }
-
-        let reason = if update.state == AgentHookState::PermissionRequest
-            && previous_state != Some(AgentHookState::PermissionRequest)
-        {
-            Some(AgentAttentionReason::PermissionRequest)
-        } else if update.state == AgentHookState::Idle
-            && previous_state == Some(AgentHookState::Running)
-        {
-            Some(AgentAttentionReason::TaskComplete)
-        } else {
-            None
-        };
-
-        let Some(reason) = reason else {
-            return;
-        };
-
-        let stable_pane_id = Self::resolve_stable_pane_id(update);
-        if stable_pane_id.is_empty() {
-            return;
-        }
-        let context_id = update
-            .context_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(str::to_string)
-            .unwrap_or_else(|| Self::context_id_from_stable_pane_id(&stable_pane_id));
-        if context_id.is_empty() {
-            return;
-        }
-
-        self.raise_attention(AgentAttentionLatch {
-            stable_pane_id,
-            context_id,
-            reason,
-            session_id: update.session_id.clone(),
-            tool: Some(update.tool),
-            raised_at: Utc::now().to_rfc3339(),
-        });
-    }
-
-    pub fn raise_attention(&self, mut latch: AgentAttentionLatch) {
-        if latch.stable_pane_id.trim().is_empty() || latch.context_id.trim().is_empty() {
-            return;
-        }
-        latch.stable_pane_id = latch.stable_pane_id.trim().to_string();
-        latch.context_id = latch.context_id.trim().to_string();
-
-        let latch = {
-            let mut attention = self.attention.write();
-            if let Some(existing) = attention.get(&latch.stable_pane_id) {
-                // Keep the higher-urgency reason if both fire close together.
-                if existing.reason.priority() > latch.reason.priority() {
-                    return;
-                }
-            }
-            attention.insert(latch.stable_pane_id.clone(), latch.clone());
-            latch
-        };
-        self.broadcast_attention_raised(latch);
-    }
-
-    /// Clear sticky attention for a focused/acknowledged pane (and session aliases).
-    pub fn clear_attention_for_pane(&self, stable_pane_id: &str) -> Vec<String> {
-        let pane_id = stable_pane_id.trim();
-        if pane_id.is_empty() {
-            return Vec::new();
-        }
-        self.clear_attention_matching_ids(&[pane_id.to_string()])
-    }
-
-    /// Clear latches whose map key or stored `session_id` matches any of `ids`.
-    pub fn clear_attention_matching_ids(&self, ids: &[String]) -> Vec<String> {
-        let id_set: HashSet<&str> = ids
-            .iter()
-            .map(String::as_str)
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .collect();
-        if id_set.is_empty() {
-            return Vec::new();
-        }
-
-        let cleared: Vec<String> = {
-            let mut attention = self.attention.write();
-            let to_clear: Vec<String> = attention
-                .iter()
-                .filter(|(key, latch)| {
-                    id_set.contains(key.as_str()) || id_set.contains(latch.session_id.as_str())
-                })
-                .map(|(key, _)| key.clone())
-                .collect();
-            for key in &to_clear {
-                attention.remove(key);
-            }
-            to_clear
-        };
-
-        if !cleared.is_empty() {
-            self.broadcast_attention_cleared(cleared.clone());
-        }
-        cleared
-    }
-
     fn is_running_suppressed(&self, session_id: &str) -> bool {
         let now = Utc::now();
         let mut guard = self.suppress_running_until.write();
@@ -823,25 +656,6 @@ impl AgentHooksService {
             .send(AgentHookEvent::SessionsCleared { session_ids })
         {
             warn!("Failed to publish agent hook sessions cleared: {}", error);
-        }
-    }
-
-    fn broadcast_attention_raised(&self, latch: AgentAttentionLatch) {
-        debug!(
-            "Publishing attention raised: pane={} reason={:?}",
-            latch.stable_pane_id, latch.reason
-        );
-        if let Err(error) = self.event_tx.send(AgentHookEvent::AttentionRaised(latch)) {
-            warn!("Failed to publish agent attention raised: {}", error);
-        }
-    }
-
-    fn broadcast_attention_cleared(&self, stable_pane_ids: Vec<String>) {
-        if let Err(error) = self
-            .event_tx
-            .send(AgentHookEvent::AttentionCleared { stable_pane_ids })
-        {
-            warn!("Failed to publish agent attention cleared: {}", error);
         }
     }
 
@@ -1306,104 +1120,5 @@ mod tests {
             AgentHookState::Idle,
             "untracked late AskUser must not resurrect need-attention"
         );
-    }
-
-    #[test]
-    fn running_to_idle_raises_task_complete_attention() {
-        let service = AgentHooksService::new();
-        let ctx = ctx_with_pane("ws-1:main");
-        service.update_state(
-            "ws-1:main",
-            AgentToolType::ClaudeCode,
-            AgentHookState::Running,
-            Some("/tmp/p".into()),
-            &ctx,
-            StateUpdateKind::NewTurn,
-        );
-        service.update_state(
-            "ws-1:main",
-            AgentToolType::ClaudeCode,
-            AgentHookState::Idle,
-            Some("/tmp/p".into()),
-            &ctx,
-            StateUpdateKind::TerminalIdle,
-        );
-        let attention = service.get_all_attention();
-        assert_eq!(attention.len(), 1);
-        assert_eq!(attention[0].stable_pane_id, "ws-1:main");
-        assert_eq!(attention[0].context_id, "ws-1");
-        assert_eq!(attention[0].reason, AgentAttentionReason::TaskComplete);
-    }
-
-    #[test]
-    fn permission_raises_attention_and_survives_idle_session_clear() {
-        let service = AgentHooksService::new();
-        let ctx = ctx_with_pane("ws-1:main");
-        service.update_state(
-            "ws-1:main",
-            AgentToolType::ClaudeCode,
-            AgentHookState::PermissionRequest,
-            Some("/tmp/p".into()),
-            &ctx,
-            StateUpdateKind::Permission,
-        );
-        assert_eq!(service.get_all_attention().len(), 1);
-        assert_eq!(
-            service.get_all_attention()[0].reason,
-            AgentAttentionReason::PermissionRequest
-        );
-        // Idle sweeper must not drop sticky attention — only user acknowledge does.
-        service.force_session_idle("ws-1:main");
-        service.clear_idle_sessions();
-        assert!(service.get_all_sessions().is_empty());
-        assert_eq!(service.get_all_attention().len(), 1);
-    }
-
-    #[test]
-    fn clear_attention_for_pane_drops_latch() {
-        let service = AgentHooksService::new();
-        let ctx = ctx_with_pane("ws-1:main");
-        service.update_state(
-            "ws-1:main",
-            AgentToolType::ClaudeCode,
-            AgentHookState::Running,
-            Some("/tmp/p".into()),
-            &ctx,
-            StateUpdateKind::NewTurn,
-        );
-        service.update_state(
-            "ws-1:main",
-            AgentToolType::ClaudeCode,
-            AgentHookState::Idle,
-            Some("/tmp/p".into()),
-            &ctx,
-            StateUpdateKind::TerminalIdle,
-        );
-        let cleared = service.clear_attention_for_pane("ws-1:main");
-        assert_eq!(cleared, vec!["ws-1:main".to_string()]);
-        assert!(service.get_all_attention().is_empty());
-    }
-
-    #[test]
-    fn quiet_idle_does_not_raise_task_complete_attention() {
-        let service = AgentHooksService::new();
-        let ctx = ctx_with_pane("ws-1:main");
-        service.update_state(
-            "ws-1:main",
-            AgentToolType::ClaudeCode,
-            AgentHookState::Running,
-            Some("/tmp/p".into()),
-            &ctx,
-            StateUpdateKind::NewTurn,
-        );
-        service.update_state(
-            "ws-1:main",
-            AgentToolType::ClaudeCode,
-            AgentHookState::Idle,
-            Some("/tmp/p".into()),
-            &ctx,
-            StateUpdateKind::QuietIdle,
-        );
-        assert!(service.get_all_attention().is_empty());
     }
 }

--- a/crates/core-service/src/service/agent_hooks/attention.rs
+++ b/crates/core-service/src/service/agent_hooks/attention.rs
@@ -1,0 +1,318 @@
+//! Sticky attention latches for agent panes.
+//!
+//! Latches are independent of idle session rows so browser refresh still shows
+//! need-attention until the user focuses/acknowledges the pane.
+
+use std::collections::HashSet;
+
+use chrono::Utc;
+use tracing::{debug, warn};
+
+use super::{
+    AgentHookEvent, AgentHookState, AgentHookStateUpdate, AgentHooksService, AgentToolType,
+    StateUpdateKind,
+};
+
+/// Sticky "needs attention" reason (mirrors the web client latch).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentAttentionReason {
+    PermissionRequest,
+    TaskComplete,
+}
+
+impl AgentAttentionReason {
+    pub(super) fn priority(self) -> u8 {
+        match self {
+            Self::PermissionRequest => 2,
+            Self::TaskComplete => 1,
+        }
+    }
+}
+
+/// In-memory sticky attention latch for a terminal pane.
+/// Survives browser refresh until the user acknowledges the pane.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AgentAttentionLatch {
+    pub stable_pane_id: String,
+    pub context_id: String,
+    pub reason: AgentAttentionReason,
+    pub session_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool: Option<AgentToolType>,
+    /// RFC3339 timestamp when the latch was raised (or last upgraded).
+    pub raised_at: String,
+}
+
+impl AgentHooksService {
+    pub fn get_all_attention(&self) -> Vec<AgentAttentionLatch> {
+        self.attention.read().values().cloned().collect()
+    }
+
+    fn context_id_from_stable_pane_id(stable_pane_id: &str) -> String {
+        match stable_pane_id.split_once(':') {
+            Some((ctx, _)) if !ctx.is_empty() => ctx.to_string(),
+            _ => stable_pane_id.to_string(),
+        }
+    }
+
+    fn resolve_stable_pane_id(update: &AgentHookStateUpdate) -> String {
+        update
+            .pane_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(update.session_id.as_str())
+            .to_string()
+    }
+
+    /// Raise a sticky attention latch when the agent needs the user (permission
+    /// or task complete). Survives browser refresh until acknowledged.
+    pub(super) fn maybe_raise_attention(
+        &self,
+        previous_state: Option<AgentHookState>,
+        update: &AgentHookStateUpdate,
+        kind: StateUpdateKind,
+    ) {
+        // QuietIdle settles child-only work without a new task-complete signal.
+        if kind == StateUpdateKind::QuietIdle {
+            return;
+        }
+
+        let reason = if update.state == AgentHookState::PermissionRequest
+            && previous_state != Some(AgentHookState::PermissionRequest)
+        {
+            Some(AgentAttentionReason::PermissionRequest)
+        } else if update.state == AgentHookState::Idle
+            && previous_state == Some(AgentHookState::Running)
+        {
+            Some(AgentAttentionReason::TaskComplete)
+        } else {
+            None
+        };
+
+        let Some(reason) = reason else {
+            return;
+        };
+
+        let stable_pane_id = Self::resolve_stable_pane_id(update);
+        if stable_pane_id.is_empty() {
+            return;
+        }
+        let context_id = update
+            .context_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| Self::context_id_from_stable_pane_id(&stable_pane_id));
+        if context_id.is_empty() {
+            return;
+        }
+
+        self.raise_attention(AgentAttentionLatch {
+            stable_pane_id,
+            context_id,
+            reason,
+            session_id: update.session_id.clone(),
+            tool: Some(update.tool),
+            raised_at: Utc::now().to_rfc3339(),
+        });
+    }
+
+    pub fn raise_attention(&self, mut latch: AgentAttentionLatch) {
+        if latch.stable_pane_id.trim().is_empty() || latch.context_id.trim().is_empty() {
+            return;
+        }
+        latch.stable_pane_id = latch.stable_pane_id.trim().to_string();
+        latch.context_id = latch.context_id.trim().to_string();
+
+        let latch = {
+            let mut attention = self.attention.write();
+            if let Some(existing) = attention.get(&latch.stable_pane_id) {
+                // Keep the higher-urgency reason if both fire close together.
+                if existing.reason.priority() > latch.reason.priority() {
+                    return;
+                }
+            }
+            attention.insert(latch.stable_pane_id.clone(), latch.clone());
+            latch
+        };
+        self.broadcast_attention_raised(latch);
+    }
+
+    /// Clear sticky attention for a focused/acknowledged pane (and session aliases).
+    pub fn clear_attention_for_pane(&self, stable_pane_id: &str) -> Vec<String> {
+        let pane_id = stable_pane_id.trim();
+        if pane_id.is_empty() {
+            return Vec::new();
+        }
+        self.clear_attention_matching_ids(&[pane_id.to_string()])
+    }
+
+    /// Clear latches whose map key or stored `session_id` matches any of `ids`.
+    pub fn clear_attention_matching_ids(&self, ids: &[String]) -> Vec<String> {
+        let id_set: HashSet<&str> = ids
+            .iter()
+            .map(String::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect();
+        if id_set.is_empty() {
+            return Vec::new();
+        }
+
+        let cleared: Vec<String> = {
+            let mut attention = self.attention.write();
+            let to_clear: Vec<String> = attention
+                .iter()
+                .filter(|(key, latch)| {
+                    id_set.contains(key.as_str()) || id_set.contains(latch.session_id.as_str())
+                })
+                .map(|(key, _)| key.clone())
+                .collect();
+            for key in &to_clear {
+                attention.remove(key);
+            }
+            to_clear
+        };
+
+        if !cleared.is_empty() {
+            self.broadcast_attention_cleared(cleared.clone());
+        }
+        cleared
+    }
+
+    fn broadcast_attention_raised(&self, latch: AgentAttentionLatch) {
+        debug!(
+            "Publishing attention raised: pane={} reason={:?}",
+            latch.stable_pane_id, latch.reason
+        );
+        if let Err(error) = self.event_tx.send(AgentHookEvent::AttentionRaised(latch)) {
+            warn!("Failed to publish agent attention raised: {}", error);
+        }
+    }
+
+    fn broadcast_attention_cleared(&self, stable_pane_ids: Vec<String>) {
+        if let Err(error) = self
+            .event_tx
+            .send(AgentHookEvent::AttentionCleared { stable_pane_ids })
+        {
+            warn!("Failed to publish agent attention cleared: {}", error);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::agent_hooks::{
+        AgentHookState, AgentHooksService, AgentToolType, AtmosContext, StateUpdateKind,
+    };
+
+    fn ctx_with_pane(pane_id: &str) -> AtmosContext {
+        AtmosContext {
+            pane_id: Some(pane_id.to_string()),
+            ..AtmosContext::default()
+        }
+    }
+
+    #[test]
+    fn running_to_idle_raises_task_complete_attention() {
+        let service = AgentHooksService::new();
+        let ctx = ctx_with_pane("ws-1:main");
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Running,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::NewTurn,
+        );
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Idle,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::TerminalIdle,
+        );
+        let attention = service.get_all_attention();
+        assert_eq!(attention.len(), 1);
+        assert_eq!(attention[0].stable_pane_id, "ws-1:main");
+        assert_eq!(attention[0].context_id, "ws-1");
+        assert_eq!(attention[0].reason, AgentAttentionReason::TaskComplete);
+    }
+
+    #[test]
+    fn permission_raises_attention_and_survives_idle_session_clear() {
+        let service = AgentHooksService::new();
+        let ctx = ctx_with_pane("ws-1:main");
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::PermissionRequest,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::Permission,
+        );
+        assert_eq!(service.get_all_attention().len(), 1);
+        assert_eq!(
+            service.get_all_attention()[0].reason,
+            AgentAttentionReason::PermissionRequest
+        );
+        // Idle sweeper must not drop sticky attention — only user acknowledge does.
+        service.force_session_idle("ws-1:main");
+        service.clear_idle_sessions();
+        assert!(service.get_all_sessions().is_empty());
+        assert_eq!(service.get_all_attention().len(), 1);
+    }
+
+    #[test]
+    fn clear_attention_for_pane_drops_latch() {
+        let service = AgentHooksService::new();
+        let ctx = ctx_with_pane("ws-1:main");
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Running,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::NewTurn,
+        );
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Idle,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::TerminalIdle,
+        );
+        let cleared = service.clear_attention_for_pane("ws-1:main");
+        assert_eq!(cleared, vec!["ws-1:main".to_string()]);
+        assert!(service.get_all_attention().is_empty());
+    }
+
+    #[test]
+    fn quiet_idle_does_not_raise_task_complete_attention() {
+        let service = AgentHooksService::new();
+        let ctx = ctx_with_pane("ws-1:main");
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Running,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::NewTurn,
+        );
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Idle,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::QuietIdle,
+        );
+        assert!(service.get_all_attention().is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Daily code quality review for **2026-08-06** scored **78/100** (良好), triggering auto-fix.

### Original score drivers
- `ChangesCodeView` absorbed full worktree inline-edit session (~764 → ~1117)
- `agent_hooks.rs` grew sticky attention latches (~1109 → ~1409) without a submodule
- `TerminalSettingsSection` grew with cursor appearance (~440 → ~577)
- Terminal mega-components continued to amplify (left as residual risk)

### Fixes in this PR
1. Extract `useDiffWorktreeEdit` + `DiffWorktreeEditToolbar`; slim `ChangesCodeView` (~818)
2. Move attention types/API/tests to `agent_hooks/attention.rs` (~1129 main file); re-export public types
3. Extract `TerminalCursorAppearanceSettings` from `TerminalSettingsSection` (~443)

Report: `automations/review/quality/result/2026-08/08-06_score-78_RESULT.md`

## Related Issue

N/A — Atmos daily quality review automation (2026-08-06).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [x] `just fmt` (via pre-commit `cargo fmt` on Rust files)
- [x] Additional checks:
  - `cargo test -p core-service --lib agent_hooks` → 68 passed
  - `bun --filter web typecheck` → passed

## Checklist

- [x] I updated documentation if behavior changed (quality result report only)
- [x] I added/updated tests where appropriate (attention tests relocated; behavior preserved)
- [x] I followed repository conventions and AGENTS.md guidance

### Residual risk for human review
- Manual verify worktree edit: unsaved switch toast, staged save + re-stage, Cmd/Ctrl+S
- `Terminal.tsx` / `TerminalAgentInputOverlay` hubs not split in this PR (high behavior surface)

---

### Agent
Generated by **Grok Build** · Atmos daily quality review automation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits oversized areas from the 2026-08-06 quality review to lower complexity without changing behavior. Inline diff editing is now a hook + toolbar, agent attention latches live in a submodule, and terminal cursor settings are a small, focused component.

- **Refactors**
  - ChangesCodeView: extracted `useDiffWorktreeEdit` and `DiffWorktreeEditToolbar`; keeps Cmd/Ctrl+S save and staged writes; file size reduced.
  - Core service: moved sticky attention latches to `agent_hooks/attention.rs`; re-exported `AgentAttentionLatch` and `AgentAttentionReason`; tests preserved; main service file slimmed.
  - Settings: extracted `TerminalCursorAppearanceSettings`; `TerminalSettingsSection` simplified and delegates store load/expand to the new component.

<sup>Written for commit f62e0c62075b6ef768f1d5395b8bf798ecefc06e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

