### PR TITLE
refactor: address daily quality findings for 2026-08-07

### DIFF
--- a/apps/desktop-electron/src/desktop-use/grant-overlay-panel.ts
+++ b/apps/desktop-electron/src/desktop-use/grant-overlay-panel.ts
@@ -1,0 +1,428 @@
+/**
+ * Grant overlay panel HTML, copy, and chip icons.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { nativeImage } from "electron";
+import { getResolvedAppIcons } from "../branding.js";
+
+export type GrantOverlayPurpose = "accessibility" | "screen_recording";
+
+export type GrantOverlayOptions = {
+  hostAppPath: string;
+  hostAppName?: string;
+  /** BCP-47-ish language tag; used for in-panel copy. */
+  locale?: string;
+  /** Which Settings pane was opened (affects instruction copy). */
+  purpose?: GrantOverlayPurpose;
+  /**
+   * Screen-point origin for the fly animation (typically the Grant button
+   * center, converted from the host BrowserWindow content bounds).
+   */
+  sourceOrigin?: { x: number; y: number };
+};
+
+export type GrantState = {
+  hostAppPath: string;
+  hostAppName: string;
+  instruction: string;
+  chipLabel: string;
+  /** data:image/... URL for the chip icon, or empty for CSS fallback. */
+  iconDataUrl: string;
+  /**
+   * Pre-rendered full-chip PNG for startDrag ghost (set from renderer after paint).
+   * Falls back to app icon only when missing.
+   */
+  dragPreviewDataUrl: string | null;
+};
+
+export function isZh(locale: string | undefined): boolean {
+  return (locale ?? "").toLowerCase().startsWith("zh");
+}
+
+export function buildInstruction(
+  hostAppName: string,
+  purpose: GrantOverlayPurpose,
+  locale?: string,
+): string {
+  if (isZh(locale)) {
+    // Match macOS System Settings Chinese labels: 无障碍 / 屏幕录制.
+    const goal =
+      purpose === "screen_recording" ? "允许屏幕录制" : "允许无障碍";
+    return `将「${hostAppName}」拖到上方列表以${goal}`;
+  }
+  const goal =
+    purpose === "screen_recording"
+      ? "to allow Screen Recording"
+      : "to allow Accessibility";
+  return `Drag ${hostAppName} to the list above ${goal}`;
+}
+
+function iconRoots(): string[] {
+  const roots: string[] = [];
+  const resourcesPath =
+    typeof process.resourcesPath === "string" ? process.resourcesPath : "";
+  const here = dirname(fileURLToPath(import.meta.url));
+  if (resourcesPath) {
+    roots.push(join(resourcesPath, "icons"));
+  }
+  roots.push(join(here, "..", "resources", "icons"));
+  roots.push(join(here, "..", "..", "resources", "icons"));
+  return roots;
+}
+
+function firstExistingIcon(names: string[]): string | null {
+  for (const root of iconRoots()) {
+    for (const name of names) {
+      const p = join(root, name);
+      if (existsSync(p)) return p;
+    }
+  }
+  return null;
+}
+
+/**
+ * Prefer PNG for nativeImage — .icns via createFromPath is flaky on some
+ * Electron builds (empty / wrong size), which makes startDrag fail on macOS
+ * (icon must be non-empty).
+ */
+function resolveBrandPngPath(): string | null {
+  const icons = getResolvedAppIcons();
+  return (
+    firstExistingIcon(["128x128.png", "32x32.png", "icon.png"]) ??
+    icons.pngPath ??
+    null
+  );
+}
+
+function loadNativeIcon(path: string, size: number): Electron.NativeImage | null {
+  try {
+    const img = nativeImage.createFromPath(path);
+    if (img.isEmpty()) return null;
+    const resized = img.resize({ width: size, height: size });
+    return resized.isEmpty() ? null : resized;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveAppIconOnly(hostAppPath: string): Electron.NativeImage {
+  const brandPng = resolveBrandPngPath();
+  if (brandPng) {
+    const img = loadNativeIcon(brandPng, 64);
+    if (img) return img;
+  }
+
+  for (const p of [
+    join(hostAppPath, "Contents", "Resources", "AppIcon.icns"),
+    join(hostAppPath, "Contents", "Resources", "icon.icns"),
+  ]) {
+    if (!existsSync(p)) continue;
+    const img = loadNativeIcon(p, 64);
+    if (img) return img;
+  }
+
+  // Minimal non-empty 32×32 blue PNG (required on macOS startDrag).
+  const png = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAaElEQVRYR+2WMQ4AIAgD7f8f" +
+      "zcbBxMHB2kBJuAZSWigAZgYz8z0zO+8dERExM7M+gPkA5gOYD2A+gPkA5gOYD2A+gPkA5gOY" +
+      "D2A+gPkA5gOYD2A+gPkA5gOYD2A+gPkA5gOYD2A+gPkA5gOYD2A+gPkA5gOYD/gA1dYBvQ1vS5QAAAAASUVO" +
+      "RK5CYII=",
+    "base64",
+  );
+  const fallback = nativeImage.createFromBuffer(png);
+  return fallback.isEmpty() ? nativeImage.createEmpty() : fallback;
+}
+
+export function nativeImageFromDataUrl(dataUrl: string): Electron.NativeImage | null {
+  try {
+    const img = nativeImage.createFromDataURL(dataUrl);
+    return img.isEmpty() ? null : img;
+  } catch {
+    return null;
+  }
+}
+
+/** Chip UI icon as data URL (CSP allows img-src data:). */
+export function resolveChipIconDataUrl(hostAppPath: string): string {
+  const brandPng = resolveBrandPngPath();
+  if (brandPng) {
+    try {
+      const buf = readFileSync(brandPng);
+      return `data:image/png;base64,${buf.toString("base64")}`;
+    } catch {
+      /* fall through */
+    }
+    const img = loadNativeIcon(brandPng, 56);
+    if (img) {
+      try {
+        return img.toDataURL();
+      } catch {
+        /* fall through */
+      }
+    }
+  }
+
+  for (const p of [
+    join(hostAppPath, "Contents", "Resources", "AppIcon.icns"),
+    join(hostAppPath, "Contents", "Resources", "icon.icns"),
+  ]) {
+    if (!existsSync(p)) continue;
+    const img = loadNativeIcon(p, 56);
+    if (!img) continue;
+    try {
+      return img.toDataURL();
+    } catch {
+      /* continue */
+    }
+  }
+  return "";
+}
+
+export function panelHtml(state: GrantState, locale?: string): string {
+  const instruction = escapeHtml(state.instruction);
+  const chip = escapeHtml(state.chipLabel);
+  const closeLabel = isZh(locale) ? "关闭" : "Close";
+  const iconHtml = state.iconDataUrl
+    ? `<img class="icon" src="${state.iconDataUrl}" width="28" height="28" alt="" draggable="false" />`
+    : `<div class="icon icon-fallback" aria-hidden="true"></div>`;
+  return `<!DOCTYPE html>
+<html lang="${isZh(locale) ? "zh" : "en"}">
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:" />
+  <title>Desktop Use permissions</title>
+  <style>
+    html, body {
+      margin: 0; padding: 0; width: 100%; height: 100%;
+      overflow: hidden; background: transparent;
+      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif;
+      user-select: none; -webkit-user-select: none;
+    }
+    .shell {
+      box-sizing: border-box;
+      margin: 6px;
+      height: calc(100% - 12px);
+      padding: 14px 16px 14px 16px;
+      border-radius: 14px;
+      background: rgba(40, 40, 42, 0.94);
+      border: 1px solid rgba(255,255,255,0.10);
+      box-shadow: 0 10px 36px rgba(0,0,0,0.42);
+      color: #f2f2f2;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      justify-content: center;
+      /* Whole-shell window drag breaks file drag — only non-chip chrome may drag. */
+      -webkit-app-region: no-drag;
+      /* Local entrance while the BrowserWindow flies across the desktop. */
+      animation: grant-enter 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
+    }
+    @keyframes grant-enter {
+      from {
+        opacity: 0;
+        transform: scale(0.9) translateY(10px);
+      }
+      to {
+        opacity: 1;
+        transform: scale(1) translateY(0);
+      }
+    }
+    .header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-height: 24px;
+      -webkit-app-region: drag;
+    }
+    .arrow {
+      flex-shrink: 0;
+      width: 22px;
+      height: 22px;
+      color: #2f7cff;
+      -webkit-app-region: no-drag;
+    }
+    .instruction {
+      flex: 1;
+      font-size: 13px;
+      line-height: 1.35;
+      font-weight: 500;
+      color: rgba(255,255,255,0.92);
+      letter-spacing: -0.01em;
+    }
+    .close {
+      -webkit-app-region: no-drag;
+      border: 0; background: transparent;
+      color: rgba(255,255,255,0.4);
+      font-size: 13px; cursor: pointer;
+      width: 22px; height: 22px; border-radius: 6px; line-height: 1;
+      flex-shrink: 0;
+      padding: 0;
+    }
+    .close:hover { background: rgba(255,255,255,0.08); color: #fff; }
+    .chip {
+      -webkit-app-region: no-drag;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      height: 46px;
+      padding: 0 14px;
+      border-radius: 11px;
+      background: rgba(255,255,255,0.06);
+      border: 1px solid rgba(255,255,255,0.12);
+      cursor: grab;
+    }
+    .chip:active { cursor: grabbing; background: rgba(255,255,255,0.10); }
+    .icon {
+      width: 28px; height: 28px; border-radius: 7px;
+      flex-shrink: 0;
+      object-fit: cover;
+      pointer-events: none;
+    }
+    .icon-fallback {
+      background: linear-gradient(145deg, #3b82f6, #1d4ed8);
+    }
+    .name {
+      font-size: 14px; font-weight: 500;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+      pointer-events: none;
+      color: rgba(255,255,255,0.95);
+    }
+  </style>
+</head>
+<body>
+  <div class="shell" id="shell">
+    <div class="header">
+      <svg class="arrow" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M12 3.2 5.6 9.6a1.1 1.1 0 0 0 1.55 1.56L11 7.3V19.5a1.1 1.1 0 0 0 2.2 0V7.3l3.85 3.86a1.1 1.1 0 1 0 1.55-1.56L12 3.2Z"/>
+      </svg>
+      <div class="instruction">${instruction}</div>
+      <button class="close" type="button" title="${closeLabel}" id="close" aria-label="${closeLabel}">✕</button>
+    </div>
+    <div class="chip" id="chip" draggable="true" title="${chip}">
+      ${iconHtml}
+      <div class="name">${chip}</div>
+    </div>
+  </div>
+  <script>
+    const chip = document.getElementById('chip');
+    const close = document.getElementById('close');
+
+    function roundedRect(ctx, x, y, w, h, r) {
+      const rr = Math.min(r, w / 2, h / 2);
+      ctx.beginPath();
+      ctx.moveTo(x + rr, y);
+      ctx.arcTo(x + w, y, x + w, y + h, rr);
+      ctx.arcTo(x + w, y + h, x, y + h, rr);
+      ctx.arcTo(x, y + h, x, y, rr);
+      ctx.arcTo(x, y, x + w, y, rr);
+      ctx.closePath();
+    }
+
+    /**
+     * Paint icon+label chip into a PNG for startDrag ghost.
+     * IMPORTANT: Electron startDrag on macOS draws the bitmap at 1 device
+     * pixel ≈ 1 screen point. Do NOT multiply by devicePixelRatio or the
+     * ghost is 2× (or larger) than the on-screen chip.
+     */
+    function buildDragPreview() {
+      try {
+        const rect = chip.getBoundingClientRect();
+        // Logical CSS size only — matches the chip the user is grabbing.
+        const w = Math.max(1, Math.round(rect.width));
+        const h = Math.max(1, Math.round(rect.height));
+        const canvas = document.createElement('canvas');
+        canvas.width = w;
+        canvas.height = h;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) return;
+
+        // Match .chip styles so the ghost looks like the row itself.
+        ctx.fillStyle = 'rgba(55, 55, 58, 0.96)';
+        roundedRect(ctx, 0.5, 0.5, w - 1, h - 1, 11);
+        ctx.fill();
+        ctx.strokeStyle = 'rgba(255,255,255,0.16)';
+        ctx.lineWidth = 1;
+        roundedRect(ctx, 0.5, 0.5, w - 1, h - 1, 11);
+        ctx.stroke();
+
+        const padX = 14;
+        const iconSize = 28;
+        const gap = 10;
+        const iconY = (h - iconSize) / 2;
+        const img = chip.querySelector('img.icon');
+        if (img && img.complete && img.naturalWidth > 0) {
+          ctx.save();
+          roundedRect(ctx, padX, iconY, iconSize, iconSize, 7);
+          ctx.clip();
+          ctx.drawImage(img, padX, iconY, iconSize, iconSize);
+          ctx.restore();
+        } else {
+          ctx.fillStyle = '#2563eb';
+          roundedRect(ctx, padX, iconY, iconSize, iconSize, 7);
+          ctx.fill();
+        }
+
+        const nameEl = chip.querySelector('.name');
+        const label = (nameEl && nameEl.textContent) || '';
+        ctx.fillStyle = 'rgba(255,255,255,0.95)';
+        ctx.font = '500 14px -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif';
+        ctx.textBaseline = 'middle';
+        const textX = padX + iconSize + gap;
+        const maxTextW = w - textX - 14;
+        let draw = label;
+        if (ctx.measureText(draw).width > maxTextW) {
+          while (draw.length > 1 && ctx.measureText(draw + '…').width > maxTextW) {
+            draw = draw.slice(0, -1);
+          }
+          draw = draw + '…';
+        }
+        ctx.fillText(draw, textX, h / 2);
+
+        const dataUrl = canvas.toDataURL('image/png');
+        window.atmosGrant?.setDragPreview(dataUrl);
+      } catch (err) {
+        console.warn('[grant] buildDragPreview failed', err);
+      }
+    }
+
+    // Build after layout + icon decode so the ghost includes the real mark.
+    const icon = chip.querySelector('img.icon');
+    if (icon && !icon.complete) {
+      icon.addEventListener('load', () => buildDragPreview(), { once: true });
+      icon.addEventListener('error', () => buildDragPreview(), { once: true });
+    }
+    requestAnimationFrame(() => requestAnimationFrame(buildDragPreview));
+
+    // Electron file drag: must use dragstart and call startDrag before return.
+    chip.addEventListener('dragstart', (e) => {
+      e.preventDefault();
+      try {
+        const result = window.atmosGrant?.startDrag();
+        if (result && result.ok === false) {
+          console.warn('[grant] startDrag failed', result.error);
+        }
+      } catch (err) {
+        console.warn('[grant] startDrag threw', err);
+      }
+    });
+    chip.addEventListener('drag', (e) => { e.preventDefault(); });
+    close.addEventListener('click', () => window.atmosGrant?.close());
+    window.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') window.atmosGrant?.close();
+    });
+  </script>
+</body>
+</html>`;
+}
+
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+

--- a/apps/desktop-electron/src/desktop-use/grant-overlay-position.ts
+++ b/apps/desktop-electron/src/desktop-use/grant-overlay-position.ts
@@ -1,0 +1,113 @@
+/**
+ * Geometry helpers for the Accessibility/Screen Recording grant overlay.
+ */
+
+import { screen } from "electron";
+
+export const PANEL_WIDTH = 460;
+export const PANEL_HEIGHT = 128;
+
+export type Rect = { x: number; y: number; width: number; height: number };
+
+export function parseBoundsOutput(out: string): Rect | null {
+  const nums = out.match(/-?\d+/g)?.map((n) => Number(n));
+  if (!nums || nums.length < 4) return null;
+  const [x, y, width, height] = nums;
+  if (
+    typeof x !== "number" ||
+    typeof y !== "number" ||
+    typeof width !== "number" ||
+    typeof height !== "number" ||
+    !Number.isFinite(x) ||
+    !Number.isFinite(y) ||
+    width < 120 ||
+    height < 120
+  ) {
+    return null;
+  }
+  return { x, y, width, height };
+}
+
+/**
+ * Parse AppleScript `bounds` list `{x1, y1, x2, y2}` → Rect.
+ */
+export function parseAppleBoundsList(out: string): Rect | null {
+  const nums = out.match(/-?\d+/g)?.map((n) => Number(n));
+  if (!nums || nums.length < 4) return null;
+  const [x1, y1, x2, y2] = nums;
+  if (
+    typeof x1 !== "number" ||
+    typeof y1 !== "number" ||
+    typeof x2 !== "number" ||
+    typeof y2 !== "number" ||
+    !Number.isFinite(x1) ||
+    !Number.isFinite(y1) ||
+    x2 - x1 < 120 ||
+    y2 - y1 < 120
+  ) {
+    return null;
+  }
+  return { x: x1, y: y1, width: x2 - x1, height: y2 - y1 };
+}
+
+export function computePanelPosition(
+  settings: Rect | null,
+  ww: number,
+  wh: number,
+  nearPoint?: { x: number; y: number } | null,
+): { x: number; y: number } {
+  if (settings) {
+    // Detail pane ≈ right of the sidebar on Ventura+ System Settings.
+    const sidebar = Math.min(
+      300,
+      Math.max(240, Math.round(settings.width * 0.34)),
+    );
+    const padX = 20;
+    const padBottom = 36;
+    const padTop = 96;
+
+    const contentLeft = settings.x + sidebar;
+    const contentRight = settings.x + settings.width - padX;
+    const contentWidth = Math.max(contentRight - contentLeft, ww);
+
+    let x = contentLeft + (contentWidth - ww) / 2;
+    // Sit just above the bottom edge, overlapping the app list (reference UX).
+    let y = settings.y + settings.height - wh - padBottom;
+
+    // Hard clamp: panel must stay fully inside the Settings frame.
+    const minX = settings.x + padX;
+    const maxX = settings.x + settings.width - ww - padX;
+    const minY = settings.y + padTop;
+    const maxY = settings.y + settings.height - wh - 12;
+    if (maxX >= minX) x = Math.min(Math.max(x, minX), maxX);
+    else x = settings.x + Math.max(0, (settings.width - ww) / 2);
+    if (maxY >= minY) y = Math.min(Math.max(y, minY), maxY);
+    else y = settings.y + Math.max(0, (settings.height - wh) / 2);
+
+    return clampToWorkArea(x, y, ww, wh);
+  }
+
+  // No Settings bounds yet: park near the Grant button / Atmos window on the
+  // same display — not the primary display's bottom edge.
+  const anchor = nearPoint ?? { x: 0, y: 0 };
+  const display = screen.getDisplayNearestPoint({
+    x: Math.round(anchor.x + ww / 2),
+    y: Math.round(anchor.y + wh / 2),
+  });
+  const { width: sw, height: sh, x: sx, y: sy } = display.workArea;
+  return {
+    x: Math.round(
+      Math.min(
+        Math.max(anchor.x, sx + 12),
+        sx + sw - ww - 12,
+      ),
+    ),
+    y: Math.round(
+      Math.min(
+        Math.max(anchor.y - 24, sy + 48),
+        sy + sh - wh - 24,
+      ),
+    ),
+  };
+}
+

--- a/apps/desktop-electron/src/desktop-use/grant-overlay.structural.test.ts
+++ b/apps/desktop-electron/src/desktop-use/grant-overlay.structural.test.ts
@@ -2,13 +2,23 @@ import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
+function readGrantSources() {
+  const main = readFileSync(join(import.meta.dir, "grant-overlay.ts"), "utf8");
+  const panel = readFileSync(
+    join(import.meta.dir, "grant-overlay-panel.ts"),
+    "utf8",
+  );
+  const position = readFileSync(
+    join(import.meta.dir, "grant-overlay-position.ts"),
+    "utf8",
+  );
+  return { main, panel, position, all: `${main}\n${panel}\n${position}` };
+}
+
 describe("desktop-use grant overlay", () => {
   it("uses Electron startDrag and never embeds third-party grant brands", () => {
-    const src = readFileSync(
-      join(import.meta.dir, "grant-overlay.ts"),
-      "utf8",
-    );
-    expect(src).toContain("startDrag");
+    const { main, all: src } = readGrantSources();
+    expect(main).toContain("startDrag");
     expect(src).toContain("hostAppPath");
     expect(src.toLowerCase()).not.toContain("chatgpt");
     expect(src.toLowerCase()).not.toContain("codex");
@@ -31,46 +41,36 @@ describe("desktop-use grant overlay", () => {
   });
 
   it("uses dragstart not mousedown for file drag", () => {
-    const src = readFileSync(
-      join(import.meta.dir, "grant-overlay.ts"),
-      "utf8",
-    );
+    const { all: src } = readGrantSources();
     expect(src).toContain("dragstart");
     expect(src).not.toContain("addEventListener('mousedown'");
   });
 
   it("matches in-window placement and reference UX (no chip/Finder)", () => {
-    const src = readFileSync(
-      join(import.meta.dir, "grant-overlay.ts"),
-      "utf8",
-    );
+    const { main, all: src } = readGrantSources();
     expect(src).not.toContain("芯片");
     expect(src).not.toMatch(/Drag the chip/i);
     expect(src).not.toContain("Finder");
     expect(src).not.toContain("desktop-use-grant-reveal");
-    expect(src).toContain("getSystemSettingsWindowBounds");
-    expect(src).toContain("positionInsideSettingsWindow");
+    expect(main).toContain("getSystemSettingsWindowBounds");
+    expect(main).toContain("positionInsideSettingsWindow");
     expect(src).toContain("buildDragPreview");
     expect(src).toContain("list above");
     expect(src).toContain("img-src data:");
     expect(src).toContain("resolveChipIconDataUrl");
     // Never block main with sync osascript (beach-ball / stuck hover).
     expect(src).not.toContain("execFileSync");
-    expect(src).toContain("execFileAsync");
+    expect(main).toContain("execFileAsync");
     // Fly from Atmos → System Settings while bounds resolve mid-animation.
-    expect(src).toContain("flyFromAtmosToSettings");
-    expect(src).toContain("getFlySourceOrigin");
+    expect(main).toContain("flyFromAtmosToSettings");
+    expect(main).toContain("getFlySourceOrigin");
     expect(src).toContain("sourceOrigin");
-    expect(src).toContain("easeOutCubic");
+    expect(main).toContain("easeOutCubic");
     expect(src).toContain("grant-enter");
     // Wait for Settings bounds before committing fly end-point.
-    expect(src).toContain("waitForSystemSettingsBounds");
-    expect(src).toContain("BOUNDS_WAIT_MS");
+    expect(main).toContain("waitForSystemSettingsBounds");
+    expect(main).toContain("BOUNDS_WAIT_MS");
     // Drag ghost must stay 1× CSS size (no devicePixelRatio inflate).
     expect(src).toMatch(/Do NOT multiply by devicePixelRatio/);
   });
 });
-
-
-
-

--- a/apps/desktop-electron/src/desktop-use/grant-overlay.ts
+++ b/apps/desktop-electron/src/desktop-use/grant-overlay.ts
@@ -9,47 +9,39 @@
  * Drag uses Electron `webContents.startDrag` from a **dragstart** handler
  * (mousedown + async IPC does not start a macOS file drag). The drag ghost
  * is a pre-rendered PNG of the full chip (icon + label container).
+ *
+ * Panel HTML/icons: grant-overlay-panel.ts; pure geometry: grant-overlay-position.ts.
  */
 
 import { execFile } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 import { BrowserWindow, ipcMain, nativeImage, screen } from "electron";
-import { getResolvedAppIcons } from "../branding.js";
+import {
+  buildInstruction,
+  nativeImageFromDataUrl,
+  panelHtml,
+  resolveAppIconOnly,
+  resolveChipIconDataUrl,
+  type GrantOverlayOptions,
+  type GrantOverlayPurpose,
+  type GrantState,
+} from "./grant-overlay-panel.js";
+import {
+  PANEL_HEIGHT,
+  PANEL_WIDTH,
+  computePanelPosition,
+  parseAppleBoundsList,
+  parseBoundsOutput,
+  type Rect,
+} from "./grant-overlay-position.js";
+
+// Re-export public option types for callers.
+export type { GrantOverlayOptions, GrantOverlayPurpose } from "./grant-overlay-panel.js";
 
 const execFileAsync = promisify(execFile);
-
-export type GrantOverlayPurpose = "accessibility" | "screen_recording";
-
-export type GrantOverlayOptions = {
-  hostAppPath: string;
-  hostAppName?: string;
-  /** BCP-47-ish language tag; used for in-panel copy. */
-  locale?: string;
-  /** Which Settings pane was opened (affects instruction copy). */
-  purpose?: GrantOverlayPurpose;
-  /**
-   * Screen-point origin for the fly animation (typically the Grant button
-   * center, converted from the host BrowserWindow content bounds).
-   */
-  sourceOrigin?: { x: number; y: number };
-};
-
-type GrantState = {
-  hostAppPath: string;
-  hostAppName: string;
-  instruction: string;
-  chipLabel: string;
-  /** data:image/... URL for the chip icon, or empty for CSS fallback. */
-  iconDataUrl: string;
-  /**
-   * Pre-rendered full-chip PNG for startDrag ghost (set from renderer after paint).
-   * Falls back to app icon only when missing.
-   */
-  dragPreviewDataUrl: string | null;
-};
 
 let grantWindow: BrowserWindow | null = null;
 let grantState: GrantState | null = null;
@@ -68,9 +60,6 @@ let flyGeneration = 0;
 /** Optional fly start (Grant button screen coords) for the next open. */
 let pendingSourceOrigin: { x: number; y: number } | null = null;
 
-/** Panel outer size (matches reference card proportions). */
-const PANEL_WIDTH = 460;
-const PANEL_HEIGHT = 128;
 /** How long to reuse the last System Settings bounds (ms). */
 const SETTINGS_BOUNDS_TTL_MS = 400;
 /** Only move the overlay when it drifts by more than this many points. */
@@ -103,443 +92,6 @@ function grantPreloadPath(): string {
   );
 }
 
-function isZh(locale: string | undefined): boolean {
-  return (locale ?? "").toLowerCase().startsWith("zh");
-}
-
-function buildInstruction(
-  hostAppName: string,
-  purpose: GrantOverlayPurpose,
-  locale?: string,
-): string {
-  if (isZh(locale)) {
-    // Match macOS System Settings Chinese labels: 无障碍 / 屏幕录制.
-    const goal =
-      purpose === "screen_recording" ? "允许屏幕录制" : "允许无障碍";
-    return `将「${hostAppName}」拖到上方列表以${goal}`;
-  }
-  const goal =
-    purpose === "screen_recording"
-      ? "to allow Screen Recording"
-      : "to allow Accessibility";
-  return `Drag ${hostAppName} to the list above ${goal}`;
-}
-
-function iconRoots(): string[] {
-  const roots: string[] = [];
-  const resourcesPath =
-    typeof process.resourcesPath === "string" ? process.resourcesPath : "";
-  const here = dirname(fileURLToPath(import.meta.url));
-  if (resourcesPath) {
-    roots.push(join(resourcesPath, "icons"));
-  }
-  roots.push(join(here, "..", "resources", "icons"));
-  roots.push(join(here, "..", "..", "resources", "icons"));
-  return roots;
-}
-
-function firstExistingIcon(names: string[]): string | null {
-  for (const root of iconRoots()) {
-    for (const name of names) {
-      const p = join(root, name);
-      if (existsSync(p)) return p;
-    }
-  }
-  return null;
-}
-
-/**
- * Prefer PNG for nativeImage — .icns via createFromPath is flaky on some
- * Electron builds (empty / wrong size), which makes startDrag fail on macOS
- * (icon must be non-empty).
- */
-function resolveBrandPngPath(): string | null {
-  const icons = getResolvedAppIcons();
-  return (
-    firstExistingIcon(["128x128.png", "32x32.png", "icon.png"]) ??
-    icons.pngPath ??
-    null
-  );
-}
-
-function loadNativeIcon(path: string, size: number): Electron.NativeImage | null {
-  try {
-    const img = nativeImage.createFromPath(path);
-    if (img.isEmpty()) return null;
-    const resized = img.resize({ width: size, height: size });
-    return resized.isEmpty() ? null : resized;
-  } catch {
-    return null;
-  }
-}
-
-function resolveAppIconOnly(hostAppPath: string): Electron.NativeImage {
-  const brandPng = resolveBrandPngPath();
-  if (brandPng) {
-    const img = loadNativeIcon(brandPng, 64);
-    if (img) return img;
-  }
-
-  for (const p of [
-    join(hostAppPath, "Contents", "Resources", "AppIcon.icns"),
-    join(hostAppPath, "Contents", "Resources", "icon.icns"),
-  ]) {
-    if (!existsSync(p)) continue;
-    const img = loadNativeIcon(p, 64);
-    if (img) return img;
-  }
-
-  // Minimal non-empty 32×32 blue PNG (required on macOS startDrag).
-  const png = Buffer.from(
-    "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAaElEQVRYR+2WMQ4AIAgD7f8f" +
-      "zcbBxMHB2kBJuAZSWigAZgYz8z0zO+8dERExM7M+gPkA5gOYD2A+gPkA5gOYD2A+gPkA5gOY" +
-      "D2A+gPkA5gOYD2A+gPkA5gOYD2A+gPkA5gOYD2A+gPkA5gOYD2A+gPkA5gOYD/gA1dYBvQ1vS5QAAAAASUVO" +
-      "RK5CYII=",
-    "base64",
-  );
-  const fallback = nativeImage.createFromBuffer(png);
-  return fallback.isEmpty() ? nativeImage.createEmpty() : fallback;
-}
-
-function nativeImageFromDataUrl(dataUrl: string): Electron.NativeImage | null {
-  try {
-    const img = nativeImage.createFromDataURL(dataUrl);
-    return img.isEmpty() ? null : img;
-  } catch {
-    return null;
-  }
-}
-
-/** Chip UI icon as data URL (CSP allows img-src data:). */
-function resolveChipIconDataUrl(hostAppPath: string): string {
-  const brandPng = resolveBrandPngPath();
-  if (brandPng) {
-    try {
-      const buf = readFileSync(brandPng);
-      return `data:image/png;base64,${buf.toString("base64")}`;
-    } catch {
-      /* fall through */
-    }
-    const img = loadNativeIcon(brandPng, 56);
-    if (img) {
-      try {
-        return img.toDataURL();
-      } catch {
-        /* fall through */
-      }
-    }
-  }
-
-  for (const p of [
-    join(hostAppPath, "Contents", "Resources", "AppIcon.icns"),
-    join(hostAppPath, "Contents", "Resources", "icon.icns"),
-  ]) {
-    if (!existsSync(p)) continue;
-    const img = loadNativeIcon(p, 56);
-    if (!img) continue;
-    try {
-      return img.toDataURL();
-    } catch {
-      /* continue */
-    }
-  }
-  return "";
-}
-
-function panelHtml(state: GrantState, locale?: string): string {
-  const instruction = escapeHtml(state.instruction);
-  const chip = escapeHtml(state.chipLabel);
-  const closeLabel = isZh(locale) ? "关闭" : "Close";
-  const iconHtml = state.iconDataUrl
-    ? `<img class="icon" src="${state.iconDataUrl}" width="28" height="28" alt="" draggable="false" />`
-    : `<div class="icon icon-fallback" aria-hidden="true"></div>`;
-  return `<!DOCTYPE html>
-<html lang="${isZh(locale) ? "zh" : "en"}">
-<head>
-  <meta charset="utf-8" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:" />
-  <title>Desktop Use permissions</title>
-  <style>
-    html, body {
-      margin: 0; padding: 0; width: 100%; height: 100%;
-      overflow: hidden; background: transparent;
-      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif;
-      user-select: none; -webkit-user-select: none;
-    }
-    .shell {
-      box-sizing: border-box;
-      margin: 6px;
-      height: calc(100% - 12px);
-      padding: 14px 16px 14px 16px;
-      border-radius: 14px;
-      background: rgba(40, 40, 42, 0.94);
-      border: 1px solid rgba(255,255,255,0.10);
-      box-shadow: 0 10px 36px rgba(0,0,0,0.42);
-      color: #f2f2f2;
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-      justify-content: center;
-      /* Whole-shell window drag breaks file drag — only non-chip chrome may drag. */
-      -webkit-app-region: no-drag;
-      /* Local entrance while the BrowserWindow flies across the desktop. */
-      animation: grant-enter 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
-    }
-    @keyframes grant-enter {
-      from {
-        opacity: 0;
-        transform: scale(0.9) translateY(10px);
-      }
-      to {
-        opacity: 1;
-        transform: scale(1) translateY(0);
-      }
-    }
-    .header {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      min-height: 24px;
-      -webkit-app-region: drag;
-    }
-    .arrow {
-      flex-shrink: 0;
-      width: 22px;
-      height: 22px;
-      color: #2f7cff;
-      -webkit-app-region: no-drag;
-    }
-    .instruction {
-      flex: 1;
-      font-size: 13px;
-      line-height: 1.35;
-      font-weight: 500;
-      color: rgba(255,255,255,0.92);
-      letter-spacing: -0.01em;
-    }
-    .close {
-      -webkit-app-region: no-drag;
-      border: 0; background: transparent;
-      color: rgba(255,255,255,0.4);
-      font-size: 13px; cursor: pointer;
-      width: 22px; height: 22px; border-radius: 6px; line-height: 1;
-      flex-shrink: 0;
-      padding: 0;
-    }
-    .close:hover { background: rgba(255,255,255,0.08); color: #fff; }
-    .chip {
-      -webkit-app-region: no-drag;
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      height: 46px;
-      padding: 0 14px;
-      border-radius: 11px;
-      background: rgba(255,255,255,0.06);
-      border: 1px solid rgba(255,255,255,0.12);
-      cursor: grab;
-    }
-    .chip:active { cursor: grabbing; background: rgba(255,255,255,0.10); }
-    .icon {
-      width: 28px; height: 28px; border-radius: 7px;
-      flex-shrink: 0;
-      object-fit: cover;
-      pointer-events: none;
-    }
-    .icon-fallback {
-      background: linear-gradient(145deg, #3b82f6, #1d4ed8);
-    }
-    .name {
-      font-size: 14px; font-weight: 500;
-      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-      pointer-events: none;
-      color: rgba(255,255,255,0.95);
-    }
-  </style>
-</head>
-<body>
-  <div class="shell" id="shell">
-    <div class="header">
-      <svg class="arrow" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-        <path d="M12 3.2 5.6 9.6a1.1 1.1 0 0 0 1.55 1.56L11 7.3V19.5a1.1 1.1 0 0 0 2.2 0V7.3l3.85 3.86a1.1 1.1 0 1 0 1.55-1.56L12 3.2Z"/>
-      </svg>
-      <div class="instruction">${instruction}</div>
-      <button class="close" type="button" title="${closeLabel}" id="close" aria-label="${closeLabel}">✕</button>
-    </div>
-    <div class="chip" id="chip" draggable="true" title="${chip}">
-      ${iconHtml}
-      <div class="name">${chip}</div>
-    </div>
-  </div>
-  <script>
-    const chip = document.getElementById('chip');
-    const close = document.getElementById('close');
-
-    function roundedRect(ctx, x, y, w, h, r) {
-      const rr = Math.min(r, w / 2, h / 2);
-      ctx.beginPath();
-      ctx.moveTo(x + rr, y);
-      ctx.arcTo(x + w, y, x + w, y + h, rr);
-      ctx.arcTo(x + w, y + h, x, y + h, rr);
-      ctx.arcTo(x, y + h, x, y, rr);
-      ctx.arcTo(x, y, x + w, y, rr);
-      ctx.closePath();
-    }
-
-    /**
-     * Paint icon+label chip into a PNG for startDrag ghost.
-     * IMPORTANT: Electron startDrag on macOS draws the bitmap at 1 device
-     * pixel ≈ 1 screen point. Do NOT multiply by devicePixelRatio or the
-     * ghost is 2× (or larger) than the on-screen chip.
-     */
-    function buildDragPreview() {
-      try {
-        const rect = chip.getBoundingClientRect();
-        // Logical CSS size only — matches the chip the user is grabbing.
-        const w = Math.max(1, Math.round(rect.width));
-        const h = Math.max(1, Math.round(rect.height));
-        const canvas = document.createElement('canvas');
-        canvas.width = w;
-        canvas.height = h;
-        const ctx = canvas.getContext('2d');
-        if (!ctx) return;
-
-        // Match .chip styles so the ghost looks like the row itself.
-        ctx.fillStyle = 'rgba(55, 55, 58, 0.96)';
-        roundedRect(ctx, 0.5, 0.5, w - 1, h - 1, 11);
-        ctx.fill();
-        ctx.strokeStyle = 'rgba(255,255,255,0.16)';
-        ctx.lineWidth = 1;
-        roundedRect(ctx, 0.5, 0.5, w - 1, h - 1, 11);
-        ctx.stroke();
-
-        const padX = 14;
-        const iconSize = 28;
-        const gap = 10;
-        const iconY = (h - iconSize) / 2;
-        const img = chip.querySelector('img.icon');
-        if (img && img.complete && img.naturalWidth > 0) {
-          ctx.save();
-          roundedRect(ctx, padX, iconY, iconSize, iconSize, 7);
-          ctx.clip();
-          ctx.drawImage(img, padX, iconY, iconSize, iconSize);
-          ctx.restore();
-        } else {
-          ctx.fillStyle = '#2563eb';
-          roundedRect(ctx, padX, iconY, iconSize, iconSize, 7);
-          ctx.fill();
-        }
-
-        const nameEl = chip.querySelector('.name');
-        const label = (nameEl && nameEl.textContent) || '';
-        ctx.fillStyle = 'rgba(255,255,255,0.95)';
-        ctx.font = '500 14px -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif';
-        ctx.textBaseline = 'middle';
-        const textX = padX + iconSize + gap;
-        const maxTextW = w - textX - 14;
-        let draw = label;
-        if (ctx.measureText(draw).width > maxTextW) {
-          while (draw.length > 1 && ctx.measureText(draw + '…').width > maxTextW) {
-            draw = draw.slice(0, -1);
-          }
-          draw = draw + '…';
-        }
-        ctx.fillText(draw, textX, h / 2);
-
-        const dataUrl = canvas.toDataURL('image/png');
-        window.atmosGrant?.setDragPreview(dataUrl);
-      } catch (err) {
-        console.warn('[grant] buildDragPreview failed', err);
-      }
-    }
-
-    // Build after layout + icon decode so the ghost includes the real mark.
-    const icon = chip.querySelector('img.icon');
-    if (icon && !icon.complete) {
-      icon.addEventListener('load', () => buildDragPreview(), { once: true });
-      icon.addEventListener('error', () => buildDragPreview(), { once: true });
-    }
-    requestAnimationFrame(() => requestAnimationFrame(buildDragPreview));
-
-    // Electron file drag: must use dragstart and call startDrag before return.
-    chip.addEventListener('dragstart', (e) => {
-      e.preventDefault();
-      try {
-        const result = window.atmosGrant?.startDrag();
-        if (result && result.ok === false) {
-          console.warn('[grant] startDrag failed', result.error);
-        }
-      } catch (err) {
-        console.warn('[grant] startDrag threw', err);
-      }
-    });
-    chip.addEventListener('drag', (e) => { e.preventDefault(); });
-    close.addEventListener('click', () => window.atmosGrant?.close());
-    window.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape') window.atmosGrant?.close();
-    });
-  </script>
-</body>
-</html>`;
-}
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
-
-type Rect = { x: number; y: number; width: number; height: number };
-
-function parseBoundsOutput(out: string): Rect | null {
-  const nums = out.match(/-?\d+/g)?.map((n) => Number(n));
-  if (!nums || nums.length < 4) return null;
-  const [x, y, width, height] = nums;
-  if (
-    typeof x !== "number" ||
-    typeof y !== "number" ||
-    typeof width !== "number" ||
-    typeof height !== "number" ||
-    !Number.isFinite(x) ||
-    !Number.isFinite(y) ||
-    width < 120 ||
-    height < 120
-  ) {
-    return null;
-  }
-  return { x, y, width, height };
-}
-
-/**
- * Parse AppleScript `bounds` list `{x1, y1, x2, y2}` → Rect.
- */
-function parseAppleBoundsList(out: string): Rect | null {
-  const nums = out.match(/-?\d+/g)?.map((n) => Number(n));
-  if (!nums || nums.length < 4) return null;
-  const [x1, y1, x2, y2] = nums;
-  if (
-    typeof x1 !== "number" ||
-    typeof y1 !== "number" ||
-    typeof x2 !== "number" ||
-    typeof y2 !== "number" ||
-    !Number.isFinite(x1) ||
-    !Number.isFinite(y1) ||
-    x2 - x1 < 120 ||
-    y2 - y1 < 120
-  ) {
-    return null;
-  }
-  return { x: x1, y: y1, width: x2 - x1, height: y2 - y1 };
-}
-
-/**
- * Best-effort bounds of the front System Settings window (logical points).
- *
- * MUST stay async — sync osascript on the main process freezes Electron
- * (beach-ball cursor) especially when macOS shows an Automation prompt.
- */
 async function getSystemSettingsWindowBounds(
   opts?: { bypassCache?: boolean },
 ): Promise<Rect | null> {
@@ -638,66 +190,6 @@ function clampToWorkArea(x: number, y: number, ww: number, wh: number): {
  * Falls back near `nearPoint` (button / Atmos) — never the global screen bottom,
  * which is what made the card look "randomly outside".
  */
-function computePanelPosition(
-  settings: Rect | null,
-  ww: number,
-  wh: number,
-  nearPoint?: { x: number; y: number } | null,
-): { x: number; y: number } {
-  if (settings) {
-    // Detail pane ≈ right of the sidebar on Ventura+ System Settings.
-    const sidebar = Math.min(
-      300,
-      Math.max(240, Math.round(settings.width * 0.34)),
-    );
-    const padX = 20;
-    const padBottom = 36;
-    const padTop = 96;
-
-    const contentLeft = settings.x + sidebar;
-    const contentRight = settings.x + settings.width - padX;
-    const contentWidth = Math.max(contentRight - contentLeft, ww);
-
-    let x = contentLeft + (contentWidth - ww) / 2;
-    // Sit just above the bottom edge, overlapping the app list (reference UX).
-    let y = settings.y + settings.height - wh - padBottom;
-
-    // Hard clamp: panel must stay fully inside the Settings frame.
-    const minX = settings.x + padX;
-    const maxX = settings.x + settings.width - ww - padX;
-    const minY = settings.y + padTop;
-    const maxY = settings.y + settings.height - wh - 12;
-    if (maxX >= minX) x = Math.min(Math.max(x, minX), maxX);
-    else x = settings.x + Math.max(0, (settings.width - ww) / 2);
-    if (maxY >= minY) y = Math.min(Math.max(y, minY), maxY);
-    else y = settings.y + Math.max(0, (settings.height - wh) / 2);
-
-    return clampToWorkArea(x, y, ww, wh);
-  }
-
-  // No Settings bounds yet: park near the Grant button / Atmos window on the
-  // same display — not the primary display's bottom edge.
-  const anchor = nearPoint ?? { x: 0, y: 0 };
-  const display = screen.getDisplayNearestPoint({
-    x: Math.round(anchor.x + ww / 2),
-    y: Math.round(anchor.y + wh / 2),
-  });
-  const { width: sw, height: sh, x: sx, y: sy } = display.workArea;
-  return {
-    x: Math.round(
-      Math.min(
-        Math.max(anchor.x, sx + 12),
-        sx + sw - ww - 12,
-      ),
-    ),
-    y: Math.round(
-      Math.min(
-        Math.max(anchor.y - 24, sy + 48),
-        sy + sh - wh - 24,
-      ),
-    ),
-  };
-}
 
 function applyPanelPosition(
   win: BrowserWindow,

--- a/apps/web/src/features/browser/components/morphing-tabs-parts.tsx
+++ b/apps/web/src/features/browser/components/morphing-tabs-parts.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import {
+  motion,
+  useMotionValue,
+  useSpring,
+  useTransform,
+  type MotionValue,
+} from "motion/react";
+import { Plus } from "lucide-react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/shared/lib/utils";
+import { SPRING_GLIDE, SPRING_PRESS } from "../lib/morphing-ease";
+import {
+  ADD_BUTTON_SIZE,
+  LIQUID_JOIN,
+  PANEL_RADIUS,
+  RAIL_HEIGHT,
+  SURFACE_INSET,
+  TAB_HEIGHT,
+  TAB_RADIUS,
+  TAB_TOP,
+  TAB_WIDTH,
+  liquidPanelOnlyPath,
+  liquidTabPath,
+} from "../lib/morphing-tabs-geometry";
+
+export type SpringTabProps = {
+  id: string;
+  targetLeft: number;
+  dragging: boolean;
+  dragLeft: MotionValue<number>;
+  surfaceLeft: MotionValue<number>;
+  /** Horizontal scroll of the tab strip — liquid is root-fixed so subtract this. */
+  scrollLeft: MotionValue<number>;
+  reduce: boolean;
+  active: boolean;
+  anyDragging: boolean;
+  surfaceHost: HTMLDivElement | null;
+  surfaceWidth: number;
+  surfaceClassName?: string;
+  zIndex: number;
+  className: string;
+  children: ReactNode;
+  registerPosition: (id: string, position: MotionValue<number> | null) => void;
+  onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerMove: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerUp: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerCancel: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onLostPointerCapture: (event: ReactPointerEvent<HTMLDivElement>) => void;
+};
+
+
+export function SpringTab({
+  id,
+  targetLeft,
+  dragging,
+  dragLeft,
+  surfaceLeft,
+  scrollLeft,
+  reduce,
+  active,
+  anyDragging,
+  surfaceHost,
+  surfaceWidth,
+  surfaceClassName,
+  zIndex,
+  className,
+  children,
+  registerPosition,
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
+  onPointerCancel,
+  onLostPointerCapture,
+}: SpringTabProps) {
+  const target = useMotionValue(targetLeft);
+  const position = useSpring(target, SPRING_GLIDE);
+  const settledTransform = useTransform(
+    reduce ? target : position,
+    (left) => `translate3d(${left}px, 0, 0)`,
+  );
+  const draggedTransform = useTransform(
+    dragLeft,
+    (left) => `translate3d(${left}px, 0, 0)`,
+  );
+
+  useLayoutEffect(() => {
+    target.set(targetLeft);
+    if (reduce) position.jump(targetLeft);
+  }, [position, reduce, target, targetLeft]);
+
+  useLayoutEffect(() => {
+    registerPosition(id, position);
+    return () => registerPosition(id, null);
+  }, [id, position, registerPosition]);
+
+  const liquidDriver = anyDragging
+    ? dragging
+      ? dragLeft
+      : position
+    : surfaceLeft;
+
+  return (
+    <>
+      {active && surfaceHost && surfaceWidth > SURFACE_INSET * 2
+        ? createPortal(
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              viewBox={`0 0 ${surfaceWidth} ${RAIL_HEIGHT + PANEL_RADIUS}`}
+              preserveAspectRatio="none"
+              className={cn(
+                // Always below the content panel (z-20). Raising to z-20 on drag
+                // (beui default) paints the full-width panel strip over the toolbar.
+                "pointer-events-none absolute inset-x-0 top-0 z-[15] w-full text-background",
+                surfaceClassName,
+              )}
+              style={{ height: RAIL_HEIGHT + PANEL_RADIUS }}
+            >
+              <LiquidSurfacePath
+                key={
+                  anyDragging
+                    ? dragging
+                      ? "dragged"
+                      : "displaced"
+                    : "idle"
+                }
+                left={liquidDriver}
+                scrollLeft={scrollLeft}
+                surfaceWidth={surfaceWidth}
+              />
+            </svg>,
+            surfaceHost,
+          )
+        : null}
+      <motion.div
+        style={{
+          zIndex,
+          transform: dragging ? draggedTransform : settledTransform,
+        }}
+        className={className}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerCancel}
+        onLostPointerCapture={onLostPointerCapture}
+      >
+        {children}
+      </motion.div>
+    </>
+  );
+}
+
+export function LiquidSurfacePath({
+  left,
+  scrollLeft,
+  surfaceWidth,
+}: {
+  /** Active tab left in track coordinates. */
+  left: MotionValue<number>;
+  /** Tab strip scroll — liquid SVG is root-fixed, so tab x = left − scroll. */
+  scrollLeft: MotionValue<number>;
+  surfaceWidth: number;
+}) {
+  const path = useTransform([left, scrollLeft], ([tabLeft, scroll]: number[]) =>
+    liquidTabPath(tabLeft - scroll, surfaceWidth),
+  );
+  return <motion.path d={path} fill="currentColor" />;
+}
+
+export function AddTabButton({
+  ariaLabel,
+  onClick,
+}: {
+  ariaLabel: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      title={ariaLabel}
+      onClick={onClick}
+      className="desktop-no-drag flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/50 hover:text-foreground"
+    >
+      <Plus className="size-3.5" />
+    </button>
+  );
+}
+

--- a/apps/web/src/features/browser/components/morphing-tabs.tsx
+++ b/apps/web/src/features/browser/components/morphing-tabs.tsx
@@ -2,16 +2,15 @@
 // Adapted from beui.dev Morphing Tabs (MIT) — density + Atmos tokens only.
 // https://beui.dev/components/blocks/morphing-tabs
 // Drag / reorder / liquid path logic is intentionally unchanged from upstream.
+// Geometry pure helpers: lib/morphing-tabs-geometry.ts; SpringTab/liquid UI: morphing-tabs-parts.tsx.
 
-import { Plus, X } from "lucide-react";
+import { X } from "lucide-react";
 import {
   AnimatePresence,
   animate as animateValue,
   motion,
   useMotionValue,
   useReducedMotion,
-  useSpring,
-  useTransform,
   type MotionValue,
 } from "motion/react";
 import {
@@ -25,10 +24,29 @@ import {
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from "react";
-import { createPortal } from "react-dom";
 import { cn } from "@/shared/lib/utils";
 
 import { EASE_OUT, SPRING_GLIDE, SPRING_PRESS } from "../lib/morphing-ease";
+import {
+  ADD_BUTTON_GAP,
+  ADD_BUTTON_SIZE,
+  DRAG_THRESHOLD,
+  PANEL_RADIUS,
+  RAIL_HEIGHT,
+  SCROLL_EDGE_PAD,
+  SURFACE_INSET,
+  TAB_HEIGHT,
+  TAB_TOP,
+  TAB_WIDTH,
+  moveItem,
+  safeId,
+  sameOrder,
+} from "../lib/morphing-tabs-geometry";
+import {
+  AddTabButton,
+  LiquidSurfacePath,
+  SpringTab,
+} from "./morphing-tabs-parts";
 
 export type MorphingTabsItem = {
   id: string;
@@ -92,273 +110,6 @@ type DragSession = {
   startOrder: string[];
   slotLefts: number[];
 };
-
-type SpringTabProps = {
-  id: string;
-  targetLeft: number;
-  dragging: boolean;
-  dragLeft: MotionValue<number>;
-  surfaceLeft: MotionValue<number>;
-  /** Horizontal scroll of the tab strip — liquid is root-fixed so subtract this. */
-  scrollLeft: MotionValue<number>;
-  reduce: boolean;
-  active: boolean;
-  anyDragging: boolean;
-  surfaceHost: HTMLDivElement | null;
-  surfaceWidth: number;
-  surfaceClassName?: string;
-  zIndex: number;
-  className: string;
-  children: ReactNode;
-  registerPosition: (id: string, position: MotionValue<number> | null) => void;
-  onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
-  onPointerMove: (event: ReactPointerEvent<HTMLDivElement>) => void;
-  onPointerUp: (event: ReactPointerEvent<HTMLDivElement>) => void;
-  onPointerCancel: (event: ReactPointerEvent<HTMLDivElement>) => void;
-  onLostPointerCapture: (event: ReactPointerEvent<HTMLDivElement>) => void;
-};
-
-const DRAG_THRESHOLD = 5;
-/** Dense browser chrome scale of beui defaults (logic unchanged). */
-const TAB_WIDTH = 156;
-const TAB_HEIGHT = 28;
-const TAB_TOP = 2;
-const TAB_RADIUS = 10;
-const RAIL_HEIGHT = 30;
-/** 0 = flush with panel edge so first active tab joins square TL (beui inset was 16). */
-const SURFACE_INSET = 0;
-const LIQUID_JOIN = 12;
-/** How far the liquid fill dips into the content panel for corner morphs.
- *  Keep small — dense chrome toolbar sits right under the rail. */
-const PANEL_RADIUS = 8;
-const ADD_BUTTON_SIZE = 24;
-const ADD_BUTTON_GAP = 4;
-/** Extra scroll room so active-tab liquid ears (bottom L/R) are not clipped by
- *  the scrollport edge — symmetric when the tab is not flush with the strip end. */
-const SCROLL_EDGE_PAD = LIQUID_JOIN + 4;
-
-function sameOrder(a: string[], b: string[]) {
-  return a.length === b.length && a.every((id, index) => id === b[index]);
-}
-
-function safeId(value: string) {
-  return value.replace(/[^a-zA-Z0-9_-]/g, "-");
-}
-
-function moveItem(order: string[], from: number, to: number) {
-  if (from === to) return order.slice();
-  const next = order.slice();
-  const [item] = next.splice(from, 1);
-  next.splice(to, 0, item);
-  return next;
-}
-
-/** Panel top edge only (full corner radii) — used when the active tab has
- *  scrolled fully out of the visible strip so the fill is not pinned at an edge. */
-function liquidPanelOnlyPath(surfaceWidth: number) {
-  const panelLeft = SURFACE_INSET;
-  const panelRight = Math.max(panelLeft + TAB_WIDTH, surfaceWidth - SURFACE_INSET);
-  const bottom = RAIL_HEIGHT;
-  const r = PANEL_RADIUS;
-  return [
-    `M${panelLeft} ${bottom + r}`,
-    `V${bottom + r}`,
-    `Q${panelLeft} ${bottom} ${panelLeft + r} ${bottom}`,
-    `H${panelRight - r}`,
-    `Q${panelRight} ${bottom} ${panelRight} ${bottom + r}`,
-    `V${bottom + r}`,
-    "Z",
-  ].join(" ");
-}
-
-function liquidTabPath(tabLeft: number, surfaceWidth: number) {
-  const panelLeft = SURFACE_INSET;
-  const panelRight = Math.max(panelLeft + TAB_WIDTH, surfaceWidth - SURFACE_INSET);
-  // Viewport x of the active tab (track left − scroll). Do NOT clamp into the
-  // panel — clamping pinned the silhouette at the left/right when scrolling.
-  const left = tabLeft;
-  const right = left + TAB_WIDTH;
-  const top = RAIL_HEIGHT - TAB_HEIGHT;
-  const bottom = RAIL_HEIGHT;
-
-  // Fully off-screen → only the content top strip (no stuck edge tab fill).
-  if (right < panelLeft || left > panelRight) {
-    return liquidPanelOnlyPath(surfaceWidth);
-  }
-
-  const leftJoin = Math.max(panelLeft, left - LIQUID_JOIN);
-  const rightJoin = Math.min(panelRight, right + LIQUID_JOIN);
-  const leftDepth = Math.max(0, Math.min(LIQUID_JOIN, left - leftJoin));
-  const rightDepth = Math.max(0, Math.min(LIQUID_JOIN, rightJoin - right));
-  const leftControl = leftDepth * 0.55;
-  const rightControl = rightDepth * 0.55;
-  // Flush with content left only when the tab edge is at/near panelLeft.
-  // Scrolled past the left edge → full radius (not square residual).
-  const leftPanelRadius =
-    left <= panelLeft
-      ? Math.min(PANEL_RADIUS, Math.max(0, panelLeft - left))
-      : Math.min(PANEL_RADIUS, Math.max(0, leftJoin - panelLeft));
-  const rightPanelRadius =
-    right >= panelRight
-      ? Math.min(PANEL_RADIUS, Math.max(0, right - panelRight))
-      : Math.min(PANEL_RADIUS, Math.max(0, panelRight - rightJoin));
-
-  return [
-    `M${panelLeft} ${bottom + PANEL_RADIUS}`,
-    `V${bottom + leftPanelRadius}`,
-    `Q${panelLeft} ${bottom} ${panelLeft + leftPanelRadius} ${bottom}`,
-    `H${leftJoin}`,
-    `C${leftJoin + leftControl} ${bottom} ${left} ${bottom - leftDepth + leftControl} ${left} ${bottom - leftDepth}`,
-    `V${top + TAB_RADIUS}`,
-    `Q${left} ${top} ${left + TAB_RADIUS} ${top}`,
-    `H${right - TAB_RADIUS}`,
-    `Q${right} ${top} ${right} ${top + TAB_RADIUS}`,
-    `V${bottom - rightDepth}`,
-    `C${right} ${bottom - rightDepth + rightControl} ${rightJoin - rightControl} ${bottom} ${rightJoin} ${bottom}`,
-    `H${panelRight - rightPanelRadius}`,
-    `Q${panelRight} ${bottom} ${panelRight} ${bottom + rightPanelRadius}`,
-    `V${bottom + PANEL_RADIUS}`,
-    "Z",
-  ].join(" ");
-}
-
-function SpringTab({
-  id,
-  targetLeft,
-  dragging,
-  dragLeft,
-  surfaceLeft,
-  scrollLeft,
-  reduce,
-  active,
-  anyDragging,
-  surfaceHost,
-  surfaceWidth,
-  surfaceClassName,
-  zIndex,
-  className,
-  children,
-  registerPosition,
-  onPointerDown,
-  onPointerMove,
-  onPointerUp,
-  onPointerCancel,
-  onLostPointerCapture,
-}: SpringTabProps) {
-  const target = useMotionValue(targetLeft);
-  const position = useSpring(target, SPRING_GLIDE);
-  const settledTransform = useTransform(
-    reduce ? target : position,
-    (left) => `translate3d(${left}px, 0, 0)`,
-  );
-  const draggedTransform = useTransform(
-    dragLeft,
-    (left) => `translate3d(${left}px, 0, 0)`,
-  );
-
-  useLayoutEffect(() => {
-    target.set(targetLeft);
-    if (reduce) position.jump(targetLeft);
-  }, [position, reduce, target, targetLeft]);
-
-  useLayoutEffect(() => {
-    registerPosition(id, position);
-    return () => registerPosition(id, null);
-  }, [id, position, registerPosition]);
-
-  const liquidDriver = anyDragging
-    ? dragging
-      ? dragLeft
-      : position
-    : surfaceLeft;
-
-  return (
-    <>
-      {active && surfaceHost && surfaceWidth > SURFACE_INSET * 2
-        ? createPortal(
-            <svg
-              aria-hidden="true"
-              focusable="false"
-              viewBox={`0 0 ${surfaceWidth} ${RAIL_HEIGHT + PANEL_RADIUS}`}
-              preserveAspectRatio="none"
-              className={cn(
-                // Always below the content panel (z-20). Raising to z-20 on drag
-                // (beui default) paints the full-width panel strip over the toolbar.
-                "pointer-events-none absolute inset-x-0 top-0 z-[15] w-full text-background",
-                surfaceClassName,
-              )}
-              style={{ height: RAIL_HEIGHT + PANEL_RADIUS }}
-            >
-              <LiquidSurfacePath
-                key={
-                  anyDragging
-                    ? dragging
-                      ? "dragged"
-                      : "displaced"
-                    : "idle"
-                }
-                left={liquidDriver}
-                scrollLeft={scrollLeft}
-                surfaceWidth={surfaceWidth}
-              />
-            </svg>,
-            surfaceHost,
-          )
-        : null}
-      <motion.div
-        style={{
-          zIndex,
-          transform: dragging ? draggedTransform : settledTransform,
-        }}
-        className={className}
-        onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
-        onPointerUp={onPointerUp}
-        onPointerCancel={onPointerCancel}
-        onLostPointerCapture={onLostPointerCapture}
-      >
-        {children}
-      </motion.div>
-    </>
-  );
-}
-
-function LiquidSurfacePath({
-  left,
-  scrollLeft,
-  surfaceWidth,
-}: {
-  /** Active tab left in track coordinates. */
-  left: MotionValue<number>;
-  /** Tab strip scroll — liquid SVG is root-fixed, so tab x = left − scroll. */
-  scrollLeft: MotionValue<number>;
-  surfaceWidth: number;
-}) {
-  const path = useTransform([left, scrollLeft], ([tabLeft, scroll]: number[]) =>
-    liquidTabPath(tabLeft - scroll, surfaceWidth),
-  );
-  return <motion.path d={path} fill="currentColor" />;
-}
-
-function AddTabButton({
-  ariaLabel,
-  onClick,
-}: {
-  ariaLabel: string;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      aria-label={ariaLabel}
-      title={ariaLabel}
-      onClick={onClick}
-      className="desktop-no-drag flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/50 hover:text-foreground"
-    >
-      <Plus className="size-3.5" />
-    </button>
-  );
-}
 
 export function MorphingTabs({
   items,

--- a/apps/web/src/features/browser/lib/__tests__/morphing-tabs-geometry.test.ts
+++ b/apps/web/src/features/browser/lib/__tests__/morphing-tabs-geometry.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  moveItem,
+  sameOrder,
+  safeId,
+  liquidPanelOnlyPath,
+  liquidTabPath,
+} from "../morphing-tabs-geometry";
+
+describe("morphing-tabs-geometry", () => {
+  it("sameOrder compares sequence equality", () => {
+    expect(sameOrder(["a", "b"], ["a", "b"])).toBe(true);
+    expect(sameOrder(["a", "b"], ["b", "a"])).toBe(false);
+    expect(sameOrder(["a"], ["a", "b"])).toBe(false);
+  });
+
+  it("moveItem reorders without mutating source", () => {
+    const order = ["a", "b", "c"];
+    expect(moveItem(order, 0, 2)).toEqual(["b", "c", "a"]);
+    expect(order).toEqual(["a", "b", "c"]);
+    expect(moveItem(order, 1, 1)).toEqual(["a", "b", "c"]);
+  });
+
+  it("safeId strips unsafe characters", () => {
+    expect(safeId("foo/bar:baz")).toBe("foo-bar-baz");
+  });
+
+  it("liquid paths are non-empty SVG d strings", () => {
+    expect(liquidPanelOnlyPath(200).startsWith("M")).toBe(true);
+    expect(liquidTabPath(10, 200).startsWith("M")).toBe(true);
+  });
+});

--- a/apps/web/src/features/browser/lib/morphing-tabs-geometry.ts
+++ b/apps/web/src/features/browser/lib/morphing-tabs-geometry.ts
@@ -1,0 +1,106 @@
+/** Geometry + pure helpers for MorphingTabs (no React). */
+
+export const DRAG_THRESHOLD = 5;
+/** Dense browser chrome scale of beui defaults (logic unchanged). */
+export const TAB_WIDTH = 156;
+export const TAB_HEIGHT = 28;
+export const TAB_TOP = 2;
+export const TAB_RADIUS = 10;
+export const RAIL_HEIGHT = 30;
+/** 0 = flush with panel edge so first active tab joins square TL (beui inset was 16). */
+export const SURFACE_INSET = 0;
+export const LIQUID_JOIN = 12;
+/** How far the liquid fill dips into the content panel for corner morphs.
+ *  Keep small — dense chrome toolbar sits right under the rail. */
+export const PANEL_RADIUS = 8;
+export const ADD_BUTTON_SIZE = 24;
+export const ADD_BUTTON_GAP = 4;
+/** Extra scroll room so active-tab liquid ears (bottom L/R) are not clipped by
+ *  the scrollport edge — symmetric when the tab is not flush with the strip end. */
+export const SCROLL_EDGE_PAD = LIQUID_JOIN + 4;
+
+export function sameOrder(a: string[], b: string[]) {
+  return a.length === b.length && a.every((id, index) => id === b[index]);
+}
+
+export function safeId(value: string) {
+  return value.replace(/[^a-zA-Z0-9_-]/g, "-");
+}
+
+export function moveItem(order: string[], from: number, to: number) {
+  if (from === to) return order.slice();
+  const next = order.slice();
+  const [item] = next.splice(from, 1);
+  next.splice(to, 0, item);
+  return next;
+}
+
+/** Panel top edge only (full corner radii) — used when the active tab has
+ *  scrolled fully out of the visible strip so the fill is not pinned at an edge. */
+export function liquidPanelOnlyPath(surfaceWidth: number) {
+  const panelLeft = SURFACE_INSET;
+  const panelRight = Math.max(panelLeft + TAB_WIDTH, surfaceWidth - SURFACE_INSET);
+  const bottom = RAIL_HEIGHT;
+  const r = PANEL_RADIUS;
+  return [
+    `M${panelLeft} ${bottom + r}`,
+    `V${bottom + r}`,
+    `Q${panelLeft} ${bottom} ${panelLeft + r} ${bottom}`,
+    `H${panelRight - r}`,
+    `Q${panelRight} ${bottom} ${panelRight} ${bottom + r}`,
+    `V${bottom + r}`,
+    "Z",
+  ].join(" ");
+}
+
+export function liquidTabPath(tabLeft: number, surfaceWidth: number) {
+  const panelLeft = SURFACE_INSET;
+  const panelRight = Math.max(panelLeft + TAB_WIDTH, surfaceWidth - SURFACE_INSET);
+  // Viewport x of the active tab (track left − scroll). Do NOT clamp into the
+  // panel — clamping pinned the silhouette at the left/right when scrolling.
+  const left = tabLeft;
+  const right = left + TAB_WIDTH;
+  const top = RAIL_HEIGHT - TAB_HEIGHT;
+  const bottom = RAIL_HEIGHT;
+
+  // Fully off-screen → only the content top strip (no stuck edge tab fill).
+  if (right < panelLeft || left > panelRight) {
+    return liquidPanelOnlyPath(surfaceWidth);
+  }
+
+  const leftJoin = Math.max(panelLeft, left - LIQUID_JOIN);
+  const rightJoin = Math.min(panelRight, right + LIQUID_JOIN);
+  const leftDepth = Math.max(0, Math.min(LIQUID_JOIN, left - leftJoin));
+  const rightDepth = Math.max(0, Math.min(LIQUID_JOIN, rightJoin - right));
+  const leftControl = leftDepth * 0.55;
+  const rightControl = rightDepth * 0.55;
+  // Flush with content left only when the tab edge is at/near panelLeft.
+  // Scrolled past the left edge → full radius (not square residual).
+  const leftPanelRadius =
+    left <= panelLeft
+      ? Math.min(PANEL_RADIUS, Math.max(0, panelLeft - left))
+      : Math.min(PANEL_RADIUS, Math.max(0, leftJoin - panelLeft));
+  const rightPanelRadius =
+    right >= panelRight
+      ? Math.min(PANEL_RADIUS, Math.max(0, right - panelRight))
+      : Math.min(PANEL_RADIUS, Math.max(0, panelRight - rightJoin));
+
+  return [
+    `M${panelLeft} ${bottom + PANEL_RADIUS}`,
+    `V${bottom + leftPanelRadius}`,
+    `Q${panelLeft} ${bottom} ${panelLeft + leftPanelRadius} ${bottom}`,
+    `H${leftJoin}`,
+    `C${leftJoin + leftControl} ${bottom} ${left} ${bottom - leftDepth + leftControl} ${left} ${bottom - leftDepth}`,
+    `V${top + TAB_RADIUS}`,
+    `Q${left} ${top} ${left + TAB_RADIUS} ${top}`,
+    `H${right - TAB_RADIUS}`,
+    `Q${right} ${top} ${right} ${top + TAB_RADIUS}`,
+    `V${bottom - rightDepth}`,
+    `C${right} ${bottom - rightDepth + rightControl} ${rightJoin - rightControl} ${bottom} ${rightJoin} ${bottom}`,
+    `H${panelRight - rightPanelRadius}`,
+    `Q${panelRight} ${bottom} ${panelRight} ${bottom + rightPanelRadius}`,
+    `V${bottom + PANEL_RADIUS}`,
+    "Z",
+  ].join(" ");
+}
+

--- a/automations/review/quality/result/2026-08/08-07_score-77_RESULT.md
+++ b/automations/review/quality/result/2026-08/08-07_score-77_RESULT.md
@@ -146,4 +146,4 @@ APP-055 与 #208 质量修复结构扎实，但同日引入 1200+ 行 `morphing-
 
 - 修复分支：`grokbuild/quality-fix/2026-08-07`
 - 修复提交：`ed8dcd863`
-- PR URL：见创建后回填
+- PR URL：https://github.com/AruNi-01/atmos/pull/209

--- a/automations/review/quality/result/2026-08/08-07_score-77_RESULT.md
+++ b/automations/review/quality/result/2026-08/08-07_score-77_RESULT.md
@@ -1,0 +1,149 @@
+# Atmos main 每日代码质量评分（2026-08-07）
+
+## 1. 审查范围
+
+- 昨日时间窗口：2026-08-07 00:00:00 到 2026-08-07 23:59:59（UTC+8 / Asia/Shanghai）。
+- 分支：`main`（日终 tip `e7a8df836`）。
+- 排除：`f62e0c620` / `90b655f86` 仅为 quality result 归档/链接，不参与评分。
+- 审查方式：以 morphing browser tabs、APP-055 Run logs、grant overlay 放大、质量修复 #208、mgmt center / release 抛光为主线。
+- 修复在独立 worktree / 分支 `grokbuild/quality-fix/2026-08-07` 完成。
+
+被审查提交（含 merge；已排除纯结果归档）：
+
+| Hash | Author | Message |
+| --- | --- | --- |
+| `e3dc444a6` | AarynLu | feat(web): replace center-stage tab pin with drag reorder |
+| `376032c36` | AarynLu | fix(desktop-use): refine Accessibility grant overlay and settings copy |
+| `2df44a0af` | AarynLu | refactor: address daily quality findings for 2026-08-06 |
+| `64e9f859b` | AarynLu | feat(web): morphing browser tabs with drag reorder and overflow scroll |
+| `a05d65b21` | lurunrun820 | fix: address PR #207 CI failures and review threads |
+| `550731580` | lurunrun820 | fix(web): ignore stale experiment settings loads after computer switch |
+| `d2d60dfdd` | lurunrun820 | fix(web): fix TS2454 in experiment settings load inflight clear |
+| `11780ccd5` | AarynLu | fix(web): keep mgmt center unsettled across computer switch |
+| `4d540e809` | AarynLu | fix(web): polish morphing browser tab strip |
+| `8bb269edc` | AarynLu | feat: add APP-055 Run terminal project logs |
+| `8ddca04cd` | AarynLu | fix(quota-usage): honor provider switches on refresh |
+| `42bce33de` | AarynLu | fix(api): install standalone CLI in background on startup |
+| `294dfe762` | AarynLu | fix(core-service): use sort_by_key in run_log_tee for clippy |
+| `9aa84f540` | AruNi_Lu | Merge pull request #207 from AruNi-01/feat/mgmt-center-item-switches-placement |
+| `fb6e48325` | AruNi_Lu | Merge pull request #208 from AruNi-01/grokbuild/quality-fix/2026-08-06 |
+| `bd8d1def0` | AarynLu | chore(cli): bump version to 2026.8.7 |
+| `e9c8bc050` | AarynLu | chore: bump local runtime version to 2026.8.7 |
+| `b8b1d762c` | AarynLu | chore(desktop-electron): release 2026.8.7-beta.1 |
+| `ae16976ec` | AarynLu | fix(web): put compact refresh icon last on Files Diff hover |
+| `1397298df` | AarynLu | fix(web): polish left sidebar management center and group headers |
+| `be5427438` | AarynLu | fix(desktop): tighten browser traffic lights and tab rail inset |
+| `1e1703d0b` | AarynLu | fix(web): wrap code agent run config collapsible body for border layout |
+| `6b0a67ef9` | AarynLu | fix(web,desktop): stop Grok TUI hop flash and runtime mac chrome |
+| `f84c1b10c` | AarynLu | fix(desktop): keep browser DevTools available in release |
+| `144f6e6a7` | AarynLu | fix(desktop): use Turbopack for non-Windows static web builds |
+| `d1b69c39b` | AarynLu | fix(web): restore left sidebar edge-hover peek when collapsed |
+| `1759b8626` | AarynLu | chore(desktop-electron): release 2026.8.7 |
+| `e7a8df836` | AarynLu | chore(landing): add desktop 2026.8.7 changelog entry |
+
+## 2. 一份好代码应该是什么样
+
+本日标准看「新引入的交互子系统是否可按职责导航」。液体 Tab 动画应把几何纯函数、弹簧/液面子件与编排状态机拆开；grant overlay 应把 HTML 面板、几何定位与 Electron 生命周期隔离；Run log tee 应把 ANSI 纯变换与磁盘 IO 分开。昨日质量修复落地与 APP-055 的分层（core-engine 路径 + service tee + 薄 web lib）应作为正向对照。
+
+## 3. 评分方法
+
+- 100 分制：设计与分层 30、可读性与复杂度 25、体量与内聚 20、可维护性与复用 15、工程卫生 10。
+- 高/中/低严重度分别约扣 8–15 / 3–7 / 1–2 分；同一根因不重复计数。
+- 体量阈值作信号：服务/管理器 800+、UI 组件 400+、单函数 80+ 且职责混杂时才明确扣分。
+- 不把历史债务整包算到当日；#208 质量修复计入正向观察。
+
+## 4. 总分
+
+总分：77/100。总体判断：良好。
+
+APP-055 与 #208 质量修复结构扎实，但同日引入 1200+ 行 `morphing-tabs.tsx` 与 grant-overlay 膨胀至 ~1158 行，枢纽体量问题突出。
+
+## 5. 分项评分
+
+| 维度 | 得分 | 扣分原因 |
+| --- | ---: | --- |
+| 设计与分层 | 24/30 | 正向：APP-055 `project_atmos` / `run_log_tee` / web `run-log-context`；#208 拆 Changes 编辑与 attention。扣分：morphing tabs 几何+拖拽+滚动同文件；grant overlay 面板 HTML / osascript / fly 动画同文件。 |
+| 可读性与复杂度 | 19/25 | `MorphingTabs` 拖拽状态机 + 多 MotionValue 协同难扫读；grant 模块级可变状态多（poll/fly/generation）。 |
+| 体量与内聚 | 12/20 | 日终：`morphing-tabs.tsx` ~1215（单组件 ~850+）、`grant-overlay.ts` ~1158、`run_log_tee.rs` ~673、`Terminal.tsx` ~1682（+~64）、`LeftSidebar` ~1567（当日仅小改）。 |
+| 可维护性与复用 | 12/15 | 正向：`morphing-ease`、`browser-mac-chrome`、run-log 单测。扣分：order/liquid 纯函数未抽测；grant 面板字符串难单测直至拆分。 |
+| 工程卫生 | 10/10 | structural tests、specs APP-055、gitignore/tee 注释清晰；clipper/CI 跟进及时。 |
+
+## 6. 主要问题清单
+
+### 中高：新建 `morphing-tabs.tsx` ~1215 行，`MorphingTabs` 编排过重
+
+- 提交：`64e9f859b`、`4d540e809`
+- 文件：`apps/web/src/features/browser/components/morphing-tabs.tsx`
+- 问题：改编自 beui 的液体 Tab 把常量、SVG path、SpringTab、拖拽 session、滚动边缘、键盘重排堆在同一文件；`export function MorphingTabs` 约 850+ 行。
+- 为什么是质量问题：改密度 token 或拖拽阈值需加载整份动画状态机；纯 `moveItem`/`liquidTabPath` 本可单测却无测试边界。
+- 优化建议：`lib/morphing-tabs-geometry.ts` 承载常量与 path/order 纯函数并补单测；`morphing-tabs-parts.tsx` 承载 SpringTab/LiquidSurface/Add；主文件只保留 MorphingTabs 编排。
+
+### 中高：`grant-overlay.ts` ~347→~1158，面板/定位/飞入/IPC 未分文件
+
+- 提交：`376032c36`
+- 文件：`apps/desktop-electron/src/desktop-use/grant-overlay.ts`
+- 问题：`panelHtml` 单函数 ~237 行内联脚本；osascript bounds、fly 动画、position poll、startDrag IPC 同模块十余个 let 全局。
+- 为什么是质量问题：改文案/CSP 与改定位算法互相干扰；回归依赖整文件 structural 字符串扫描。
+- 优化建议：`grant-overlay-panel.ts`（HTML/copy/icon）、`grant-overlay-position.ts`（Rect/parse/compute）、主文件保留 window 生命周期与 fly/IPC。
+
+### 中：`run_log_tee.rs` 单文件 ~673 行，ANSI 解析与 IO 同居
+
+- 提交：`8bb269edc`
+- 文件：`crates/core-service/src/service/terminal/run_log_tee.rs`
+- 问题：`strip_ansi_and_controls` ~90 行与 start/append/prune 文件管线同文件；整体仍可导航但接近中风险上沿。
+- 为什么是质量问题：改 tee 配额策略时被迫阅读 ANSI 状态机。
+- 优化建议：抽出 `run_log_ansi.rs`（或 `strip_ansi` 模块）并保持 tee 公共 API 不变。
+
+### 低：`Terminal.tsx` 继续 +64 行处理 Grok hop flash
+
+- 提交：`6b0a67ef9`
+- 文件：`apps/web/src/features/terminal/components/Terminal.tsx`（~1682）
+- 问题：历史枢纽上继续叠写合并策略。
+- 优化建议：中期将 write coalesce / opacity stack 收到 `useTerminalWriteCoalesce` 一类 hook（本次未强行大拆，避免无 E2E 回归）。
+
+## 7. 正向观察
+
+- **#208 质量修复落地**：Changes 内联编辑 hook、attention 子模块、cursor appearance 设置组已合入 main。
+- **APP-055 分层正确**：`core-engine/project_atmos`、service tee、web `run-log-context` + 测试 + 完整 specs。
+- **center-stage 去 pin 换 drag**：净删除，模型更简单。
+- **browser-mac-chrome** 纯函数 + 测试；release/Turbopack 平台路径有注释。
+
+## 8. Review 建议
+
+1. Morphing tabs：拖拽完成 onOrderChange、overflow 滚动与 liquid 对齐。
+2. Grant overlay：System Settings bounds 超时/飞入落点/startDrag 幽灵尺寸。
+3. Run log：rotate、gitignore、ANSI 剥离与 reattach 不重复 dump。
+4. 是否还有新的 1000+ 单文件在 UI 动画/桌面辅助路径引入。
+
+## 9. 自动修复与 PR
+
+总分 77 < 90，已触发自动修复。
+
+### 修复摘要
+
+1. MorphingTabs：`morphing-tabs-geometry.ts` + 单测；`morphing-tabs-parts.tsx`；主文件瘦身。
+2. Grant overlay：`grant-overlay-panel.ts` + `grant-overlay-position.ts`；主文件 ~650 行；structural tests 覆盖多文件。
+3. Run log：`run_log_ansi.rs` 抽出 ANSI strip；tee 测试 8 passed。
+
+### 验证
+
+- `cargo test -p core-service --lib run_log`：8 passed
+- `bun --filter web typecheck`：通过
+- `bun test` grant-overlay structural：4 passed
+- pre-commit `cargo fmt`：通过
+
+### 剩余风险
+
+- `MorphingTabs` 主编排仍偏长（状态机本身复杂）；未拆 drag hook。
+- Grant fly/IPC 仍在主文件；需人工点验 macOS Accessibility 流程。
+- Terminal 枢纽未在本次拆分。
+
+## 10. 结果文件
+
+- `automations/review/quality/result/2026-08/08-07_score-77_RESULT.md`
+
+## 11. 结果提交与推送
+
+- 修复分支：`grokbuild/quality-fix/2026-08-07`
+- 修复提交：`ed8dcd863`
+- PR URL：见创建后回填

--- a/crates/core-service/src/service/terminal.rs
+++ b/crates/core-service/src/service/terminal.rs
@@ -22,6 +22,7 @@ use tracing::{debug, error, info, warn};
 
 mod management;
 mod mouse_mode_watch;
+mod run_log_ansi;
 mod run_log_tee;
 mod runtime;
 mod types;

--- a/crates/core-service/src/service/terminal/run_log_ansi.rs
+++ b/crates/core-service/src/service/terminal/run_log_ansi.rs
@@ -1,0 +1,93 @@
+//! ANSI / control-sequence stripping for Run log tee plain-text projection.
+
+pub fn strip_ansi_and_controls(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = String::with_capacity(input.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == 0x1b {
+            i += 1;
+            if i >= bytes.len() {
+                break;
+            }
+            match bytes[i] {
+                b'[' => {
+                    i += 1;
+                    while i < bytes.len() {
+                        let c = bytes[i];
+                        i += 1;
+                        if (0x40..=0x7e).contains(&c) {
+                            break;
+                        }
+                    }
+                }
+                b']' => {
+                    i += 1;
+                    while i < bytes.len() {
+                        let c = bytes[i];
+                        i += 1;
+                        if c == 0x07 {
+                            break;
+                        }
+                        if c == 0x1b && i < bytes.len() && bytes[i] == b'\\' {
+                            i += 1;
+                            break;
+                        }
+                    }
+                }
+                b'P' | b'X' | b'^' | b'_' => {
+                    i += 1;
+                    while i < bytes.len() {
+                        if bytes[i] == 0x1b {
+                            i += 1;
+                            if i < bytes.len() && bytes[i] == b'\\' {
+                                i += 1;
+                                break;
+                            }
+                        } else {
+                            i += 1;
+                        }
+                    }
+                }
+                b'(' | b')' | b'*' | b'+' => {
+                    // charset designation: ESC ( B etc.
+                    i += 1;
+                    if i < bytes.len() {
+                        i += 1;
+                    }
+                }
+                _ => {
+                    // Single-char ESC sequences
+                    i += 1;
+                }
+            }
+            continue;
+        }
+        // Keep tab and newline; drop other C0 controls and DEL.
+        if b == b'\n' || b == b'\t' || b == b'\r' {
+            if b == b'\r' {
+                // Normalize CR to nothing if followed by LF; else treat as newline.
+                if i + 1 < bytes.len() && bytes[i + 1] == b'\n' {
+                    i += 1;
+                    continue;
+                }
+                out.push('\n');
+            } else {
+                out.push(b as char);
+            }
+            i += 1;
+            continue;
+        }
+        if b < 0x20 || b == 0x7f {
+            i += 1;
+            continue;
+        }
+        // UTF-8: take valid leading bytes as chars via lossy slice walk
+        let ch = input[i..].chars().next().unwrap_or('\u{FFFD}');
+        let len = ch.len_utf8();
+        out.push(ch);
+        i += len;
+    }
+    out
+}

--- a/crates/core-service/src/service/terminal/run_log_tee.rs
+++ b/crates/core-service/src/service/terminal/run_log_tee.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+pub use super::run_log_ansi::strip_ansi_and_controls;
 use chrono::Utc;
 use tracing::debug;
 
@@ -49,98 +50,6 @@ pub fn run_logs_dir(project_root: &Path) -> PathBuf {
 
 pub fn latest_log_path(project_root: &Path, window_name: &str) -> PathBuf {
     run_logs_dir(project_root).join(format!("{}.latest.log", sanitize_window_name(window_name)))
-}
-
-pub fn strip_ansi_and_controls(input: &str) -> String {
-    let bytes = input.as_bytes();
-    let mut out = String::with_capacity(input.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        let b = bytes[i];
-        if b == 0x1b {
-            i += 1;
-            if i >= bytes.len() {
-                break;
-            }
-            match bytes[i] {
-                b'[' => {
-                    i += 1;
-                    while i < bytes.len() {
-                        let c = bytes[i];
-                        i += 1;
-                        if (0x40..=0x7e).contains(&c) {
-                            break;
-                        }
-                    }
-                }
-                b']' => {
-                    i += 1;
-                    while i < bytes.len() {
-                        let c = bytes[i];
-                        i += 1;
-                        if c == 0x07 {
-                            break;
-                        }
-                        if c == 0x1b && i < bytes.len() && bytes[i] == b'\\' {
-                            i += 1;
-                            break;
-                        }
-                    }
-                }
-                b'P' | b'X' | b'^' | b'_' => {
-                    i += 1;
-                    while i < bytes.len() {
-                        if bytes[i] == 0x1b {
-                            i += 1;
-                            if i < bytes.len() && bytes[i] == b'\\' {
-                                i += 1;
-                                break;
-                            }
-                        } else {
-                            i += 1;
-                        }
-                    }
-                }
-                b'(' | b')' | b'*' | b'+' => {
-                    // charset designation: ESC ( B etc.
-                    i += 1;
-                    if i < bytes.len() {
-                        i += 1;
-                    }
-                }
-                _ => {
-                    // Single-char ESC sequences
-                    i += 1;
-                }
-            }
-            continue;
-        }
-        // Keep tab and newline; drop other C0 controls and DEL.
-        if b == b'\n' || b == b'\t' || b == b'\r' {
-            if b == b'\r' {
-                // Normalize CR to nothing if followed by LF; else treat as newline.
-                if i + 1 < bytes.len() && bytes[i + 1] == b'\n' {
-                    i += 1;
-                    continue;
-                }
-                out.push('\n');
-            } else {
-                out.push(b as char);
-            }
-            i += 1;
-            continue;
-        }
-        if b < 0x20 || b == 0x7f {
-            i += 1;
-            continue;
-        }
-        // UTF-8: take valid leading bytes as chars via lossy slice walk
-        let ch = input[i..].chars().next().unwrap_or('\u{FFFD}');
-        let len = ch.len_utf8();
-        out.push(ch);
-        i += len;
-    }
-    out
 }
 
 fn utc_stamp_for_archive() -> String {


### PR DESCRIPTION
## Summary

Daily code quality review for **2026-08-07** scored **77/100** (良好), triggering auto-fix.

### Score drivers
- New `morphing-tabs.tsx` ~1215 lines (liquid tab geometry + drag orchestration)
- `grant-overlay.ts` grew ~347 → ~1158 (panel HTML, bounds, fly, IPC)
- `run_log_tee.rs` ~673 with ANSI strip co-located
- Positive: APP-055 layering, quality-fix #208 land, center-stage de-pin

### Fixes
1. Split MorphingTabs → `morphing-tabs-geometry.ts` (+ tests) + `morphing-tabs-parts.tsx`
2. Split grant overlay → `grant-overlay-panel.ts` + `grant-overlay-position.ts`; update structural tests
3. Extract `run_log_ansi.rs` from run log tee

Report: `automations/review/quality/result/2026-08/08-07_score-77_RESULT.md`

## Related Issue

N/A — Atmos daily quality review automation (2026-08-07).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [x] `cargo fmt` (pre-commit)
- [x] Additional checks:
  - `cargo test -p core-service --lib run_log` → 8 passed
  - `bun --filter web typecheck` → passed
  - `bun test` grant-overlay structural → 4 passed

## Checklist

- [x] Quality result report included
- [x] Structural/unit tests updated where modules split
- [x] Followed repository conventions

### Residual risk
- MorphingTabs orchestrator still long (drag state machine)
- Grant fly/IPC still in main file — manual macOS Accessibility check recommended
- Terminal hub not split this cycle

---

### Agent
Generated by **Grok Build** · Atmos daily quality review automation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split oversized modules into focused files for Morphing Tabs and the macOS grant overlay, and extracted ANSI stripping for run logs. This reduces file size, improves testability, and keeps behavior unchanged.

- **Refactors**
  - Web: split `morphing-tabs.tsx` into `morphing-tabs-geometry.ts` (pure geometry + helpers) and `morphing-tabs-parts.tsx` (SpringTab/liquid UI); added `morphing-tabs-geometry.test.ts`.
  - Desktop: split `grant-overlay.ts` into `grant-overlay-panel.ts` (HTML/copy/icon) and `grant-overlay-position.ts` (bounds/placement); updated structural tests.
  - Core: extracted `run_log_ansi.rs` from `run_log_tee.rs` and re-exported; wired module in `terminal.rs`.

<sup>Written for commit 99ea7a9dcd2ed2c131114892c3b569874f6ae729. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a localized permission overlay with application icons, clear instructions, draggable interactions, and keyboard dismissal.
  - Improved overlay positioning within system settings and available display areas.
  - Added animated browser tabs with dragging, reduced-motion support, liquid transitions, and an accessible add-tab control.
- **Bug Fixes**
  - Improved handling of tab layouts, scrolling, clipping, and off-screen states.
  - Terminal output now presents cleaner plain text by removing formatting and control characters while preserving readable spacing.
- **Tests**
  - Added coverage for tab ordering, identifier handling, movement, and SVG geometry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->