### PR TITLE
refactor: address daily quality findings for 2026-08-08

### DIFF
--- a/apps/desktop-electron/src/browser/browser-use-chrome.ts
+++ b/apps/desktop-electron/src/browser/browser-use-chrome.ts
@@ -1,0 +1,119 @@
+/**
+ * Embedded Browser Use chrome helpers (Desktop Use highlight + cursor).
+ * Kept out of the HTTP control plane so guest automation routing stays navigable.
+ */
+
+import { spawn } from "node:child_process";
+import {
+  DESKTOP_USE_MANIFEST_ENV,
+  resolveAtmosCliPath,
+  resolveDesktopUseManifestPath,
+} from "../desktop-use/client.js";
+
+/** Session id shared with Rust browser-use chrome (Desktop Use cursor palette). */
+const BROWSER_USE_CHROME_SESSION = "atmos-browser-use";
+
+/**
+ * Map guest-local element rect → approximate screen (logical) coords using the
+ * host BrowserWindow content origin. Best-effort: webview offset inside the
+ * page is not measured (may be slightly off; click path stays CDP/DOM).
+ */
+export function mapGuestRectToScreen(
+  hostContent: { x: number; y: number; width: number; height: number },
+  rect: { x: number; y: number; width: number; height: number },
+): {
+  cursor: { x: number; y: number };
+  bounds: { x: number; y: number; width: number; height: number };
+} {
+  const x = hostContent.x + rect.x;
+  const y = hostContent.y + rect.y;
+  const width = Math.max(1, rect.width);
+  const height = Math.max(1, rect.height);
+  return {
+    cursor: { x: x + width / 2, y: y + height / 2 },
+    bounds: { x, y, width, height },
+  };
+}
+
+/**
+ * Spawn detached without risking Electron main uncaughtException on ENOENT
+ * (missing ATMOS_CLI / ~/.atmos/bin/atmos). Mirrors control-plane listen hardening.
+ */
+function spawnDetachedQuiet(command: string, args: string[]): void {
+  try {
+    const env = { ...process.env };
+    const manifest = resolveDesktopUseManifestPath();
+    if (manifest) env[DESKTOP_USE_MANIFEST_ENV] = manifest;
+    const child = spawn(command, args, {
+      detached: true,
+      stdio: "ignore",
+      env,
+    });
+    child.on("error", (err) => {
+      // Missing binary, EACCES, etc. — never crash the main process.
+      console.warn(
+        `[browser-use] chrome spawn failed cmd=${command}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+    child.unref();
+  } catch (err) {
+    console.warn(
+      `[browser-use] chrome spawn threw cmd=${command}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+/**
+ * Fire-and-forget Desktop Use chrome (operation border + agent cursor).
+ * Reuses `atmos desktop-use drive highlight|move` — same overlay stack as Desktop Use.
+ * Never throws; missing CLI only logs a warning (does not crash main).
+ */
+export function showEmbeddedBrowserChrome(opts: {
+  status: string;
+  cursor: { x: number; y: number };
+  bounds: { x: number; y: number; width: number; height: number };
+  session?: string;
+}): void {
+  // Prefer App-bundled runner (same pin authority as Desktop Use client).
+  const atmos =
+    process.env.ATMOS_CLI?.trim() ||
+    process.env.ATMOS_CLI_PATH?.trim() ||
+    resolveAtmosCliPath();
+  const session = opts.session?.trim() || BROWSER_USE_CHROME_SESSION;
+  const b = opts.bounds;
+  const c = opts.cursor;
+  // Border around the element (or host content when bounds are large).
+  spawnDetachedQuiet(atmos, [
+    "desktop-use",
+    "--json",
+    "drive",
+    "highlight",
+    "--mode",
+    "window",
+    "--x",
+    String(Math.round(b.x)),
+    "--y",
+    String(Math.round(b.y)),
+    "--width",
+    String(Math.round(b.width)),
+    "--height",
+    String(Math.round(b.height)),
+    "--status",
+    opts.status,
+  ]);
+  // Agent cursor overlay (not OS pointer steal).
+  spawnDetachedQuiet(atmos, [
+    "desktop-use",
+    "--json",
+    "drive",
+    "move",
+    "--x",
+    String(Math.round(c.x)),
+    "--y",
+    String(Math.round(c.y)),
+    "--coord-space",
+    "points",
+    "--session",
+    session,
+  ]);
+}

--- a/apps/desktop-electron/src/browser/browser-use-control.structural.test.ts
+++ b/apps/desktop-electron/src/browser/browser-use-control.structural.test.ts
@@ -31,11 +31,13 @@ describe("browser-use-control structural", () => {
   });
 
   it("wires Desktop Use agent chrome on embedded click/type", () => {
-    const src = readFileSync(join(root, "browser/browser-use-control.ts"), "utf8");
+    const control = readFileSync(join(root, "browser/browser-use-control.ts"), "utf8");
+    const chrome = readFileSync(join(root, "browser/browser-use-chrome.ts"), "utf8");
+    const src = `${control}\n${chrome}`;
     expect(src).toContain("showEmbeddedBrowserChrome");
     expect(src).toContain("mapGuestRectToScreen");
-    expect(src).toContain("showChromeForRef");
-    expect(src).toContain("spawnDetachedQuiet");
+    expect(control).toContain("showChromeForRef");
+    expect(chrome).toContain("spawnDetachedQuiet");
     expect(src).toContain('child.on("error"');
     expect(src).toContain("desktop-use");
     expect(src).toContain("drive");

--- a/apps/desktop-electron/src/browser/browser-use-control.ts
+++ b/apps/desktop-electron/src/browser/browser-use-control.ts
@@ -6,129 +6,23 @@
  */
 
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import { spawn } from "node:child_process";
 import { mkdirSync, writeFileSync, unlinkSync, existsSync } from "node:fs";
 import { basename, join } from "node:path";
 import { homedir } from "node:os";
 import type { Debugger, DownloadItem, WebContents } from "electron";
-import {
-  DESKTOP_USE_MANIFEST_ENV,
-  resolveAtmosCliPath,
-  resolveDesktopUseManifestPath,
-} from "../desktop-use/client.js";
 import type { BrowserSurfaceManager } from "./surface-manager.js";
+import {
+  mapGuestRectToScreen,
+  showEmbeddedBrowserChrome,
+} from "./browser-use-chrome.js";
+
+// Re-export chrome helpers for existing callers.
+export { mapGuestRectToScreen, showEmbeddedBrowserChrome } from "./browser-use-chrome.js";
 
 const CONTROL_DIR = () =>
   process.env.ATMOS_BROWSER_USE_HOME?.trim() ||
   join(homedir(), ".atmos", "browser-use");
 
-/** Session id shared with Rust browser-use chrome (Desktop Use cursor palette). */
-const BROWSER_USE_CHROME_SESSION = "atmos-browser-use";
-
-/**
- * Map guest-local element rect → approximate screen (logical) coords using the
- * host BrowserWindow content origin. Best-effort: webview offset inside the
- * page is not measured (may be slightly off; click path stays CDP/DOM).
- */
-export function mapGuestRectToScreen(
-  hostContent: { x: number; y: number; width: number; height: number },
-  rect: { x: number; y: number; width: number; height: number },
-): {
-  cursor: { x: number; y: number };
-  bounds: { x: number; y: number; width: number; height: number };
-} {
-  const x = hostContent.x + rect.x;
-  const y = hostContent.y + rect.y;
-  const width = Math.max(1, rect.width);
-  const height = Math.max(1, rect.height);
-  return {
-    cursor: { x: x + width / 2, y: y + height / 2 },
-    bounds: { x, y, width, height },
-  };
-}
-
-/**
- * Spawn detached without risking Electron main uncaughtException on ENOENT
- * (missing ATMOS_CLI / ~/.atmos/bin/atmos). Mirrors control-plane listen hardening.
- */
-function spawnDetachedQuiet(command: string, args: string[]): void {
-  try {
-    const env = { ...process.env };
-    const manifest = resolveDesktopUseManifestPath();
-    if (manifest) env[DESKTOP_USE_MANIFEST_ENV] = manifest;
-    const child = spawn(command, args, {
-      detached: true,
-      stdio: "ignore",
-      env,
-    });
-    child.on("error", (err) => {
-      // Missing binary, EACCES, etc. — never crash the main process.
-      console.warn(
-        `[browser-use] chrome spawn failed cmd=${command}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    });
-    child.unref();
-  } catch (err) {
-    console.warn(
-      `[browser-use] chrome spawn threw cmd=${command}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
-}
-
-/**
- * Fire-and-forget Desktop Use chrome (operation border + agent cursor).
- * Reuses `atmos desktop-use drive highlight|move` — same overlay stack as Desktop Use.
- * Never throws; missing CLI only logs a warning (does not crash main).
- */
-export function showEmbeddedBrowserChrome(opts: {
-  status: string;
-  cursor: { x: number; y: number };
-  bounds: { x: number; y: number; width: number; height: number };
-  session?: string;
-}): void {
-  // Prefer App-bundled runner (same pin authority as Desktop Use client).
-  const atmos =
-    process.env.ATMOS_CLI?.trim() ||
-    process.env.ATMOS_CLI_PATH?.trim() ||
-    resolveAtmosCliPath();
-  const session = opts.session?.trim() || BROWSER_USE_CHROME_SESSION;
-  const b = opts.bounds;
-  const c = opts.cursor;
-  // Border around the element (or host content when bounds are large).
-  spawnDetachedQuiet(atmos, [
-    "desktop-use",
-    "--json",
-    "drive",
-    "highlight",
-    "--mode",
-    "window",
-    "--x",
-    String(Math.round(b.x)),
-    "--y",
-    String(Math.round(b.y)),
-    "--width",
-    String(Math.round(b.width)),
-    "--height",
-    String(Math.round(b.height)),
-    "--status",
-    opts.status,
-  ]);
-  // Agent cursor overlay (not OS pointer steal).
-  spawnDetachedQuiet(atmos, [
-    "desktop-use",
-    "--json",
-    "drive",
-    "move",
-    "--x",
-    String(Math.round(c.x)),
-    "--y",
-    String(Math.round(c.y)),
-    "--coord-space",
-    "points",
-    "--session",
-    session,
-  ]);
-}
 
 type SnapshotEl = {
   ref: string;

--- a/apps/desktop-electron/src/desktop-use/host-capture.test.ts
+++ b/apps/desktop-electron/src/desktop-use/host-capture.test.ts
@@ -24,7 +24,7 @@ describe("host engine capture routing", () => {
 
   it("reads Atmos-normalized capture.png_base64 (not phantom engine keys only)", () => {
     const src = readFileSync(join(import.meta.dir, "host-capture.ts"), "utf8");
-    expect(src).toContain("capture.png_base64");
+    expect(src).toMatch(/capture[\s\S]{0,80}png_base64/);
     expect(src).toContain("r.png_base64");
     expect(src).toContain("throw new Error");
     expect(src).not.toContain("host_engine_screenshot_missing");

--- a/apps/desktop-electron/src/desktop-use/host-capture.ts
+++ b/apps/desktop-electron/src/desktop-use/host-capture.ts
@@ -6,6 +6,25 @@
  */
 
 import {
+  appNamesLooselyEqual,
+  hostWindowToFrontmost,
+  matchWindowForFrontmost,
+  mergeFrontmostIdentity,
+  pickFrontmostWindow,
+  shouldUseHostEngineCapture,
+  type HostWindowRow,
+} from "./host-window-match.js";
+export type { HostWindowRow } from "./host-window-match.js";
+export {
+  appNamesLooselyEqual,
+  hostWindowToFrontmost,
+  matchWindowForFrontmost,
+  mergeFrontmostIdentity,
+  pickFrontmostWindow,
+  shouldUseHostEngineCapture,
+} from "./host-window-match.js";
+
+import {
   buildAppshotContextMarkdown,
   desktopUseReadFrontmost,
   type DesktopUseFrontmost,
@@ -23,297 +42,11 @@ import {
   type LogicalBounds,
 } from "./window-crop.js";
 
-export type HostWindowRow = {
-  app_name?: string;
-  title?: string;
-  pid?: number;
-  window_id?: number;
-  is_on_screen?: boolean;
-  z_index?: number | null;
-  bounds?: { x?: number; y?: number; width?: number; height?: number };
-};
-
-/** Overlay / helper processes that are never the user's AppShot target. */
-const SKIP_APP_NAMES = new Set(
-  [
-    "CursorUIViewService",
-    "Window Server",
-    "WindowManager",
-    "WindowManager Server",
-    "NotificationCenter",
-    "Control Center",
-    "ControlCentre",
-    "Dock",
-    "SystemUIServer",
-    "TextInputMenuAgent",
-    "TextInputSwitcher",
-    "Spotlight",
-    "SpotlightUIServer",
-    "Universal Control",
-    "AirPlayUIAgent",
-    "UserNotificationCenter",
-    "coreautha",
-    "loginwindow",
-    "Wallpaper",
-    "WidgetKit Simulator",
-    "JavaApplicationStub", // rarely useful as "frontmost" alone
-  ].map((s) => s.toLowerCase()),
-);
-
-/** Minimum window area (logical points²) to count as a real content window. */
-const MIN_WINDOW_AREA = 120 * 120;
-/** Reject menu/title chrome strips even when width is full-screen. */
-const MIN_WINDOW_EDGE = 64;
-
-/** Pure: use host engine capture iff control engine is installed. */
-export function shouldUseHostEngineCapture(
-  status: Pick<DesktopUseStatusJson, "driver"> | null | undefined,
-): boolean {
-  return Boolean(status?.driver?.installed);
-}
-
-function windowArea(w: HostWindowRow): number {
-  const b = w.bounds;
-  if (!b) return 0;
-  const width = typeof b.width === "number" ? b.width : 0;
-  const height = typeof b.height === "number" ? b.height : 0;
-  if (width <= 0 || height <= 0) return 0;
-  return width * height;
-}
-
-function isSkippedApp(name: string | undefined | null): boolean {
-  const n = (name ?? "").trim().toLowerCase();
-  if (!n) return true;
-  if (SKIP_APP_NAMES.has(n)) return true;
-  // Generic agent / UI helper suffixes
-  if (n.endsWith("uiviewservice") || n.endsWith("uiagent")) return true;
-  return false;
-}
-
-/**
- * Loose app-name equality for host list vs System Events.
- * Primary match is always **pid**; this only helps when names differ by
- * localization/spacing (generic contains / strip-space), not app-specific lists.
- */
-export function appNamesLooselyEqual(a: string, b: string): boolean {
-  const na = a.trim().toLowerCase().replace(/\s+/g, "");
-  const nb = b.trim().toLowerCase().replace(/\s+/g, "");
-  if (!na || !nb) return false;
-  if (na === nb) return true;
-  // Generic substring (handles many EN/localized process name pairs).
-  if (na.length >= 2 && nb.length >= 2 && (na.includes(nb) || nb.includes(na))) {
-    return true;
-  }
-  return false;
-}
-
-function scoreWindow(
-  w: HostWindowRow,
-  opts: {
-    preferPid?: number | null;
-    preferApp?: string | null;
-    selfNames: Set<string>;
-    anyOnScreen: boolean;
-  },
-): number {
-  const app = (w.app_name ?? "").trim();
-  if (!app || isSkippedApp(app)) return -Infinity;
-
-  const b = w.bounds;
-  const wW = typeof b?.width === "number" ? b.width : 0;
-  const wH = typeof b?.height === "number" ? b.height : 0;
-  // Always drop title-bar / menu chrome (e.g. 1512×33) even for preferred pid.
-  if (wW > 0 && wH > 0 && (wW < MIN_WINDOW_EDGE || wH < MIN_WINDOW_EDGE)) {
-    return -Infinity;
-  }
-
-  const preferredByPid =
-    opts.preferPid != null && typeof w.pid === "number" && w.pid === opts.preferPid;
-  const preferredByApp =
-    Boolean(opts.preferApp) && appNamesLooselyEqual(app, opts.preferApp!);
-  const preferred = preferredByPid || preferredByApp;
-
-  // Skip Atmos/self chrome unless this row is the explicitly focused app
-  // (AppShot of Atmos itself is allowed and needs real window bounds).
-  if (opts.selfNames.has(app) && !preferred) return -Infinity;
-
-  const area = windowArea(w);
-  if (area > 0 && area < MIN_WINDOW_AREA) return -Infinity;
-
-  let score = 0;
-  const z = typeof w.z_index === "number" ? w.z_index : 0;
-  // Among same-pid windows, area dominates z (chrome strips often have higher z).
-  score += Math.min(area, 8_000_000) / 100;
-  score += z;
-
-  if (opts.anyOnScreen) {
-    if (w.is_on_screen) score += 1_000_000;
-    else score -= 100_000; // don't fully discard; host often marks false
-  }
-
-  if (preferredByPid) score += 5_000_000;
-  if (preferredByApp) score += 2_000_000;
-
-  const title = (w.title ?? "").trim();
-  if (title) score += 50_000;
-
-  return score;
-}
-
-/**
- * Pick the best window for AppShot context.
- * Prefer focused app (pid/name), real on-screen content windows, non-empty
- * titles, and higher z — never bare utility overlays.
- */
-export function pickFrontmostWindow(
-  windows: HostWindowRow[],
-  options: {
-    preferPid?: number | null;
-    preferApp?: string | null;
-    selfAppNames?: Set<string>;
-  } = {},
-): HostWindowRow | null {
-  if (!windows.length) return null;
-  const selfNames =
-    options.selfAppNames ??
-    new Set(["Atmos", "Atmos Electron", "Atmos Desktop", "Electron"]);
-  const anyOnScreen = windows.some((w) => w.is_on_screen);
-
-  let best: HostWindowRow | null = null;
-  let bestScore = -Infinity;
-  for (const w of windows) {
-    const s = scoreWindow(w, {
-      preferPid: options.preferPid,
-      preferApp: options.preferApp,
-      selfNames,
-      anyOnScreen,
-    });
-    if (s > bestScore) {
-      bestScore = s;
-      best = w;
-    }
-  }
-  return bestScore > -Infinity ? best : null;
-}
-
-/**
- * Match host list_windows rows to a System Events frontmost identity.
- */
-export function matchWindowForFrontmost(
-  windows: HostWindowRow[],
-  frontmost: Pick<DesktopUseFrontmost, "appName" | "processId">,
-  selfAppNames?: Set<string>,
-): HostWindowRow | null {
-  return pickFrontmostWindow(windows, {
-    preferPid: frontmost.processId,
-    preferApp: frontmost.appName,
-    selfAppNames,
-  });
-}
-
-export function hostWindowToFrontmost(w: HostWindowRow | null): DesktopUseFrontmost {
-  const b = w?.bounds;
-  const appName = (w?.app_name ?? "Unknown App").trim() || "Unknown App";
-  const title = w?.title?.trim() || null;
-  return {
-    appName,
-    // Empty titles stay null — UI should not invent "Untitled window" when the
-    // app name already identifies the capture.
-    windowTitle: title && title !== appName ? title : title || null,
-    bundleId: null,
-    processId: typeof w?.pid === "number" ? w.pid : null,
-    windowId: typeof w?.window_id === "number" ? String(w.window_id) : null,
-    x: typeof b?.x === "number" ? b.x : null,
-    y: typeof b?.y === "number" ? b.y : null,
-    width: typeof b?.width === "number" && b.width > 0 ? b.width : null,
-    height: typeof b?.height === "number" && b.height > 0 ? b.height : null,
-  };
-}
-
-function hasCompleteBounds(fm: {
-  x: number | null;
-  y: number | null;
-  width: number | null;
-  height: number | null;
-}): boolean {
-  return (
-    fm.x != null &&
-    fm.y != null &&
-    fm.width != null &&
-    fm.height != null &&
-    fm.width >= 64 &&
-    fm.height >= 64
-  );
-}
-
-/**
- * Merge focus identity (CG / System Events) with host window row geometry.
- *
- * **Critical:** match by **pid** (or loose app name). Do not require exact
- * app_name equality — SE/NSWorkspace often say "QQMusic" while host list says
- * "QQ音乐"; strict name match previously dropped host bounds and killed crop +
- * border/fly animations.
- *
- * Geometry is atomic (x/y/w/h together). Never take host width/height while
- * leaving SE null x/y — that fails hasUsableWindowBounds and both crop + anim.
- */
-export function mergeFrontmostIdentity(
-  systemEvents: DesktopUseFrontmost | null,
-  hostRow: HostWindowRow | null,
-): DesktopUseFrontmost {
-  const fromHost = hostWindowToFrontmost(hostRow);
-  if (!systemEvents) return fromHost;
-
-  const seApp = systemEvents.appName.trim() || "Unknown App";
-  const hostApp = fromHost.appName.trim();
-  const samePid =
-    hostRow != null &&
-    systemEvents.processId != null &&
-    fromHost.processId != null &&
-    systemEvents.processId === fromHost.processId;
-  const sameName =
-    hostRow != null && appNamesLooselyEqual(hostApp, seApp);
-  // Trust host rect when pid matches OR names loosely match.
-  const trustHostRow = samePid || sameName;
-  const hostHas = hasCompleteBounds(fromHost);
-  const seHas = hasCompleteBounds(systemEvents);
-  const useHostGeometry = trustHostRow && hostHas;
-
-  const windowTitle =
-    (trustHostRow && fromHost.windowTitle) ||
-    systemEvents.windowTitle?.trim() ||
-    null;
-
-  // Prefer SE/CG app label for product identity; keep host geometry as a unit.
-  return {
-    appName: seApp,
-    windowTitle:
-      windowTitle && windowTitle !== seApp ? windowTitle : windowTitle || null,
-    bundleId: systemEvents.bundleId ?? fromHost.bundleId,
-    processId: systemEvents.processId ?? fromHost.processId,
-    windowId: useHostGeometry
-      ? fromHost.windowId ?? systemEvents.windowId
-      : systemEvents.windowId ?? fromHost.windowId,
-    x: useHostGeometry ? fromHost.x : seHas ? systemEvents.x : null,
-    y: useHostGeometry ? fromHost.y : seHas ? systemEvents.y : null,
-    width: useHostGeometry ? fromHost.width : seHas ? systemEvents.width : null,
-    height: useHostGeometry
-      ? fromHost.height
-      : seHas
-        ? systemEvents.height
-        : null,
-  };
-}
-
-/**
- * Read Atmos-normalized PNG from `drive screenshot` JSON.
- * Rust extracts engine shapes (MCP image / screenshot_file_path / --screenshot-out-file)
- * and injects `png_base64` / `capture.png_base64` — do not re-invent phantom engine keys.
- */
 function extractPngBase64(payload: unknown): string | null {
   if (!payload || typeof payload !== "object") return null;
   const o = payload as Record<string, unknown>;
 
+  // Atmos normalizes engine payloads and injects `png_base64` / `capture.png_base64` — do not re-invent phantom engine keys.
   // DriveResult.capture (Atmos CaptureResult)
   const capture = o.capture;
   if (capture && typeof capture === "object") {

--- a/apps/desktop-electron/src/desktop-use/host-window-match.ts
+++ b/apps/desktop-electron/src/desktop-use/host-window-match.ts
@@ -1,0 +1,297 @@
+/**
+ * Pure frontmost-window scoring / identity merge for host engine capture.
+ * IO (drive calls, PNG crop) stays in host-capture.ts.
+ */
+
+import type {
+  DesktopUseFrontmost,
+  DesktopUseStatusJson,
+} from "./client.js";
+
+export type HostWindowRow = {
+  app_name?: string;
+  title?: string;
+  pid?: number;
+  window_id?: number;
+  is_on_screen?: boolean;
+  z_index?: number | null;
+  bounds?: { x?: number; y?: number; width?: number; height?: number };
+};
+
+/** Overlay / helper processes that are never the user's AppShot target. */
+const SKIP_APP_NAMES = new Set(
+  [
+    "CursorUIViewService",
+    "Window Server",
+    "WindowManager",
+    "WindowManager Server",
+    "NotificationCenter",
+    "Control Center",
+    "ControlCentre",
+    "Dock",
+    "SystemUIServer",
+    "TextInputMenuAgent",
+    "TextInputSwitcher",
+    "Spotlight",
+    "SpotlightUIServer",
+    "Universal Control",
+    "AirPlayUIAgent",
+    "UserNotificationCenter",
+    "coreautha",
+    "loginwindow",
+    "Wallpaper",
+    "WidgetKit Simulator",
+    "JavaApplicationStub", // rarely useful as "frontmost" alone
+  ].map((s) => s.toLowerCase()),
+);
+
+/** Minimum window area (logical points²) to count as a real content window. */
+const MIN_WINDOW_AREA = 120 * 120;
+/** Reject menu/title chrome strips even when width is full-screen. */
+const MIN_WINDOW_EDGE = 64;
+
+/** Pure: use host engine capture iff control engine is installed. */
+export function shouldUseHostEngineCapture(
+  status: Pick<DesktopUseStatusJson, "driver"> | null | undefined,
+): boolean {
+  return Boolean(status?.driver?.installed);
+}
+
+function windowArea(w: HostWindowRow): number {
+  const b = w.bounds;
+  if (!b) return 0;
+  const width = typeof b.width === "number" ? b.width : 0;
+  const height = typeof b.height === "number" ? b.height : 0;
+  if (width <= 0 || height <= 0) return 0;
+  return width * height;
+}
+
+function isSkippedApp(name: string | undefined | null): boolean {
+  const n = (name ?? "").trim().toLowerCase();
+  if (!n) return true;
+  if (SKIP_APP_NAMES.has(n)) return true;
+  // Generic agent / UI helper suffixes
+  if (n.endsWith("uiviewservice") || n.endsWith("uiagent")) return true;
+  return false;
+}
+
+/**
+ * Loose app-name equality for host list vs System Events.
+ * Primary match is always **pid**; this only helps when names differ by
+ * localization/spacing (generic contains / strip-space), not app-specific lists.
+ */
+export function appNamesLooselyEqual(a: string, b: string): boolean {
+  const na = a.trim().toLowerCase().replace(/\s+/g, "");
+  const nb = b.trim().toLowerCase().replace(/\s+/g, "");
+  if (!na || !nb) return false;
+  if (na === nb) return true;
+  // Generic substring (handles many EN/localized process name pairs).
+  if (na.length >= 2 && nb.length >= 2 && (na.includes(nb) || nb.includes(na))) {
+    return true;
+  }
+  return false;
+}
+
+function scoreWindow(
+  w: HostWindowRow,
+  opts: {
+    preferPid?: number | null;
+    preferApp?: string | null;
+    selfNames: Set<string>;
+    anyOnScreen: boolean;
+  },
+): number {
+  const app = (w.app_name ?? "").trim();
+  if (!app || isSkippedApp(app)) return -Infinity;
+
+  const b = w.bounds;
+  const wW = typeof b?.width === "number" ? b.width : 0;
+  const wH = typeof b?.height === "number" ? b.height : 0;
+  // Always drop title-bar / menu chrome (e.g. 1512×33) even for preferred pid.
+  if (wW > 0 && wH > 0 && (wW < MIN_WINDOW_EDGE || wH < MIN_WINDOW_EDGE)) {
+    return -Infinity;
+  }
+
+  const preferredByPid =
+    opts.preferPid != null && typeof w.pid === "number" && w.pid === opts.preferPid;
+  const preferredByApp =
+    Boolean(opts.preferApp) && appNamesLooselyEqual(app, opts.preferApp!);
+  const preferred = preferredByPid || preferredByApp;
+
+  // Skip Atmos/self chrome unless this row is the explicitly focused app
+  // (AppShot of Atmos itself is allowed and needs real window bounds).
+  if (opts.selfNames.has(app) && !preferred) return -Infinity;
+
+  const area = windowArea(w);
+  if (area > 0 && area < MIN_WINDOW_AREA) return -Infinity;
+
+  let score = 0;
+  const z = typeof w.z_index === "number" ? w.z_index : 0;
+  // Among same-pid windows, area dominates z (chrome strips often have higher z).
+  score += Math.min(area, 8_000_000) / 100;
+  score += z;
+
+  if (opts.anyOnScreen) {
+    if (w.is_on_screen) score += 1_000_000;
+    else score -= 100_000; // don't fully discard; host often marks false
+  }
+
+  if (preferredByPid) score += 5_000_000;
+  if (preferredByApp) score += 2_000_000;
+
+  const title = (w.title ?? "").trim();
+  if (title) score += 50_000;
+
+  return score;
+}
+
+/**
+ * Pick the best window for AppShot context.
+ * Prefer focused app (pid/name), real on-screen content windows, non-empty
+ * titles, and higher z — never bare utility overlays.
+ */
+export function pickFrontmostWindow(
+  windows: HostWindowRow[],
+  options: {
+    preferPid?: number | null;
+    preferApp?: string | null;
+    selfAppNames?: Set<string>;
+  } = {},
+): HostWindowRow | null {
+  if (!windows.length) return null;
+  const selfNames =
+    options.selfAppNames ??
+    new Set(["Atmos", "Atmos Electron", "Atmos Desktop", "Electron"]);
+  const anyOnScreen = windows.some((w) => w.is_on_screen);
+
+  let best: HostWindowRow | null = null;
+  let bestScore = -Infinity;
+  for (const w of windows) {
+    const s = scoreWindow(w, {
+      preferPid: options.preferPid,
+      preferApp: options.preferApp,
+      selfNames,
+      anyOnScreen,
+    });
+    if (s > bestScore) {
+      bestScore = s;
+      best = w;
+    }
+  }
+  return bestScore > -Infinity ? best : null;
+}
+
+/**
+ * Match host list_windows rows to a System Events frontmost identity.
+ */
+export function matchWindowForFrontmost(
+  windows: HostWindowRow[],
+  frontmost: Pick<DesktopUseFrontmost, "appName" | "processId">,
+  selfAppNames?: Set<string>,
+): HostWindowRow | null {
+  return pickFrontmostWindow(windows, {
+    preferPid: frontmost.processId,
+    preferApp: frontmost.appName,
+    selfAppNames,
+  });
+}
+
+export function hostWindowToFrontmost(w: HostWindowRow | null): DesktopUseFrontmost {
+  const b = w?.bounds;
+  const appName = (w?.app_name ?? "Unknown App").trim() || "Unknown App";
+  const title = w?.title?.trim() || null;
+  return {
+    appName,
+    // Empty titles stay null — UI should not invent "Untitled window" when the
+    // app name already identifies the capture.
+    windowTitle: title && title !== appName ? title : title || null,
+    bundleId: null,
+    processId: typeof w?.pid === "number" ? w.pid : null,
+    windowId: typeof w?.window_id === "number" ? String(w.window_id) : null,
+    x: typeof b?.x === "number" ? b.x : null,
+    y: typeof b?.y === "number" ? b.y : null,
+    width: typeof b?.width === "number" && b.width > 0 ? b.width : null,
+    height: typeof b?.height === "number" && b.height > 0 ? b.height : null,
+  };
+}
+
+function hasCompleteBounds(fm: {
+  x: number | null;
+  y: number | null;
+  width: number | null;
+  height: number | null;
+}): boolean {
+  return (
+    fm.x != null &&
+    fm.y != null &&
+    fm.width != null &&
+    fm.height != null &&
+    fm.width >= 64 &&
+    fm.height >= 64
+  );
+}
+
+/**
+ * Merge focus identity (CG / System Events) with host window row geometry.
+ *
+ * **Critical:** match by **pid** (or loose app name). Do not require exact
+ * app_name equality — SE/NSWorkspace often say "QQMusic" while host list says
+ * "QQ音乐"; strict name match previously dropped host bounds and killed crop +
+ * border/fly animations.
+ *
+ * Geometry is atomic (x/y/w/h together). Never take host width/height while
+ * leaving SE null x/y — that fails hasUsableWindowBounds and both crop + anim.
+ */
+export function mergeFrontmostIdentity(
+  systemEvents: DesktopUseFrontmost | null,
+  hostRow: HostWindowRow | null,
+): DesktopUseFrontmost {
+  const fromHost = hostWindowToFrontmost(hostRow);
+  if (!systemEvents) return fromHost;
+
+  const seApp = systemEvents.appName.trim() || "Unknown App";
+  const hostApp = fromHost.appName.trim();
+  const samePid =
+    hostRow != null &&
+    systemEvents.processId != null &&
+    fromHost.processId != null &&
+    systemEvents.processId === fromHost.processId;
+  const sameName =
+    hostRow != null && appNamesLooselyEqual(hostApp, seApp);
+  // Trust host rect when pid matches OR names loosely match.
+  const trustHostRow = samePid || sameName;
+  const hostHas = hasCompleteBounds(fromHost);
+  const seHas = hasCompleteBounds(systemEvents);
+  const useHostGeometry = trustHostRow && hostHas;
+
+  const windowTitle =
+    (trustHostRow && fromHost.windowTitle) ||
+    systemEvents.windowTitle?.trim() ||
+    null;
+
+  // Prefer SE/CG app label for product identity; keep host geometry as a unit.
+  return {
+    appName: seApp,
+    windowTitle:
+      windowTitle && windowTitle !== seApp ? windowTitle : windowTitle || null,
+    bundleId: systemEvents.bundleId ?? fromHost.bundleId,
+    processId: systemEvents.processId ?? fromHost.processId,
+    windowId: useHostGeometry
+      ? fromHost.windowId ?? systemEvents.windowId
+      : systemEvents.windowId ?? fromHost.windowId,
+    x: useHostGeometry ? fromHost.x : seHas ? systemEvents.x : null,
+    y: useHostGeometry ? fromHost.y : seHas ? systemEvents.y : null,
+    width: useHostGeometry ? fromHost.width : seHas ? systemEvents.width : null,
+    height: useHostGeometry
+      ? fromHost.height
+      : seHas
+        ? systemEvents.height
+        : null,
+  };
+}
+
+/**
+ * Read Atmos-normalized PNG from `drive screenshot` JSON.
+ * Rust extracts engine shapes (MCP image / screenshot_file_path / --screenshot-out-file)
+ * and injects `png_base64` / `capture.png_base64` — do not re-invent phantom engine keys.
+ */

--- a/apps/web/src/features/settings/components/DesktopUseEngineProgressBar.tsx
+++ b/apps/web/src/features/settings/components/DesktopUseEngineProgressBar.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+/** Compact install/update progress bar for Desktop Use engine settings. */
+export function DesktopUseEngineProgressBar({ value }: { value: number }) {
+  const pct = Math.min(100, Math.max(0, value));
+  return (
+    <div
+      className="h-1.5 w-20 overflow-hidden rounded-full bg-muted sm:w-28"
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={Math.round(pct)}
+    >
+      <div
+        className="h-full rounded-full bg-primary transition-all duration-300"
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/settings/components/DesktopUseSettingsSection.tsx
+++ b/apps/web/src/features/settings/components/DesktopUseSettingsSection.tsx
@@ -27,6 +27,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { DesktopUsePermissionsPanel } from "@/features/settings/components/DesktopUsePermissionsPanel";
+import { DesktopUseEngineProgressBar } from "@/features/settings/components/DesktopUseEngineProgressBar";
 import {
   SettingsGroupCard,
   SettingsGroupRow,
@@ -83,24 +84,6 @@ type RuntimeCheckResult = {
     engine_version?: string | null;
   };
 };
-
-function EngineProgressBar({ value }: { value: number }) {
-  const pct = Math.min(100, Math.max(0, value));
-  return (
-    <div
-      className="h-1.5 w-20 overflow-hidden rounded-full bg-muted sm:w-28"
-      role="progressbar"
-      aria-valuemin={0}
-      aria-valuemax={100}
-      aria-valuenow={Math.round(pct)}
-    >
-      <div
-        className="h-full rounded-full bg-primary transition-all duration-300"
-        style={{ width: `${pct}%` }}
-      />
-    </div>
-  );
-}
 
 export function DesktopUseSettingsSection() {
   const t = useTranslations("settings.desktopUse");
@@ -507,7 +490,7 @@ export function DesktopUseSettingsSection() {
   const downloadProgressAside =
     isDownloading && progressPct !== null ? (
       <div className="flex items-center gap-2">
-        <EngineProgressBar value={progressPct} />
+        <DesktopUseEngineProgressBar value={progressPct} />
         <span className="min-w-9 text-right text-xs tabular-nums text-muted-foreground">
           {progressPct}%
         </span>

--- a/automations/review/quality/result/2026-08/08-08_score-75_RESULT.md
+++ b/automations/review/quality/result/2026-08/08-08_score-75_RESULT.md
@@ -1,0 +1,153 @@
+# Atmos main 每日代码质量评分（2026-08-08）
+
+## 1. 审查范围
+
+- 昨日时间窗口：2026-08-08 00:00:00 到 2026-08-08 23:59:59（UTC+8 / Asia/Shanghai）。
+- 分支：`main`（日终 tip `a0da25776`）。
+- 排除：窗口内无纯 quality result 归档提交。
+- 审查方式：以 AppShot host 路径、Browser Use 控制面扩展、Desktop Use 设置/引擎 pin、grant overlay 抛光为主线。
+- 修复在独立 worktree / 分支 `grokbuild/quality-fix/2026-08-08` 完成。
+
+被审查提交（按时间）：
+
+| `ecf1f950b` | AarynLu | perf(landing): use static posters for feature sphere covers |
+| `d054cd131` | AarynLu | fix(web): stop install-terminal modal clipping bottom content |
+| `ad74b542b` | AarynLu | fix(web): align onboarding Browse button height with path input |
+| `17af27edc` | AarynLu | feat(web): default more Management Center items to Outside |
+| `70cad52da` | AarynLu | fix(web): defer quota usage opt-in to a dedicated onboarding step |
+| `0f8cb422b` | AarynLu | fix(web): move Desktop Use uninstall next to engine status |
+| `e68eca04d` | AarynLu | fix(desktop-use): refresh permissions after install and stabilize grant overlay |
+| `64846e9bd` | AarynLu | fix(appshot): run dual-shift under Atmos Desktop Use host identity |
+| `ad6341c1c` | AarynLu | fix(appshot): keep host dual-shift socket reconnected after host restart |
+| `fe7d56dc7` | AarynLu | fix(appshot): fix host identity, drop capture_via noise, stop Untitled spam |
+| `fb3582f9d` | AarynLu | perf(appshot): cut dual-shift capture latency on the hot path |
+| `1112cb552` | AarynLu | fix(appshot): crop host full-display shots to the focused window |
+| `0371e61c8` | AarynLu | feat(web): group remote access settings and polish section headers |
+| `7f6cade5b` | AarynLu | fix(appshot): allow capturing Atmos without self-frontmost warning |
+| `ec42377aa` | AarynLu | chore(desktop-use): remove unused is_self_app after allowing Atmos capture |
+| `9febc1db6` | AarynLu | fix(appshot): resolve real content-window bounds for host crop |
+| `50edb857e` | AarynLu | fix(appshot): crop QQ Music-style windows and restore border flash |
+| `957bb000a` | AarynLu | docs(appshot): clarify window bounds resolve is generic, not QQ-only |
+| `d68ebf10c` | AarynLu | feat(appshot): CGWindowList frontmost for Electron-style apps |
+| `30e1beb97` | AarynLu | style(appshot): brighten capture border flash affordance |
+| `081c0140a` | AarynLu | feat(appshot): fly thumbnail in an arc from source app into Atmos |
+| `46894d0c5` | AarynLu | fix(appshot): stop showing permissions CTA after successful host capture |
+| `068bce6ed` | AarynLu | fix(appshot): drop noisy screencapture -l and speed fly-in |
+| `100065bac` | AarynLu | fix(appshot): keep host bounds when app names differ by localization |
+| `58621ce15` | AarynLu | fix(appshot): restore window bounds for crop and animations |
+| `d010a10cb` | AarynLu | feat(desktop-use): pin control engine to 0.19.2 |
+| `a06f32451` | AarynLu | feat(desktop-use): ship engine pin in Desktop app and auto-update |
+| `8106c1bf4` | AarynLu | feat(browser-use): expand control APIs and Desktop/CLI surface |
+| `015521068` | AarynLu | fix(web): exclusive active state for management-center overlays |
+| `a0da25776` | AarynLu | chore(desktop-electron): release 2026.8.8-beta.1 |
+
+## 2. 一份好代码应该是什么样
+
+本日标准看「截图/控制热路径是否把纯规则与 IO/编排切开」。frontmost 打分与窗口裁剪应可单测；HTTP 控制面扩展应避免单 class 继续吞掉 dialog/download/chrome；设置页引擎卡应与状态机职责分离。已抽出的 `window-crop` / `frontmost-cg` / `capture-fly` 是正确方向。
+
+## 3. 评分方法
+
+- 100 分制：设计与分层 30、可读性与复杂度 25、体量与内聚 20、可维护性与复用 15、工程卫生 10。
+- 高/中/低约扣 8–15 / 3–7 / 1–2；同一根因不重复计数。
+- 只计当日引入/放大问题；纯测试与 pure 模块正向记录。
+
+## 4. 总分
+
+总分：75/100。总体判断：良好。
+
+AppShot 抽出多块 pure 模块与测试，但 `browser-use-control.ts`（~1117）、`DesktopUseSettingsSection`（~805）、`host-capture.ts`（~736）、`appshot/service.ts`（~1037）同日显著膨胀。
+
+## 5. 分项评分
+
+| 维度 | 得分 | 扣分原因 |
+| --- | ---: | --- |
+| 设计与分层 | 23/30 | 正向：`window-crop`、`frontmost-cg`、`capture-fly`、`host-shift`、`auto-update`。扣分：`BrowserUseControlPlane` 继续吞 dialog/download/pointer；settings 引擎/权限/可见性仍单文件。 |
+| 可读性与复杂度 | 18/25 | control plane `handle` 路由表 + 长 private 方法链；settings 多状态与 install/update/runtime 交叉。 |
+| 体量与内聚 | 12/20 | 日终：control ~1117（+~600）、settings ~805（+~310）、host-capture ~736（+~500）、service ~1037、grant-overlay ~1270。 |
+| 可维护性与复用 | 13/15 | 正向：host-capture / window-crop / frontmost 测试充分；crop 纯函数复用。扣分：control 能力扩展未按动作域拆文件。 |
+| 工程卫生 | 9/10 | 大量 unit/structural tests；少量 structural 字符串耦合（已随拆分调整）。 |
+
+## 6. 主要问题清单
+
+### 中高：`browser-use-control.ts` ~567→~1117，单 class 承载全动作面
+
+- 提交：`8106c1bf4`
+- 文件：`apps/desktop-electron/src/browser/browser-use-control.ts`
+- 问题：`BrowserUseControlPlane` 增加 dialog CDP、download、pointer 等；chrome spawn 与 HTTP 路由同居；`handle` 超长。
+- 为什么是质量问题：改 click 路径需加载 dialog/download 状态；后续能力只能继续堆 private 方法。
+- 优化建议：抽出 `browser-use-chrome.ts`（highlight/move spawn）；中期按 `dialog` / `download` / `pointer` 拆 action 模块或子类。
+
+### 中：`host-capture.ts` ~232→~736，打分与 IO 混杂
+
+- 提交：`1112cb552`、`9febc1db6`、`50edb857e`、`100065bac` 等
+- 文件：`apps/desktop-electron/src/desktop-use/host-capture.ts`
+- 问题：`pickFrontmostWindow` / `mergeFrontmostIdentity` 与 screenshot/crop IO 同文件（虽有测试）。
+- 为什么是质量问题：改 hot-path 延迟时被迫读完整打分规则。
+- 优化建议：`host-window-match.ts` 承载 pure 打分与 identity merge；host-capture 只做 drive 调用与 PNG 处理。
+
+### 中：`DesktopUseSettingsSection` ~492→~805
+
+- 提交：`a06f32451`、`0f8cb422b`、`e68eca04d` 等
+- 文件：`apps/web/src/features/settings/components/DesktopUseSettingsSection.tsx`
+- 问题：引擎安装/更新/runtime、卸载对话框、权限组、border 开关单组件；状态字段很多。
+- 为什么是质量问题：引擎卡 UI 与 load/doctor 状态机耦合，后续加 auto-update 行只能继续撑大。
+- 优化建议：至少抽出 progress 小组件与引擎卡 presentational 块；load/doctor 可进 hook。
+
+### 低：`appshot/service.ts` ~780→~1037，`triggerCapture` 仍长
+
+- 提交：多枚 appshot fix/feat
+- 文件：`apps/desktop-electron/src/appshot/service.ts`
+- 问题：host 路径与 fly 动画接线堆在 service；部分已外移到 `capture-fly` / `host-shift`（正向）。
+- 优化建议：继续把 route resolve + host capture 调用收到 `capture-route.ts`。
+
+### 低：`grant-overlay.ts` 再增 ~112 行
+
+- 提交：`e68eca04d`
+- 文件：`apps/desktop-electron/src/desktop-use/grant-overlay.ts`（~1270）
+- 问题：在已超大文件上继续补权限刷新相关逻辑（前一日拆分若未合入则仍为单文件）。
+- 优化建议：保持 panel/position 模块边界（见 08-07 PR 若仍打开）。
+
+## 7. 正向观察
+
+- **AppShot pure 模块**：`window-crop`、`frontmost-cg`、`capture-fly`、`host-shift` + 对应测试。
+- **engine pin / auto-update**：manifest 与 structural test 边界清晰。
+- **host-capture 测试矩阵**：pid/localization/overlay 打分场景覆盖好。
+- **landing posters**：静态封面 perf 改动范围克制。
+
+## 8. Review 建议
+
+1. Browser Use：dialog 监听生命周期、download 路径、chrome spawn 失败不崩 main。
+2. AppShot dual-shift：host 路由缓存、window crop 失败回退 full-display 警告文案。
+3. Desktop Use settings：install/update/stop 与 permissions re-doctor 时序。
+4. 是否还有 >1000 行 Electron 控制/服务文件在当日继续膨胀。
+
+## 9. 自动修复与 PR
+
+总分 75 < 90，已触发自动修复。
+
+### 修复摘要
+
+1. `browser-use-chrome.ts`：mapGuestRect / spawnDetached / showEmbeddedBrowserChrome；control 再导出。
+2. `host-window-match.ts`：pure 打分与 identity merge；host-capture 聚焦 IO。
+3. `DesktopUseEngineProgressBar`：设置页 progress 小组件。
+
+### 验证
+
+- `bun test` browser-use-control structural + host-capture：17 pass
+- `bun --filter web typecheck`：通过
+
+### 剩余风险
+
+- `BrowserUseControlPlane` 仍 ~1000 行（dialog/download 未拆）。
+- Settings 引擎卡 JSX 仍大。
+- appshot service / grant-overlay 未本轮大拆。
+
+## 10. 结果文件
+
+- `automations/review/quality/result/2026-08/08-08_score-75_RESULT.md`
+
+## 11. 结果提交与推送
+
+- 修复分支：`grokbuild/quality-fix/2026-08-08`
+- 修复提交：`4ca13198f`
+- PR URL：见创建后回填

--- a/automations/review/quality/result/2026-08/08-08_score-75_RESULT.md
+++ b/automations/review/quality/result/2026-08/08-08_score-75_RESULT.md
@@ -150,4 +150,4 @@ AppShot 抽出多块 pure 模块与测试，但 `browser-use-control.ts`（~1117
 
 - 修复分支：`grokbuild/quality-fix/2026-08-08`
 - 修复提交：`4ca13198f`
-- PR URL：见创建后回填
+- PR URL：https://github.com/AruNi-01/atmos/pull/210


### PR DESCRIPTION
## Summary

Daily code quality review for **2026-08-08** scored **75/100** (良好), triggering auto-fix.

### Score drivers
- `browser-use-control.ts` ~567→~1117 (dialog/download/pointer + chrome)
- `host-capture.ts` ~232→~736 (scoring mixed with IO)
- `DesktopUseSettingsSection` ~492→~805
- Positive: `window-crop`, `frontmost-cg`, `capture-fly`, host-capture tests

### Fixes
1. `browser-use-chrome.ts` — chrome spawn/map helpers; re-export from control
2. `host-window-match.ts` — pure frontmost scoring / identity merge
3. `DesktopUseEngineProgressBar` — small settings extraction

Report: `automations/review/quality/result/2026-08/08-08_score-75_RESULT.md`

## Related Issue

N/A — Atmos daily quality review automation (2026-08-08).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [x] Additional checks:
  - `bun test` browser-use-control structural + host-capture → 17 pass
  - `bun --filter web typecheck` → passed

## Checklist

- [x] Quality result report included
- [x] Structural tests updated for module splits
- [x] Followed repository conventions

### Residual risk
- `BrowserUseControlPlane` still ~1000 lines (dialog/download not split)
- Settings engine card JSX still large
- appshot service / grant-overlay not split this cycle

---

### Agent
Generated by **Grok Build** · Atmos daily quality review automation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split oversized hot paths to smaller modules for clarity and safer control-plane behavior. Extracted browser chrome helpers and host-window matching; added a small progress bar component in settings.

- **Refactors**
  - Added `browser-use-chrome.ts` with `mapGuestRectToScreen`, `showEmbeddedBrowserChrome`, and quiet detached spawn; re-exported from `browser-use-control.ts`. Updated structural test.
  - Moved frontmost scoring/identity merge to `host-window-match.ts` (`pickFrontmostWindow`, `matchWindowForFrontmost`, `mergeFrontmostIdentity`, etc.). `host-capture.ts` now focuses on capture/crop IO; test updated to match normalized `capture.png_base64`.
  - Added `DesktopUseEngineProgressBar` and replaced the inline progress bar in `DesktopUseSettingsSection`.

<sup>Written for commit d03269c8157174c71e8937edacc6901c66a56afb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

