### PR TITLE
docs(APP-056): Hub identity, usage share & device credentials

### DIFF
--- a/specs/APP/APP-056_usage-share-and-accounts/BRAINSTORM.md
+++ b/specs/APP/APP-056_usage-share-and-accounts/BRAINSTORM.md
@@ -1,0 +1,182 @@
+# Brainstorm · APP-056: Usage Share, Users & Devices
+
+> Problem space and exploration. Settled content graduates to PRD.md; committed architecture graduates to TECH.md.
+
+## Context
+
+Atmos already has a strong **local** Token Usage dashboard (`crates/token-usage` + tokscale, UI under `apps/web` Token Usage). Share today is **client-only**: capture overview DOM → compose branded PNG → clipboard / system share / social intent ([`token-usage-share-card.ts`](../../../apps/web/src/app-shell/token-usage-share-card.ts)). There is **no public URL**, no hosted page, and no cloud identity for “whose usage is this?”
+
+Relay identity (APP-016 / APP-020) is **Access Token possession = tenant**. D1 holds `tenants`, `computers`, sessions, and APP-019 GitHub install/routes. GitHub OAuth on relay is **only** for verifying installation ownership during setup — not product login. Relay AGENTS.md forbids putting Atmos business logic (projects, terminals, canvas, usage) into the Worker.
+
+Users now want a **Token usage sharing page**: a link others can open. That forces three questions this brainstorm settles:
+
+1. Host inside relay, or elsewhere?
+2. Do we need real login (GitHub / Google / email)?
+3. What is the optimal identity model if we may overturn prior design?
+
+## Goals (draft)
+
+- Let users publish a **shareable public (or unlisted) usage page** with stable URL and social OG.
+- Keep **local-first**: viewing and analyzing usage on a machine never requires cloud login.
+- Give public pages a **real owner** that survives Access Token rotation and multi-device use.
+- Keep **relay** a thin connection fabric; do not overload it with product content.
+- Prefer privacy-preserving **aggregate snapshots** over uploading raw agent sessions.
+
+## Options
+
+### Option A — Bolt share onto `packages/relay` + existing Access Token
+
+Add `/v1/usage/*` to the relay Worker; authenticate publish with Bearer Access Token; store snapshots keyed by `tenant_id`.
+
+**Pros**: Fastest ship; reuses D1 and domain (`relay.atmos.land`); no new deploy target.  
+**Cons**: Violates relay boundary; public read traffic shares fate with WS/gateway control plane; Access Token is a bad public identity (leak = impersonation, lost token = orphan pages); no display name/avatar/handle without more hacks.  
+**Unknown**: Whether Cloudflare cache/CDN patterns for public pages fit the same Worker cleanly.
+
+### Option B — New heavy backend (VPS / separate cloud)
+
+Build a traditional API + DB for users and share pages outside Cloudflare.
+
+**Pros**: Full freedom of stack.  
+**Cons**: New ops surface while the product already standardizes on Workers + D1; slower and more expensive for this scope.  
+**Unknown**: Team capacity to run a second platform.
+
+### Option C — Independent CF Worker `packages/hub` + GitHub Atmos Account + snapshot publish
+
+New monorepo package / Worker (`hub.atmos.land`) owns:
+
+- GitHub OAuth → `accounts`
+- Session cookies for app/landing
+- Usage share documents (redacted aggregates)
+- Public read API
+
+`apps/landing` (or edge SSR) renders `atmos.land/s/:id` and `/u/:handle`. Relay stays connection-only. Hub session mints **device credentials**; Computers owned by `user_id` (Phase 1).
+
+**Pros**: Correct separation of concerns; natural GitHub identity for agentic builders; reuses CF/D1 ops; local-first preserved; path to lost-token recovery and multi-device rollup.  
+**Cons**: New package + auth surface; Phase 1 does not yet fully replace token-tenant ownership for Computers.  
+**Unknown**: Whether one shared D1 or two D1 databases is cleaner for ops.
+
+### Option D — Continuous cloud sync of usage (not just publish)
+
+Always-on ingest of local aggregates to cloud; public profile always “live”.
+
+**Pros**: Multi-machine totals “just work”.  
+**Cons**: Higher privacy surface, always-on dependency, harder consent model; overkill for first shareable page.  
+**Unknown**: Merge rules across Computers and partial offline windows.
+
+## Key forks in the road
+
+| Fork | Decision (settled for this spec) |
+|------|----------------------------------|
+| Where to host share/account logic | **Not relay.** New `packages/hub` (CF Worker). Public HTML on `apps/landing` (`atmos.land`). |
+| Auth for publish & account | **GitHub + Google OAuth (Better Auth).** No password / email magic link in v1. |
+| Auth for local dashboard | **None.** Local Token Usage stays offline-capable. |
+| Data model for share | **Explicit snapshot publish** of redacted aggregates (v1). Continuous sync deferred. |
+| Identity root | **User** (`user_id` = Better Auth `user.id`; GitHub or Google login). **No user-generated Access Token.** Hub session mints/rotates **device credentials**. Computers owned by `user_id`. Better Auth `account` = OAuth link only, not owner FK. |
+| Default visibility | **Unlisted link** default; public profile (`/u/:handle`) opt-in. |
+| Cost on public page | **Off by default**; user can include estimated cost. |
+| OG image | Reuse client-composed share card PNG upload to R2 (v1); server-side render later. |
+| Backward compat | **Not a goal** for identity model; phased migration allowed. Existing PNG share remains. |
+
+## Naming fork (settled)
+
+**Canonical name:** `packages/hub` · domain `hub.atmos.land` · D1 `atmos-hub` · env `NEXT_PUBLIC_ATMOS_HUB_URL`.
+
+| Layer | Atmos | Industry analogue |
+|-------|--------|-------------------|
+| Local agent/product server | `apps/api` (Atmos Server) | OpenCode **Server** (`opencode serve`); LobeHub desktop talking to a server |
+| Connection to user machines | `packages/relay` | LobeHub **device-gateway** |
+| Hosted multi-tenant **control plane** (auth, share, later entitlements) | **`packages/hub`** | SaaS **control plane** / platform API; LobeHub official app auth surface (not their agent-gateway) |
+| Hosted agent compute (future) | `packages/sandbox` / `run.*` | LobeHub **sandbox** / agent-gateway compute path; not Hub |
+| Marketing umbrella (optional) | “Atmos Cloud” | Product tier name only — **never** a package name |
+
+| Candidate | Verdict |
+|-----------|---------|
+| `packages/cloud` / `cloud.atmos.land` | **Reject.** Collides with future hosted Agent/sandbox; kitchen-sink. |
+| `packages/identity` / `auth` | Too narrow for share + later public features. |
+| `packages/share` | Too narrow for OAuth/accounts. |
+| `packages/gateway` / `server` / `api` | Collides with relay, local Server, model gateways. |
+| `packages/platform` | Acceptable alternate; more empty. Prefer **hub**. |
+| **`packages/hub` / `hub.atmos.land`** | **Choose.** Third-party auth + public share + extensible control-plane features. |
+| Future `packages/sandbox` + `run.atmos.land` | Hosted Agent runtime; separate service. |
+
+### What belongs in Hub (membership test)
+
+A feature belongs in Hub if roughly all hold:
+
+1. Needs an **Atmos Account** (or anonymous public read of user-owned resources).
+2. Needs **Atmos-operated public internet** (works without the user’s local Server).
+3. Is **control data** (identity, permissions, published snapshots, entitlements) — not agent execution and not Computer traffic relay.
+
+| In Hub | Out of Hub |
+|--------|------------|
+| GitHub/Google OAuth, sessions, profiles | Local Token Usage computation (`crates/token-usage` / `apps/api`) |
+| Usage share publish + public JSON | Relay WS / register / gateway (`packages/relay`) |
+| Device↔account link records | Hosted sandbox PTY / cloud Agent runtime |
+| Later: billing entitlements, public marketplace read APIs | Model proxy / LLM gateway product (if any) |
+
+## Rejected approaches
+
+- Using only Access Token as the owner of public pages.
+- Using GitHub `installation_id` as the user id (org installs ≠ person).
+- Uploading raw session logs / prompts to cloud to recompute tokscale remotely.
+- Forcing cloud login before opening the local Token Usage page.
+- Merging share routes into `packages/relay/src/index.ts` “for convenience”.
+- Naming the account/share service `cloud` (collides with future hosted compute).
+- User-generated Relay Access Token as the primary identity (copy/paste token in Settings).
+- Keeping dual identity (manual token + OAuth) once accounts exist — pick Account as root.
+
+## Open questions
+
+- [x] Relay vs new service? → New hub Worker (`packages/hub`); relay stays fabric.
+- [x] Login provider v1? → **GitHub + Google** (Better Auth). No email/password.
+- [x] Snapshot vs continuous sync v1? → Snapshot publish.
+- [x] Shared D1 with relay vs separate `atmos-hub` D1? → **Separate D1** `atmos-hub` (blast radius); link later via `user_id` / `devices`.
+- [x] Handle mutability? → Default `github_login`; **one rename / 30d cooldown** (TECH).
+- [x] Package name? → **`packages/hub`** (not cloud/platform/gateway).
+- [x] Auth framework? → **Better Auth + Drizzle + D1** on Hub only; Relay stays raw D1 SQL.
+- [x] Relay Access Token UX? → **Removed as user-facing identity.** Hub session enrolls devices; mints/rotates device credentials; Computers hang on `user_id`. No backward compat (no production users).
+
+## References
+
+- Code: `apps/web/src/app-shell/TokenUsagePage.tsx`, `TokenUsageShareDialog.tsx`, `token-usage-share-card.ts`, `crates/token-usage/`, `packages/relay/`, `packages/relay/migrations/`
+- Specs: [APP-016 Atmos Computer](../APP-016_atmos-computer/TECH.md), [APP-019 GitHub Automation Triggers](../APP-019_github-automation-triggers/TECH.md), [APP-020 Relay Stable Tenant Identity](../APP-020_relay-stable-tenant-identity/TECH.md)
+- Relay boundary: [packages/relay/AGENTS.md](../../../packages/relay/AGENTS.md)
+
+
+## Device credentials vs Access Token (settled)
+
+**Problem with Access Token as identity:** Once Atmos Account exists, asking users to generate/import a high-entropy token is a second identity that can desync from the login, blocks recovery, and conflicts with “login owns my Computers.”
+
+**Optimal model (no backward compatibility):**
+
+```text
+Atmos Account (Hub / Better Auth)
+  ├── OAuth identities: GitHub, Google
+  ├── Browser sessions (cookie) — interactive control plane
+  └── Devices (Desktop / CLI / browser install)
+        ├── device_id
+        ├── device_credential (shown once at mint; stored hashed)
+        └── can act for user on Relay management APIs
+Computers + GitHub installs → owned by user_id (not by a free-floating token tenant)
+```
+
+| Credential | Who holds it | Lifetime | Used for |
+|------------|--------------|----------|----------|
+| Hub session cookie | Browser | Short / idle timeout | Login UI, publish share, **mint/rotate/revoke devices** |
+| Device credential | Local install (`~/.atmos/…`) | Long-lived until rotated/revoked | Relay Bearer for list/register computers, client sessions |
+| Computer `server_secret` | Atmos Server machine | Long-lived until revoke | Outbound `/ws/server` only |
+
+**Rotation:** Prefer **Hub session** authorizes rotate (Settings “This device” / “Rotate credential”). Optional: present current device credential for headless rotate. Old credential dies immediately; Computers stay on `user_id`.
+
+**Enroll UX:** Sign in → “Trust this device” (or automatic on first Relay action while logged in) → credential written locally. **No “Generate Access Token” primary path.** Headless VPS: from logged-in UI, “Add Computer” one-time register command / device code flow.
+
+**Rejected:** Session cookie alone as Relay Bearer (cookies don’t fit CLI/VPS well; Hub and Relay hosts differ).
+
+## Ready to promote
+
+- Promote to PRD: Local Token Usage remains login-free; hub publish requires Atmos Account (GitHub or Google).
+- Promote to PRD: Share is redacted aggregate snapshot with unlisted/public visibility, not raw session sync.
+- Promote to TECH: `packages/hub` Worker + D1 + optional R2; landing public routes; client publish next to existing PNG share.
+- Promote to TECH: Better Auth + Drizzle; device credentials minted by Hub; Relay computers under `user_id`; supersedes APP-016/020 token-tenant as product identity.
+- Promote to TECH: GitHub + Google social providers only in v1.
+- Promote to TEST: Auth, snapshot CRUD, public read, privacy redaction, unpublish, OG, and non-regression of local usage / relay.

--- a/specs/APP/APP-056_usage-share-and-accounts/PRD.md
+++ b/specs/APP/APP-056_usage-share-and-accounts/PRD.md
@@ -1,0 +1,145 @@
+# PRD · APP-056: Usage Share, Users & Devices
+
+> Product Requirements · WHAT and WHY. Settled direction for GitHub-based Atmos Accounts and public Token Usage share pages.
+
+## Context
+
+- **Problem**: Users can analyze AI token usage locally and export a PNG share card, but cannot give someone a **URL** that opens a live usage page owned by them. Without a cloud identity, a public page has no safe owner, recovery, or unpublish story.
+- **Why now**: Token Usage is a marketed product surface; PNG-only share is weak for social proof and collaboration. Relay already has D1 + GitHub App plumbing, but its identity is token-possession and its role is connection fabric — the wrong place to grow product accounts and public content.
+- **Product direction**: Introduce **Atmos Hub** for **third-party auth (GitHub + Google), device credentials, and public share**. Keep **local-first** Token Usage without login. Keep **relay** as connection fabric only. **User is the only product identity root** — no user-generated Relay Access Token.
+- **Service name (settled)**: package `packages/hub`, host `hub.atmos.land`, D1 `atmos-hub`. Engineering term: **hosted control plane**. Marketing **“Cloud”** (if used) is only a future compute umbrella — never this package name.
+- **Hub growth**: more account/public features later; must **not** absorb relay traffic or sandbox/agent execution.
+- **Auth stack (settled)**: **Better Auth + Drizzle + D1** on Hub. Relay remains raw D1 SQL (no Better Auth).
+- **Owner id (settled)**: product owner is Better Auth **`user.id` → column/API `user_id`**. Better Auth’s **`account` table is only OAuth provider links** (GitHub/Google), not billing and not the Computer owner FK. UI may still say “Atmos Account” for the signed-in person.
+- **Relay identity (settled, no backward compat)**: Hub session **mints/rotates/revokes device credentials**; Computers and GitHub installs are owned by **`user_id`**. Device credential is a machine secret, not a user-managed password-like token.
+- **Related specs**: [APP-016 Atmos Computer](../APP-016_atmos-computer/TECH.md), [APP-019 GitHub Automation Triggers](../APP-019_github-automation-triggers/TECH.md), [APP-020 Relay Stable Tenant Identity](../APP-020_relay-stable-tenant-identity/TECH.md). This spec **supersedes** “Access Token = identity root” (APP-016/020 product identity); no production migration required.
+
+## Goals
+
+1. Let users publish a shareable Token Usage page with a stable link and social-friendly preview.
+2. Keep local Token Usage fully usable without any cloud account or network.
+3. Establish the **Atmos user** (GitHub or Google sign-in; `user_id`) as the owner of published content, devices, and Computers (via Hub-issued device credentials).
+4. Preserve privacy: only redacted aggregates leave the machine, and only after explicit publish.
+5. Keep relay free of usage/content business logic; hub is a separate service surface.
+
+## Users & Scenarios
+
+- **Primary persona**: Agentic builder who wants to show token/cost intensity (heatmap, agent mix) on X/Reddit or in a portfolio.
+- **Secondary persona**: Teammate sharing an unlisted link with a coworker without making a public profile.
+- **Power persona**: Multi-machine user who later wants one user to own Computers + shares (Phase 2).
+
+### Key scenarios
+
+1. User opens Token Usage locally (no login), explores charts, then clicks **Publish page**, signs in with GitHub once, and gets `https://atmos.land/s/...`.
+2. User posts the link; a visitor (logged out) sees the snapshot page and OG preview on social platforms.
+3. User updates the published snapshot after more local usage, same URL refreshes.
+4. User unpublishes; the link stops showing data.
+5. User keeps using PNG share without ever creating an account.
+6. User enrolls a second device while signed in and sees the same Computers without pasting any token.
+
+## User Stories
+
+- As a user, I want a public or unlisted usage URL, so that I can share stats without attaching a screenshot every time.
+- As a user, I want local Token Usage to work offline, so that cloud outages or privacy preference never block analysis.
+- As a user, I want GitHub or Google sign-in, so that ownership is obvious and I do not manage another password or Access Token.
+- As a user, I want signing in to enroll this device automatically (or with one click), so that I never copy-paste a Relay Access Token.
+- As a user, I want to rotate this device’s credential while logged in, so that a leaked machine secret dies without losing my Computers.
+- As a privacy-conscious user, I want only aggregate stats published, so that prompts, paths, and projects never leave my machine.
+- As a user, I want to hide estimated cost by default, so that money figures are not leaked accidentally.
+- As a user, I want to unpublish or rotate a share, so that I control exposure after posting.
+- As a multi-device user, I want my user identity—not a free-floating token—to own Computers, shares, and installs, so that rotating a device credential never orphans resources.
+
+## Functional Requirements
+
+### Must Have
+
+- **M1 · Local-first dashboard**: Existing Token Usage page continues without Atmos Account login.
+- **M2 · Atmos user / sign-in (GitHub + Google)**: User can sign in / out with **GitHub or Google** via Hub (Better Auth). Account stores provider subject ids, display name, avatar; no password product.
+- **M3 · Publish snapshot**: From Token Usage UI, authenticated user can publish a redacted aggregate snapshot derived from the current local overview (and selected options).
+- **M4 · Share URL**: Each share has a stable id URL (`/s/{share_id}`). Copy link is one click from the share UI.
+- **M5 · Visibility**: At least **unlisted** (link-only) and **public** (eligible for profile listing). Default = unlisted.
+- **M6 · Public read**: Logged-out visitors can open unlisted/public share URLs and see the snapshot UI (summary, heatmap/timeline as available, agent/model mix).
+- **M7 · Update & unpublish**: Owner can replace snapshot content on the same share id, or revoke so the URL no longer shows content.
+- **M8 · Privacy redaction**: Snapshot schema excludes prompts, messages, file paths, project names, repo paths, and credentials. Only aggregates and display labels the user already sees on the local overview.
+- **M9 · Cost opt-in**: Estimated cost fields are omitted unless the user enables “Include cost”.
+- **M10 · Service separation**: Account, auth, device credentials, and usage share APIs live in **`packages/hub`**. Relay remains connection fabric (WS/gateway/register), not product login.
+- **M11 · Existing PNG share**: Current image capture / clipboard / native share remains available without account.
+- **M12 · Session security**: Hub sessions are HttpOnly Secure cookies (Better Auth); OAuth provider tokens are not the long-term client session; device credentials are never logged.
+- **M13 · Device enroll (no user Access Token)**: While logged in, user can enroll the current install; Hub **mints** a device credential written locally. There is **no** primary UX to generate/import a free-floating Relay Access Token.
+- **M14 · Device rotate / revoke via login**: Logged-in user can rotate or revoke this device (and list other devices). Rotation preserves Computers under the same user. Old device credential fails immediately.
+- **M15 · User-owned Computers**: Relay Computer rows and APP-019 installs are scoped to **`user_id`**. Any non-revoked device credential of that user may manage them (subject to product policy).
+- **M16 · Headless / VPS enroll**: Logged-in UI can produce a one-time register path (command or device code) so a Server can join the user without pasting a long-lived user token.
+
+### Should Have
+
+- **S1 · Profile handle**: Account has a public `handle` (default GitHub login); optional `/u/{handle}` profile that can feature a primary public share.
+- **S2 · OG image**: Share pages expose Open Graph / Twitter card metadata; v1 may use client-uploaded share-card PNG.
+- **S3 · Device list UI**: Settings shows enrolled devices (label, last seen) with revoke.
+- **S4 · Share list**: Owner can list their shares and see last updated time.
+- **S5 · Data provenance badge**: Public page shows “Local aggregate snapshot · generated …” so visitors know it is not live billing data.
+
+### Nice to Have
+
+- **N1 · Continuous multi-Computer rollup** under user.
+- **N2 · Email magic-link** or additional OAuth providers.
+- **N3 · Server-rendered OG** without client PNG upload.
+- **N4 · Year-in-review / leaderboard** (strict opt-in).
+- **N5 · Password-protected shares**.
+- **N6 · Org / team accounts** and shared Computer pools.
+
+## Out of Scope
+
+- Moving raw tokscale session files or agent transcripts to the cloud.
+- Putting usage share routes or account tables into the **relay** Worker as the product home (may later *reference* `user_id` from relay tables in Phase 2, but share product is not relay).
+- Replacing local Token Usage computation with a cloud-only dashboard.
+- Team org accounts / SSO (future).
+- Billing Atmos itself based on token usage.
+- Forcing login for **pure local** Atmos Server use (no Relay).
+- User-generated Access Token as a supported identity mode.
+- Password/email-only accounts in v1.
+- Putting Better Auth on `packages/relay`.
+
+## Success Metrics
+
+| Metric | Target (direction) |
+|--------|--------------------|
+| Publish completion | Token Usage → GitHub/Google login → live `/s/...` URL |
+| Local independence | 100% of local Token Usage features work signed-out |
+| Privacy | Zero raw prompts/paths in stored `snapshot_json` (schema + review) |
+| Separation | No new usage/account business routes in `packages/relay` public API surface for this feature |
+| Unpublish latency | Revoked share returns not-found/gone to public readers immediately after revoke |
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Accidental oversharing of cost or agent mix | Default unlisted; cost off; clear publish checklist |
+| Account vs device confusion | UI: “Signed in as …” vs “This device credential” (never “Access Token identity”) |
+| Relay scope creep | Hard package boundary + AGENTS.md for hub |
+| Social login vs GitHub App install | Product login = Better Auth GitHub/Google; APP-019 install stays GitHub App on relay |
+| Public page abuse / spam | Rate limit publish; bind to GitHub account; optional future abuse reporting |
+| Stale snapshots mistaken for live billing | Provenance badge + generated_at on page |
+
+## Milestones
+
+- **Phase 1 · Hub identity + Share + device credentials**: GitHub/Google login (Better Auth), device mint/rotate/revoke, user-owned Computers on Relay, snapshot publish, public `/s/{id}`. (**Must Haves including M13–M16.**)
+- **Phase 2 · Multi-device polish & recovery UX**: richer device labels, cross-device revoke everywhere, optional continuous usage rollup.
+- **Phase 3 · Social depth**: server OG, leaderboards (opt-in), more auth providers if needed.
+
+## Dependencies
+
+- Existing local Token Usage overview API and UI.
+- Cloudflare (Workers, D1, R2 optional, DNS on `atmos.land`).
+- GitHub OAuth App + Google OAuth client for Better Auth (separate from APP-019 GitHub App install secrets where practical).
+- Relay schema/API changes for `user_id` + device credentials (this monorepo; no external users to migrate).
+- Landing app deploy path for public share routes.
+
+## Open product choices settled here
+
+- **Login v1 = GitHub + Google only** (Better Auth + Drizzle + D1 on Hub).
+- **No user-generated Relay Access Token**; Hub session mints/rotates device credentials.
+- **Computers owned by `user_id`.**
+- **Share v1 = explicit snapshot**, default unlisted.
+- **Hub ≠ relay ≠ sandbox.**
+- **No backward compatibility** for token-tenant identity (zero production users).
+- Supersedes product identity assumptions in APP-016/APP-020 where they conflict (Access Token = tenant root).

--- a/specs/APP/APP-056_usage-share-and-accounts/TECH.md
+++ b/specs/APP/APP-056_usage-share-and-accounts/TECH.md
@@ -1,0 +1,648 @@
+# TECH · APP-056: Usage Share, Users & Devices
+
+> Technical Design · HOW. Implements PRD APP-056 Phase 1 (accounts + snapshot share) and defines the Phase 2 ownership seam without implementing full Computer migration in Phase 1.
+
+## Scope summary
+
+| In Phase 1 | Out of Phase 1 (later) |
+|------------|------------------------|
+| `packages/hub` + Better Auth + Drizzle + D1 + optional R2 | Email magic link / more OAuth providers |
+| GitHub **and** Google social login | Continuous multi-device usage rollup |
+| Device mint / rotate / revoke via Hub session | Server-side OG canvas render |
+| Relay: user-owned Computers; device credential Bearer | Leaderboards / year-in-review |
+| Snapshot publish + public `/s/:id`, `/u/:handle` | Org/team accounts |
+| Web Token Usage “Publish page” + Settings devices UI | Hosted sandbox compute |
+
+This spec **does** change Relay **identity** (user_id + device credentials) but **does not** put usage-share product routes into Relay. **No backward compatibility** with user-generated Access Token tenants.
+
+
+## Naming (why not `cloud`)
+
+**Do not** name this package/service `cloud`. The word is reserved as the **product umbrella** for future hosted compute (cloud Agents, sandboxes, managed runtime). This Phase 1 surface is only **accounts + public shares**.
+
+| Layer | Name | Domain | Responsibility |
+|-------|------|--------|----------------|
+| Product umbrella (marketing) | **Atmos Cloud** (optional later) | — | Hosted product tier narrative, not a single Worker |
+| Identity & social control plane | **`packages/hub`** | `hub.atmos.land` | GitHub accounts, sessions, usage shares, profiles, later billing/entitlements |
+| Connection fabric | **`packages/relay`** | `relay.atmos.land` | Computers, WS, gateway, GitHub trigger ingress |
+| Hosted agent compute (future) | **`packages/sandbox`** (or `hosted-runtime`) | `run.atmos.land` / `sandbox.atmos.land` | Provision sandbox, runtime, agent execution |
+| Public pages | **`apps/landing`** | `atmos.land/s`, `/u` | SEO/OG HTML |
+
+**Hub vs future sandbox:** Hub authenticates the user and may later call “create run” APIs; it does **not** host PTY/agent processes. Sandbox/runtime is a separate blast-radius and scaling domain.
+
+**Env var:** `NEXT_PUBLIC_ATMOS_HUB_URL` (not `…_CLOUD_URL`).
+
+
+## Terminology (Better Auth vs product)
+
+| Term | Meaning in this spec |
+|------|----------------------|
+| **User** / `user_id` | Better Auth **`user`** row. **Canonical owner** of devices, shares, Computers, installs. All FKs use `user_id`. |
+| **Session** | Better Auth browser session (login cookie). Not a Relay Bearer. |
+| **Account** (Better Auth table) | **OAuth provider link only** (`account` table: GitHub/Google subject + tokens). **Not** billing, **not** the product owner id. |
+| **Atmos Account** (product copy) | Marketing/UI name for “signed-in Atmos user”. Maps to `user`, never to Better Auth `account` row id. |
+| **Device** | Machine credential under `user_id`; Relay Bearer. |
+| **Billing account / subscription** | Out of scope; if added later, separate table (e.g. `subscriptions`) keyed by `user_id` — still not Better Auth `account`. |
+
+**Rule:** Never name a column `account_id` for the product owner. Use **`user_id`** (= `user.id`). When you mean OAuth link rows, say **provider account** or table `account`.
+
+## Hub membership rules
+
+**Hub** is Atmos’s **hosted control plane** Worker. Package: `packages/hub`. Host: `hub.atmos.land`.
+
+### In scope for this package (now and later)
+
+- Third-party auth (**GitHub + Google** via Better Auth; no email/password v1).
+- Accounts, sessions, handles, avatars.
+- Features that need **public internet** without the user’s local Atmos Server (usage share APIs, public profile JSON, OG asset hosting).
+- Device credential lifecycle (mint/rotate/revoke) and later entitlements/billing metadata.
+- OAuth callbacks and session cookies for `app.atmos.land` / `atmos.land`.
+
+### Out of scope for this package
+
+| Concern | Owner |
+|---------|--------|
+| Local overview / tokscale | `crates/token-usage`, `apps/api` |
+| Computer online presence, WS, HTTP gateway | `packages/relay` |
+| GitHub **webhook → automation dispatch** | `packages/relay` (APP-019); ownership may reference `user_id` later |
+| Hosted Agent sandbox / managed runtime | Future `packages/sandbox` (or `hosted-runtime`) |
+| Product UI chrome | `apps/web`, `apps/landing` (landing only renders public share HTML) |
+
+### Growth rule
+
+New Hub modules are fine when they pass the membership test (user-owned + public multi-tenant + control data). **Do not** grow Hub into a second “Atmos Server” or a sandbox host. Prefer new packages when traffic mix or blast radius diverges (compute, long-lived WS to user machines, GPU/CPU isolation).
+
+### Canonical identifiers
+
+| Item | Value |
+|------|--------|
+| Package path | `packages/hub` |
+| Worker name | `atmos-hub` |
+| Public API host | `https://hub.atmos.land` |
+| D1 binding name | `DB` on database `atmos-hub` |
+| Client env | `NEXT_PUBLIC_ATMOS_HUB_URL` |
+| Session cookie | Better Auth session on Hub only (not used as Relay Bearer) |
+
+## Architecture overview
+
+```mermaid
+flowchart TB
+  subgraph local [Local machine]
+    TU[crates/token-usage]
+    API[apps/api]
+    WEB[apps/web Token Usage]
+    TU --> API --> WEB
+  end
+
+  subgraph edge [Cloudflare edge]
+    RELAY[packages/relay<br/>relay.atmos.land]
+    HUB[packages/hub<br/>hub.atmos.land]
+    D1[(D1 atmos-hub)]
+    R2[(R2 usage-og)]
+    HUB --> D1
+    HUB --> R2
+  end
+
+  subgraph public [Public site]
+    LAND[apps/landing<br/>atmos.land/s /u]
+  end
+
+  WEB -->|GitHub OAuth + publish| HUB
+  WEB -.->|device credential| RELAY
+  LAND -->|GET public snapshot| HUB
+  GH[GitHub OAuth] --> HUB
+```
+
+### Domain map
+
+| Host | Owner package | Role |
+|------|---------------|------|
+| `relay.atmos.land` | `packages/relay` | Computers, WS, gateway, GitHub **webhook/trigger** ingress |
+| `hub.atmos.land` | `packages/hub` | Accounts, sessions, usage shares, public JSON |
+| `app.atmos.land` | `apps/web` | Product UI; local usage; publish controls |
+| `atmos.land` | `apps/landing` | Marketing + public share/profile HTML + OG meta |
+
+### Decisions
+
+| Fork | Decision |
+|------|----------|
+| New service location | Monorepo `packages/hub` Cloudflare Worker (Hono-style router OK) |
+| Database | **Separate D1** `atmos-hub` + Drizzle; Relay keeps its own D1 with raw SQL |
+| Auth framework | **Better Auth** on Hub only |
+| Auth providers v1 | **GitHub + Google** social only |
+| Session | Better Auth session cookie (`HttpOnly; Secure; SameSite=Lax`); CSRF/origin rules per Better Auth + Hub allowlist |
+| ORM | **Drizzle** for Hub (auth tables + business tables). Relay: **no ORM** |
+| Snapshot source | Client builds JSON from local `TokenUsageOverview` after redaction |
+| OG | Client may `PUT` PNG to hub → R2 |
+| Product identity root | **User** (`user_id` = Better Auth `user.id`) |
+| Relay client credential | **Hub-minted device credential** (Bearer), not user-generated Access Token |
+| Computer ownership | **`user_id`** on Relay; any active device of that user may manage |
+
+## Package layout
+
+```
+packages/hub/
+├── AGENTS.md
+├── README.md
+├── package.json
+├── wrangler.toml              # name atmos-hub, route hub.atmos.land
+├── drizzle.config.ts
+├── src/
+│   ├── index.ts               # Worker fetch router
+│   ├── env.ts
+│   ├── db/
+│   │   ├── client.ts          # drizzle(D1)
+│   │   └── schema.ts          # Better Auth tables + devices + usage_shares + profiles
+│   ├── auth/
+│   │   └── index.ts           # betterAuth({ … socialProviders github, google })
+│   ├── devices.ts             # mint / rotate / revoke / list
+│   ├── usage-shares.ts
+│   ├── public.ts
+│   ├── relay-sync.ts          # service calls into Relay for user/device projection
+│   ├── redaction.ts
+│   └── cors.ts
+└── test/
+```
+
+Web client additions (illustrative paths):
+
+- `apps/web/src/features/account/` — session probe, login redirect, logout
+- `apps/web/src/app-shell/TokenUsageShareDialog.tsx` — Publish page section
+- `apps/web/src/features/quota-usage/lib/build-usage-share-snapshot.ts` — redaction builder
+
+Landing:
+
+- `apps/landing/src/app/s/[shareId]/page.tsx`
+- `apps/landing/src/app/u/[handle]/page.tsx`
+- metadata helpers for OG
+
+## Data model
+
+### Hub D1 (`atmos-hub`) — Drizzle + Better Auth
+
+Better Auth owns core identity tables (names follow Better Auth defaults; pin versions in implementation):
+
+- `user`, `session`, `account` (provider links), `verification`
+
+Hub business tables (Drizzle):
+
+```sql
+-- devices: machine credentials minted by Hub (replaces user Access Token)
+CREATE TABLE devices (
+  device_id TEXT PRIMARY KEY,              -- dev_...
+  user_id TEXT NOT NULL,               -- Better Auth user.id
+  credential_hash TEXT NOT NULL UNIQUE,   -- sha256(device_credential)
+  label TEXT,                              -- "MacBook", "CI"
+  app_device_id TEXT,                      -- optional stable install fingerprint
+  created_at INTEGER NOT NULL,
+  last_seen_at INTEGER,
+  rotated_at INTEGER,
+  revoked_at INTEGER
+);
+
+CREATE INDEX idx_devices_user ON devices(user_id);
+
+CREATE TABLE usage_shares (
+  share_id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  visibility TEXT NOT NULL,                -- 'unlisted' | 'public'
+  title TEXT,
+  period_start TEXT,
+  period_end TEXT,
+  include_cost INTEGER NOT NULL DEFAULT 0,
+  snapshot_json TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 1,
+  og_object_key TEXT,
+  published_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  revoked_at INTEGER
+);
+
+CREATE INDEX idx_usage_shares_user ON usage_shares(user_id, updated_at);
+
+CREATE TABLE user_profiles (
+  user_id TEXT PRIMARY KEY,
+  handle TEXT NOT NULL UNIQUE,
+  handle_changed_at INTEGER,
+  primary_share_id TEXT,
+  profile_public INTEGER NOT NULL DEFAULT 0,
+  updated_at INTEGER NOT NULL
+);
+```
+
+`user_id` everywhere = Better Auth `user.id`.  
+Handle default: GitHub login if present, else Google-derived slug; one rename / 30 days.
+
+### Relay D1 — identity rewrite (raw SQL migrations; no ORM)
+
+**Supersedes** APP-016/020 product assumption that Access Token possession is the tenant root.
+
+Target:
+
+```sql
+-- users are not stored on Relay; `user_id` is an opaque foreign id from Hub (Better Auth user.id)
+CREATE TABLE devices (
+  device_id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  credential_hash TEXT NOT NULL UNIQUE,
+  label TEXT,
+  created_at INTEGER NOT NULL,
+  last_seen_at INTEGER,
+  revoked_at INTEGER
+);
+
+CREATE TABLE computers (
+  server_id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,          -- owner
+  enrolled_by_device_id TEXT,        -- audit
+  secret_hash TEXT NOT NULL,
+  revoked INTEGER NOT NULL DEFAULT 0,
+  display_name TEXT,
+  created_at INTEGER NOT NULL,
+  last_seen_at INTEGER,
+  updated_at INTEGER,
+  registration_meta TEXT,
+  app_device_id TEXT
+);
+
+-- github_* tables: tenant_id → user_id (same opaque id)
+-- register_tokens / client_sessions: user_id (+ optional device_id)
+```
+
+**Removed product APIs:** `POST /v1/tenants` with user-chosen token; user-facing “generate Access Token”.  
+**Relay does not run Better Auth.** It only verifies **device credential** hashes (projected from Hub) or Hub-signed service assertions.
+
+### Snapshot JSON schema (v1)
+
+Server **rejects** unknown top-level keys and any field matching denylist (`prompt`, `path`, `cwd`, `messages`, `content`, raw arrays of chat, etc.).
+
+```ts
+type UsageShareSnapshotV1 = {
+  schema_version: 1;
+  generated_at: number;
+  range?: { start?: string; end?: string };
+  summary: {
+    total_tokens: number;
+    total_messages: number;
+    active_days: number;
+    total_cost_usd?: number | null;
+  };
+  by_day: Array<{
+    date: string;
+    total_tokens: number;
+    message_count: number;
+    total_cost_usd?: number | null;
+  }>;
+  by_client: Array<{
+    client_id: string;
+    total_tokens: number;
+    message_count: number;
+    total_cost_usd?: number | null;
+  }>;
+  by_model: Array<{
+    client_id: string;
+    provider_id: string;
+    model_id: string;
+    total_tokens: number;
+    message_count: number;
+    total_cost_usd?: number | null;
+  }>;
+  partial_warnings?: string[];
+};
+```
+
+Size cap: **256 KiB** UTF-8.
+
+## Auth & device credential flows
+
+### Stack
+
+| Piece | Choice |
+|-------|--------|
+| Framework | **Better Auth** on `packages/hub` |
+| DB adapter | **Drizzle** → D1 (`atmos-hub`) |
+| Providers | **GitHub**, **Google** only in Phase 1 |
+| Password / email OTP | Not enabled |
+| Relay | No Better Auth; device credential hash only |
+
+```ts
+// packages/hub/src/auth/index.ts (illustrative)
+betterAuth({
+  database: drizzleAdapter(db, { provider: "sqlite" }),
+  socialProviders: {
+    github: { clientId, clientSecret, scope: ["read:user", "user:email"] },
+    google: { clientId, clientSecret, scope: ["openid", "email", "profile"] },
+  },
+  baseURL: "https://hub.atmos.land",
+  trustedOrigins: ["https://app.atmos.land", "https://atmos.land", /* dev */],
+});
+```
+
+Mount Better Auth handler under `/api/auth/*` (or `/v1/auth/*` — pick one in implementation and keep stable).
+
+**Secrets:** `BETTER_AUTH_SECRET`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`.  
+**Do not** reuse APP-019 GitHub App install secrets for product login if avoidable.
+
+### Login
+
+1. App opens Hub Better Auth social sign-in (GitHub or Google).
+2. Callback on `hub.atmos.land` establishes session cookie.
+3. `GET /v1/me` (session) returns `{ user_id, handle, display_name, avatar_url, providers[] }`.
+
+### Device enroll (replaces Access Token generation)
+
+```http
+POST /v1/devices
+Cookie: <hub session>
+Content-Type: application/json
+
+{ "label": "MacBook Pro", "app_device_id": "<optional stable install id>" }
+```
+
+Response **once**:
+
+```json
+{
+  "device_id": "dev_…",
+  "device_credential": "<high-entropy secret, show once>",
+  "user_id": "…"
+}
+```
+
+Hub:
+
+1. Inserts `devices` row with `credential_hash`.
+2. **Projects** to Relay via authenticated service call (`relay-sync`): upsert Relay `devices(user_id, device_id, credential_hash)`.
+3. Client stores credential in existing local settings path (replace `computer-client` access token field with device credential + device_id + user_id).
+
+**Auto-enroll policy (recommended):** first Relay-related Settings open while logged in with no local device credential → prompt “Trust this device” → enroll.
+
+### Device rotate (session-first)
+
+```http
+POST /v1/devices/:device_id/rotate
+Cookie: <hub session>
+```
+
+Optional headless:
+
+```http
+POST /v1/devices/:device_id/rotate
+Authorization: Bearer <current device_credential>
+```
+
+Rules:
+
+- New credential minted; old hash replaced; `rotated_at` set.
+- Relay projection updated in the same logical operation (Hub then Relay; retry Relay if needed).
+- Computers **unchanged** (`user_id` stable).
+- Short-lived register/client sessions for that device (or whole account — prefer **account-wide client session revoke on rotate of any device** only if simpler; default: revoke sessions created by that device_id when tracked).
+
+### Device revoke
+
+```http
+POST /v1/devices/:device_id/revoke
+Cookie: <hub session>
+```
+
+Sets `revoked_at`; Relay rejects credential; Computers remain unless user deletes them.
+
+### Relay API auth (new contract)
+
+| Old | New |
+|-----|-----|
+| Bearer user Access Token → tenant | Bearer **device_credential** → `devices` → `user_id` |
+| `POST /v1/tenants` user token register | **Removed** |
+| `POST /v1/tenants/rotate_token` | **Removed**; use Hub device rotate |
+| Computers by `tenant_id` | Computers by **`user_id`** |
+
+Relay management endpoints (`register_tokens`, `GET /v1/computers`, client_sessions, github setup) authorize with device credential and authorize rows where `user_id` matches.
+
+**Service auth Hub→Relay:** `Authorization: Bearer <RELAY_HUB_SYNC_SECRET>` or mTLS-equivalent Worker secret on routes under `/v1/internal/…` (not public).
+
+### Computer register (unchanged envelope, new owner)
+
+1. Device credential → `POST /v1/register_tokens` (as today shape).
+2. Server consumes register token → computer row with `user_id` from the device’s user.
+3. `server_secret` remains server-local for `/ws/server`.
+
+### Headless VPS
+
+From logged-in app:
+
+```http
+POST /v1/computers/enroll_tokens
+Cookie: session
+{ "label": "prod-vps" }
+→ { "register_command": "atmos computer start --token …", "expires_at": … }
+```
+
+Hub or Relay issues one-time `register_token` bound to `user_id` (not to a user-copied long-lived token).
+
+### CSRF / CORS
+
+- Browser Hub mutations: session cookie + Better Auth CSRF / `Origin` allowlist.
+- Device credential is **not** a cookie; CLI/Desktop send `Authorization: Bearer`.
+- CORS credentials for `app.atmos.land` ↔ `hub.atmos.land`.
+
+### What we do not do
+
+- Do not use Hub session cookie as Relay Bearer across hosts.
+- Do not let users mint arbitrary Access Tokens as identity.
+- Do not put Better Auth on Relay.
+- Do not require login for pure local Server without Relay.
+
+## HTTP API (hub)
+
+All JSON. Public routes unauthenticated; owner routes require session.
+
+| Method | Path | Auth | Notes |
+|--------|------|------|-------|
+| GET | `/healthz` | — | liveness |
+| * | `/api/auth/*` | — | Better Auth (GitHub + Google) |
+| POST | `/v1/auth/logout` | session | if not covered by Better Auth signOut |
+| GET | `/v1/me` | session | user profile + providers |
+| PATCH | `/v1/me` | session | handle rename (one / 30d) |
+| GET | `/v1/devices` | session | list devices |
+| POST | `/v1/devices` | session | enroll; returns `device_credential` **once** |
+| POST | `/v1/devices/:id/rotate` | session or current device Bearer | new credential once |
+| POST | `/v1/devices/:id/revoke` | session | |
+| POST | `/v1/computers/enroll_tokens` | session | one-time VPS/register helper |
+| GET | `/v1/usage/shares` | session | list owner shares |
+| POST | `/v1/usage/shares` | session | create share |
+| GET | `/v1/usage/shares/:share_id` | session | owner detail |
+| PATCH | `/v1/usage/shares/:share_id` | session | update |
+| DELETE | `/v1/usage/shares/:share_id` | session | soft revoke |
+| PUT | `/v1/usage/shares/:share_id/og` | session | PNG → R2 |
+| GET | `/v1/public/shares/:share_id` | — | public/unlisted read |
+| GET | `/v1/public/u/:handle` | — | profile |
+
+### Create share body
+
+```json
+{
+  "visibility": "unlisted",
+  "title": "My 2026 usage",
+  "include_cost": false,
+  "snapshot": { "schema_version": 1, "...": "..." }
+}
+```
+
+Response:
+
+```json
+{
+  "share_id": "sh_…",
+  "url": "https://atmos.land/s/sh_…",
+  "visibility": "unlisted",
+  "published_at": 1760000000000
+}
+```
+
+### Public share response
+
+Omit owner-only fields. Include:
+
+```json
+{
+  "share_id": "sh_…",
+  "visibility": "public",
+  "title": "…",
+  "owner": { "handle": "aruni", "display_name": "…", "avatar_url": "…" },
+  "period_start": "…",
+  "period_end": "…",
+  "include_cost": false,
+  "snapshot": { },
+  "og_image_url": "https://…",
+  "published_at": 0,
+  "updated_at": 0,
+  "provenance": "local_aggregate_snapshot"
+}
+```
+
+Rate limits (per IP / per user isolate maps, same pattern as relay):
+
+- OAuth start: 20/min/IP
+- Publish/update: 30/hour/account
+- Public GET: high, cacheable (`Cache-Control: public, max-age=60` for public; `private, max-age=0` for unlisted optional)
+
+## Client design (`apps/web`)
+
+### Redaction builder
+
+```ts
+function buildUsageShareSnapshot(
+  overview: TokenUsageOverviewResponse,
+  opts: { includeCost: boolean },
+): UsageShareSnapshotV1
+```
+
+Rules:
+
+- Map only known fields from overview.
+- Drop `cost` fields when `!includeCost`.
+- Cap `by_day` / `by_model` arrays to sane limits (e.g. 400 days, 50 models) for payload size.
+- Never include partial_warnings that might embed paths (if any do, strip).
+
+### Share popover UX
+
+1. **Image share** (existing) — no login  
+2. **Publish page** — requires Hub session (GitHub or Google)  
+   - 401 → “Sign in with GitHub” / “Sign in with Google”  
+   - Else publish/update + copy URL + optional OG upload  
+
+### Connection / Settings UX
+
+- Remove primary “Generate Access Token” identity flow.
+- **Sign in** → **Trust this device** (enroll) → device credential stored.
+- **Rotate device credential** / **Revoke other devices** while signed in.
+- VPS: **Add Computer** → one-time command from session.
+
+Env:
+
+- `NEXT_PUBLIC_ATMOS_HUB_URL=https://hub.atmos.land`
+
+### CORS + credentials
+
+Browser calls hub with `credentials: 'include'` for cookie session. Hub `Access-Control-Allow-Credentials: true` and explicit origin (not `*`).
+
+## Landing public pages
+
+- Fetch `GET {HUB}/v1/public/shares/:id` on server (or client with loading state).
+- Render summary cards + simple heatmap (can port a slim presentational subset; avoid pulling entire app-shell).
+- `generateMetadata` sets title, description, `og:image`.
+- Revoked/missing → 404 page.
+
+Profile `/u/[handle]`:
+
+- If `profile_public` and primary share public → show; else 404 or minimal “not public”.
+
+## Phase 2 ownership seam (design only)
+
+Goal: Access Token is no longer the identity root.
+
+
+## Security
+
+| Topic | Rule |
+|-------|------|
+| Tokens | Never log OAuth codes, session tokens, Access Tokens, GitHub client secrets |
+| Snapshot | Server schema allowlist; size cap; no HTML stored raw for XSS — JSON only, landing escapes |
+| Cookie | Better Auth session Secure + HttpOnly; logout revokes session |
+| Origin | Strict allowlist for OAuth return and CORS |
+| Unlisted | Security through unguessable `share_id` entropy (≥ 128 bits random); not a secret ACL for highly sensitive data — product copy says aggregates only |
+| R2 OG | Private bucket + Worker signed public URL or public bucket with unguessable keys |
+| Separation | Hub ≠ Relay D1; public share read cannot yield `server_secret` or device credentials |
+| Device credential | Treat like a password hash at rest; show plaintext only once at mint/rotate |
+
+## Rollout
+
+1. Create D1 `atmos-hub`, R2 bucket, wrangler route `hub.atmos.land`.
+2. Configure GitHub OAuth App callback `https://hub.atmos.land/v1/auth/github/callback`.
+3. Deploy Worker; apply migrations.
+4. Ship landing routes behind feature flag or soft launch.
+5. Ship web publish UI with `NEXT_PUBLIC_ATMOS_HUB_URL`.
+6. Document in `packages/hub/README.md` + root AGENTS index entry.
+
+### Feature flag
+
+Optional flags: `NEXT_PUBLIC_ATMOS_HUB_URL` empty disables Hub features; enroll required only when using Relay/share publish.
+
+## Testing notes (see TEST.md)
+
+- Cloud unit/integration with miniflare or wrangler vitest.
+- Redaction builder pure unit tests in web or shared package.
+- Manual: OAuth on real GitHub App staging.
+- agent-browser: public page layout + app publish flow when harness available.
+
+## Identity model summary (Phase 1 ships this)
+
+```text
+User (Better Auth `user`)
+  ├── sessions (browser)
+  ├── devices (device_credential) ──Bearer──► Relay management APIs
+  ├── usage_shares
+  └── (via Relay projection) computers, github installs, routes
+```
+
+APP-016/APP-020 **token-tenant product identity is superseded**. Keep useful pieces (stable ids, rotate without dropping computers) but the root is **`user_id`**, not a user-copied token.
+
+Local-only Server without Relay: unchanged; no Hub login required.
+
+## Non-goals in code
+
+- Do **not** add usage-share product routes to `packages/relay`.
+- Do **not** require Hub session for local `token_usage.overview`.
+- Do **not** upload tokscale raw sessions.
+- Do **not** keep user-generated Access Token as a supported identity.
+- Do **not** run Better Auth inside Relay.
+- APP-019 install remains on Relay but **user_id** ownership replaces token-tenant.
+
+## Related files (current)
+
+- `apps/web/src/app-shell/token-usage-share-card.ts`
+- `apps/web/src/app-shell/TokenUsageShareDialog.tsx`
+- `apps/web/src/app-shell/TokenUsagePage.tsx`
+- `crates/token-usage/src/models.rs`
+- `packages/relay/src/index.ts` (boundary only)
+- `packages/relay/src/github-app.ts` (OAuth patterns to mirror carefully)

--- a/specs/APP/APP-056_usage-share-and-accounts/TEST.md
+++ b/specs/APP/APP-056_usage-share-and-accounts/TEST.md
@@ -1,0 +1,326 @@
+# TEST · APP-056: Usage Share, Users & Devices
+
+> Test Plan · how we verify GitHub Atmos Accounts and Token Usage share pages. References PRD APP-056 and TECH APP-056.
+
+## Test strategy
+
+- **Hub unit/integration**: Better Auth config (GitHub + Google providers enabled; password disabled), session `/v1/me`, device mint/rotate/revoke, Relay projection, snapshot CRUD, public 404, CORS.
+- **Relay unit/integration**: device credential auth; computers by `user_id`; reject user Access Token tenant APIs if removed; rotate does not drop computers.
+- **Client unit**: snapshot redaction; local storage of device credential (never log).
+- **Web integration**: PNG share without login; publish gated on session; device enroll/rotate Settings; no Generate Access Token primary UX.
+- **Landing**: public share page + 404 after revoke.
+- **Regression**: local Token Usage signed-out; pure local Server without Hub still works.
+- **Manual-only**: real GitHub + Google OAuth on staging; cookie domain across hub/app.
+
+## Coverage map
+
+| PRD item | Scenario IDs |
+|----------|--------------|
+| M1 | S1, S14 |
+| M2 | S2, S3, S4, S19 |
+| M3 | S5, S6 |
+| M4 | S5, S12 |
+| M5 | S5, S7, S8 |
+| M6 | S7, S8, S9 |
+| M7 | S10, S11 |
+| M8 | S6, S15 |
+| M9 | S6 |
+| M10 | S16 |
+| M11 | S1 |
+| M12 | S3, S4 |
+| M13 | S20, S21 |
+| M14 | S22, S23 |
+| M15 | S21, S24 |
+| M16 | S25 |
+| S1 | S13 |
+| S2 | S17 |
+| S3 | S18 |
+| S5 | S9 |
+
+## Execution map
+
+| ID | Level | Expected tool | Target / command | Fixtures | Status |
+|----|-------|---------------|------------------|----------|--------|
+| S1 | Web unit / manual | bun test / agent-browser | Token Usage page signed-out | local api mock | pending |
+| S2 | Cloud integration | bun test / vitest | OAuth callback mock | fake GitHub token exchange | pending |
+| S3 | Cloud integration | bun test | session cookie + `/v1/me` | D1 test | pending |
+| S4 | Cloud integration | bun test | logout clears session | D1 test | pending |
+| S5 | Cloud integration | bun test | `POST /v1/usage/shares` | session + snapshot | pending |
+| S6 | Client unit | bun test | `buildUsageShareSnapshot` | overview fixture | pending |
+| S7 | Cloud integration | bun test | public GET unlisted by id | share row | pending |
+| S8 | Cloud integration | bun test | public profile lists only public | shares + profile | pending |
+| S9 | Landing | Playwright or agent-browser | `/s/:id` render | mock hub | pending |
+| S10 | Cloud integration | bun test | PATCH updates snapshot | share row | pending |
+| S11 | Cloud integration | bun test | DELETE/revoke → public 404 | share row | pending |
+| S12 | Web integration | bun test / agent-browser | copy share URL UI | mock hub | pending |
+| S13 | Cloud + landing | bun test | handle + `/u/:handle` | account | pending |
+| S14 | API/WS regression | existing token-usage tests | `cargo test -p token-usage` + web overview | none | pending |
+| S15 | Cloud unit | bun test | reject denylist keys / oversized body | malicious JSON | pending |
+| S16 | Static review | grep / review | no usage routes in `packages/relay` | tree | pending |
+| S17 | Cloud + landing | integration | OG url in public payload + meta | R2 mock | pending |
+| S18 | Cloud integration | bun test | `POST /v1/devices/link` | session | pending |
+
+## Scenarios
+
+### S1 - Local Token Usage works signed out
+
+- **Level**: Web / product regression
+- **Given**: no Atmos Cloud session cookie.
+- **When**: user opens Token Usage and refreshes overview.
+- **Then**: charts and stats load from local API; PNG share still available.
+- **Signals**: no redirect to GitHub; overview request succeeds; Publish CTA may invite login but does not block local view.
+
+### S2 - GitHub OAuth creates account (Better Auth)
+
+- **Level**: Cloud integration
+- **Given**: mocked GitHub exchange returns user id `42`, login `aruni`.
+- **When**: callback completes with valid state.
+- **Then**: `accounts` row upserted; session created; redirect hits allowlisted `return_to`.
+- **Signals**: `github_user_id=42`; `handle` default `aruni`; `Set-Cookie` present; invalid `return_to` rejected.
+
+### S3 - Session resolves `/v1/me`
+
+- **Level**: Cloud integration
+- **Given**: valid session cookie.
+- **When**: `GET /v1/me`.
+- **Then**: account profile returned.
+- **Signals**: 200 with `user_id`, `handle`; missing/expired cookie → 401.
+
+### S4 - Logout
+
+- **Level**: Cloud integration
+- **Given**: active session.
+- **When**: `POST /v1/auth/logout`.
+- **Then**: session row deleted; subsequent `/v1/me` is 401.
+- **Signals**: cookie cleared; old raw token hash no longer matches a row.
+
+### S5 - Publish creates unlisted share by default
+
+- **Level**: Cloud integration
+- **Given**: signed-in account and valid redacted snapshot.
+- **When**: `POST /v1/usage/shares` without visibility (or visibility unlisted).
+- **Then**: share stored with `visibility=unlisted`, `revoked_at` null, stable `share_id`.
+- **Signals**: response includes `https://atmos.land/s/{share_id}`; D1 row exists.
+
+### S6 - Redaction strips cost and sensitive fields
+
+- **Level**: Client unit (+ server reject)
+- **Given**: overview with costs and a malicious extra field `prompt`.
+- **When**: builder runs with `includeCost: false`; server validates.
+- **Then**: snapshot has no cost fields; server rejects payloads that still contain denylisted keys.
+- **Signals**: unit asserts absence of `total_cost_usd`; server returns `400 invalid_snapshot`.
+
+### S7 - Public read of unlisted share by id
+
+- **Level**: Cloud integration
+- **Given**: unlisted non-revoked share.
+- **When**: anonymous `GET /v1/public/shares/:share_id`.
+- **Then**: snapshot returned with owner public profile fields.
+- **Signals**: 200; no session required; response includes `provenance`.
+
+### S8 - Unlisted share does not appear on public profile listing
+
+- **Level**: Cloud integration
+- **Given**: account has unlisted share and public share; profile public.
+- **When**: `GET /v1/public/u/:handle`.
+- **Then**: only public primary/listing data is exposed; unlisted ids not enumerated.
+- **Signals**: unlisted `share_id` absent from profile payload.
+
+### S9 - Landing page renders share
+
+- **Level**: Landing / agent-browser
+- **Given**: public API returns a snapshot.
+- **When**: visitor opens `/s/{share_id}`.
+- **Then**: title/summary visible; no app shell login wall.
+- **Signals**: text for total tokens visible; console free of uncaught errors.
+
+### S10 - Owner updates snapshot in place
+
+- **Level**: Cloud integration
+- **Given**: existing share owned by user A.
+- **When**: A PATCHes new snapshot.
+- **Then**: same `share_id`; `updated_at` increases; public GET shows new totals.
+- **Signals**: row count unchanged; `updated_at > published_at` possible.
+
+### S11 - Unpublish hides public content
+
+- **Level**: Cloud integration
+- **Given**: published share.
+- **When**: owner DELETE/revoke.
+- **Then**: public GET returns 404/410; owner list shows revoked or omits per API design.
+- **Signals**: `revoked_at` set; anonymous read fails.
+
+### S12 - UI copy share URL
+
+- **Level**: Web integration
+- **Given**: publish succeeded.
+- **When**: user clicks copy link.
+- **Then**: clipboard or visible field contains `atmos.land/s/...`.
+- **Signals**: success toast; URL matches API response.
+
+### S13 - Handle based profile
+
+- **Level**: Cloud + landing
+- **Given**: `profile_public=1` and primary public share.
+- **When**: visitor opens `/u/{handle}`.
+- **Then**: profile renders; private profile → 404.
+- **Signals**: handle match case-insensitive as designed.
+
+### S14 - token-usage crate regression
+
+- **Level**: Rust unit
+- **Given**: existing tests.
+- **When**: `cargo test -p token-usage`.
+- **Then**: all pass; overview model unchanged for local path.
+- **Signals**: green test run.
+
+### S15 - Server rejects oversized or illegal snapshot
+
+- **Level**: Cloud unit
+- **Given**: body > 256 KiB or contains `messages` array.
+- **When**: POST share.
+- **Then**: 400; no row written.
+- **Signals**: error code `invalid_snapshot` or `payload_too_large`.
+
+### S16 - Relay surface stays free of usage share product routes; Hub is the only share/auth host
+
+- **Level**: Static / review
+- **Given**: monorepo after implementation.
+- **When**: search `packages/relay` for usage share account APIs.
+- **Then**: no `/v1/usage/shares` product implementation in relay; auth/share live under `packages/hub` and `hub.atmos.land`.
+- **Signals**: `rg "usage/shares" packages/relay` only docs cross-links; `packages/hub` exists with auth + usage share routes; no package named `packages/cloud` for this feature.
+
+### S17 - OG image metadata
+
+- **Level**: Integration
+- **Given**: owner uploaded OG PNG.
+- **When**: public GET + landing metadata.
+- **Then**: `og_image_url` non-null; landing meta includes image.
+- **Signals**: URL fetch returns image/png in staging.
+
+### S18 - Device list returns enrolled devices
+
+- **Level**: Cloud integration
+- **Given**: signed-in user has enrolled a device.
+- **When**: `GET /v1/devices`.
+- **Then**: device appears with label; raw credential is not returned.
+- **Signals**: no `device_credential` field on list; `revoked_at` null.
+
+
+### S19 - Google OAuth creates/links account
+
+- **Level**: Hub integration
+- **Given**: mocked Google token exchange returns subject `g-1`, email `a@gmail.com`.
+- **When**: Better Auth Google callback completes.
+- **Then**: user exists; provider account linked; session established.
+- **Signals**: `/v1/me` shows google in providers; GitHub-only fields optional null.
+
+### S20 - Device mint returns credential once
+
+- **Level**: Hub integration
+- **Given**: valid Hub session.
+- **When**: `POST /v1/devices` with label.
+- **Then**: response includes `device_credential` and `device_id`; subsequent list omits credential; Hub stores only hash.
+- **Signals**: DB has `credential_hash`; plaintext not in DB.
+
+### S21 - Relay accepts device credential under account
+
+- **Level**: Relay integration
+- **Given**: Hub projected device to Relay; computer registered to `user_id`.
+- **When**: `GET /v1/computers` with Bearer device_credential.
+- **Then**: computer list returns that user’s computers.
+- **Signals**: 200; wrong credential 401.
+
+### S22 - Rotate via Hub session preserves computers
+
+- **Level**: Hub + Relay
+- **Given**: account has computers; device A enrolled.
+- **When**: session calls rotate on device A.
+- **Then**: new credential works; computers still listed; `user_id` unchanged.
+- **Signals**: computer row count unchanged; `server_secret` hash unchanged.
+
+### S23 - Old device credential dies after rotate
+
+- **Level**: Hub + Relay
+- **Given**: rotate succeeded.
+- **When**: old credential calls Relay.
+- **Then**: 401.
+- **Signals**: no tenant/device resolve on old hash.
+
+### S24 - Two devices same user share Computers
+
+- **Level**: Relay
+- **Given**: device A and B for same `user_id`; computer registered via A.
+- **When**: B lists computers.
+- **Then**: same computer visible.
+- **Signals**: both Bearers authorize same `user_id` rows.
+
+### S25 - One-time enroll token for VPS
+
+- **Level**: Hub
+- **Given**: session.
+- **When**: `POST /v1/computers/enroll_tokens`.
+- **Then**: returns short-lived register material bound to account; reuse after expiry fails.
+- **Signals**: second consume rejected; computer `user_id` set.
+
+### S26 - No user-generated Access Token primary UX
+
+- **Level**: Product / UI
+- **Given**: Settings connection UI after this ships.
+- **When**: user manages remote Computer access.
+- **Then**: primary path is Sign in + Trust device / Add Computer; no “generate access token as identity” primary CTA.
+- **Signals**: copy review + optional e2e.
+
+## Exploratory agent-browser checks
+
+Before running, load Agent Browser skill or `agent-browser skills get core --full` if available; else mark `not_run`.
+
+1. Token Usage → Share → Publish: copy and empty states clear in en/zh if applicable.
+2. Public `/s/...` at 390px width: no horizontal overflow; stats readable.
+3. After unpublish, hard refresh shows 404.
+4. Signed-out publish attempt never exposes other users’ data.
+
+## Regression checklist
+
+- [ ] Local Token Usage refresh/signed-out path
+- [ ] Existing PNG capture/share still works
+- [ ] Relay computer list / GitHub setup unaffected
+- [ ] `cargo test -p token-usage`
+- [ ] Cloud deploy dry-run / wrangler tests
+- [ ] Landing build typecheck for new routes
+
+## Acceptance criteria
+
+1. A user can publish a redacted usage snapshot after GitHub login and open it while logged out.
+2. Local Token Usage never requires hub login.
+3. Revoked shares are not publicly readable.
+4. Snapshots cannot retain denylisted sensitive keys under validation.
+5. Usage share product is not implemented inside `packages/relay`.
+6. Cost omitted unless opted in.
+7. PRD Must Haves M1–M12 have at least one scenario with a planned automated or explicit manual check.
+
+## Manual verification steps
+
+1. Staging Hub + GitHub + Google OAuth clients + Relay internal sync secret.
+2. Sign in GitHub; enroll device; register a Computer; list from same device.
+3. Sign in Google (fresh account); enroll; publish share.
+4. Rotate device while logged in; old credential fails; computers remain.
+5. Second device enroll; both see same computers.
+6. Publish/unpublish share; private window checks.
+7. Pure local Server without login still works.
+
+## Non-coverage
+
+- Real GitHub outage behavior beyond error toast.
+- Full Phase 2 Computer ownership migration and lost-token recovery product.
+- Continuous multi-device rollup accuracy.
+- Abuse/spam ML detection.
+- Legal export of all account data (GDPR package) beyond delete share + logout.
+
+## Coverage Status
+
+> Fill after implementation / test runs.
+
+| Date | What ran | Result | Gaps |
+|------|----------|--------|------|
+| — | — | not_started | Spec only |


### PR DESCRIPTION
## Summary

Adds **APP-056** product specs for Atmos Hub and token-usage sharing:

- **`packages/hub`** (`hub.atmos.land`) as hosted control plane — not relay, not `cloud`
- **Auth**: Better Auth + Drizzle + D1; **GitHub + Google** only (v1)
- **Owner id**: Better Auth `user.id` → **`user_id`** (BA `account` table = OAuth links only)
- **Identity**: no user-generated Access Token; Hub session **mints/rotates device credentials**; Computers owned by `user_id`
- **Share**: redacted local snapshot publish; unlisted default; public `/s/:id` on landing
- Relay stays connection fabric; raw D1 SQL (no Better Auth on relay)

Files: `specs/APP/APP-056_usage-share-and-accounts/{BRAINSTORM,PRD,TECH,TEST}.md`

## Key decisions (no backward compat)

| Topic | Decision |
|-------|----------|
| Service name | `hub` not `cloud` |
| Login | GitHub + Google |
| Stack | Better Auth + Drizzle on Hub only |
| Computers | `user_id` ownership |
| Access Token UX | Removed as product identity |

Supersedes product identity assumptions in APP-016/APP-020 where Access Token = tenant root (no production users to migrate).

## Test plan

- [ ] Spec review: naming, membership rules, auth stack
- [ ] Confirm APP-019 install stays on relay; product login is Hub Better Auth
- [ ] Confirm `user_id` vs Better Auth `account` terminology is clear
- [ ] Follow-up: implement `packages/hub` + Relay identity migrations per TECH

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds APP-056 specs for Atmos Hub: a hosted control plane with GitHub/Google login, shareable token-usage snapshots, and device credentials that replace user-generated Access Tokens. Keeps relay as the connection fabric and moves product identity to `user_id` ownership.

- **New Features**
  - New `packages/hub` (`hub.atmos.land`) with Better Auth + Drizzle on D1.
  - Hub mints/rotates device credentials; no user-generated Access Token.
  - `user_id` is the owner for Computers and shares; `packages/relay` remains WS/gateway with raw D1 SQL.
  - Publish redacted local usage snapshots; default unlisted; public at `atmos.land/s/:id` with optional `/u/:handle`.
  - Public read API and optional OG image upload; cost display is opt-in.
  - Clear hub/relay boundaries and privacy guarantees (aggregates only).

- **Migration**
  - Identity shifts to `user_id` + device credentials; token-tenant model is superseded (no production migration needed).
  - Follow-up: implement `packages/hub` and update `packages/relay` to authorize via device credentials and scope by `user_id` (per APP-056).

<sup>Written for commit 8f8bbe75845c5df06349a7b94309aab54f33797d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added product requirements, technical design, and test planning for Atmos Hub.
  * Documented GitHub and Google sign-in, device management, and account ownership.
  * Defined optional usage sharing through redacted aggregate snapshots with unlisted public pages.
  * Documented local-first usage without login and secure publishing workflows.
  * Added rollout guidance, security considerations, acceptance criteria, and testing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->