### PR TITLE
feat(agent-hooks): unattended need-attention auto-summary

### DIFF
--- a/apps/api/src/api/hooks/mod.rs
+++ b/apps/api/src/api/hooks/mod.rs
@@ -68,6 +68,8 @@ pub fn routes() -> Router<AppState> {
         )
         .route("/sessions/{session_id}", delete(remove_hook_session))
         // Attention routes before `/{tool}/…` so "attention" is not parsed as a tool name.
+        // REST (not WS): same pre-connection bootstrap as GET /attention — used to hydrate
+        // sticky latch/summary state on browser refresh before the WS session is ready.
         .route("/attention", get(list_attention))
         .route("/attention/clear", post(clear_attention))
         .route("/attention/summaries", get(list_attention_summaries))

--- a/apps/api/src/api/hooks/mod.rs
+++ b/apps/api/src/api/hooks/mod.rs
@@ -264,6 +264,10 @@ struct ClearAttentionBody {
     stable_pane_id: Option<String>,
     #[serde(default)]
     stable_pane_ids: Option<Vec<String>>,
+    /// When set (RFC3339), only clear latches raised at or before this time so a
+    /// late dismiss cannot wipe a newer turn that landed after the client acted.
+    #[serde(default)]
+    not_after: Option<String>,
 }
 
 async fn clear_attention(
@@ -276,7 +280,29 @@ async fn clear_attention(
             ids.push(id);
         }
     }
-    let cleared = if ids.len() == 1 {
+    let not_after = body
+        .not_after
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let cleared = if let Some(cutoff) = not_after {
+        if ids.len() == 1 {
+            state
+                .agent_hooks_service
+                .clear_attention_for_pane_not_after(ids[0].as_str(), cutoff)
+        } else {
+            // Multi-id guarded clear: reuse single-id path per id.
+            let mut all = Vec::new();
+            for id in &ids {
+                all.extend(
+                    state
+                        .agent_hooks_service
+                        .clear_attention_for_pane_not_after(id.as_str(), cutoff),
+                );
+            }
+            all
+        }
+    } else if ids.len() == 1 {
         state
             .agent_hooks_service
             .clear_attention_for_pane(ids[0].as_str())

--- a/apps/api/src/api/hooks/mod.rs
+++ b/apps/api/src/api/hooks/mod.rs
@@ -70,6 +70,7 @@ pub fn routes() -> Router<AppState> {
         // Attention routes before `/{tool}/…` so "attention" is not parsed as a tool name.
         .route("/attention", get(list_attention))
         .route("/attention/clear", post(clear_attention))
+        .route("/attention/summaries", get(list_attention_summaries))
         .route("/install", post(install_hooks))
         .route("/uninstall", post(uninstall_hooks))
         .route("/status", get(hooks_status))
@@ -247,6 +248,11 @@ async fn list_hook_sessions(State(state): State<AppState>) -> Json<Value> {
 async fn list_attention(State(state): State<AppState>) -> Json<Value> {
     let attention = state.agent_hooks_service.get_all_attention();
     Json(serde_json::json!({ "attention": attention }))
+}
+
+async fn list_attention_summaries(State(state): State<AppState>) -> Json<Value> {
+    let summaries = state.agent_hooks_service.get_all_attention_summaries();
+    Json(serde_json::json!({ "summaries": summaries }))
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/api/src/api/ws/message.rs
+++ b/apps/api/src/api/ws/message.rs
@@ -744,6 +744,10 @@ pub enum WsEvent {
     AgentAttentionRaised,
     /// Sticky need-attention latch(es) cleared after user acknowledge
     AgentAttentionCleared,
+    /// Unattended task-complete auto-summary lifecycle update
+    AgentAttentionSummaryUpdated,
+    /// Unattended auto-summary cleared with the attention latch
+    AgentAttentionSummaryCleared,
     /// Agent notification (permission request, task complete, etc.)
     AgentNotification,
     /// Current branch PR status should be refreshed
@@ -1093,6 +1097,14 @@ pub struct CodeAgentCustomUpdateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentBehaviourSettingsUpdateRequest {
     pub idle_session_timeout_mins: u64,
+    #[serde(default)]
+    pub attention_summary_enabled: Option<bool>,
+    #[serde(default)]
+    pub attention_summary_delay_mins: Option<u64>,
+    #[serde(default)]
+    pub attention_summary_agent_id: Option<String>,
+    #[serde(default)]
+    pub attention_summary_model: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/apps/api/src/api/ws/router/github.rs
+++ b/apps/api/src/api/ws/router/github.rs
@@ -2407,7 +2407,7 @@ impl WsMessageService {
             .and_then(|job| {
                 job.get("steps").and_then(Value::as_array).map(|arr| {
                     arr.iter()
-                        .filter_map(|step| {
+                        .map(|step| {
                             let number = step.get("number").and_then(Value::as_u64).unwrap_or(0);
                             let name = step
                                 .get("name")
@@ -2422,13 +2422,13 @@ impl WsMessageService {
                                 parse_github_time(step.get("started_at").and_then(Value::as_str));
                             let completed_at =
                                 parse_github_time(step.get("completed_at").and_then(Value::as_str));
-                            Some(JobStepMeta {
+                            JobStepMeta {
                                 number,
                                 name,
                                 conclusion,
                                 started_at,
                                 completed_at,
-                            })
+                            }
                         })
                         .collect::<Vec<_>>()
                 })

--- a/apps/api/src/api/ws/router/settings.rs
+++ b/apps/api/src/api/ws/router/settings.rs
@@ -100,7 +100,14 @@ impl WsMessageService {
             .get("idle_session_timeout_mins")
             .and_then(|v| v.as_u64())
             .unwrap_or(30);
-        Ok(json!({ "idle_session_timeout_mins": timeout }))
+        let summary_settings = core_service::AttentionSummarySettings::from_json(&val);
+        Ok(json!({
+            "idle_session_timeout_mins": timeout,
+            "attention_summary_enabled": summary_settings.enabled,
+            "attention_summary_delay_mins": summary_settings.delay_mins,
+            "attention_summary_agent_id": summary_settings.agent_id,
+            "attention_summary_model": summary_settings.model,
+        }))
     }
 
     fn read_llm_providers() -> Result<Value> {
@@ -238,6 +245,33 @@ impl WsMessageService {
             json!({ "agents": [] })
         };
         val["idle_session_timeout_mins"] = json!(req.idle_session_timeout_mins);
+        if let Some(enabled) = req.attention_summary_enabled {
+            val["attention_summary_enabled"] = json!(enabled);
+        }
+        if let Some(delay) = req.attention_summary_delay_mins {
+            let delay = delay.clamp(1, 24 * 60);
+            val["attention_summary_delay_mins"] = json!(delay);
+        }
+        if let Some(agent_id) = req.attention_summary_agent_id {
+            let trimmed = agent_id.trim();
+            if trimmed.is_empty() {
+                if let Some(obj) = val.as_object_mut() {
+                    obj.remove("attention_summary_agent_id");
+                }
+            } else {
+                val["attention_summary_agent_id"] = json!(trimmed);
+            }
+        }
+        if let Some(model) = req.attention_summary_model {
+            let trimmed = model.trim();
+            if trimmed.is_empty() {
+                if let Some(obj) = val.as_object_mut() {
+                    obj.remove("attention_summary_model");
+                }
+            } else {
+                val["attention_summary_model"] = json!(trimmed);
+            }
+        }
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
                 ServiceError::Validation(format!("Failed to create ~/.atmos/agent dir: {}", e))

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -106,6 +106,14 @@ fn spawn_agent_hook_forwarder(
                             WsEvent::AgentAttentionCleared,
                             json!({ "stable_pane_ids": stable_pane_ids }),
                         ),
+                        AgentHookEvent::AttentionSummaryUpdated(summary) => (
+                            WsEvent::AgentAttentionSummaryUpdated,
+                            json!(summary),
+                        ),
+                        AgentHookEvent::AttentionSummaryCleared { stable_pane_ids } => (
+                            WsEvent::AgentAttentionSummaryCleared,
+                            json!({ "stable_pane_ids": stable_pane_ids }),
+                        ),
                     };
                     if let Err(error) = ws_manager
                         .broadcast(&WsMessage::notification(ws_event, data))
@@ -251,6 +259,8 @@ fn spawn_non_critical_startup_tasks(
 
 /// Product job id for agent-hooks idle session cleanup (APP-051).
 const AGENT_HOOKS_IDLE_CLEANUP_JOB_ID: &str = "agent-hooks.idle_session_cleanup";
+/// Product job id for unattended need-attention auto-summary.
+const AGENT_HOOKS_ATTENTION_SUMMARY_JOB_ID: &str = "agent-hooks.attention_auto_summary";
 
 /// Register the agent-hook session cleanup interval job (every 5 minutes).
 async fn register_idle_session_cleanup_job(
@@ -287,19 +297,94 @@ async fn register_idle_session_cleanup_job(
     }
 }
 
+/// Poll sticky task-complete attention and spawn headless auto-summaries.
+async fn register_attention_summary_job(
+    jobs: Arc<LocalScheduler>,
+    agent_hooks_service: Arc<core_service::AgentHooksService>,
+) {
+    if let Err(error) = jobs
+        .set_interval_job(
+            JobId::new(AGENT_HOOKS_ATTENTION_SUMMARY_JOB_ID),
+            IntervalSpec {
+                // 30s keeps the configurable delay responsive without busy-looping.
+                every: std::time::Duration::from_secs(30),
+                skip_if_running: true,
+                fire_immediately: false,
+            },
+            RetryPolicy::none(),
+            move || {
+                let agent_hooks_service = Arc::clone(&agent_hooks_service);
+                async move {
+                    tick_attention_auto_summary(agent_hooks_service).await;
+                    Ok(())
+                }
+            },
+        )
+        .await
+    {
+        warn!(
+            "Failed to register agent-hooks attention auto-summary job: {}",
+            error
+        );
+    }
+}
+
+async fn tick_attention_auto_summary(agent_hooks_service: Arc<core_service::AgentHooksService>) {
+    let settings = read_attention_summary_settings();
+    if !settings.enabled {
+        return;
+    }
+    let due = agent_hooks_service.attention_due_for_summary(settings.delay());
+    for latch in due {
+        let Some((latch, _row, generation)) =
+            agent_hooks_service.begin_attention_summary(&latch.stable_pane_id)
+        else {
+            continue;
+        };
+        let service = Arc::clone(&agent_hooks_service);
+        let settings = settings.clone();
+        tokio::spawn(async move {
+            match core_service::generate_attention_summary(&latch, &settings).await {
+                Ok(payload) => {
+                    let _ = service.complete_attention_summary(
+                        &latch.stable_pane_id,
+                        generation,
+                        payload,
+                    );
+                }
+                Err(error) => {
+                    warn!(
+                        pane = %latch.stable_pane_id,
+                        "Attention auto-summary failed: {error}"
+                    );
+                    let _ = service.fail_attention_summary(
+                        &latch.stable_pane_id,
+                        generation,
+                        error.to_string(),
+                    );
+                }
+            }
+        });
+    }
+}
+
 struct AgentHookSessionTimeouts {
     idle_mins: u64,
     active_stale_mins: u64,
 }
 
-fn read_agent_hook_session_timeouts() -> AgentHookSessionTimeouts {
-    const DEFAULT_IDLE: u64 = 30;
-    const DEFAULT_ACTIVE_STALE: u64 = 30;
-    let path = dirs::home_dir()
+fn terminal_code_agent_settings_path() -> std::path::PathBuf {
+    dirs::home_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("."))
         .join(".atmos")
         .join("agent")
-        .join("terminal_code_agent.json");
+        .join("terminal_code_agent.json")
+}
+
+fn read_agent_hook_session_timeouts() -> AgentHookSessionTimeouts {
+    const DEFAULT_IDLE: u64 = 30;
+    const DEFAULT_ACTIVE_STALE: u64 = 30;
+    let path = terminal_code_agent_settings_path();
     let Ok(content) = std::fs::read_to_string(&path) else {
         return AgentHookSessionTimeouts {
             idle_mins: DEFAULT_IDLE,
@@ -322,6 +407,17 @@ fn read_agent_hook_session_timeouts() -> AgentHookSessionTimeouts {
             .and_then(|v| v.as_u64())
             .unwrap_or(DEFAULT_ACTIVE_STALE),
     }
+}
+
+fn read_attention_summary_settings() -> core_service::AttentionSummarySettings {
+    let path = terminal_code_agent_settings_path();
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return core_service::AttentionSummarySettings::default();
+    };
+    let Ok(val) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return core_service::AttentionSummarySettings::default();
+    };
+    core_service::AttentionSummarySettings::from_json(&val)
 }
 
 /// rustls 0.23+ requires an explicit process-wide provider before TLS (relay WSS, reqwest, etc.).
@@ -782,7 +878,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Arc::clone(&agent_hooks_for_startup),
         actual_addr.port(),
     );
-    register_idle_session_cleanup_job(Arc::clone(&jobs), agent_hooks_for_startup).await;
+    register_idle_session_cleanup_job(Arc::clone(&jobs), Arc::clone(&agent_hooks_for_startup)).await;
+    register_attention_summary_job(Arc::clone(&jobs), agent_hooks_for_startup).await;
 
     // Serve with graceful shutdown — ensures PTY resources are cleaned up
     // when the process receives SIGTERM/SIGINT (e.g., during hot-reload).

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -106,10 +106,9 @@ fn spawn_agent_hook_forwarder(
                             WsEvent::AgentAttentionCleared,
                             json!({ "stable_pane_ids": stable_pane_ids }),
                         ),
-                        AgentHookEvent::AttentionSummaryUpdated(summary) => (
-                            WsEvent::AgentAttentionSummaryUpdated,
-                            json!(summary),
-                        ),
+                        AgentHookEvent::AttentionSummaryUpdated(summary) => {
+                            (WsEvent::AgentAttentionSummaryUpdated, json!(summary))
+                        }
                         AgentHookEvent::AttentionSummaryCleared { stable_pane_ids } => (
                             WsEvent::AgentAttentionSummaryCleared,
                             json!({ "stable_pane_ids": stable_pane_ids }),
@@ -334,8 +333,11 @@ async fn tick_attention_auto_summary(agent_hooks_service: Arc<core_service::Agen
     if !settings.enabled {
         return;
     }
+    // Bound concurrent headless summaries so one idle burst cannot spawn
+    // an agent-cli process per pane in a single tick.
+    const MAX_SUMMARIES_PER_TICK: usize = 3;
     let due = agent_hooks_service.attention_due_for_summary(settings.delay());
-    for latch in due {
+    for latch in due.into_iter().take(MAX_SUMMARIES_PER_TICK) {
         let Some((latch, _row, generation)) =
             agent_hooks_service.begin_attention_summary(&latch.stable_pane_id)
         else {
@@ -878,7 +880,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Arc::clone(&agent_hooks_for_startup),
         actual_addr.port(),
     );
-    register_idle_session_cleanup_job(Arc::clone(&jobs), Arc::clone(&agent_hooks_for_startup)).await;
+    register_idle_session_cleanup_job(Arc::clone(&jobs), Arc::clone(&agent_hooks_for_startup))
+        .await;
     register_attention_summary_job(Arc::clone(&jobs), agent_hooks_for_startup).await;
 
     // Serve with graceful shutdown — ensures PTY resources are cleaned up

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5369,10 +5369,21 @@
       },
       "behavior": {
         "title": "Behaviour",
-        "description": "Configure how idle agent sessions are managed in memory.",
+        "description": "Configure idle session cleanup and unattended need-attention auto-summary.",
         "idleCleanupTitle": "Idle session cleanup",
         "idleCleanupDescription": "Idle agent sessions older than this duration are automatically removed every 5 minutes.",
-        "minutes": "min"
+        "minutes": "min",
+        "summaryTitle": "Need-attention auto-summary",
+        "summaryDescription": "When a finished agent turn stays unacknowledged, spawn a headless summarizer and show next steps above the AI input.",
+        "summaryEnabled": "Enable auto-summary",
+        "summaryDelayTitle": "Wait before summarizing",
+        "summaryDelayDescription": "How long a task-complete attention latch can sit unacknowledged before summarizing.",
+        "summaryAgentTitle": "Summary agent",
+        "summaryAgentDescription": "Terminal agent id used for the headless session (same as Automations). Leave empty to use the default LLM provider.",
+        "summaryAgentPlaceholder": "e.g. claude-code, codex",
+        "summaryModelTitle": "Summary model",
+        "summaryModelDescription": "Optional model override for the summary agent.",
+        "summaryModelPlaceholder": "optional model id"
       }
     },
     "canvasSection": {
@@ -8897,6 +8908,15 @@
       "close": {
         "title": "Close (⌘W)"
       }
+    },
+    "attentionSummary": {
+      "loadingTitle": "Summarizing recent work…",
+      "readyTitle": "While you were away",
+      "errorTitle": "Could not summarize",
+      "errorFallback": "The headless summary agent failed. You can still continue in this session.",
+      "canCloseBadge": "Safe to close",
+      "keepOpenBadge": "Keep open",
+      "dismiss": "Dismiss"
     }
   },
   "app": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -5374,7 +5374,7 @@
         "idleCleanupDescription": "超过该时长的空闲 Agent 会话会每 5 分钟自动清理一次。",
         "minutes": "分钟",
         "summaryTitle": "Need-attention 自动总结",
-        "summaryDescription": "当 Agent 任务完成且长时间未被确认时，无头 spawn 总结会话，并在 AI 输入框上方展示下一步建议。",
+        "summaryDescription": "当 Agent 任务完成且长时间未被确认时，启动后台总结会话，并在 AI 输入框上方展示下一步建议。",
         "summaryEnabled": "启用自动总结",
         "summaryDelayTitle": "总结前等待",
         "summaryDelayDescription": "task-complete 的 attention 在未被确认后，等待多久再触发总结。",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -5369,10 +5369,21 @@
       },
       "behavior": {
         "title": "行为",
-        "description": "配置空闲 Agent 会话在内存中的管理方式。",
+        "description": "配置空闲会话清理，以及未处理 need-attention 时的自动总结。",
         "idleCleanupTitle": "空闲会话清理",
         "idleCleanupDescription": "超过该时长的空闲 Agent 会话会每 5 分钟自动清理一次。",
-        "minutes": "分钟"
+        "minutes": "分钟",
+        "summaryTitle": "Need-attention 自动总结",
+        "summaryDescription": "当 Agent 任务完成且长时间未被确认时，无头 spawn 总结会话，并在 AI 输入框上方展示下一步建议。",
+        "summaryEnabled": "启用自动总结",
+        "summaryDelayTitle": "总结前等待",
+        "summaryDelayDescription": "task-complete 的 attention 在未被确认后，等待多久再触发总结。",
+        "summaryAgentTitle": "总结 Agent",
+        "summaryAgentDescription": "无头总结使用的终端 Agent（与 Automations 相同）。留空则使用默认 LLM 提供方。",
+        "summaryAgentPlaceholder": "例如 claude-code、codex",
+        "summaryModelTitle": "总结模型",
+        "summaryModelDescription": "可选，覆盖总结 Agent 使用的模型。",
+        "summaryModelPlaceholder": "可选模型 id"
       }
     },
     "canvasSection": {
@@ -8897,6 +8908,15 @@
       "close": {
         "title": "关闭（⌘W）"
       }
+    },
+    "attentionSummary": {
+      "loadingTitle": "正在总结最近工作…",
+      "readyTitle": "你离开时发生了这些",
+      "errorTitle": "总结失败",
+      "errorFallback": "无头总结 Agent 运行失败，你仍可继续当前会话。",
+      "canCloseBadge": "可关闭会话",
+      "keepOpenBadge": "建议保持打开",
+      "dismiss": "关闭"
     }
   },
   "app": {

--- a/apps/web/src/api/rest-api.ts
+++ b/apps/web/src/api/rest-api.ts
@@ -665,12 +665,15 @@ export const agentHooksApi = {
   clearAttention: async (input: {
     stablePaneId?: string;
     stablePaneIds?: string[];
+    /** RFC3339: only clear latches raised at or before this (dismiss race guard). */
+    notAfter?: string;
   }): Promise<{ cleared: string[] }> => {
     return fetchHooksApi<{ cleared: string[] }>('/hooks/attention/clear', {
       method: 'POST',
       body: JSON.stringify({
         stable_pane_id: input.stablePaneId,
         stable_pane_ids: input.stablePaneIds,
+        not_after: input.notAfter,
       }),
     });
   },

--- a/apps/web/src/api/rest-api.ts
+++ b/apps/web/src/api/rest-api.ts
@@ -675,6 +675,15 @@ export const agentHooksApi = {
     });
   },
 
+  /** Unattended task-complete auto-summaries held in API memory. */
+  listAttentionSummaries: async (): Promise<{
+    summaries: AgentAttentionSummaryDto[];
+  }> => {
+    return fetchHooksApi<{ summaries: AgentAttentionSummaryDto[] }>(
+      '/hooks/attention/summaries',
+    );
+  },
+
   /** Resolve contested short CLI names (e.g. bare `agent`) to a product owner. */
   getCliIdentity: async (command = 'agent'): Promise<CliIdentityResponse> => {
     return fetchHooksApi<CliIdentityResponse>(
@@ -691,7 +700,23 @@ export type AgentAttentionLatchDto = {
   reason: AgentAttentionReasonDto;
   session_id: string;
   tool?: string | null;
+  project_path?: string | null;
   raised_at: string;
+};
+
+export type AttentionSummaryStatusDto = 'summarizing' | 'ready' | 'error';
+
+export type AgentAttentionSummaryDto = {
+  stable_pane_id: string;
+  context_id: string;
+  session_id: string;
+  status: AttentionSummaryStatusDto;
+  summary?: string | null;
+  next_steps?: string[] | null;
+  can_close_session?: boolean | null;
+  error?: string | null;
+  started_at: string;
+  completed_at?: string | null;
 };
 
 // ===== Workspace Terminal Layout API =====

--- a/apps/web/src/api/ws/settings-api.ts
+++ b/apps/web/src/api/ws/settings-api.ts
@@ -297,6 +297,10 @@ export const codeAgentCustomApi = {
 
 export interface AgentBehaviourSettings {
   idle_session_timeout_mins: number;
+  attention_summary_enabled?: boolean;
+  attention_summary_delay_mins?: number;
+  attention_summary_agent_id?: string | null;
+  attention_summary_model?: string | null;
 }
 
 export const agentBehaviourSettingsApi = {

--- a/apps/web/src/features/agent/store/agent-attention-store.ts
+++ b/apps/web/src/features/agent/store/agent-attention-store.ts
@@ -5,6 +5,7 @@ import {
   agentHooksApi,
   type AgentAttentionLatchDto,
 } from "@/api/rest-api";
+import { useAgentAttentionSummaryStore } from "@/features/agent/store/agent-attention-summary-store";
 
 export type AttentionReason = "permission_request" | "task_complete";
 
@@ -205,6 +206,8 @@ export const useAgentAttentionStore = create<AgentAttentionStore>((set, get) => 
       const filterMode = panes.size === 0 ? false : state.filterMode;
       return { panes, filterMode, revision: state.revision + 1 };
     });
+    // Keep auto-summary chrome in sync with local acknowledge.
+    useAgentAttentionSummaryStore.getState().clearPane(stablePaneId);
   },
 
   clearMatchingSessionIds: (ids) => {

--- a/apps/web/src/features/agent/store/agent-attention-summary-store.ts
+++ b/apps/web/src/features/agent/store/agent-attention-summary-store.ts
@@ -1,0 +1,147 @@
+"use client";
+
+import { create } from "zustand";
+import {
+  agentHooksApi,
+  type AgentAttentionSummaryDto,
+  type AttentionSummaryStatusDto,
+} from "@/api/rest-api";
+
+export type AttentionSummaryStatus = AttentionSummaryStatusDto;
+
+export type PaneAttentionSummary = {
+  stablePaneId: string;
+  contextId: string;
+  sessionId: string;
+  status: AttentionSummaryStatus;
+  summary?: string;
+  nextSteps: string[];
+  canCloseSession?: boolean;
+  error?: string;
+  startedAt: number;
+  completedAt?: number;
+};
+
+type AgentAttentionSummaryStore = {
+  panes: Map<string, PaneAttentionSummary>;
+  revision: number;
+
+  upsert: (row: PaneAttentionSummary) => void;
+  hydrateFromServer: (rows: readonly AgentAttentionSummaryDto[]) => void;
+  clearMatchingIds: (ids: readonly string[]) => void;
+  clearPane: (stablePaneId: string) => void;
+  getPane: (stablePaneId: string) => PaneAttentionSummary | null;
+};
+
+function parseTime(value: string | number | undefined | null): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const ms = Date.parse(value);
+    if (Number.isFinite(ms)) return ms;
+  }
+  return undefined;
+}
+
+function fromDto(dto: AgentAttentionSummaryDto): PaneAttentionSummary | null {
+  const stablePaneId = dto.stable_pane_id?.trim();
+  const contextId = dto.context_id?.trim();
+  if (!stablePaneId || !contextId) return null;
+  if (
+    dto.status !== "summarizing" &&
+    dto.status !== "ready" &&
+    dto.status !== "error"
+  ) {
+    return null;
+  }
+  return {
+    stablePaneId,
+    contextId,
+    sessionId: dto.session_id?.trim() || stablePaneId,
+    status: dto.status,
+    summary: dto.summary?.trim() || undefined,
+    nextSteps: Array.isArray(dto.next_steps)
+      ? dto.next_steps.map((s) => String(s).trim()).filter(Boolean)
+      : [],
+    canCloseSession:
+      typeof dto.can_close_session === "boolean" ? dto.can_close_session : undefined,
+    error: dto.error?.trim() || undefined,
+    startedAt: parseTime(dto.started_at) ?? Date.now(),
+    completedAt: parseTime(dto.completed_at ?? undefined),
+  };
+}
+
+export const useAgentAttentionSummaryStore = create<AgentAttentionSummaryStore>(
+  (set, get) => ({
+    panes: new Map(),
+    revision: 0,
+
+    upsert: (row) => {
+      const stablePaneId = row.stablePaneId?.trim();
+      if (!stablePaneId) return;
+      set((state) => {
+        const panes = new Map(state.panes);
+        panes.set(stablePaneId, { ...row, stablePaneId });
+        return { panes, revision: state.revision + 1 };
+      });
+    },
+
+    hydrateFromServer: (rows) => {
+      const panes = new Map<string, PaneAttentionSummary>();
+      for (const dto of rows) {
+        const row = fromDto(dto);
+        if (!row) continue;
+        panes.set(row.stablePaneId, row);
+      }
+      set((state) => ({ panes, revision: state.revision + 1 }));
+    },
+
+    clearMatchingIds: (ids) => {
+      const idSet = new Set(ids.map((id) => id.trim()).filter(Boolean));
+      if (idSet.size === 0) return;
+      set((state) => {
+        let changed = false;
+        const panes = new Map(state.panes);
+        for (const [key, row] of state.panes) {
+          if (idSet.has(key) || idSet.has(row.sessionId)) {
+            panes.delete(key);
+            changed = true;
+          }
+        }
+        if (!changed) return state;
+        return { panes, revision: state.revision + 1 };
+      });
+    },
+
+    clearPane: (stablePaneId) => {
+      const id = stablePaneId?.trim();
+      if (!id) return;
+      set((state) => {
+        if (!state.panes.has(id)) return state;
+        const panes = new Map(state.panes);
+        panes.delete(id);
+        return { panes, revision: state.revision + 1 };
+      });
+    },
+
+    getPane: (stablePaneId) => get().panes.get(stablePaneId) ?? null,
+  }),
+);
+
+export function selectPaneAttentionSummary(
+  stablePaneId: string,
+): (state: AgentAttentionSummaryStore) => PaneAttentionSummary | null {
+  return (state) => state.panes.get(stablePaneId) ?? null;
+}
+
+/** Recover summaries after refresh / reconnect (fire-and-forget). */
+export async function hydrateAttentionSummariesFromServer(): Promise<void> {
+  try {
+    const { summaries } = await agentHooksApi.listAttentionSummaries();
+    useAgentAttentionSummaryStore.getState().hydrateFromServer(summaries ?? []);
+  } catch (error) {
+    console.warn(
+      "[AgentAttentionSummaryStore] Failed to hydrate summaries:",
+      error,
+    );
+  }
+}

--- a/apps/web/src/features/agent/store/agent-attention-summary-store.ts
+++ b/apps/web/src/features/agent/store/agent-attention-summary-store.ts
@@ -135,8 +135,11 @@ export function selectPaneAttentionSummary(
 
 /** Recover summaries after refresh / reconnect (fire-and-forget). */
 export async function hydrateAttentionSummariesFromServer(): Promise<void> {
+  const revision = useAgentAttentionSummaryStore.getState().revision;
   try {
     const { summaries } = await agentHooksApi.listAttentionSummaries();
+    // Skip if a WebSocket update advanced the store while the REST call was in flight.
+    if (useAgentAttentionSummaryStore.getState().revision !== revision) return;
     useAgentAttentionSummaryStore.getState().hydrateFromServer(summaries ?? []);
   } catch (error) {
     console.warn(

--- a/apps/web/src/features/agent/store/agent-hooks-store.ts
+++ b/apps/web/src/features/agent/store/agent-hooks-store.ts
@@ -4,10 +4,15 @@ import { create } from "zustand";
 import { useWebSocketStore } from "@/features/connection/hooks/use-websocket";
 import { getRuntimeApiConfig, httpBase } from "@/shared/lib/desktop-runtime";
 import { agentHooksApi } from "@/api/rest-api";
+import type { AgentAttentionSummaryDto } from "@/api/rest-api";
 import {
   setAgentPaneAcknowledgedHandler,
   useAgentAttentionStore,
 } from "@/features/agent/store/agent-attention-store";
+import {
+  hydrateAttentionSummariesFromServer,
+  useAgentAttentionSummaryStore,
+} from "@/features/agent/store/agent-attention-summary-store";
 import {
   collectIdleSessionIdsForPane,
   resolveAgentStateForPaneId,
@@ -253,14 +258,56 @@ export const useAgentHooksStore = create<AgentHooksStore>((set, get) => ({
         const { stable_pane_ids } = data as { stable_pane_ids?: string[] };
         if (!stable_pane_ids?.length) return;
         useAgentAttentionStore.getState().clearMatchingSessionIds(stable_pane_ids);
+        // Backend also clears summaries, but keep client in sync if events reorder.
+        useAgentAttentionSummaryStore
+          .getState()
+          .clearMatchingIds(stable_pane_ids);
       },
     );
+
+    const unsubscribeAttentionSummaryUpdated = useWebSocketStore
+      .getState()
+      .onEvent("agent_attention_summary_updated", (data: unknown) => {
+        const dto = data as AgentAttentionSummaryDto;
+        if (!dto?.stable_pane_id || !dto.status) return;
+        useAgentAttentionSummaryStore.getState().upsert({
+          stablePaneId: dto.stable_pane_id,
+          contextId: dto.context_id,
+          sessionId: dto.session_id || dto.stable_pane_id,
+          status: dto.status,
+          summary: dto.summary ?? undefined,
+          nextSteps: Array.isArray(dto.next_steps)
+            ? dto.next_steps.map(String).filter(Boolean)
+            : [],
+          canCloseSession:
+            typeof dto.can_close_session === "boolean"
+              ? dto.can_close_session
+              : undefined,
+          error: dto.error ?? undefined,
+          startedAt: dto.started_at ? Date.parse(dto.started_at) : Date.now(),
+          completedAt: dto.completed_at
+            ? Date.parse(dto.completed_at)
+            : undefined,
+        });
+      });
+
+    const unsubscribeAttentionSummaryCleared = useWebSocketStore
+      .getState()
+      .onEvent("agent_attention_summary_cleared", (data: unknown) => {
+        const { stable_pane_ids } = data as { stable_pane_ids?: string[] };
+        if (!stable_pane_ids?.length) return;
+        useAgentAttentionSummaryStore
+          .getState()
+          .clearMatchingIds(stable_pane_ids);
+      });
 
     const _unsubscribe = () => {
       unsubscribeStateChanged();
       unsubscribeCleared();
       unsubscribeAttentionRaised();
       unsubscribeAttentionCleared();
+      unsubscribeAttentionSummaryUpdated();
+      unsubscribeAttentionSummaryCleared();
     };
     set({ _unsubscribe });
 
@@ -283,6 +330,8 @@ export const useAgentHooksStore = create<AgentHooksStore>((set, get) => ({
       if (latches.length === 0) return;
       useAgentAttentionStore.getState().hydrateFromServer(latches);
     });
+
+    void hydrateAttentionSummariesFromServer();
   },
 
   cleanup: () => {
@@ -291,6 +340,7 @@ export const useAgentHooksStore = create<AgentHooksStore>((set, get) => ({
       _unsubscribe();
       setAgentPaneAcknowledgedHandler(null);
       set({ _unsubscribe: null, sessions: new Map() });
+      useAgentAttentionSummaryStore.getState().hydrateFromServer([]);
     }
   },
 

--- a/apps/web/src/features/settings/components/CodeAgentSettingsSection.tsx
+++ b/apps/web/src/features/settings/components/CodeAgentSettingsSection.tsx
@@ -10,6 +10,7 @@ import {
   Input,
   Skeleton,
   Switch,
+  cn,
 } from "@workspace/ui";
 import { Bot, ChevronDown, LoaderCircle, Package, Plus, Trash2, UserCog, Zap } from "lucide-react";
 import { AGENT_OPTIONS, getInteractiveAgentParams } from "@/features/wiki/components/AgentSelect";
@@ -34,6 +35,10 @@ interface CodeAgentSettingsSectionProps {
   customAgents: CodeAgentCustomEntry[];
   customAgentsExpanded: boolean;
   idleSessionTimeoutMins: number;
+  attentionSummaryEnabled: boolean;
+  attentionSummaryDelayMins: number;
+  attentionSummaryAgentId: string;
+  attentionSummaryModel: string;
   runConfigAgentOptions: AgentOption[];
   runConfigsLoading: boolean;
   removingCustomAgentIds: Record<string, boolean>;
@@ -41,6 +46,10 @@ interface CodeAgentSettingsSectionProps {
   savedAgentCustomSettings: BuiltInAgentSettings;
   savedCustomAgents: CodeAgentCustomEntry[];
   savedIdleSessionTimeoutMins: number;
+  savedAttentionSummaryEnabled: boolean;
+  savedAttentionSummaryDelayMins: number;
+  savedAttentionSummaryAgentId: string;
+  savedAttentionSummaryModel: string;
   savingBuiltInAgentIds: Record<string, boolean>;
   savingCustomAgentIds: Record<string, boolean>;
   savingIdleTimeout: boolean;
@@ -70,6 +79,10 @@ interface CodeAgentSettingsSectionProps {
   setCustomAgentOpen: React.Dispatch<React.SetStateAction<Record<string, boolean>>>;
   setCustomAgentsExpanded: React.Dispatch<React.SetStateAction<boolean>>;
   setIdleSessionTimeoutMins: React.Dispatch<React.SetStateAction<number>>;
+  setAttentionSummaryEnabled: React.Dispatch<React.SetStateAction<boolean>>;
+  setAttentionSummaryDelayMins: React.Dispatch<React.SetStateAction<number>>;
+  setAttentionSummaryAgentId: React.Dispatch<React.SetStateAction<string>>;
+  setAttentionSummaryModel: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export function CodeAgentSettingsSection({
@@ -81,6 +94,10 @@ export function CodeAgentSettingsSection({
   customAgents,
   customAgentsExpanded,
   idleSessionTimeoutMins,
+  attentionSummaryEnabled,
+  attentionSummaryDelayMins,
+  attentionSummaryAgentId,
+  attentionSummaryModel,
   runConfigAgentOptions,
   runConfigsLoading,
   removingCustomAgentIds,
@@ -88,6 +105,10 @@ export function CodeAgentSettingsSection({
   savedAgentCustomSettings,
   savedCustomAgents,
   savedIdleSessionTimeoutMins,
+  savedAttentionSummaryEnabled,
+  savedAttentionSummaryDelayMins,
+  savedAttentionSummaryAgentId,
+  savedAttentionSummaryModel,
   savingBuiltInAgentIds,
   savingCustomAgentIds,
   savingIdleTimeout,
@@ -117,6 +138,10 @@ export function CodeAgentSettingsSection({
   setCustomAgentOpen,
   setCustomAgentsExpanded,
   setIdleSessionTimeoutMins,
+  setAttentionSummaryEnabled,
+  setAttentionSummaryDelayMins,
+  setAttentionSummaryAgentId,
+  setAttentionSummaryModel,
 }: CodeAgentSettingsSectionProps) {
   const t = useTranslations("settings.codeAgentSection");
 
@@ -466,7 +491,7 @@ export function CodeAgentSettingsSection({
             </p>
           </div>
         </div>
-        <div className="border-t border-border px-6 py-5">
+        <div className="space-y-5 border-t border-border px-6 py-5">
           <div className="flex items-center justify-between gap-6">
             <div className="min-w-0">
               <p className="text-sm font-medium text-foreground">{t("behavior.idleCleanupTitle")}</p>
@@ -484,13 +509,105 @@ export function CodeAgentSettingsSection({
                 className="h-8 w-20 text-center text-sm"
               />
               <span className="text-sm text-muted-foreground whitespace-nowrap">{t("behavior.minutes")}</span>
-              {idleSessionTimeoutMins !== savedIdleSessionTimeoutMins ? (
-                <Button size="sm" disabled={savingIdleTimeout} onClick={onSaveIdleTimeout}>
-                  {savingIdleTimeout ? <LoaderCircle className="size-3.5 animate-spin-reverse" /> : t("common.save")}
-                </Button>
-              ) : null}
             </div>
           </div>
+
+          <div className="border-t border-border pt-5">
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-foreground">{t("behavior.summaryTitle")}</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {t("behavior.summaryDescription")}
+                </p>
+              </div>
+              <Switch
+                checked={attentionSummaryEnabled}
+                onCheckedChange={(checked) => setAttentionSummaryEnabled(!!checked)}
+              />
+            </div>
+
+            <div
+              className={cn(
+                "mt-4 space-y-4",
+                !attentionSummaryEnabled && "pointer-events-none opacity-50",
+              )}
+            >
+              <div className="flex items-center justify-between gap-6">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-foreground">
+                    {t("behavior.summaryDelayTitle")}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {t("behavior.summaryDelayDescription")}
+                  </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <Input
+                    type="number"
+                    min={1}
+                    max={1440}
+                    value={attentionSummaryDelayMins}
+                    onChange={(event) =>
+                      setAttentionSummaryDelayMins(Math.max(1, Number(event.target.value) || 1))
+                    }
+                    className="h-8 w-20 text-center text-sm"
+                  />
+                  <span className="text-sm text-muted-foreground whitespace-nowrap">
+                    {t("behavior.minutes")}
+                  </span>
+                </div>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div>
+                  <label className="mb-1 block text-xs text-muted-foreground">
+                    {t("behavior.summaryAgentTitle")}
+                  </label>
+                  <Input
+                    value={attentionSummaryAgentId}
+                    placeholder={t("behavior.summaryAgentPlaceholder")}
+                    onChange={(event) => setAttentionSummaryAgentId(event.target.value)}
+                    className="h-9 text-sm font-mono"
+                  />
+                  <p className="mt-1 text-[11px] leading-4 text-muted-foreground">
+                    {t("behavior.summaryAgentDescription")}
+                  </p>
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs text-muted-foreground">
+                    {t("behavior.summaryModelTitle")}
+                  </label>
+                  <Input
+                    value={attentionSummaryModel}
+                    placeholder={t("behavior.summaryModelPlaceholder")}
+                    onChange={(event) => setAttentionSummaryModel(event.target.value)}
+                    className="h-9 text-sm font-mono"
+                  />
+                  <p className="mt-1 text-[11px] leading-4 text-muted-foreground">
+                    {t("behavior.summaryModelDescription")}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {(
+            idleSessionTimeoutMins !== savedIdleSessionTimeoutMins ||
+            attentionSummaryEnabled !== savedAttentionSummaryEnabled ||
+            attentionSummaryDelayMins !== savedAttentionSummaryDelayMins ||
+            attentionSummaryAgentId !== savedAttentionSummaryAgentId ||
+            attentionSummaryModel !== savedAttentionSummaryModel
+          ) ? (
+            <div className="flex justify-end border-t border-border pt-4">
+              <Button size="sm" disabled={savingIdleTimeout} onClick={onSaveIdleTimeout}>
+                {savingIdleTimeout ? (
+                  <LoaderCircle className="size-3.5 animate-spin-reverse" />
+                ) : (
+                  t("common.save")
+                )}
+              </Button>
+            </div>
+          ) : null}
         </div>
       </div>
     </div>

--- a/apps/web/src/features/settings/components/CodeAgentSettingsSection.tsx
+++ b/apps/web/src/features/settings/components/CodeAgentSettingsSection.tsx
@@ -523,6 +523,7 @@ export function CodeAgentSettingsSection({
               <Switch
                 checked={attentionSummaryEnabled}
                 onCheckedChange={(checked) => setAttentionSummaryEnabled(!!checked)}
+                aria-label={t("behavior.summaryEnabled")}
               />
             </div>
 
@@ -547,8 +548,11 @@ export function CodeAgentSettingsSection({
                     min={1}
                     max={1440}
                     value={attentionSummaryDelayMins}
+                    disabled={!attentionSummaryEnabled}
                     onChange={(event) =>
-                      setAttentionSummaryDelayMins(Math.max(1, Number(event.target.value) || 1))
+                      setAttentionSummaryDelayMins(
+                        Math.min(1440, Math.max(1, Number(event.target.value) || 1)),
+                      )
                     }
                     className="h-8 w-20 text-center text-sm"
                   />
@@ -566,6 +570,7 @@ export function CodeAgentSettingsSection({
                   <Input
                     value={attentionSummaryAgentId}
                     placeholder={t("behavior.summaryAgentPlaceholder")}
+                    disabled={!attentionSummaryEnabled}
                     onChange={(event) => setAttentionSummaryAgentId(event.target.value)}
                     className="h-9 text-sm font-mono"
                   />
@@ -580,6 +585,7 @@ export function CodeAgentSettingsSection({
                   <Input
                     value={attentionSummaryModel}
                     placeholder={t("behavior.summaryModelPlaceholder")}
+                    disabled={!attentionSummaryEnabled}
                     onChange={(event) => setAttentionSummaryModel(event.target.value)}
                     className="h-9 text-sm font-mono"
                   />

--- a/apps/web/src/features/settings/components/SettingsModal.tsx
+++ b/apps/web/src/features/settings/components/SettingsModal.tsx
@@ -258,6 +258,14 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
   const [removingCustomAgentIds, setRemovingCustomAgentIds] = useState<Record<string, boolean>>({});
   const [idleSessionTimeoutMins, setIdleSessionTimeoutMins] = useState<number>(30);
   const [savedIdleSessionTimeoutMins, setSavedIdleSessionTimeoutMins] = useState<number>(30);
+  const [attentionSummaryEnabled, setAttentionSummaryEnabled] = useState(true);
+  const [savedAttentionSummaryEnabled, setSavedAttentionSummaryEnabled] = useState(true);
+  const [attentionSummaryDelayMins, setAttentionSummaryDelayMins] = useState(5);
+  const [savedAttentionSummaryDelayMins, setSavedAttentionSummaryDelayMins] = useState(5);
+  const [attentionSummaryAgentId, setAttentionSummaryAgentId] = useState("");
+  const [savedAttentionSummaryAgentId, setSavedAttentionSummaryAgentId] = useState("");
+  const [attentionSummaryModel, setAttentionSummaryModel] = useState("");
+  const [savedAttentionSummaryModel, setSavedAttentionSummaryModel] = useState("");
   const [savingIdleTimeout, setSavingIdleTimeout] = useState(false);
   const [savedRunConfigs, setSavedRunConfigs] = useState<TerminalAgentSavedRunConfig[]>([]);
   const [runConfigsLoading, setRunConfigsLoading] = useState(false);
@@ -343,6 +351,18 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
       const timeout = behaviourData?.idle_session_timeout_mins ?? 30;
       setIdleSessionTimeoutMins(timeout);
       setSavedIdleSessionTimeoutMins(timeout);
+      const summaryEnabled = behaviourData?.attention_summary_enabled ?? true;
+      setAttentionSummaryEnabled(summaryEnabled);
+      setSavedAttentionSummaryEnabled(summaryEnabled);
+      const summaryDelay = behaviourData?.attention_summary_delay_mins ?? 5;
+      setAttentionSummaryDelayMins(summaryDelay);
+      setSavedAttentionSummaryDelayMins(summaryDelay);
+      const summaryAgent = behaviourData?.attention_summary_agent_id ?? "";
+      setAttentionSummaryAgentId(summaryAgent || "");
+      setSavedAttentionSummaryAgentId(summaryAgent || "");
+      const summaryModel = behaviourData?.attention_summary_model ?? "";
+      setAttentionSummaryModel(summaryModel || "");
+      setSavedAttentionSummaryModel(summaryModel || "");
 
       const agentCli = (functionSettings as Record<string, unknown>)?.agent_cli as
         | Record<string, unknown>
@@ -714,12 +734,26 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
     try {
       await agentBehaviourSettingsApi.update({
         idle_session_timeout_mins: idleSessionTimeoutMins,
+        attention_summary_enabled: attentionSummaryEnabled,
+        attention_summary_delay_mins: attentionSummaryDelayMins,
+        attention_summary_agent_id: attentionSummaryAgentId,
+        attention_summary_model: attentionSummaryModel,
       });
       setSavedIdleSessionTimeoutMins(idleSessionTimeoutMins);
+      setSavedAttentionSummaryEnabled(attentionSummaryEnabled);
+      setSavedAttentionSummaryDelayMins(attentionSummaryDelayMins);
+      setSavedAttentionSummaryAgentId(attentionSummaryAgentId);
+      setSavedAttentionSummaryModel(attentionSummaryModel);
     } finally {
       setSavingIdleTimeout(false);
     }
-  }, [idleSessionTimeoutMins]);
+  }, [
+    idleSessionTimeoutMins,
+    attentionSummaryEnabled,
+    attentionSummaryDelayMins,
+    attentionSummaryAgentId,
+    attentionSummaryModel,
+  ]);
 
   const loadLlmConfig = React.useCallback(async () => {
     setIsLlmConfigLoading(true);
@@ -1014,6 +1048,10 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                     customAgents={customAgents}
                     customAgentsExpanded={customAgentsExpanded}
                     idleSessionTimeoutMins={idleSessionTimeoutMins}
+                    attentionSummaryEnabled={attentionSummaryEnabled}
+                    attentionSummaryDelayMins={attentionSummaryDelayMins}
+                    attentionSummaryAgentId={attentionSummaryAgentId}
+                    attentionSummaryModel={attentionSummaryModel}
                     runConfigAgentOptions={runConfigAgentOptions}
                     runConfigsLoading={runConfigsLoading}
                     removingCustomAgentIds={removingCustomAgentIds}
@@ -1021,6 +1059,10 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                     savedAgentCustomSettings={savedAgentCustomSettings}
                     savedCustomAgents={savedCustomAgents}
                     savedIdleSessionTimeoutMins={savedIdleSessionTimeoutMins}
+                    savedAttentionSummaryEnabled={savedAttentionSummaryEnabled}
+                    savedAttentionSummaryDelayMins={savedAttentionSummaryDelayMins}
+                    savedAttentionSummaryAgentId={savedAttentionSummaryAgentId}
+                    savedAttentionSummaryModel={savedAttentionSummaryModel}
                     savingBuiltInAgentIds={savingBuiltInAgentIds}
                     savingCustomAgentIds={savingCustomAgentIds}
                     savingIdleTimeout={savingIdleTimeout}
@@ -1066,6 +1108,10 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                     setCustomAgentOpen={setCustomAgentOpen}
                     setCustomAgentsExpanded={setCustomAgentsExpanded}
                     setIdleSessionTimeoutMins={setIdleSessionTimeoutMins}
+                    setAttentionSummaryEnabled={setAttentionSummaryEnabled}
+                    setAttentionSummaryDelayMins={setAttentionSummaryDelayMins}
+                    setAttentionSummaryAgentId={setAttentionSummaryAgentId}
+                    setAttentionSummaryModel={setAttentionSummaryModel}
                     handleLlmConfigUpdate={handleLlmConfigUpdate}
                     handleProviderEnabledChange={handleProviderEnabledChange}
                     isLlmConfigLoading={isLlmConfigLoading}

--- a/apps/web/src/features/settings/components/SettingsModalSections.tsx
+++ b/apps/web/src/features/settings/components/SettingsModalSections.tsx
@@ -67,6 +67,10 @@ interface SettingsModalSectionsProps {
   customAgents: CodeAgentCustomEntry[];
   customAgentsExpanded: boolean;
   idleSessionTimeoutMins: number;
+  attentionSummaryEnabled: boolean;
+  attentionSummaryDelayMins: number;
+  attentionSummaryAgentId: string;
+  attentionSummaryModel: string;
   runConfigAgentOptions: AgentOption[];
   runConfigsLoading: boolean;
   removingCustomAgentIds: Record<string, boolean>;
@@ -74,6 +78,10 @@ interface SettingsModalSectionsProps {
   savedAgentCustomSettings: BuiltInAgentSettings;
   savedCustomAgents: CodeAgentCustomEntry[];
   savedIdleSessionTimeoutMins: number;
+  savedAttentionSummaryEnabled: boolean;
+  savedAttentionSummaryDelayMins: number;
+  savedAttentionSummaryAgentId: string;
+  savedAttentionSummaryModel: string;
   savingBuiltInAgentIds: Record<string, boolean>;
   savingCustomAgentIds: Record<string, boolean>;
   savingIdleTimeout: boolean;
@@ -103,6 +111,10 @@ interface SettingsModalSectionsProps {
   setCustomAgentOpen: React.Dispatch<React.SetStateAction<Record<string, boolean>>>;
   setCustomAgentsExpanded: React.Dispatch<React.SetStateAction<boolean>>;
   setIdleSessionTimeoutMins: React.Dispatch<React.SetStateAction<number>>;
+  setAttentionSummaryEnabled: React.Dispatch<React.SetStateAction<boolean>>;
+  setAttentionSummaryDelayMins: React.Dispatch<React.SetStateAction<number>>;
+  setAttentionSummaryAgentId: React.Dispatch<React.SetStateAction<string>>;
+  setAttentionSummaryModel: React.Dispatch<React.SetStateAction<string>>;
   handleLlmConfigUpdate: (
     key: string,
     updater: (current: LlmProvidersFile) => LlmProvidersFile,
@@ -189,6 +201,10 @@ export function SettingsModalSections(props: SettingsModalSectionsProps) {
           customAgents={props.customAgents}
           customAgentsExpanded={props.customAgentsExpanded}
           idleSessionTimeoutMins={props.idleSessionTimeoutMins}
+          attentionSummaryEnabled={props.attentionSummaryEnabled}
+          attentionSummaryDelayMins={props.attentionSummaryDelayMins}
+          attentionSummaryAgentId={props.attentionSummaryAgentId}
+          attentionSummaryModel={props.attentionSummaryModel}
           runConfigAgentOptions={props.runConfigAgentOptions}
           runConfigsLoading={props.runConfigsLoading}
           removingCustomAgentIds={props.removingCustomAgentIds}
@@ -196,6 +212,10 @@ export function SettingsModalSections(props: SettingsModalSectionsProps) {
           savedAgentCustomSettings={props.savedAgentCustomSettings}
           savedCustomAgents={props.savedCustomAgents}
           savedIdleSessionTimeoutMins={props.savedIdleSessionTimeoutMins}
+          savedAttentionSummaryEnabled={props.savedAttentionSummaryEnabled}
+          savedAttentionSummaryDelayMins={props.savedAttentionSummaryDelayMins}
+          savedAttentionSummaryAgentId={props.savedAttentionSummaryAgentId}
+          savedAttentionSummaryModel={props.savedAttentionSummaryModel}
           savingBuiltInAgentIds={props.savingBuiltInAgentIds}
           savingCustomAgentIds={props.savingCustomAgentIds}
           savingIdleTimeout={props.savingIdleTimeout}
@@ -225,6 +245,10 @@ export function SettingsModalSections(props: SettingsModalSectionsProps) {
           setCustomAgentOpen={props.setCustomAgentOpen}
           setCustomAgentsExpanded={props.setCustomAgentsExpanded}
           setIdleSessionTimeoutMins={props.setIdleSessionTimeoutMins}
+          setAttentionSummaryEnabled={props.setAttentionSummaryEnabled}
+          setAttentionSummaryDelayMins={props.setAttentionSummaryDelayMins}
+          setAttentionSummaryAgentId={props.setAttentionSummaryAgentId}
+          setAttentionSummaryModel={props.setAttentionSummaryModel}
         />
       );
     case 'workspace':

--- a/apps/web/src/features/task/components/task-github-drawer/TaskGithubDrawerHost.tsx
+++ b/apps/web/src/features/task/components/task-github-drawer/TaskGithubDrawerHost.tsx
@@ -187,19 +187,19 @@ function DrawerLayer({
     setOpen(true);
   }, [entryKey]);
 
-  if (!entry) return null;
-
-  const isRoot = index === 0;
-  const hasChildInStack = index < stack.length - 1;
-  // Front = still open and no non-exiting layer above us.
-  const isFront = open && index === visualLen - 1;
-
   const beginClose = React.useCallback(() => {
     if (dismissedRef.current) return;
     setOpen(false);
     // Parent peeks restore immediately; unmount waits for animation end.
     onExitStart(index);
   }, [index, onExitStart]);
+
+  if (!entry) return null;
+
+  const isRoot = index === 0;
+  const hasChildInStack = index < stack.length - 1;
+  // Front = still open and no non-exiting layer above us.
+  const isFront = open && index === visualLen - 1;
 
   const { top, right, bottom, left } = insets;
   const peekX = levelsBehind * NEST_PEEK_X;

--- a/apps/web/src/features/terminal/components/AttentionSummaryPanel.tsx
+++ b/apps/web/src/features/terminal/components/AttentionSummaryPanel.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import React from "react";
+import { useTranslations } from "next-intl";
+import { CheckCircle2, Loader2, XCircle } from "lucide-react";
+import { cn } from "@workspace/ui";
+
+import type { PaneAttentionSummary } from "@/features/agent/store/agent-attention-summary-store";
+
+export function AttentionSummaryPanel({
+  summary,
+  onPickNextStep,
+  onDismiss,
+}: {
+  summary: PaneAttentionSummary;
+  onPickNextStep: (step: string) => void;
+  onDismiss?: () => void;
+}) {
+  const t = useTranslations("terminal.attentionSummary");
+  const isLoading = summary.status === "summarizing";
+  const isReady = summary.status === "ready";
+  const isError = summary.status === "error";
+
+  return (
+    <div
+      className={cn(
+        "attention-summary-panel mb-1.5 w-full overflow-hidden rounded-2xl border px-3.5 py-3",
+        "border-sky-500/35 bg-sky-500/8 shadow-[0_10px_28px_rgba(14,165,233,0.12)]",
+        "dark:border-sky-400/30 dark:bg-sky-400/10",
+      )}
+      data-status={summary.status}
+    >
+      <div className="flex items-start gap-2.5">
+        <div className="mt-0.5 shrink-0 text-sky-500 dark:text-sky-300">
+          {isLoading ? (
+            <Loader2 className="size-4 animate-spin" aria-hidden />
+          ) : isError ? (
+            <XCircle className="size-4 text-amber-500" aria-hidden />
+          ) : (
+            <CheckCircle2 className="size-4" aria-hidden />
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-xs font-medium tracking-wide text-sky-700 dark:text-sky-200">
+              {isLoading
+                ? t("loadingTitle")
+                : isError
+                  ? t("errorTitle")
+                  : t("readyTitle")}
+            </p>
+            {isReady && typeof summary.canCloseSession === "boolean" ? (
+              <span
+                className={cn(
+                  "inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium",
+                  summary.canCloseSession
+                    ? "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300"
+                    : "bg-amber-500/15 text-amber-700 dark:text-amber-300",
+                )}
+              >
+                {summary.canCloseSession
+                  ? t("canCloseBadge")
+                  : t("keepOpenBadge")}
+              </span>
+            ) : null}
+            {onDismiss && (isReady || isError) ? (
+              <button
+                type="button"
+                className="ml-auto text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+                onClick={onDismiss}
+              >
+                {t("dismiss")}
+              </button>
+            ) : null}
+          </div>
+
+          {isLoading ? (
+            <div className="mt-2 space-y-2" aria-busy="true" aria-live="polite">
+              <div className="attention-summary-skeleton h-3.5 w-[88%] rounded-full" />
+              <div className="attention-summary-skeleton h-3 w-[62%] rounded-full" />
+              <div className="mt-3 flex flex-wrap gap-1.5">
+                <div className="attention-summary-skeleton h-7 w-24 rounded-full" />
+                <div className="attention-summary-skeleton h-7 w-28 rounded-full" />
+                <div className="attention-summary-skeleton h-7 w-20 rounded-full" />
+              </div>
+            </div>
+          ) : null}
+
+          {isError ? (
+            <p className="mt-1.5 text-sm leading-5 text-muted-foreground">
+              {summary.error?.trim() || t("errorFallback")}
+            </p>
+          ) : null}
+
+          {isReady ? (
+            <>
+              <p className="mt-1.5 text-sm leading-5 text-foreground">
+                {summary.summary}
+              </p>
+              {summary.nextSteps.length > 0 ? (
+                <div className="mt-2.5 flex flex-wrap gap-1.5">
+                  {summary.nextSteps.map((step) => (
+                    <button
+                      key={step}
+                      type="button"
+                      className={cn(
+                        "max-w-full truncate rounded-full border border-sky-500/30 bg-background/80",
+                        "px-2.5 py-1 text-left text-xs text-foreground transition-colors",
+                        "hover:border-sky-500/55 hover:bg-sky-500/10",
+                      )}
+                      onClick={() => onPickNextStep(step)}
+                      title={step}
+                    >
+                      {step}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.css
+++ b/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.css
@@ -175,10 +175,10 @@
 }
 
 .terminal-agent-input-trigger--pulse {
-  animation: terminalAgentInputTriggerPulse 1.1s ease-in-out infinite;
+  animation: terminal-agent-input-trigger-pulse 1.1s ease-in-out infinite;
 }
 
-@keyframes terminalAgentInputTriggerPulse {
+@keyframes terminal-agent-input-trigger-pulse {
   0%,
   100% {
     opacity: 0.55;
@@ -202,10 +202,10 @@
     color-mix(in srgb, #0ea5e9 8%, transparent) 100%
   );
   background-size: 200% 100%;
-  animation: attentionSummarySkeleton 1.2s ease-in-out infinite;
+  animation: attention-summary-skeleton 1.2s ease-in-out infinite;
 }
 
-@keyframes attentionSummarySkeleton {
+@keyframes attention-summary-skeleton {
   0% {
     background-position: 100% 0;
   }

--- a/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.css
+++ b/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.css
@@ -148,13 +148,70 @@
 }
 
 @keyframes terminalAgentSelectorShake {
-  0%, 100% { transform: translateX(0); }
-  15% { transform: translateX(-3px); }
-  30% { transform: translateX(3px); }
-  45% { transform: translateX(-2px); }
-  60% { transform: translateX(2px); }
-  75% { transform: translateX(-1px); }
-  90% { transform: translateX(1px); }
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-2px);
+  }
+  40% {
+    transform: translateX(2px);
+  }
+  60% {
+    transform: translateX(-1px);
+  }
+  80% {
+    transform: translateX(1px);
+  }
+}
+
+/* Unattended attention auto-summary trigger bar (blue solid / pulse). */
+.terminal-agent-input-trigger--summary {
+  background: #0ea5e9 !important;
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, #38bdf8 45%, transparent),
+    0 0 12px color-mix(in srgb, #0ea5e9 40%, transparent);
+}
+
+.terminal-agent-input-trigger--pulse {
+  animation: terminalAgentInputTriggerPulse 1.1s ease-in-out infinite;
+}
+
+@keyframes terminalAgentInputTriggerPulse {
+  0%,
+  100% {
+    opacity: 0.55;
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, #38bdf8 35%, transparent),
+      0 0 8px color-mix(in srgb, #0ea5e9 30%, transparent);
+  }
+  50% {
+    opacity: 1;
+    box-shadow:
+      0 0 0 2px color-mix(in srgb, #38bdf8 55%, transparent),
+      0 0 16px color-mix(in srgb, #0ea5e9 55%, transparent);
+  }
+}
+
+.attention-summary-skeleton {
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, #0ea5e9 8%, transparent) 0%,
+    color-mix(in srgb, #0ea5e9 22%, transparent) 45%,
+    color-mix(in srgb, #0ea5e9 8%, transparent) 100%
+  );
+  background-size: 200% 100%;
+  animation: attentionSummarySkeleton 1.2s ease-in-out infinite;
+}
+
+@keyframes attentionSummarySkeleton {
+  0% {
+    background-position: 100% 0;
+  }
+  100% {
+    background-position: -100% 0;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -172,5 +229,10 @@
   .terminal-agent-send-sweep,
   .terminal-agent-flying-message {
     animation-duration: 1ms;
+  }
+
+  .terminal-agent-input-trigger--pulse,
+  .attention-summary-skeleton {
+    animation: none;
   }
 }

--- a/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
+++ b/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
@@ -1198,7 +1198,11 @@ export const TerminalAgentInputOverlay = React.forwardRef<
               onDismiss={() => {
                 if (!stablePaneId) return;
                 // Capture observed latch time so a late clear cannot wipe a newer turn.
-                const latch = useAgentAttentionStore.getState().panes.get(stablePaneId);
+                const attentionStore = useAgentAttentionStore.getState();
+                const summaryStore = useAgentAttentionSummaryStore.getState();
+                const latch = attentionStore.panes.get(stablePaneId);
+                const prevSummary = summaryStore.panes.get(stablePaneId) ?? null;
+                const prevAttention = latch ?? null;
                 const notAfter = latch?.raisedAt
                   ? new Date(latch.raisedAt).toISOString()
                   : attentionSummary?.startedAt
@@ -1206,8 +1210,8 @@ export const TerminalAgentInputOverlay = React.forwardRef<
                     : undefined;
                 // Optimistic local clear, then persist via attention-clear so
                 // refresh hydration cannot resurrect the dismissed summary.
-                useAgentAttentionSummaryStore.getState().clearPane(stablePaneId);
-                useAgentAttentionStore.getState().clearPane(stablePaneId);
+                summaryStore.clearPane(stablePaneId);
+                attentionStore.clearPane(stablePaneId);
                 void agentHooksApi
                   .clearAttention({ stablePaneId, notAfter })
                   .catch((error) => {
@@ -1215,6 +1219,33 @@ export const TerminalAgentInputOverlay = React.forwardRef<
                       "[TerminalAgentInputOverlay] Failed to clear attention on dismiss:",
                       error,
                     );
+                    // Restore the pre-dismiss snapshot only if nothing newer
+                    // landed locally (WS raise / another dismiss) while the
+                    // request was in flight — otherwise a failed clear would
+                    // leave server state that rehydrates on refresh.
+                    const attentionNow = useAgentAttentionStore.getState();
+                    const summaryNow = useAgentAttentionSummaryStore.getState();
+                    const current = attentionNow.panes.get(stablePaneId);
+                    if (
+                      current &&
+                      prevAttention &&
+                      current.raisedAt > prevAttention.raisedAt
+                    ) {
+                      return;
+                    }
+                    if (!attentionNow.panes.has(stablePaneId) && prevAttention) {
+                      attentionNow.raise({
+                        stablePaneId: prevAttention.stablePaneId,
+                        contextId: prevAttention.contextId,
+                        reason: prevAttention.reason,
+                        sessionId: prevAttention.sessionId,
+                        tool: prevAttention.tool,
+                        raisedAt: prevAttention.raisedAt,
+                      });
+                    }
+                    if (!summaryNow.panes.has(stablePaneId) && prevSummary) {
+                      summaryNow.upsert(prevSummary);
+                    }
                   });
               }}
             />

--- a/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
+++ b/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
@@ -96,12 +96,19 @@ import {
   type TerminalPromptContext,
 } from "../lib/terminal-ai-context-protocol";
 import { useTerminalRichInputSettingsStore } from "@/features/settings/store/terminal-rich-input-settings-store";
+import {
+  selectPaneAttentionSummary,
+  useAgentAttentionSummaryStore,
+} from "@/features/agent/store/agent-attention-summary-store";
+import { AttentionSummaryPanel } from "./AttentionSummaryPanel";
 
 import "./TerminalAgentInputOverlay.css";
 
 interface TerminalAgentInputOverlayProps {
   activeProjectId?: string | null;
   agent?: TerminalPaneAgent | null;
+  /** Stable pane id (`{context}:{tmux_window}`) for attention auto-summary chrome. */
+  stablePaneId?: string | null;
   getSideChatFlyTargetClientPoint?: () => { x: number; y: number } | null;
   getTerminalCursorClientPoint?: () => { x: number; y: number } | null;
   isTerminalReady?: boolean;
@@ -149,6 +156,7 @@ export const TerminalAgentInputOverlay = React.forwardRef<
 >(function TerminalAgentInputOverlay({
   activeProjectId,
   agent,
+  stablePaneId = null,
   getSideChatFlyTargetClientPoint,
   getTerminalCursorClientPoint,
   isTerminalReady = true,
@@ -176,6 +184,15 @@ export const TerminalAgentInputOverlay = React.forwardRef<
   // Until prefs hydrate, treat Rich Input as off so a previously disabled
   // preference does not flash the composer for a frame.
   const richInputActive = richInputSettingsLoaded && richInputEnabled;
+  const attentionSummary = useAgentAttentionSummaryStore(
+    selectPaneAttentionSummary(stablePaneId ?? ""),
+  );
+  const hasAttentionSummary = !!attentionSummary;
+  const isSummarySummarizing = attentionSummary?.status === "summarizing";
+  const isSummaryActive =
+    attentionSummary?.status === "summarizing" ||
+    attentionSummary?.status === "ready" ||
+    attentionSummary?.status === "error";
   const composerRef = React.useRef<ComposerHandle | null>(null);
   const inputShellRef = React.useRef<HTMLDivElement | null>(null);
   const delayedSubmitTimerRef = React.useRef<number | null>(null);
@@ -199,6 +216,13 @@ export const TerminalAgentInputOverlay = React.forwardRef<
     setIsOpen(false);
     setIsPinned(false);
   }, [richInputActive]);
+
+  // Auto-open rich input when unattended summary starts or is ready so the
+  // loading / result panel is visible above the composer.
+  React.useEffect(() => {
+    if (!richInputActive || !isSummaryActive) return;
+    setIsOpen(true);
+  }, [isSummaryActive, richInputActive]);
   const [text, setText] = React.useState("");
   const [isSending, setIsSending] = React.useState(false);
   const [isSendAnimating, setIsSendAnimating] = React.useState(false);
@@ -224,7 +248,8 @@ export const TerminalAgentInputOverlay = React.forwardRef<
   const [sideChatRunConfigs, setSideChatRunConfigs] = React.useState<
     Record<string, TerminalAgentRunConfigInput | null>
   >({});
-  const isOverlayVisible = isOpen || isSendAnimating || isSendExiting;
+  const isOverlayVisible =
+    isOpen || isSendAnimating || isSendExiting || isSummaryActive;
   const canSubmit = isTerminalReady && text.trim().length > 0 && !isSending && !isSendAnimating && !isSendExiting;
 
   const runnableSideChatAgents = React.useMemo(
@@ -1139,11 +1164,43 @@ export const TerminalAgentInputOverlay = React.forwardRef<
           appendAgentContextItems(items, { x: event.clientX, y: event.clientY });
         }}
         onMouseLeave={() => {
-          if (!isPinned && !isSendAnimating && !isSendExiting && !text.trim() && attachments.length === 0) {
+          if (
+            !isPinned &&
+            !isSendAnimating &&
+            !isSendExiting &&
+            !isSummaryActive &&
+            !text.trim() &&
+            attachments.length === 0
+          ) {
             setIsOpen(false);
           }
         }}
       >
+        {hasAttentionSummary && attentionSummary ? (
+          <div
+            className={cn(
+              "w-full transition-[opacity,transform] duration-200 ease-out",
+              isOverlayVisible
+                ? "opacity-100 translate-y-0"
+                : "pointer-events-none opacity-0 translate-y-2",
+            )}
+          >
+            <AttentionSummaryPanel
+              summary={attentionSummary}
+              onPickNextStep={(step) => {
+                setIsOpen(true);
+                setText(step);
+                composerRef.current?.setText(step);
+                focusComposerSoon();
+              }}
+              onDismiss={() => {
+                if (!stablePaneId) return;
+                useAgentAttentionSummaryStore.getState().clearPane(stablePaneId);
+              }}
+            />
+          </div>
+        ) : null}
+
         <TerminalAgentInputShell
           attachments={attachments}
           canSubmit={canSubmit}
@@ -1198,9 +1255,24 @@ export const TerminalAgentInputOverlay = React.forwardRef<
             <button
               type="button"
               aria-label="Open agent input"
+              data-attention-summary={
+                isSummaryActive
+                  ? isSummarySummarizing
+                    ? "summarizing"
+                    : "ready"
+                  : undefined
+              }
               className={cn(
-                "h-1 w-28 rounded-full bg-foreground/25 shadow-[0_1px_4px_rgba(0,0,0,0.16)] transition-opacity duration-200",
-                isOverlayVisible ? "opacity-0" : "opacity-100 hover:bg-foreground/35",
+                "h-1 w-28 rounded-full shadow-[0_1px_4px_rgba(0,0,0,0.16)] transition-[opacity,background-color,box-shadow] duration-200",
+                isSummaryActive
+                  ? "terminal-agent-input-trigger--summary bg-sky-500"
+                  : "bg-foreground/25",
+                isSummarySummarizing && "terminal-agent-input-trigger--pulse",
+                isOverlayVisible && !isSummaryActive
+                  ? "opacity-0"
+                  : isSummaryActive
+                    ? "opacity-100"
+                    : "opacity-100 hover:bg-foreground/35",
               )}
               onFocus={() => setIsOpen(true)}
               onClick={focusInput}

--- a/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
+++ b/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
@@ -1212,6 +1212,13 @@ export const TerminalAgentInputOverlay = React.forwardRef<
                 // refresh hydration cannot resurrect the dismissed summary.
                 summaryStore.clearPane(stablePaneId);
                 attentionStore.clearPane(stablePaneId);
+                // Snapshot revisions *after* optimistic clear. If a WS clear /
+                // raise advances either store while the request is in flight,
+                // we must not roll back over that authoritative update.
+                const attentionRevAfterClear =
+                  useAgentAttentionStore.getState().revision;
+                const summaryRevAfterClear =
+                  useAgentAttentionSummaryStore.getState().revision;
                 void agentHooksApi
                   .clearAttention({ stablePaneId, notAfter })
                   .catch((error) => {
@@ -1219,18 +1226,14 @@ export const TerminalAgentInputOverlay = React.forwardRef<
                       "[TerminalAgentInputOverlay] Failed to clear attention on dismiss:",
                       error,
                     );
-                    // Restore the pre-dismiss snapshot only if nothing newer
-                    // landed locally (WS raise / another dismiss) while the
-                    // request was in flight — otherwise a failed clear would
-                    // leave server state that rehydrates on refresh.
                     const attentionNow = useAgentAttentionStore.getState();
                     const summaryNow = useAgentAttentionSummaryStore.getState();
-                    const current = attentionNow.panes.get(stablePaneId);
                     if (
-                      current &&
-                      prevAttention &&
-                      current.raisedAt > prevAttention.raisedAt
+                      attentionNow.revision !== attentionRevAfterClear ||
+                      summaryNow.revision !== summaryRevAfterClear
                     ) {
+                      // Focus ack, another clear, or a newer raise already
+                      // mutated local state — leave it alone.
                       return;
                     }
                     if (!attentionNow.panes.has(stablePaneId) && prevAttention) {
@@ -1244,7 +1247,11 @@ export const TerminalAgentInputOverlay = React.forwardRef<
                       });
                     }
                     if (!summaryNow.panes.has(stablePaneId) && prevSummary) {
-                      summaryNow.upsert(prevSummary);
+                      // raise() does not restore summary chrome; re-upsert only
+                      // when the store is still at the post-dismiss revision.
+                      useAgentAttentionSummaryStore
+                        .getState()
+                        .upsert(prevSummary);
                     }
                   });
               }}

--- a/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
+++ b/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
@@ -1197,12 +1197,19 @@ export const TerminalAgentInputOverlay = React.forwardRef<
               }}
               onDismiss={() => {
                 if (!stablePaneId) return;
+                // Capture observed latch time so a late clear cannot wipe a newer turn.
+                const latch = useAgentAttentionStore.getState().panes.get(stablePaneId);
+                const notAfter = latch?.raisedAt
+                  ? new Date(latch.raisedAt).toISOString()
+                  : attentionSummary?.startedAt
+                    ? new Date(attentionSummary.startedAt).toISOString()
+                    : undefined;
                 // Optimistic local clear, then persist via attention-clear so
                 // refresh hydration cannot resurrect the dismissed summary.
                 useAgentAttentionSummaryStore.getState().clearPane(stablePaneId);
                 useAgentAttentionStore.getState().clearPane(stablePaneId);
                 void agentHooksApi
-                  .clearAttention({ stablePaneId })
+                  .clearAttention({ stablePaneId, notAfter })
                   .catch((error) => {
                     console.warn(
                       "[TerminalAgentInputOverlay] Failed to clear attention on dismiss:",

--- a/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
+++ b/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
@@ -100,6 +100,8 @@ import {
   selectPaneAttentionSummary,
   useAgentAttentionSummaryStore,
 } from "@/features/agent/store/agent-attention-summary-store";
+import { useAgentAttentionStore } from "@/features/agent/store/agent-attention-store";
+import { agentHooksApi } from "@/api/rest-api";
 import { AttentionSummaryPanel } from "./AttentionSummaryPanel";
 
 import "./TerminalAgentInputOverlay.css";
@@ -1195,7 +1197,18 @@ export const TerminalAgentInputOverlay = React.forwardRef<
               }}
               onDismiss={() => {
                 if (!stablePaneId) return;
+                // Optimistic local clear, then persist via attention-clear so
+                // refresh hydration cannot resurrect the dismissed summary.
                 useAgentAttentionSummaryStore.getState().clearPane(stablePaneId);
+                useAgentAttentionStore.getState().clearPane(stablePaneId);
+                void agentHooksApi
+                  .clearAttention({ stablePaneId })
+                  .catch((error) => {
+                    console.warn(
+                      "[TerminalAgentInputOverlay] Failed to clear attention on dismiss:",
+                      error,
+                    );
+                  });
               }}
             />
           </div>

--- a/apps/web/src/features/terminal/components/terminal-mosaic-scoped-pane-window.tsx
+++ b/apps/web/src/features/terminal/components/terminal-mosaic-scoped-pane-window.tsx
@@ -485,6 +485,7 @@ export function TerminalMosaicScopedPaneWindow({
           }}
           activeProjectId={activeProject?.id ?? null}
           agent={agentForSubmit ?? null}
+          stablePaneId={stablePaneId}
           getTerminalCursorClientPoint={() =>
             terminalRefsMap.current.get(id)?.getCursorClientPoint() ?? null
           }

--- a/apps/web/src/features/terminal/components/terminal-mosaic-workspace-pane-window.tsx
+++ b/apps/web/src/features/terminal/components/terminal-mosaic-workspace-pane-window.tsx
@@ -523,6 +523,7 @@ export function TerminalMosaicWorkspacePaneWindow(props: TerminalMosaicWorkspace
           }}
           activeProjectId={activeProject?.id ?? null}
           agent={agentForSubmit ?? null}
+          stablePaneId={stablePaneId}
           getTerminalCursorClientPoint={() =>
             terminalRefsMap.current.get(id)?.getCursorClientPoint() ?? null
           }

--- a/crates/core-service/src/lib.rs
+++ b/crates/core-service/src/lib.rs
@@ -5,7 +5,11 @@ pub mod utils;
 
 pub use error::{Result, ServiceError};
 pub use service::agent::AgentService;
-pub use service::agent_hooks::{AgentHookEvent, AgentHooksService};
+pub use service::agent_hooks::{
+    generate_attention_summary, AgentAttentionLatch, AgentAttentionReason, AgentAttentionSummary,
+    AgentHookEvent, AgentHooksService, AttentionSummaryPayload, AttentionSummarySettings,
+    AttentionSummaryStatus,
+};
 pub use service::agent_session::{AgentSessionService, LazySessionSpec, ResumeNativeSessionSpec};
 pub use service::automation::{
     ensure_builtin_terminal_agents_upgraded, AutomationAgentCapability, TerminalAgentCliStatus,

--- a/crates/core-service/src/service/agent_hooks.rs
+++ b/crates/core-service/src/service/agent_hooks.rs
@@ -238,6 +238,26 @@ impl AgentHooksService {
         *self.notification_service.write() = Some(service);
     }
 
+    /// Test-only: drop a latch without clearing its summary (orphan simulation).
+    #[cfg(test)]
+    pub(crate) fn test_remove_attention_latch_only(&self, stable_pane_id: &str) {
+        self.attention.write().remove(stable_pane_id);
+    }
+
+    /// Test-only: rewrite summary timestamps so stale pruning can be exercised.
+    #[cfg(test)]
+    pub(crate) fn test_set_summary_timestamps(
+        &self,
+        stable_pane_id: &str,
+        started_at: String,
+        completed_at: Option<String>,
+    ) {
+        if let Some(entry) = self.summaries.write().get_mut(stable_pane_id) {
+            entry.started_at = started_at;
+            entry.completed_at = completed_at;
+        }
+    }
+
     pub fn subscribe_events(&self) -> broadcast::Receiver<AgentHookEvent> {
         self.event_tx.subscribe()
     }

--- a/crates/core-service/src/service/agent_hooks.rs
+++ b/crates/core-service/src/service/agent_hooks.rs
@@ -1,6 +1,8 @@
 mod ampcode;
 mod antigravity;
 mod attention;
+mod attention_summary;
+mod attention_summary_generate;
 mod child_agent;
 mod child_lifecycle;
 mod claude_code;
@@ -28,6 +30,11 @@ use tracing::{debug, info, warn};
 use super::notification::NotificationService;
 
 pub use attention::{AgentAttentionLatch, AgentAttentionReason};
+pub use attention_summary::{
+    AgentAttentionSummary, AttentionSummaryPayload, AttentionSummarySettings,
+    AttentionSummaryStatus,
+};
+pub use attention_summary_generate::generate_attention_summary;
 pub(super) use child_agent::{extract_child_agent_id, is_child_start_event, is_child_stop_event};
 
 /// How long late mid-turn progress events are ignored after a terminal idle /
@@ -169,6 +176,8 @@ pub enum AgentHookEvent {
     SessionsCleared { session_ids: Vec<String> },
     AttentionRaised(AgentAttentionLatch),
     AttentionCleared { stable_pane_ids: Vec<String> },
+    AttentionSummaryUpdated(AgentAttentionSummary),
+    AttentionSummaryCleared { stable_pane_ids: Vec<String> },
 }
 
 /// Snapshot of a lead TerminalIdle that arrived while child agents were still
@@ -187,6 +196,10 @@ pub struct AgentHooksService {
     /// Sticky attention latches keyed by stable pane id (`{context}:{tmux_window}`).
     /// Independent of idle session rows so refresh still shows need-attention.
     attention: RwLock<HashMap<String, AgentAttentionLatch>>,
+    /// Unattended task-complete auto-summaries keyed by stable pane id.
+    summaries: RwLock<HashMap<String, AgentAttentionSummary>>,
+    /// Monotonic token for in-flight summary generations.
+    summary_generation: RwLock<u64>,
     /// After terminal/forced idle, ignore Progress→Running until this time.
     suppress_running_until: RwLock<HashMap<String, DateTime<Utc>>>,
     /// Lead session → active child agent ids (Task / SubagentStart roster).
@@ -209,6 +222,8 @@ impl AgentHooksService {
         Self {
             sessions: RwLock::new(HashMap::new()),
             attention: RwLock::new(HashMap::new()),
+            summaries: RwLock::new(HashMap::new()),
+            summary_generation: RwLock::new(0),
             suppress_running_until: RwLock::new(HashMap::new()),
             active_children: RwLock::new(HashMap::new()),
             pending_terminal_idle: RwLock::new(HashMap::new()),

--- a/crates/core-service/src/service/agent_hooks/attention.rs
+++ b/crates/core-service/src/service/agent_hooks/attention.rs
@@ -40,6 +40,9 @@ pub struct AgentAttentionLatch {
     pub session_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool: Option<AgentToolType>,
+    /// Project / workspace path when known (used by unattended auto-summary).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_path: Option<String>,
     /// RFC3339 timestamp when the latch was raised (or last upgraded).
     pub raised_at: String,
 }
@@ -116,6 +119,7 @@ impl AgentHooksService {
             reason,
             session_id: update.session_id.clone(),
             tool: Some(update.tool),
+            project_path: update.project_path.clone(),
             raised_at: Utc::now().to_rfc3339(),
         });
     }
@@ -133,6 +137,10 @@ impl AgentHooksService {
                 // Keep the higher-urgency reason if both fire close together.
                 if existing.reason.priority() > latch.reason.priority() {
                     return;
+                }
+                // Preserve project_path if the upgrade omits it.
+                if latch.project_path.is_none() {
+                    latch.project_path = existing.project_path.clone();
                 }
             }
             attention.insert(latch.stable_pane_id.clone(), latch.clone());
@@ -178,6 +186,10 @@ impl AgentHooksService {
         };
 
         if !cleared.is_empty() {
+            // User attention / pane dismiss also drops any auto-summary chrome.
+            let mut summary_ids = cleared.clone();
+            summary_ids.extend(ids.iter().cloned());
+            self.clear_attention_summaries_matching_ids(&summary_ids);
             self.broadcast_attention_cleared(cleared.clone());
         }
         cleared
@@ -242,6 +254,7 @@ mod tests {
         assert_eq!(attention[0].stable_pane_id, "ws-1:main");
         assert_eq!(attention[0].context_id, "ws-1");
         assert_eq!(attention[0].reason, AgentAttentionReason::TaskComplete);
+        assert_eq!(attention[0].project_path.as_deref(), Some("/tmp/p"));
     }
 
     #[test]

--- a/crates/core-service/src/service/agent_hooks/attention.rs
+++ b/crates/core-service/src/service/agent_hooks/attention.rs
@@ -156,9 +156,7 @@ impl AgentHooksService {
                 let pane = latch.stable_pane_id.as_str();
                 let to_clear: Vec<String> = summaries
                     .iter()
-                    .filter(|(key, row)| {
-                        key.as_str() == pane || row.session_id.as_str() == pane
-                    })
+                    .filter(|(key, row)| key.as_str() == pane || row.session_id.as_str() == pane)
                     .map(|(key, _)| key.clone())
                     .collect();
                 for key in &to_clear {

--- a/crates/core-service/src/service/agent_hooks/attention.rs
+++ b/crates/core-service/src/service/agent_hooks/attention.rs
@@ -131,7 +131,14 @@ impl AgentHooksService {
         latch.stable_pane_id = latch.stable_pane_id.trim().to_string();
         latch.context_id = latch.context_id.trim().to_string();
 
-        let latch = {
+        // Insert the latch and drop any pane-keyed summary under the *same*
+        // attention write lock. Holding attention.write across the summary
+        // clear closes the race where `complete_attention_summary` could:
+        //   1. pass its latch-exists check against the *new* turn, then
+        //   2. write the previous generation's payload before the clear ran.
+        // `complete` always acquires `attention` before `summaries`, so it
+        // cannot interleave between insert and clear while we hold this write.
+        let (latch, cleared_summaries) = {
             let mut attention = self.attention.write();
             if let Some(existing) = attention.get(&latch.stable_pane_id) {
                 // Keep the higher-urgency reason if both fire close together.
@@ -143,12 +150,29 @@ impl AgentHooksService {
                     latch.project_path = existing.project_path.clone();
                 }
             }
+
+            let cleared_summaries = {
+                let mut summaries = self.summaries.write();
+                let pane = latch.stable_pane_id.as_str();
+                let to_clear: Vec<String> = summaries
+                    .iter()
+                    .filter(|(key, row)| {
+                        key.as_str() == pane || row.session_id.as_str() == pane
+                    })
+                    .map(|(key, _)| key.clone())
+                    .collect();
+                for key in &to_clear {
+                    summaries.remove(key);
+                }
+                to_clear
+            };
+
             attention.insert(latch.stable_pane_id.clone(), latch.clone());
-            latch
+            (latch, cleared_summaries)
         };
-        // A new/upgraded latch belongs to a new turn — drop any pane-keyed
-        // summary so an in-flight generation cannot complete for the previous turn.
-        self.clear_attention_summaries_matching_ids(std::slice::from_ref(&latch.stable_pane_id));
+        if !cleared_summaries.is_empty() {
+            self.broadcast_summary_cleared(cleared_summaries);
+        }
         self.broadcast_attention_raised(latch);
     }
 

--- a/crates/core-service/src/service/agent_hooks/attention.rs
+++ b/crates/core-service/src/service/agent_hooks/attention.rs
@@ -146,6 +146,9 @@ impl AgentHooksService {
             attention.insert(latch.stable_pane_id.clone(), latch.clone());
             latch
         };
+        // A new/upgraded latch belongs to a new turn — drop any pane-keyed
+        // summary so an in-flight generation cannot complete for the previous turn.
+        self.clear_attention_summaries_matching_ids(std::slice::from_ref(&latch.stable_pane_id));
         self.broadcast_attention_raised(latch);
     }
 
@@ -185,11 +188,13 @@ impl AgentHooksService {
             to_clear
         };
 
+        // Always drop summary chrome for the requested ids, even when no latch
+        // matched (orphan summary after latch was already cleared).
+        let mut summary_ids = cleared.clone();
+        summary_ids.extend(ids.iter().cloned());
+        self.clear_attention_summaries_matching_ids(&summary_ids);
+
         if !cleared.is_empty() {
-            // User attention / pane dismiss also drops any auto-summary chrome.
-            let mut summary_ids = cleared.clone();
-            summary_ids.extend(ids.iter().cloned());
-            self.clear_attention_summaries_matching_ids(&summary_ids);
             self.broadcast_attention_cleared(cleared.clone());
         }
         cleared
@@ -218,6 +223,9 @@ impl AgentHooksService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::service::agent_hooks::attention_summary::{
+        AttentionSummaryPayload, AttentionSummaryStatus,
+    };
     use crate::service::agent_hooks::{
         AgentHookState, AgentHooksService, AgentToolType, AtmosContext, StateUpdateKind,
     };
@@ -327,5 +335,107 @@ mod tests {
             StateUpdateKind::QuietIdle,
         );
         assert!(service.get_all_attention().is_empty());
+    }
+
+    #[test]
+    fn new_task_complete_turn_invalidates_in_flight_summary() {
+        let service = AgentHooksService::new();
+        let ctx = ctx_with_pane("ws-1:main");
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Running,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::NewTurn,
+        );
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Idle,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::TerminalIdle,
+        );
+        let (_, _, gen) = service
+            .begin_attention_summary("ws-1:main")
+            .expect("begin first summary");
+        assert_eq!(
+            service.get_attention_summary("ws-1:main").unwrap().status,
+            AttentionSummaryStatus::Summarizing
+        );
+
+        // Second turn on the same pane replaces the latch and drops the summary.
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Running,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::NewTurn,
+        );
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Idle,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::TerminalIdle,
+        );
+        assert!(service.get_attention_summary("ws-1:main").is_none());
+
+        // Stale completion from the previous generation must not reappear.
+        assert!(service
+            .complete_attention_summary(
+                "ws-1:main",
+                gen,
+                AttentionSummaryPayload {
+                    summary: "stale prior turn".into(),
+                    next_steps: vec![],
+                    can_close_session: true,
+                },
+            )
+            .is_none());
+        assert!(service.get_attention_summary("ws-1:main").is_none());
+    }
+
+    #[test]
+    fn clear_attention_drops_orphan_summary_without_latch() {
+        let service = AgentHooksService::new();
+        let ctx = ctx_with_pane("ws-1:main");
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Running,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::NewTurn,
+        );
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Idle,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::TerminalIdle,
+        );
+        let (_, _, gen) = service.begin_attention_summary("ws-1:main").expect("begin");
+        let _ = service.complete_attention_summary(
+            "ws-1:main",
+            gen,
+            AttentionSummaryPayload {
+                summary: "done".into(),
+                next_steps: vec![],
+                can_close_session: true,
+            },
+        );
+        // Remove latch without going through clear (simulate orphan).
+        service.test_remove_attention_latch_only("ws-1:main");
+        assert!(service.get_attention_summary("ws-1:main").is_some());
+
+        // Clear by pane id must still drop the orphan summary.
+        let cleared = service.clear_attention_for_pane("ws-1:main");
+        assert!(cleared.is_empty());
+        assert!(service.get_attention_summary("ws-1:main").is_none());
     }
 }

--- a/crates/core-service/src/service/agent_hooks/attention.rs
+++ b/crates/core-service/src/service/agent_hooks/attention.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashSet;
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use tracing::{debug, warn};
 
 use super::{
@@ -161,8 +161,30 @@ impl AgentHooksService {
         self.clear_attention_matching_ids(&[pane_id.to_string()])
     }
 
+    /// Like [`Self::clear_attention_for_pane`], but skip latches raised after
+    /// `not_after` (RFC3339). Prevents a late dismiss from wiping a newer turn.
+    pub fn clear_attention_for_pane_not_after(
+        &self,
+        stable_pane_id: &str,
+        not_after: &str,
+    ) -> Vec<String> {
+        let pane_id = stable_pane_id.trim();
+        if pane_id.is_empty() {
+            return Vec::new();
+        }
+        self.clear_attention_matching_ids_not_after(&[pane_id.to_string()], Some(not_after))
+    }
+
     /// Clear latches whose map key or stored `session_id` matches any of `ids`.
     pub fn clear_attention_matching_ids(&self, ids: &[String]) -> Vec<String> {
+        self.clear_attention_matching_ids_not_after(ids, None)
+    }
+
+    fn clear_attention_matching_ids_not_after(
+        &self,
+        ids: &[String],
+        not_after: Option<&str>,
+    ) -> Vec<String> {
         let id_set: HashSet<&str> = ids
             .iter()
             .map(String::as_str)
@@ -173,12 +195,32 @@ impl AgentHooksService {
             return Vec::new();
         }
 
+        let not_after_ts = not_after.and_then(|raw| {
+            DateTime::parse_from_rfc3339(raw.trim())
+                .ok()
+                .map(|t| t.with_timezone(&Utc))
+        });
+
         let cleared: Vec<String> = {
             let mut attention = self.attention.write();
             let to_clear: Vec<String> = attention
                 .iter()
                 .filter(|(key, latch)| {
-                    id_set.contains(key.as_str()) || id_set.contains(latch.session_id.as_str())
+                    if !(id_set.contains(key.as_str())
+                        || id_set.contains(latch.session_id.as_str()))
+                    {
+                        return false;
+                    }
+                    if let Some(cutoff) = not_after_ts {
+                        let Ok(raised) = DateTime::parse_from_rfc3339(&latch.raised_at) else {
+                            return true;
+                        };
+                        // Skip latches raised after the client observed state.
+                        if raised.with_timezone(&Utc) > cutoff {
+                            return false;
+                        }
+                    }
+                    true
                 })
                 .map(|(key, _)| key.clone())
                 .collect();
@@ -188,10 +230,28 @@ impl AgentHooksService {
             to_clear
         };
 
-        // Always drop summary chrome for the requested ids, even when no latch
-        // matched (orphan summary after latch was already cleared).
+        // Drop summary chrome for cleared panes. When not_after guards skipped a
+        // newer latch, leave its summary alone (to_clear won't include it).
+        // Also drop orphan summaries for the requested ids only when we are not
+        // guarded, or when no newer latch remains for that id.
         let mut summary_ids = cleared.clone();
-        summary_ids.extend(ids.iter().cloned());
+        if not_after_ts.is_none() {
+            summary_ids.extend(ids.iter().cloned());
+        } else {
+            // For guarded clears: also drop orphan summaries for requested ids
+            // that currently have no latch (dismiss of a finished summary whose
+            // latch was already gone).
+            let attention = self.attention.read();
+            for id in &id_set {
+                if !attention.contains_key(*id)
+                    && !attention
+                        .values()
+                        .any(|latch| latch.session_id.as_str() == *id)
+                {
+                    summary_ids.push((*id).to_string());
+                }
+            }
+        }
         self.clear_attention_summaries_matching_ids(&summary_ids);
 
         if !cleared.is_empty() {
@@ -437,5 +497,55 @@ mod tests {
         let cleared = service.clear_attention_for_pane("ws-1:main");
         assert!(cleared.is_empty());
         assert!(service.get_attention_summary("ws-1:main").is_none());
+    }
+
+    #[test]
+    fn clear_not_after_skips_newer_latch() {
+        let service = AgentHooksService::new();
+        let ctx = ctx_with_pane("ws-1:main");
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Running,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::NewTurn,
+        );
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Idle,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::TerminalIdle,
+        );
+        let old_raised = service.get_all_attention()[0].raised_at.clone();
+
+        // Newer turn.
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Running,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::NewTurn,
+        );
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Idle,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::TerminalIdle,
+        );
+        assert_eq!(service.get_all_attention().len(), 1);
+        let new_raised = service.get_all_attention()[0].raised_at.clone();
+        assert_ne!(old_raised, new_raised);
+
+        // Dismiss with the old raised_at must not wipe the newer latch.
+        let cleared = service.clear_attention_for_pane_not_after("ws-1:main", &old_raised);
+        assert!(cleared.is_empty());
+        assert_eq!(service.get_all_attention().len(), 1);
+        assert_eq!(service.get_all_attention()[0].raised_at, new_raised);
     }
 }

--- a/crates/core-service/src/service/agent_hooks/attention_summary.rs
+++ b/crates/core-service/src/service/agent_hooks/attention_summary.rs
@@ -275,13 +275,18 @@ impl AgentHooksService {
         if pane_id.is_empty() {
             return None;
         }
-        // Still need the latch — user may have acknowledged mid-flight.
-        if !self.attention.read().contains_key(pane_id) {
-            self.clear_attention_summaries_matching_ids(&[pane_id.to_string()]);
-            return None;
-        }
 
+        // Hold attention.read across the summaries write so a concurrent
+        // `raise_attention` cannot insert a replacement latch and leave us
+        // completing the previous generation against the new turn.
         let updated = {
+            let attention = self.attention.read();
+            if !attention.contains_key(pane_id) {
+                drop(attention);
+                self.clear_attention_summaries_matching_ids(&[pane_id.to_string()]);
+                return None;
+            }
+
             let mut summaries = self.summaries.write();
             let entry = summaries.get_mut(pane_id)?;
             if entry.generation != generation {
@@ -320,12 +325,15 @@ impl AgentHooksService {
         if pane_id.is_empty() {
             return None;
         }
-        if !self.attention.read().contains_key(pane_id) {
-            self.clear_attention_summaries_matching_ids(&[pane_id.to_string()]);
-            return None;
-        }
 
         let updated = {
+            let attention = self.attention.read();
+            if !attention.contains_key(pane_id) {
+                drop(attention);
+                self.clear_attention_summaries_matching_ids(&[pane_id.to_string()]);
+                return None;
+            }
+
             let mut summaries = self.summaries.write();
             let entry = summaries.get_mut(pane_id)?;
             if entry.generation != generation {
@@ -382,7 +390,7 @@ impl AgentHooksService {
         }
     }
 
-    fn broadcast_summary_cleared(&self, stable_pane_ids: Vec<String>) {
+    pub(crate) fn broadcast_summary_cleared(&self, stable_pane_ids: Vec<String>) {
         if let Err(error) = self
             .event_tx
             .send(AgentHookEvent::AttentionSummaryCleared { stable_pane_ids })

--- a/crates/core-service/src/service/agent_hooks/attention_summary.rs
+++ b/crates/core-service/src/service/agent_hooks/attention_summary.rs
@@ -215,50 +215,53 @@ impl AgentHooksService {
             return None;
         }
 
-        let latch = {
+        // Hold attention.read across the summaries insert so a concurrent clear
+        // cannot drop the latch between our latch check and the row insert
+        // (which would orphan a Summarizing row with no latch).
+        let (latch, summary, generation) = {
             let attention = self.attention.read();
-            attention.get(pane_id).cloned()
-        }?;
-        if latch.reason != AgentAttentionReason::TaskComplete {
-            return None;
-        }
-
-        {
-            let summaries = self.summaries.read();
-            if summaries.contains_key(pane_id) {
+            let latch = attention.get(pane_id).cloned()?;
+            if latch.reason != AgentAttentionReason::TaskComplete {
                 return None;
             }
-        }
+            if self.summaries.read().contains_key(pane_id) {
+                return None;
+            }
 
-        let generation = {
-            let mut gen = self.summary_generation.write();
-            let next = gen.saturating_add(1).max(1);
-            *gen = next;
-            next
-        };
+            let generation = {
+                let mut gen = self.summary_generation.write();
+                let next = gen.saturating_add(1).max(1);
+                *gen = next;
+                next
+            };
 
-        let summary = AgentAttentionSummary {
-            stable_pane_id: latch.stable_pane_id.clone(),
-            context_id: latch.context_id.clone(),
-            session_id: latch.session_id.clone(),
-            status: AttentionSummaryStatus::Summarizing,
-            summary: None,
-            next_steps: Vec::new(),
-            can_close_session: None,
-            error: None,
-            started_at: Utc::now().to_rfc3339(),
-            completed_at: None,
-            generation,
-        };
+            let summary = AgentAttentionSummary {
+                stable_pane_id: latch.stable_pane_id.clone(),
+                context_id: latch.context_id.clone(),
+                session_id: latch.session_id.clone(),
+                status: AttentionSummaryStatus::Summarizing,
+                summary: None,
+                next_steps: Vec::new(),
+                can_close_session: None,
+                error: None,
+                started_at: Utc::now().to_rfc3339(),
+                completed_at: None,
+                generation,
+            };
 
-        {
             let mut summaries = self.summaries.write();
             // Race: another begin won.
             if summaries.contains_key(pane_id) {
                 return None;
             }
+            // Latch may have been cleared if we only held a stale snapshot —
+            // re-check under the same attention read guard.
+            if !attention.contains_key(pane_id) {
+                return None;
+            }
             summaries.insert(pane_id.to_string(), summary.clone());
-        }
+            (latch, summary, generation)
+        };
 
         self.broadcast_summary_updated(summary.clone());
         Some((latch, summary, generation))

--- a/crates/core-service/src/service/agent_hooks/attention_summary.rs
+++ b/crates/core-service/src/service/agent_hooks/attention_summary.rs
@@ -189,9 +189,13 @@ impl AgentHooksService {
 
         let cutoff = Utc::now()
             - chrono::Duration::from_std(delay).unwrap_or_else(|_| chrono::Duration::minutes(5));
+        // Lock order is always attention → summaries (same as raise_attention /
+        // begin / complete). Taking summaries first then attention deadlocks
+        // against raise_attention which holds attention.write then waits for
+        // summaries.write.
+        let attention = self.attention.read();
         let summaries = self.summaries.read();
-        self.attention
-            .read()
+        attention
             .values()
             .filter(|latch| latch.reason == AgentAttentionReason::TaskComplete)
             .filter(|latch| !summaries.contains_key(&latch.stable_pane_id))

--- a/crates/core-service/src/service/agent_hooks/attention_summary.rs
+++ b/crates/core-service/src/service/agent_hooks/attention_summary.rs
@@ -1,0 +1,481 @@
+//! Unattended task-complete attention → headless auto-summary.
+//!
+//! When a `task_complete` latch stays unacknowledged past a configurable delay,
+//! the API spawns a headless agent-cli (or LLM) session to produce structured
+//! next-step JSON without polluting the original pane context. State lives in
+//! API memory and is pushed over WebSocket so browser refresh keeps the UI.
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use tracing::{debug, warn};
+
+use super::{
+    AgentAttentionLatch, AgentAttentionReason, AgentHookEvent, AgentHooksService,
+};
+
+/// Lifecycle of an attention auto-summary for one pane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttentionSummaryStatus {
+    /// Headless summarizer is running.
+    Summarizing,
+    /// Structured result is ready for the rich input chrome.
+    Ready,
+    /// Generation failed (payload may include an error string).
+    Error,
+}
+
+/// Structured payload the headless agent must return (JSON object).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct AttentionSummaryPayload {
+    /// One-sentence summary of recent work.
+    pub summary: String,
+    /// Suggested next actions the user can pick (filled into the composer).
+    #[serde(default)]
+    pub next_steps: Vec<String>,
+    /// Whether the original agent session can safely be closed.
+    #[serde(default)]
+    pub can_close_session: bool,
+}
+
+/// In-memory summary state for a terminal pane (keyed by stable pane id).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AgentAttentionSummary {
+    pub stable_pane_id: String,
+    pub context_id: String,
+    pub session_id: String,
+    pub status: AttentionSummaryStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_steps: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub can_close_session: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// RFC3339 when summarization started.
+    pub started_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<String>,
+    /// Monotonic generation token so late results cannot overwrite a newer run.
+    #[serde(skip)]
+    pub generation: u64,
+}
+
+/// Settings for unattended attention auto-summary (from terminal_code_agent.json).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttentionSummarySettings {
+    pub enabled: bool,
+    pub delay_mins: u64,
+    pub agent_id: Option<String>,
+    pub model: Option<String>,
+}
+
+impl Default for AttentionSummarySettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            delay_mins: 5,
+            agent_id: None,
+            model: None,
+        }
+    }
+}
+
+impl AttentionSummarySettings {
+    pub fn from_json(val: &serde_json::Value) -> Self {
+        let enabled = val
+            .get("attention_summary_enabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        let delay_mins = val
+            .get("attention_summary_delay_mins")
+            .and_then(|v| v.as_u64())
+            .filter(|v| *v >= 1)
+            .unwrap_or(5)
+            .min(24 * 60);
+        let agent_id = val
+            .get("attention_summary_agent_id")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        let model = val
+            .get("attention_summary_model")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        Self {
+            enabled,
+            delay_mins,
+            agent_id,
+            model,
+        }
+    }
+
+    pub fn delay(&self) -> Duration {
+        Duration::from_secs(self.delay_mins.saturating_mul(60).max(60))
+    }
+}
+
+impl AgentHooksService {
+    pub fn get_all_attention_summaries(&self) -> Vec<AgentAttentionSummary> {
+        self.summaries.read().values().cloned().collect()
+    }
+
+    pub fn get_attention_summary(&self, stable_pane_id: &str) -> Option<AgentAttentionSummary> {
+        self.summaries.read().get(stable_pane_id).cloned()
+    }
+
+    /// Task-complete latches that have waited past `delay` and do not yet have
+    /// an in-flight or finished summary. Permission latches are never summarized.
+    pub fn attention_due_for_summary(&self, delay: Duration) -> Vec<AgentAttentionLatch> {
+        let cutoff = Utc::now()
+            - chrono::Duration::from_std(delay).unwrap_or_else(|_| chrono::Duration::minutes(5));
+        let summaries = self.summaries.read();
+        self.attention
+            .read()
+            .values()
+            .filter(|latch| latch.reason == AgentAttentionReason::TaskComplete)
+            .filter(|latch| !summaries.contains_key(&latch.stable_pane_id))
+            .filter(|latch| {
+                DateTime::parse_from_rfc3339(&latch.raised_at)
+                    .map(|t| t.with_timezone(&Utc) <= cutoff)
+                    .unwrap_or(true)
+            })
+            .cloned()
+            .collect()
+    }
+
+    /// Mark a pane as summarizing. Returns `None` if the latch is gone, not
+    /// task-complete, or a summary is already present.
+    pub fn begin_attention_summary(
+        &self,
+        stable_pane_id: &str,
+    ) -> Option<(AgentAttentionLatch, AgentAttentionSummary, u64)> {
+        let pane_id = stable_pane_id.trim();
+        if pane_id.is_empty() {
+            return None;
+        }
+
+        let latch = {
+            let attention = self.attention.read();
+            attention.get(pane_id).cloned()
+        }?;
+        if latch.reason != AgentAttentionReason::TaskComplete {
+            return None;
+        }
+
+        {
+            let summaries = self.summaries.read();
+            if summaries.contains_key(pane_id) {
+                return None;
+            }
+        }
+
+        let generation = {
+            let mut gen = self.summary_generation.write();
+            let next = gen.saturating_add(1).max(1);
+            *gen = next;
+            next
+        };
+
+        let summary = AgentAttentionSummary {
+            stable_pane_id: latch.stable_pane_id.clone(),
+            context_id: latch.context_id.clone(),
+            session_id: latch.session_id.clone(),
+            status: AttentionSummaryStatus::Summarizing,
+            summary: None,
+            next_steps: Vec::new(),
+            can_close_session: None,
+            error: None,
+            started_at: Utc::now().to_rfc3339(),
+            completed_at: None,
+            generation,
+        };
+
+        {
+            let mut summaries = self.summaries.write();
+            // Race: another begin won.
+            if summaries.contains_key(pane_id) {
+                return None;
+            }
+            summaries.insert(pane_id.to_string(), summary.clone());
+        }
+
+        self.broadcast_summary_updated(summary.clone());
+        Some((latch, summary, generation))
+    }
+
+    /// Apply a successful generation. Ignores stale generation tokens.
+    pub fn complete_attention_summary(
+        &self,
+        stable_pane_id: &str,
+        generation: u64,
+        payload: AttentionSummaryPayload,
+    ) -> Option<AgentAttentionSummary> {
+        let pane_id = stable_pane_id.trim();
+        if pane_id.is_empty() {
+            return None;
+        }
+        // Still need the latch — user may have acknowledged mid-flight.
+        if !self.attention.read().contains_key(pane_id) {
+            self.clear_attention_summaries_matching_ids(&[pane_id.to_string()]);
+            return None;
+        }
+
+        let updated = {
+            let mut summaries = self.summaries.write();
+            let entry = summaries.get_mut(pane_id)?;
+            if entry.generation != generation {
+                debug!(
+                    "Ignoring stale attention summary completion for {} (gen {} != {})",
+                    pane_id, generation, entry.generation
+                );
+                return None;
+            }
+            entry.status = AttentionSummaryStatus::Ready;
+            entry.summary = Some(payload.summary.trim().to_string());
+            entry.next_steps = payload
+                .next_steps
+                .into_iter()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .take(6)
+                .collect();
+            entry.can_close_session = Some(payload.can_close_session);
+            entry.error = None;
+            entry.completed_at = Some(Utc::now().to_rfc3339());
+            entry.clone()
+        };
+        self.broadcast_summary_updated(updated.clone());
+        Some(updated)
+    }
+
+    /// Apply a failed generation. Ignores stale generation tokens.
+    pub fn fail_attention_summary(
+        &self,
+        stable_pane_id: &str,
+        generation: u64,
+        error: impl Into<String>,
+    ) -> Option<AgentAttentionSummary> {
+        let pane_id = stable_pane_id.trim();
+        if pane_id.is_empty() {
+            return None;
+        }
+        if !self.attention.read().contains_key(pane_id) {
+            self.clear_attention_summaries_matching_ids(&[pane_id.to_string()]);
+            return None;
+        }
+
+        let updated = {
+            let mut summaries = self.summaries.write();
+            let entry = summaries.get_mut(pane_id)?;
+            if entry.generation != generation {
+                return None;
+            }
+            entry.status = AttentionSummaryStatus::Error;
+            entry.error = Some(error.into());
+            entry.completed_at = Some(Utc::now().to_rfc3339());
+            entry.clone()
+        };
+        self.broadcast_summary_updated(updated.clone());
+        Some(updated)
+    }
+
+    /// Drop summary rows for the given pane/session ids (also on attention clear).
+    pub fn clear_attention_summaries_matching_ids(&self, ids: &[String]) -> Vec<String> {
+        let id_set: HashSet<&str> = ids
+            .iter()
+            .map(String::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect();
+        if id_set.is_empty() {
+            return Vec::new();
+        }
+
+        let cleared: Vec<String> = {
+            let mut summaries = self.summaries.write();
+            let to_clear: Vec<String> = summaries
+                .iter()
+                .filter(|(key, row)| {
+                    id_set.contains(key.as_str()) || id_set.contains(row.session_id.as_str())
+                })
+                .map(|(key, _)| key.clone())
+                .collect();
+            for key in &to_clear {
+                summaries.remove(key);
+            }
+            to_clear
+        };
+
+        if !cleared.is_empty() {
+            self.broadcast_summary_cleared(cleared.clone());
+        }
+        cleared
+    }
+
+    fn broadcast_summary_updated(&self, summary: AgentAttentionSummary) {
+        if let Err(error) = self
+            .event_tx
+            .send(AgentHookEvent::AttentionSummaryUpdated(summary))
+        {
+            warn!("Failed to publish attention summary update: {}", error);
+        }
+    }
+
+    fn broadcast_summary_cleared(&self, stable_pane_ids: Vec<String>) {
+        if let Err(error) = self
+            .event_tx
+            .send(AgentHookEvent::AttentionSummaryCleared { stable_pane_ids })
+        {
+            warn!("Failed to publish attention summary cleared: {}", error);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::agent_hooks::{
+        AgentHookState, AgentHooksService, AgentToolType, AtmosContext, StateUpdateKind,
+    };
+
+    fn ctx_with_pane(pane_id: &str) -> AtmosContext {
+        AtmosContext {
+            pane_id: Some(pane_id.to_string()),
+            context_id: Some("ws-1".to_string()),
+            ..AtmosContext::default()
+        }
+    }
+
+    fn raise_task_complete(service: &AgentHooksService, pane: &str) {
+        let ctx = ctx_with_pane(pane);
+        service.update_state(
+            pane,
+            AgentToolType::ClaudeCode,
+            AgentHookState::Running,
+            Some("/tmp/proj".into()),
+            &ctx,
+            StateUpdateKind::NewTurn,
+        );
+        service.update_state(
+            pane,
+            AgentToolType::ClaudeCode,
+            AgentHookState::Idle,
+            Some("/tmp/proj".into()),
+            &ctx,
+            StateUpdateKind::TerminalIdle,
+        );
+    }
+
+    #[test]
+    fn settings_parse_defaults_and_bounds() {
+        let defaults = AttentionSummarySettings::from_json(&serde_json::json!({}));
+        assert!(defaults.enabled);
+        assert_eq!(defaults.delay_mins, 5);
+        assert!(defaults.agent_id.is_none());
+
+        let custom = AttentionSummarySettings::from_json(&serde_json::json!({
+            "attention_summary_enabled": false,
+            "attention_summary_delay_mins": 12,
+            "attention_summary_agent_id": "  codex  ",
+            "attention_summary_model": "gpt-5",
+        }));
+        assert!(!custom.enabled);
+        assert_eq!(custom.delay_mins, 12);
+        assert_eq!(custom.agent_id.as_deref(), Some("codex"));
+        assert_eq!(custom.model.as_deref(), Some("gpt-5"));
+    }
+
+    #[test]
+    fn due_only_after_delay_and_task_complete() {
+        let service = AgentHooksService::new();
+        raise_task_complete(&service, "ws-1:main");
+        // Fresh latch is not due yet for a long delay.
+        assert!(service
+            .attention_due_for_summary(Duration::from_secs(300))
+            .is_empty());
+        // Zero-ish delay (clamped in settings, but raw Duration::ZERO here) → due.
+        let due = service.attention_due_for_summary(Duration::from_secs(0));
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].stable_pane_id, "ws-1:main");
+    }
+
+    #[test]
+    fn begin_complete_and_clear_summary_flow() {
+        let service = AgentHooksService::new();
+        raise_task_complete(&service, "ws-1:main");
+        let (latch, row, gen) = service
+            .begin_attention_summary("ws-1:main")
+            .expect("begin");
+        assert_eq!(latch.stable_pane_id, "ws-1:main");
+        assert_eq!(row.status, AttentionSummaryStatus::Summarizing);
+        assert!(service.begin_attention_summary("ws-1:main").is_none());
+
+        let ready = service
+            .complete_attention_summary(
+                "ws-1:main",
+                gen,
+                AttentionSummaryPayload {
+                    summary: "Shipped the attention summary feature.".into(),
+                    next_steps: vec!["Open PR".into(), "Write tests".into()],
+                    can_close_session: true,
+                },
+            )
+            .expect("complete");
+        assert_eq!(ready.status, AttentionSummaryStatus::Ready);
+        assert_eq!(ready.next_steps.len(), 2);
+        assert_eq!(ready.can_close_session, Some(true));
+
+        // Clear attention also drops summary.
+        service.clear_attention_for_pane("ws-1:main");
+        assert!(service.get_all_attention_summaries().is_empty());
+    }
+
+    #[test]
+    fn stale_generation_is_ignored() {
+        let service = AgentHooksService::new();
+        raise_task_complete(&service, "ws-1:main");
+        let (_, _, gen) = service
+            .begin_attention_summary("ws-1:main")
+            .expect("begin");
+        assert!(service
+            .complete_attention_summary(
+                "ws-1:main",
+                gen + 1,
+                AttentionSummaryPayload {
+                    summary: "stale".into(),
+                    next_steps: vec![],
+                    can_close_session: false,
+                },
+            )
+            .is_none());
+        assert_eq!(
+            service.get_attention_summary("ws-1:main").unwrap().status,
+            AttentionSummaryStatus::Summarizing
+        );
+    }
+
+    #[test]
+    fn permission_latches_are_not_summarized() {
+        let service = AgentHooksService::new();
+        let ctx = ctx_with_pane("ws-1:main");
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::PermissionRequest,
+            Some("/tmp/proj".into()),
+            &ctx,
+            StateUpdateKind::Permission,
+        );
+        assert!(service
+            .attention_due_for_summary(Duration::from_secs(0))
+            .is_empty());
+        assert!(service.begin_attention_summary("ws-1:main").is_none());
+    }
+}

--- a/crates/core-service/src/service/agent_hooks/attention_summary.rs
+++ b/crates/core-service/src/service/agent_hooks/attention_summary.rs
@@ -11,9 +11,13 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 use tracing::{debug, warn};
 
-use super::{
-    AgentAttentionLatch, AgentAttentionReason, AgentHookEvent, AgentHooksService,
-};
+use super::{AgentAttentionLatch, AgentAttentionReason, AgentHookEvent, AgentHooksService};
+
+/// Drop abandoned in-flight generations after this bound so a hung provider
+/// cannot permanently suppress retries for the pane.
+const STALE_SUMMARIZING: Duration = Duration::from_secs(10 * 60);
+/// Allow retry after a failed generation once this bound elapses.
+const STALE_ERROR: Duration = Duration::from_secs(2 * 60);
 
 /// Lifecycle of an attention auto-summary for one pane.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -121,6 +125,35 @@ impl AttentionSummarySettings {
     }
 }
 
+fn row_timestamp(row: &AgentAttentionSummary) -> Option<DateTime<Utc>> {
+    let raw = row
+        .completed_at
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(row.started_at.as_str());
+    DateTime::parse_from_rfc3339(raw)
+        .ok()
+        .map(|t| t.with_timezone(&Utc))
+}
+
+fn is_stale_summary_row(row: &AgentAttentionSummary, now: DateTime<Utc>) -> bool {
+    let Some(ts) = row_timestamp(row) else {
+        return true;
+    };
+    let age = now.signed_duration_since(ts);
+    match row.status {
+        AttentionSummaryStatus::Summarizing => {
+            age >= chrono::Duration::from_std(STALE_SUMMARIZING)
+                .unwrap_or_else(|_| chrono::Duration::minutes(10))
+        }
+        AttentionSummaryStatus::Error => {
+            age >= chrono::Duration::from_std(STALE_ERROR)
+                .unwrap_or_else(|_| chrono::Duration::minutes(2))
+        }
+        AttentionSummaryStatus::Ready => false,
+    }
+}
+
 impl AgentHooksService {
     pub fn get_all_attention_summaries(&self) -> Vec<AgentAttentionSummary> {
         self.summaries.read().values().cloned().collect()
@@ -130,9 +163,30 @@ impl AgentHooksService {
         self.summaries.read().get(stable_pane_id).cloned()
     }
 
+    /// Drop abandoned / failed rows that would otherwise block forever, and
+    /// broadcast clear events for removed panes.
+    pub fn prune_stale_attention_summaries(&self) -> Vec<String> {
+        let now = Utc::now();
+        let stale_ids: Vec<String> = {
+            let summaries = self.summaries.read();
+            summaries
+                .iter()
+                .filter(|(_, row)| is_stale_summary_row(row, now))
+                .map(|(key, _)| key.clone())
+                .collect()
+        };
+        if stale_ids.is_empty() {
+            return Vec::new();
+        }
+        self.clear_attention_summaries_matching_ids(&stale_ids)
+    }
+
     /// Task-complete latches that have waited past `delay` and do not yet have
     /// an in-flight or finished summary. Permission latches are never summarized.
     pub fn attention_due_for_summary(&self, delay: Duration) -> Vec<AgentAttentionLatch> {
+        // Expire abandoned/failed rows first so they become eligible again.
+        self.prune_stale_attention_summaries();
+
         let cutoff = Utc::now()
             - chrono::Duration::from_std(delay).unwrap_or_else(|_| chrono::Duration::minutes(5));
         let summaries = self.summaries.read();
@@ -410,9 +464,7 @@ mod tests {
     fn begin_complete_and_clear_summary_flow() {
         let service = AgentHooksService::new();
         raise_task_complete(&service, "ws-1:main");
-        let (latch, row, gen) = service
-            .begin_attention_summary("ws-1:main")
-            .expect("begin");
+        let (latch, row, gen) = service.begin_attention_summary("ws-1:main").expect("begin");
         assert_eq!(latch.stable_pane_id, "ws-1:main");
         assert_eq!(row.status, AttentionSummaryStatus::Summarizing);
         assert!(service.begin_attention_summary("ws-1:main").is_none());
@@ -441,9 +493,7 @@ mod tests {
     fn stale_generation_is_ignored() {
         let service = AgentHooksService::new();
         raise_task_complete(&service, "ws-1:main");
-        let (_, _, gen) = service
-            .begin_attention_summary("ws-1:main")
-            .expect("begin");
+        let (_, _, gen) = service.begin_attention_summary("ws-1:main").expect("begin");
         assert!(service
             .complete_attention_summary(
                 "ws-1:main",
@@ -477,5 +527,29 @@ mod tests {
             .attention_due_for_summary(Duration::from_secs(0))
             .is_empty());
         assert!(service.begin_attention_summary("ws-1:main").is_none());
+    }
+
+    #[test]
+    fn failed_summary_expires_and_becomes_due_again() {
+        let service = AgentHooksService::new();
+        raise_task_complete(&service, "ws-1:main");
+        let (_, _, gen) = service.begin_attention_summary("ws-1:main").expect("begin");
+        service
+            .fail_attention_summary("ws-1:main", gen, "provider down")
+            .expect("fail");
+        // Fresh Error row still blocks due.
+        assert!(service
+            .attention_due_for_summary(Duration::from_secs(0))
+            .is_empty());
+
+        // Backdate completed_at past STALE_ERROR so prune can run.
+        service.test_set_summary_timestamps(
+            "ws-1:main",
+            (Utc::now() - chrono::Duration::minutes(5)).to_rfc3339(),
+            Some((Utc::now() - chrono::Duration::minutes(3)).to_rfc3339()),
+        );
+        let due = service.attention_due_for_summary(Duration::from_secs(0));
+        assert_eq!(due.len(), 1);
+        assert!(service.get_attention_summary("ws-1:main").is_none());
     }
 }

--- a/crates/core-service/src/service/agent_hooks/attention_summary_generate.rs
+++ b/crates/core-service/src/service/agent_hooks/attention_summary_generate.rs
@@ -1,0 +1,323 @@
+//! Headless generation of attention auto-summary JSON.
+//!
+//! Spawns a one-shot agent-cli (preferred, same path as automations) or falls
+//! back to the default LLM provider. Never attaches to the original pane.
+
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+use llm::{
+    FileLlmConfigStore, GenerateTextRequest, ProviderKind, ResolvedLlmProvider, ResponseFormat,
+};
+use tracing::{info, warn};
+
+use super::attention_summary::{AttentionSummaryPayload, AttentionSummarySettings};
+use super::AgentAttentionLatch;
+use crate::error::{Result, ServiceError};
+use crate::service::automation::{
+    resolve_automation_agent_with_config, AutomationAgentRunConfig,
+};
+use crate::service::llm_text_generation::generate_text;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(180);
+const MAX_CONTEXT_CHARS: usize = 12_000;
+
+const SYSTEM_PROMPT: &str = r#"You are Atmos attention-summary helper.
+A coding agent finished a turn and the user has not acknowledged it yet.
+Summarize what was recently done and suggest concise next steps.
+Respond with ONLY a single JSON object (no markdown fences) matching:
+{
+  "summary": "one sentence",
+  "next_steps": ["short action 1", "short action 2"],
+  "can_close_session": true
+}
+Rules:
+- summary: one clear sentence about recent work (max ~160 chars).
+- next_steps: 2-4 short imperative actions the user might take next.
+- can_close_session: true only if work looks complete with no obvious unfinished blockers.
+- Prefer the user's language if the context is clearly non-English; otherwise English.
+"#;
+
+/// Run headless summary generation for a sticky task-complete latch.
+pub async fn generate_attention_summary(
+    latch: &AgentAttentionLatch,
+    settings: &AttentionSummarySettings,
+) -> Result<AttentionSummaryPayload> {
+    let context = build_context_block(latch);
+    let prompt = format!(
+        "Pane: {}\nSession: {}\nTool: {}\nRaised at: {}\nProject: {}\n\nRecent work context:\n{}",
+        latch.stable_pane_id,
+        latch.session_id,
+        latch
+            .tool
+            .map(|t| t.to_string())
+            .unwrap_or_else(|| "unknown".into()),
+        latch.raised_at,
+        latch
+            .project_path
+            .as_deref()
+            .unwrap_or("(unknown project path)"),
+        if context.trim().is_empty() {
+            "(no git/terminal context available — infer cautiously)"
+        } else {
+            context.as_str()
+        }
+    );
+
+    let provider = resolve_summary_provider(settings)?;
+    info!(
+        pane = %latch.stable_pane_id,
+        provider = %provider.id,
+        agent_id = ?provider.agent_id,
+        model = %provider.model,
+        "Generating unattended attention summary"
+    );
+
+    let request = GenerateTextRequest {
+        system: Some(SYSTEM_PROMPT.to_string()),
+        prompt,
+        temperature: Some(0.2),
+        max_output_tokens: Some(provider.max_output_tokens.unwrap_or(1024).min(2048)),
+        response_format: ResponseFormat::JsonObject,
+    };
+
+    let response = generate_text(&provider, request).await.map_err(|error| {
+        ServiceError::Processing(format!("Attention summary generation failed: {error}"))
+    })?;
+
+    parse_summary_payload(&response.text)
+}
+
+fn resolve_summary_provider(settings: &AttentionSummarySettings) -> Result<ResolvedLlmProvider> {
+    if let Some(agent_id) = settings.agent_id.as_deref() {
+        // Validate the agent can run headless (automation path) before building provider.
+        let run_config = settings.model.as_ref().map(|model| AutomationAgentRunConfig {
+            model: Some(model.clone()),
+            ..Default::default()
+        });
+        let _spec = resolve_automation_agent_with_config(agent_id, run_config.as_ref())?;
+        return Ok(ResolvedLlmProvider {
+            id: format!("agent-cli:{agent_id}"),
+            kind: ProviderKind::AgentCli,
+            base_url: String::new(),
+            api_key: String::new(),
+            model: settings.model.clone().unwrap_or_default(),
+            agent_id: Some(agent_id.to_string()),
+            timeout: DEFAULT_TIMEOUT,
+            max_output_tokens: Some(1024),
+            context_window: 32_768,
+        });
+    }
+
+    // Fall back to default LLM provider (may still be agent-cli via providers.json).
+    let store = FileLlmConfigStore::new().map_err(|error| {
+        ServiceError::Validation(format!("Failed to open LLM config: {error}"))
+    })?;
+    let provider = store
+        .resolve_default_provider()
+        .map_err(|error| {
+            ServiceError::Validation(format!("Failed to resolve default LLM provider: {error}"))
+        })?
+        .ok_or_else(|| {
+            ServiceError::Validation(
+                "No attention summary agent configured and no default LLM provider is enabled"
+                    .to_string(),
+            )
+        })?;
+
+    // Optional model override for non-agent providers.
+    if let Some(model) = settings.model.as_ref() {
+        if provider.kind != ProviderKind::AgentCli {
+            return Ok(ResolvedLlmProvider {
+                model: model.clone(),
+                ..provider
+            });
+        }
+    }
+    Ok(provider)
+}
+
+fn build_context_block(latch: &AgentAttentionLatch) -> String {
+    let Some(project_path) = latch
+        .project_path
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    else {
+        return String::new();
+    };
+    let path = Path::new(project_path);
+    if !path.is_dir() {
+        return format!("Project path is not a directory: {project_path}");
+    }
+
+    let mut sections = Vec::new();
+
+    if let Some(status) = run_git_capture(path, &["status", "--short", "--branch"]) {
+        if !status.trim().is_empty() {
+            sections.push(format!("## git status\n{}", trim_chars(&status, 4_000)));
+        }
+    }
+    if let Some(log) = run_git_capture(path, &["log", "-8", "--oneline", "--decorate"]) {
+        if !log.trim().is_empty() {
+            sections.push(format!("## recent commits\n{}", trim_chars(&log, 2_000)));
+        }
+    }
+    if let Some(diff) = run_git_capture(path, &["diff", "--stat", "HEAD"]) {
+        if !diff.trim().is_empty() {
+            sections.push(format!("## diff stat\n{}", trim_chars(&diff, 3_000)));
+        }
+    }
+
+    let joined = sections.join("\n\n");
+    trim_chars(&joined, MAX_CONTEXT_CHARS)
+}
+
+fn run_git_capture(cwd: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout).ok()
+}
+
+fn trim_chars(input: &str, max: usize) -> String {
+    let count = input.chars().count();
+    if count <= max {
+        return input.to_string();
+    }
+    let kept: String = input.chars().take(max.saturating_sub(20)).collect();
+    format!("{kept}\n… (truncated)")
+}
+
+pub fn parse_summary_payload(raw: &str) -> Result<AttentionSummaryPayload> {
+    let text = raw.trim();
+    if text.is_empty() {
+        return Err(ServiceError::Processing(
+            "Attention summary agent returned empty output".into(),
+        ));
+    }
+
+    // Tolerate accidental markdown fences.
+    let stripped = strip_json_fence(text);
+    let value: serde_json::Value = serde_json::from_str(stripped).or_else(|_| {
+        // Last resort: extract first {...} block.
+        extract_json_object(stripped)
+            .ok_or_else(|| {
+                ServiceError::Processing(format!(
+                    "Attention summary output was not valid JSON: {}",
+                    trim_chars(text, 200)
+                ))
+            })
+            .and_then(|slice| {
+                serde_json::from_str(slice).map_err(|error| {
+                    ServiceError::Processing(format!(
+                        "Attention summary JSON parse failed: {error}"
+                    ))
+                })
+            })
+    })?;
+
+    let summary = value
+        .get("summary")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            ServiceError::Processing("Attention summary JSON missing non-empty `summary`".into())
+        })?
+        .to_string();
+
+    let next_steps = value
+        .get("next_steps")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| item.as_str())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .take(6)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let can_close_session = value
+        .get("can_close_session")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    if next_steps.is_empty() {
+        warn!("Attention summary had no next_steps; continuing with summary only");
+    }
+
+    Ok(AttentionSummaryPayload {
+        summary,
+        next_steps,
+        can_close_session,
+    })
+}
+
+fn strip_json_fence(text: &str) -> &str {
+    let trimmed = text.trim();
+    if let Some(rest) = trimmed.strip_prefix("```json") {
+        return rest
+            .strip_suffix("```")
+            .unwrap_or(rest)
+            .trim();
+    }
+    if let Some(rest) = trimmed.strip_prefix("```") {
+        return rest.strip_suffix("```").unwrap_or(rest).trim();
+    }
+    trimmed
+}
+
+fn extract_json_object(text: &str) -> Option<&str> {
+    let start = text.find('{')?;
+    let end = text.rfind('}')?;
+    if end <= start {
+        return None;
+    }
+    Some(&text[start..=end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_clean_json() {
+        let payload = parse_summary_payload(
+            r#"{
+              "summary": "Implemented attention auto-summary.",
+              "next_steps": ["Open PR", "Add UI tests"],
+              "can_close_session": true
+            }"#,
+        )
+        .unwrap();
+        assert!(payload.summary.contains("attention"));
+        assert_eq!(payload.next_steps.len(), 2);
+        assert!(payload.can_close_session);
+    }
+
+    #[test]
+    fn parse_fenced_json() {
+        let payload = parse_summary_payload(
+            "```json\n{\"summary\":\"Done\",\"next_steps\":[\"Ship\"],\"can_close_session\":false}\n```",
+        )
+        .unwrap();
+        assert_eq!(payload.summary, "Done");
+        assert!(!payload.can_close_session);
+    }
+
+    #[test]
+    fn parse_rejects_missing_summary() {
+        let err = parse_summary_payload(r#"{"next_steps":["x"]}"#).unwrap_err();
+        assert!(err.to_string().contains("summary"));
+    }
+}

--- a/crates/core-service/src/service/agent_hooks/attention_summary_generate.rs
+++ b/crates/core-service/src/service/agent_hooks/attention_summary_generate.rs
@@ -15,13 +15,12 @@ use tracing::{info, warn};
 use super::attention_summary::{AttentionSummaryPayload, AttentionSummarySettings};
 use super::AgentAttentionLatch;
 use crate::error::{Result, ServiceError};
-use crate::service::automation::{
-    resolve_automation_agent_with_config, AutomationAgentRunConfig,
-};
+use crate::service::automation::{resolve_automation_agent_with_config, AutomationAgentRunConfig};
 use crate::service::llm_text_generation::generate_text;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(180);
 const MAX_CONTEXT_CHARS: usize = 12_000;
+const GIT_TIMEOUT: Duration = Duration::from_secs(8);
 
 const SYSTEM_PROMPT: &str = r#"You are Atmos attention-summary helper.
 A coding agent finished a turn and the user has not acknowledged it yet.
@@ -44,7 +43,11 @@ pub async fn generate_attention_summary(
     latch: &AgentAttentionLatch,
     settings: &AttentionSummarySettings,
 ) -> Result<AttentionSummaryPayload> {
-    let context = build_context_block(latch);
+    // Git status/log/diff use std::process — keep them off the Tokio worker.
+    let latch_for_context = latch.clone();
+    let context = tokio::task::spawn_blocking(move || build_context_block(&latch_for_context))
+        .await
+        .unwrap_or_default();
     let prompt = format!(
         "Pane: {}\nSession: {}\nTool: {}\nRaised at: {}\nProject: {}\n\nRecent work context:\n{}",
         latch.stable_pane_id,
@@ -91,17 +94,21 @@ pub async fn generate_attention_summary(
 
 fn resolve_summary_provider(settings: &AttentionSummarySettings) -> Result<ResolvedLlmProvider> {
     if let Some(agent_id) = settings.agent_id.as_deref() {
-        // Validate the agent can run headless (automation path) before building provider.
-        let run_config = settings.model.as_ref().map(|model| AutomationAgentRunConfig {
-            model: Some(model.clone()),
-            ..Default::default()
-        });
+        // Only pass model when the user explicitly configured one.
+        let run_config = settings
+            .model
+            .as_ref()
+            .map(|model| AutomationAgentRunConfig {
+                model: Some(model.clone()),
+                ..Default::default()
+            });
         let _spec = resolve_automation_agent_with_config(agent_id, run_config.as_ref())?;
         return Ok(ResolvedLlmProvider {
             id: format!("agent-cli:{agent_id}"),
             kind: ProviderKind::AgentCli,
             base_url: String::new(),
             api_key: String::new(),
+            // Keep empty unless explicitly configured — agent-cli defaults apply.
             model: settings.model.clone().unwrap_or_default(),
             agent_id: Some(agent_id.to_string()),
             timeout: DEFAULT_TIMEOUT,
@@ -111,9 +118,8 @@ fn resolve_summary_provider(settings: &AttentionSummarySettings) -> Result<Resol
     }
 
     // Fall back to default LLM provider (may still be agent-cli via providers.json).
-    let store = FileLlmConfigStore::new().map_err(|error| {
-        ServiceError::Validation(format!("Failed to open LLM config: {error}"))
-    })?;
+    let store = FileLlmConfigStore::new()
+        .map_err(|error| ServiceError::Validation(format!("Failed to open LLM config: {error}")))?;
     let provider = store
         .resolve_default_provider()
         .map_err(|error| {
@@ -175,15 +181,25 @@ fn build_context_block(latch: &AgentAttentionLatch) -> String {
 }
 
 fn run_git_capture(cwd: &Path, args: &[&str]) -> Option<String> {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(cwd)
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    String::from_utf8(output.stdout).ok()
+    // Called from spawn_blocking; add a soft timeout so a locked index cannot hang forever.
+    let cwd = cwd.to_path_buf();
+    let args: Vec<String> = args.iter().map(|s| (*s).to_string()).collect();
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let result = Command::new("git")
+            .args(&args)
+            .current_dir(&cwd)
+            .output()
+            .ok()
+            .and_then(|output| {
+                if !output.status.success() {
+                    return None;
+                }
+                String::from_utf8(output.stdout).ok()
+            });
+        let _ = tx.send(result);
+    });
+    rx.recv_timeout(GIT_TIMEOUT).unwrap_or_default()
 }
 
 fn trim_chars(input: &str, max: usize) -> String {
@@ -266,10 +282,7 @@ pub fn parse_summary_payload(raw: &str) -> Result<AttentionSummaryPayload> {
 fn strip_json_fence(text: &str) -> &str {
     let trimmed = text.trim();
     if let Some(rest) = trimmed.strip_prefix("```json") {
-        return rest
-            .strip_suffix("```")
-            .unwrap_or(rest)
-            .trim();
+        return rest.strip_suffix("```").unwrap_or(rest).trim();
     }
     if let Some(rest) = trimmed.strip_prefix("```") {
         return rest.strip_suffix("```").unwrap_or(rest).trim();

--- a/crates/core-service/src/service/automation/mod.rs
+++ b/crates/core-service/src/service/automation/mod.rs
@@ -38,8 +38,8 @@ use agents::automation_agent_capabilities;
 pub use agents::AutomationAgentCapability;
 pub mod builtin_agent_upgrade;
 pub(crate) use agents::{
-    resolve_automation_agent, AutomationAgentInvocation, AutomationCommandInput, PromptDelivery,
-    StdoutParser,
+    resolve_automation_agent_with_config, AutomationAgentInvocation, AutomationCommandInput,
+    PromptDelivery, StdoutParser,
 };
 pub use agents::{
     AutomationAgentModelInputMode, AutomationAgentReasoningMode, AutomationAgentReasoningSelection,

--- a/crates/core-service/src/service/llm_text_generation.rs
+++ b/crates/core-service/src/service/llm_text_generation.rs
@@ -77,16 +77,22 @@ async fn run_agent_cli_text_stream(
             ))
         })?;
 
-    let run_config = if provider.model.trim().is_empty() {
-        None
-    } else {
-        Some(AutomationAgentRunConfig {
-            model: Some(provider.model.clone()),
-            ..Default::default()
-        })
+    let run_config = {
+        let model = provider.model.trim();
+        let agent = provider.agent_id.as_deref().unwrap_or("").trim();
+        // agent-cli providers often set model=agent_id as a placeholder; only
+        // treat a distinct non-empty value as an explicit model selection.
+        if model.is_empty() || model == agent {
+            None
+        } else {
+            Some(AutomationAgentRunConfig {
+                model: Some(model.to_string()),
+                ..Default::default()
+            })
+        }
     };
-    let agent_command =
-        resolve_automation_agent_with_config(agent_id, run_config.as_ref()).map_err(service_error_to_llm)?;
+    let agent_command = resolve_automation_agent_with_config(agent_id, run_config.as_ref())
+        .map_err(service_error_to_llm)?;
     let prompt = build_agent_cli_prompt(&request);
     let prompt_path = write_prompt_file(&prompt).await?;
     let invocation = agent_command.build_invocation(AutomationCommandInput {

--- a/crates/core-service/src/service/llm_text_generation.rs
+++ b/crates/core-service/src/service/llm_text_generation.rs
@@ -13,8 +13,9 @@ use uuid::Uuid;
 use crate::error::ServiceError;
 
 use super::automation::{
-    read_stream, resolve_automation_agent, AutomationAgentInvocation, AutomationCommandInput,
-    OutputChunk, OutputRenderer, PromptDelivery, StdoutParser,
+    read_stream, resolve_automation_agent_with_config, AutomationAgentInvocation,
+    AutomationAgentRunConfig, AutomationCommandInput, OutputChunk, OutputRenderer, PromptDelivery,
+    StdoutParser,
 };
 
 const AGENT_OUTPUT_CHANNEL_SIZE: usize = 32;
@@ -76,7 +77,16 @@ async fn run_agent_cli_text_stream(
             ))
         })?;
 
-    let agent_command = resolve_automation_agent(agent_id).map_err(service_error_to_llm)?;
+    let run_config = if provider.model.trim().is_empty() {
+        None
+    } else {
+        Some(AutomationAgentRunConfig {
+            model: Some(provider.model.clone()),
+            ..Default::default()
+        })
+    };
+    let agent_command =
+        resolve_automation_agent_with_config(agent_id, run_config.as_ref()).map_err(service_error_to_llm)?;
     let prompt = build_agent_cli_prompt(&request);
     let prompt_path = write_prompt_file(&prompt).await?;
     let invocation = agent_command.build_invocation(AutomationCommandInput {

--- a/crates/quota-usage/src/refresh.rs
+++ b/crates/quota-usage/src/refresh.rs
@@ -22,7 +22,7 @@ fn default_provider_switch() -> bool {
     false
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(crate) struct ProviderStateEntry {
     #[serde(default)]
     pub(crate) updated_at_utc: Option<String>,
@@ -30,16 +30,6 @@ pub(crate) struct ProviderStateEntry {
     pub(crate) switch: bool,
     #[serde(default)]
     pub(crate) footer_carousel_show: bool,
-}
-
-impl Default for ProviderStateEntry {
-    fn default() -> Self {
-        Self {
-            updated_at_utc: None,
-            switch: false,
-            footer_carousel_show: false,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/e2e/tests/smoke/app-shell/app-shell-navigation.e2e.ts
+++ b/e2e/tests/smoke/app-shell/app-shell-navigation.e2e.ts
@@ -24,7 +24,7 @@ test.describe("smoke app shell navigation", () => {
     await page.keyboard.press("Escape");
     await expect(page.getByRole("dialog", { name: "Command Palette" })).toBeHidden();
 
-    await page.getByRole("button", { name: "Usage" }).click();
+    await page.getByRole("button", { name: "Usage", exact: true }).click();
     const usageDialog = page.getByRole("dialog").filter({ hasText: "All Providers" });
     await expect(usageDialog).toBeVisible();
     await page.keyboard.press("Escape");


### PR DESCRIPTION
## Summary

When an agent turn finishes (`task_complete` need-attention) and stays unacknowledged past a configurable delay (default **5 minutes**), Atmos now:

1. Spawns a **headless** agent-cli / LLM summary session (same automation agent resolution path) — does **not** pollute the original pane context
2. Expects structured JSON: `{ summary, next_steps, can_close_session }`
3. Pushes state over WebSocket so the UI survives refresh
4. Surfaces the result on the **AI Input** rich-input chrome

### Backend
- Attention latches already lived in API memory; this adds an in-memory summary state machine (`summarizing` → `ready` | `error`)
- 30s job scans task-complete latches older than `attention_summary_delay_mins`
- Settings in `~/.atmos/agent/terminal_code_agent.json` (Code Agent → Behaviour)
- New WS events: `agent_attention_summary_updated` / `agent_attention_summary_cleared`
- REST hydrate: `GET /hooks/attention/summaries`
- User focus / attention clear drops the summary too

### Frontend
- Blue trigger bar (+ pulse while summarizing)
- Auto-opens rich input; loading skeleton above composer
- Ready: one-sentence summary, next-step chips (fill composer), can-close badge
- Settings UI under Code Agent behaviour (enable, delay, agent id, model)

## Test plan
- [x] `cargo test -p core-service attention` (12 unit tests)
- [x] `bun test apps/web/src/features/agent/store/agent-attention-store.test.ts`
- [ ] Manual: finish an agent turn, wait past delay (or set delay to 1 min), confirm blue pulse + summary panel
- [ ] Manual: focus the pane → summary + attention clear
- [ ] Manual: click a next-step chip → fills AI input
- [ ] Manual: configure agent/model in Settings → Code Agent → Behaviour

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically summarizes unattended task-complete attention and shows next steps above the terminal input after a configurable delay. A headless `agent-cli` (or default LLM) generates structured JSON; state is pushed over WebSocket and hydrated via REST so the UI survives refresh.

- **New Features**
  - Backend: in-memory summary state (`summarizing` → `ready` | `error`), 30s job, WS events `agent_attention_summary_updated`/`agent_attention_summary_cleared`, REST `GET /hooks/attention/summaries`; summaries clear when attention is acknowledged or the pane is focused.
  - Settings: new behaviour fields in `~/.atmos/agent/terminal_code_agent.json` and WS settings API (`attention_summary_enabled`, `attention_summary_delay_mins`, `attention_summary_agent_id`, `attention_summary_model`).
  - Frontend: blue pulse on the Rich Input trigger, auto-opens composer, panel with one-sentence summary, next-step chips that fill the input, and a can-close badge; hydrates summaries after refresh.

- **Bug Fixes**
  - Backend robustness: add `not_after` guard on attention-clear so a late dismiss can’t erase newer latches/summaries; invalidate summaries when a new latch replaces a turn and hold attention write during invalidation so an older generation can’t complete against a newer turn; close a begin/clear race to avoid orphan `summarizing` rows and restore optimistic dismiss only when store revisions still match (skip after authoritative WS clear/raise); restore the optimistic dismiss snapshot if attention-clear fails so hydration can’t resurrect a dismissed panel; clear orphan summaries; expire stale `summarizing`/`error`; cap concurrent generations; run git context on worker threads; enforce attention → summaries lock order in the due-scan to prevent deadlock; only pass explicit `agent-cli` models; persist dismiss via attention-clear; guard REST hydration against stale data.
  - Settings/UI: clamp delay and disable controls when off; add aria-label; copy fixes (EN/ZH); CSS keyframe rename; minor e2e selector fix; satisfy clippy in GitHub job-step parsing.

<sup>Written for commit f3c0d531f76c9c7ee735afbcf1c0fa464f4566cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic summaries for unattended tasks requiring attention.
  * Configure summaries with enable/disable controls, delay, summary agent, and model selection.
  * View summary status, key details, recommended next steps, and session-close guidance directly in the terminal.
  * Dismiss summaries and keep them synchronized across panes.
* **Localization**
  * Added English and Chinese translations for summary settings, statuses, actions, and errors.
* **Bug Fixes**
  * Improved attention-state cleanup when panes or tasks are cleared.
  * Included all GitHub Actions job steps in displayed log excerpts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->