### PR TITLE
feat(mobile): top flat terminal tabs for basic multi-terminal flow

### DIFF
--- a/apps/mobile/src/features/terminal/TerminalScreen.tsx
+++ b/apps/mobile/src/features/terminal/TerminalScreen.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/features/terminal/mobile-terminal-agents";
 import { useContestedCliOwners } from "@/features/terminal/use-contested-cli-owners";
 import {
-  createMobileTerminalSessionId,
+  createLocalTerminalEntry,
   resolveActiveTerminalEntry,
 } from "@/features/terminal/terminal-selection";
 import {
@@ -19,6 +19,7 @@ import {
   getTerminalShortcutInput,
   type TerminalShortcut,
 } from "@/features/terminal/terminal-shortcuts";
+import { TerminalTabStrip } from "@/features/terminal/TerminalTabStrip";
 import { useTerminalCandidates } from "@/features/terminal/use-terminal-candidates";
 import {
   useTerminalConnection,
@@ -112,15 +113,8 @@ export function TerminalScreen({
   });
 
   const createTerminalEntry = useCallback(() => {
-    const id = `${workspaceId}:mobile-${Date.now()}`;
-    addEntry({
-      id,
-      workspaceId,
-      label: `Mobile terminal ${ensuredEntries.length + 1}`,
-      sessionId: createMobileTerminalSessionId(workspaceId),
-      isNew: true,
-    });
-  }, [addEntry, ensuredEntries.length, workspaceId]);
+    addEntry(createLocalTerminalEntry(workspaceId, ensuredEntries));
+  }, [addEntry, ensuredEntries, workspaceId]);
 
   useEffect(() => {
     if (!onHeaderControlsChange) return undefined;
@@ -197,11 +191,13 @@ export function TerminalScreen({
           return;
         }
         if (shortcut.action === "workspace-list") router.push("/");
-        if (shortcut.action === "switch-terminal") setTerminalError("Use the terminal menu in the header.");
+        if (shortcut.action === "switch-terminal") {
+          setTerminalError("Use the terminal tabs at the top to switch.");
+        }
         if (shortcut.action === "new-terminal") createTerminalEntry();
       }
     },
-    [createTerminalEntry, router, sendTerminalInput],
+    [createTerminalEntry, router, sendTerminalInput, setTerminalError],
   );
 
   useEffect(() => {
@@ -214,6 +210,17 @@ export function TerminalScreen({
 
   return (
     <View style={[styles.root, { backgroundColor: theme.colors.terminalBg }]}>
+      <TerminalTabStrip
+        activeEntryId={activeEntry?.id ?? null}
+        entries={ensuredEntries.map((entry) => ({
+          id: entry.id,
+          label: entry.label,
+          dynamicTitle: entry.dynamicTitle,
+          oscTitle: entry.oscTitle,
+        }))}
+        onCreateEntry={createTerminalEntry}
+        onSelectEntry={(entryId) => setActiveEntry(workspaceId, entryId)}
+      />
       {candidates.error ? (
         <View
           style={[
@@ -262,10 +269,12 @@ export function TerminalScreen({
       ) : (
         <View style={[styles.choiceState, { backgroundColor: theme.colors.cardElevated }]}>
           <Text selectable style={[styles.choiceTitle, { color: theme.colors.label }]}>
-            Choose a terminal
+            {ensuredEntries.length === 0 ? "No terminals yet" : "Choose a terminal"}
           </Text>
           <Text selectable style={[styles.choiceText, { color: theme.colors.secondaryLabel }]}>
-            This workspace has multiple terminal candidates. Pick one above before attaching.
+            {ensuredEntries.length === 0
+              ? "Tap + in the tab strip to open a terminal."
+              : "Select a tab above, or tap + to open a new terminal."}
           </Text>
         </View>
       )}

--- a/apps/mobile/src/features/terminal/TerminalTabStrip.tsx
+++ b/apps/mobile/src/features/terminal/TerminalTabStrip.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useRef } from "react";
+import {
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  type LayoutChangeEvent,
+} from "react-native";
+import { GlassPanel } from "@/ui/primitives/glass-panel";
+import { PlusIcon } from "@/ui/icons/lucide-native";
+import { colors } from "@/theme/colors";
+import { useMobileTheme } from "@/theme/theme-store";
+import { terminalTabLabel } from "@/features/terminal/terminal-selection";
+
+export type TerminalTabStripItem = {
+  id: string;
+  label: string;
+  dynamicTitle?: string;
+  oscTitle?: string;
+};
+
+export function TerminalTabStrip({
+  activeEntryId,
+  entries,
+  onCreateEntry,
+  onSelectEntry,
+}: {
+  activeEntryId: string | null;
+  entries: TerminalTabStripItem[];
+  onCreateEntry: () => void;
+  onSelectEntry: (entryId: string) => void;
+}) {
+  const theme = useMobileTheme();
+  const scrollRef = useRef<ScrollView>(null);
+  const tabOffsetsRef = useRef<Record<string, { x: number; width: number }>>({});
+  const viewportWidthRef = useRef(0);
+
+  useEffect(() => {
+    if (!activeEntryId) return;
+    const layout = tabOffsetsRef.current[activeEntryId];
+    if (!layout || viewportWidthRef.current <= 0) return;
+    const targetX = Math.max(0, layout.x - Math.max(12, (viewportWidthRef.current - layout.width) / 2));
+    scrollRef.current?.scrollTo({ x: targetX, animated: true });
+  }, [activeEntryId, entries.length]);
+
+  const handleViewportLayout = (event: LayoutChangeEvent) => {
+    viewportWidthRef.current = event.nativeEvent.layout.width;
+  };
+
+  const strip = (
+    <View style={styles.row}>
+      <ScrollView
+        ref={scrollRef}
+        horizontal
+        onLayout={handleViewportLayout}
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.tabs}
+        style={styles.scroll}
+      >
+        {entries.map((entry) => {
+          const selected = entry.id === activeEntryId;
+          return (
+            <Pressable
+              key={entry.id}
+              accessibilityRole="tab"
+              accessibilityState={{ selected }}
+              accessibilityLabel={terminalTabLabel(entry)}
+              onLayout={(event) => {
+                tabOffsetsRef.current[entry.id] = {
+                  x: event.nativeEvent.layout.x,
+                  width: event.nativeEvent.layout.width,
+                };
+              }}
+              onPress={() => onSelectEntry(entry.id)}
+              style={[
+                styles.tab,
+                {
+                  backgroundColor: selected
+                    ? theme.isDark
+                      ? "rgba(255, 255, 255, 0.14)"
+                      : "rgba(10, 10, 11, 0.08)"
+                    : "transparent",
+                  borderColor: selected ? theme.colors.separatorStrong : "transparent",
+                },
+              ]}
+            >
+              <Text
+                numberOfLines={1}
+                style={[
+                  styles.tabLabel,
+                  {
+                    color: selected ? theme.colors.terminalFg : theme.colors.terminalMuted,
+                    fontWeight: selected ? "700" : "500",
+                  },
+                ]}
+              >
+                {terminalTabLabel(entry)}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+      <Pressable
+        accessibilityLabel="New terminal"
+        accessibilityRole="button"
+        hitSlop={8}
+        onPress={onCreateEntry}
+        style={[
+          styles.addButton,
+          {
+            backgroundColor: theme.isDark ? "rgba(255, 255, 255, 0.10)" : "rgba(10, 10, 11, 0.06)",
+            borderColor: theme.colors.separator,
+          },
+        ]}
+      >
+        <PlusIcon color={theme.colors.terminalFg} size={16} strokeWidth={2.4} />
+      </Pressable>
+    </View>
+  );
+
+  if (Platform.OS === "ios") {
+    return (
+      <View style={[styles.container, { backgroundColor: theme.colors.terminalBg }]}>
+        <GlassPanel
+          fallbackStyle={[
+            styles.glassFallback,
+            {
+              backgroundColor: theme.isDark ? "rgba(9, 9, 11, 0.92)" : "rgba(248, 250, 252, 0.94)",
+            },
+          ]}
+          glassEffectStyle={{ style: "regular", animate: true }}
+          interactive
+          shadow={false}
+          style={[styles.glass, { borderColor: theme.colors.glassBorder }]}
+          tintColor={theme.isDark ? "rgba(9, 9, 11, 0.72)" : "rgba(255, 255, 255, 0.55)"}
+        >
+          {strip}
+        </GlassPanel>
+      </View>
+    );
+  }
+
+  return (
+    <View
+      style={[
+        styles.container,
+        styles.androidChrome,
+        {
+          backgroundColor: theme.colors.terminalBg,
+          borderBottomColor: theme.colors.separator,
+        },
+      ]}
+    >
+      {strip}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  addButton: {
+    alignItems: "center",
+    borderCurve: "continuous",
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth,
+    height: 32,
+    justifyContent: "center",
+    marginLeft: 4,
+    width: 32,
+  },
+  androidChrome: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    paddingBottom: 8,
+    paddingHorizontal: 10,
+    paddingTop: 8,
+  },
+  container: {
+    backgroundColor: colors.terminalBg,
+    paddingBottom: 6,
+    paddingHorizontal: 10,
+    paddingTop: 8,
+  },
+  glass: {
+    borderCurve: "continuous",
+    borderRadius: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: "hidden",
+  },
+  glassFallback: {
+    borderRadius: 16,
+  },
+  row: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: 6,
+    minHeight: 40,
+    paddingHorizontal: 6,
+    paddingVertical: 4,
+  },
+  scroll: {
+    flex: 1,
+  },
+  tab: {
+    borderCurve: "continuous",
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth,
+    maxWidth: 168,
+    minHeight: 32,
+    justifyContent: "center",
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  tabLabel: {
+    color: colors.terminalFg,
+    fontSize: 13,
+    lineHeight: 16,
+  },
+  tabs: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: 6,
+    paddingRight: 4,
+  },
+});

--- a/apps/mobile/src/features/terminal/TerminalTabStrip.tsx
+++ b/apps/mobile/src/features/terminal/TerminalTabStrip.tsx
@@ -36,17 +36,26 @@ export function TerminalTabStrip({
   const scrollRef = useRef<ScrollView>(null);
   const tabOffsetsRef = useRef<Record<string, { x: number; width: number }>>({});
   const viewportWidthRef = useRef(0);
+  const activeEntryIdRef = useRef(activeEntryId);
+  activeEntryIdRef.current = activeEntryId;
 
-  useEffect(() => {
-    if (!activeEntryId) return;
-    const layout = tabOffsetsRef.current[activeEntryId];
+  const scrollActiveTabIntoView = (animated: boolean) => {
+    const entryId = activeEntryIdRef.current;
+    if (!entryId) return;
+    const layout = tabOffsetsRef.current[entryId];
     if (!layout || viewportWidthRef.current <= 0) return;
     const targetX = Math.max(0, layout.x - Math.max(12, (viewportWidthRef.current - layout.width) / 2));
-    scrollRef.current?.scrollTo({ x: targetX, animated: true });
+    scrollRef.current?.scrollTo({ x: targetX, animated });
+  };
+
+  useEffect(() => {
+    scrollActiveTabIntoView(true);
   }, [activeEntryId, entries.length]);
 
   const handleViewportLayout = (event: LayoutChangeEvent) => {
     viewportWidthRef.current = event.nativeEvent.layout.width;
+    // Layout may arrive after the active-tab effect ran without measurements.
+    scrollActiveTabIntoView(false);
   };
 
   const strip = (
@@ -72,6 +81,10 @@ export function TerminalTabStrip({
                   x: event.nativeEvent.layout.x,
                   width: event.nativeEvent.layout.width,
                 };
+                // Newly appended active tabs often measure after the effect — retry.
+                if (entry.id === activeEntryIdRef.current) {
+                  scrollActiveTabIntoView(true);
+                }
               }}
               onPress={() => onSelectEntry(entry.id)}
               style={[

--- a/apps/mobile/src/features/terminal/terminal-selection.test.ts
+++ b/apps/mobile/src/features/terminal/terminal-selection.test.ts
@@ -168,10 +168,27 @@ describe("terminal selection", () => {
     expect(first.id).not.toBe(second.id);
   });
 
-  test("terminalTabLabel prefers osc/dynamic titles and truncates long names", () => {
+  test("terminalTabLabel prefers dynamic over noisy OSC and truncates long names", () => {
     expect(terminalTabLabel({ label: "Fallback" })).toBe("Fallback");
     expect(terminalTabLabel({ label: "Fallback", dynamicTitle: "npm test" })).toBe("npm test");
-    expect(terminalTabLabel({ label: "Fallback", dynamicTitle: "npm test", oscTitle: "zsh" })).toBe("zsh");
+    // Shell host/cwd OSC (e.g. zsh path titles) is noise — keep dynamic command.
+    expect(terminalTabLabel({ label: "Fallback", dynamicTitle: "npm test", oscTitle: "zsh" })).toBe(
+      "npm test",
+    );
+    expect(
+      terminalTabLabel({
+        label: "Fallback",
+        dynamicTitle: "npm test",
+        oscTitle: "user@host:~/proj",
+      }),
+    ).toBe("npm test");
+    // Empty OSC must not block dynamic/label fallbacks (?? treats "" as present).
+    expect(terminalTabLabel({ label: "Fallback", dynamicTitle: "npm test", oscTitle: "" })).toBe(
+      "npm test",
+    );
+    expect(terminalTabLabel({ label: "Fallback", dynamicTitle: "", oscTitle: "" })).toBe("Fallback");
+    // Non-noisy OSC is used when there is no dynamic title.
+    expect(terminalTabLabel({ label: "Fallback", oscTitle: "my-session" })).toBe("my-session");
     const long = "a-very-long-terminal-window-title-that-needs-trim";
     expect(terminalTabLabel({ label: long }).endsWith("…")).toBe(true);
     expect(terminalTabLabel({ label: long }).length).toBeLessThanOrEqual(22);

--- a/apps/mobile/src/features/terminal/terminal-selection.test.ts
+++ b/apps/mobile/src/features/terminal/terminal-selection.test.ts
@@ -2,17 +2,21 @@
 import { describe, expect, test } from "bun:test";
 import type { MobileTerminalEntry } from "@/stores/terminal-store";
 import {
+  appendLocalTerminalEntry,
   createDefaultTerminalEntry,
+  createLocalTerminalEntry,
   mergeTerminalCandidateEntries,
   nextActiveTerminalEntryId,
   resolveActiveTerminalEntry,
+  terminalTabLabel,
 } from "./terminal-selection";
 
-function entry(id: string): MobileTerminalEntry {
+function entry(id: string, patch: Partial<MobileTerminalEntry> = {}): MobileTerminalEntry {
   return {
     id,
     workspaceId: "workspace",
     label: id,
+    ...patch,
   };
 }
 
@@ -101,5 +105,75 @@ describe("terminal selection", () => {
 
     expect(entries[0]?.sessionId).toBe("workspace:mobile:old");
     expect(entries[0]?.dynamicTitle).toBe("npm test");
+  });
+
+  test("flattens multiple server candidates into discrete tabs (no mosaic grouping)", () => {
+    const entries = mergeTerminalCandidateEntries(
+      "workspace",
+      [
+        {
+          active: true,
+          id: "tmux:workspace:0",
+          label: "pane-a",
+          tmux_window_index: 0,
+          tmux_window_name: "pane-a",
+          workspace_id: "workspace",
+        },
+        {
+          active: false,
+          id: "tmux:workspace:1",
+          label: "pane-b",
+          tmux_window_index: 1,
+          tmux_window_name: "pane-b",
+          workspace_id: "workspace",
+        },
+        {
+          active: false,
+          id: "session:extra",
+          label: "extra",
+          session_id: "extra",
+          workspace_id: "workspace",
+        },
+      ],
+      [],
+    );
+
+    expect(entries).toHaveLength(3);
+    expect(entries.map((item) => item.id)).toEqual([
+      "tmux:workspace:0",
+      "tmux:workspace:1",
+      "session:extra",
+    ]);
+    expect(nextActiveTerminalEntryId(entries, null)).toBe("tmux:workspace:0");
+  });
+
+  test("appendLocalTerminalEntry adds a tab and makes it active", () => {
+    const existing = [entry("tmux:workspace:0", { label: "main" })];
+    const result = appendLocalTerminalEntry("workspace", existing);
+
+    expect(result.entries).toHaveLength(2);
+    expect(result.entries[0]?.id).toBe("tmux:workspace:0");
+    expect(result.entry.id).toBe(result.activeEntryId);
+    expect(result.entries[1]?.id).toBe(result.activeEntryId);
+    expect(result.entry.isNew).toBe(true);
+    expect(result.entry.sessionId?.startsWith("workspace:mobile:")).toBe(true);
+    expect(resolveActiveTerminalEntry(result.entries, result.activeEntryId)?.id).toBe(result.activeEntryId);
+  });
+
+  test("createLocalTerminalEntry uses sequential terminal labels", () => {
+    const first = createLocalTerminalEntry("workspace", []);
+    const second = createLocalTerminalEntry("workspace", [first]);
+    expect(first.label).toBe("Terminal 1");
+    expect(second.label).toBe("Terminal 2");
+    expect(first.id).not.toBe(second.id);
+  });
+
+  test("terminalTabLabel prefers osc/dynamic titles and truncates long names", () => {
+    expect(terminalTabLabel({ label: "Fallback" })).toBe("Fallback");
+    expect(terminalTabLabel({ label: "Fallback", dynamicTitle: "npm test" })).toBe("npm test");
+    expect(terminalTabLabel({ label: "Fallback", dynamicTitle: "npm test", oscTitle: "zsh" })).toBe("zsh");
+    const long = "a-very-long-terminal-window-title-that-needs-trim";
+    expect(terminalTabLabel({ label: long }).endsWith("…")).toBe(true);
+    expect(terminalTabLabel({ label: long }).length).toBeLessThanOrEqual(22);
   });
 });

--- a/apps/mobile/src/features/terminal/terminal-selection.ts
+++ b/apps/mobile/src/features/terminal/terminal-selection.ts
@@ -17,6 +17,44 @@ export function createDefaultTerminalEntry(workspaceId: string): MobileTerminalE
   };
 }
 
+/** Local mobile terminal tab (not from server candidates). Becomes active after append. */
+export function createLocalTerminalEntry(
+  workspaceId: string,
+  existingEntries: MobileTerminalEntry[],
+): MobileTerminalEntry {
+  return {
+    id: `${workspaceId}:mobile-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+    workspaceId,
+    label: `Terminal ${existingEntries.length + 1}`,
+    sessionId: createMobileTerminalSessionId(workspaceId),
+    isNew: true,
+  };
+}
+
+/**
+ * Append a local terminal and select it. Pure helper for the flat multi-tab model:
+ * server candidates stay as discrete tabs; new tabs append and become active.
+ */
+export function appendLocalTerminalEntry(
+  workspaceId: string,
+  existingEntries: MobileTerminalEntry[],
+): { activeEntryId: string; entries: MobileTerminalEntry[]; entry: MobileTerminalEntry } {
+  const entry = createLocalTerminalEntry(workspaceId, existingEntries);
+  return {
+    activeEntryId: entry.id,
+    entries: [...existingEntries, entry],
+    entry,
+  };
+}
+
+/** Short label for the top tab strip (keeps chrome compact). */
+export function terminalTabLabel(entry: Pick<MobileTerminalEntry, "dynamicTitle" | "label" | "oscTitle">): string {
+  const raw = (entry.oscTitle ?? entry.dynamicTitle ?? entry.label).trim();
+  if (!raw) return "Terminal";
+  if (raw.length <= 22) return raw;
+  return `${raw.slice(0, 20)}…`;
+}
+
 export function mergeTerminalCandidateEntries(
   workspaceId: string,
   candidates: TerminalWorkspaceCandidate[],

--- a/apps/mobile/src/features/terminal/terminal-selection.ts
+++ b/apps/mobile/src/features/terminal/terminal-selection.ts
@@ -1,8 +1,33 @@
 import type { TerminalWorkspaceCandidate } from "@/api/types";
 import type { MobileTerminalEntry } from "@/stores/terminal-store";
 
+/** Cryptographically strong short id fragment (avoids Math.random for session ids). */
+function randomIdFragment(length: number): string {
+  const bytes = new Uint8Array(length);
+  globalThis.crypto.getRandomValues(bytes);
+  let out = "";
+  for (const byte of bytes) {
+    out += (byte % 36).toString(36);
+  }
+  return out;
+}
+
+/**
+ * Shell host/cwd OSC titles that crowd the tab strip without identifying work.
+ * Keep this local so pure selection helpers stay free of shared title deps.
+ */
+function isLikelyNoisyOscTitle(title: string): boolean {
+  const t = title.trim();
+  if (!t) return true;
+  // user@host:path / user@host:~ forms from common shells
+  if (/^[^@\s]+@[^:\s]+:/.test(t)) return true;
+  // Bare shell process names
+  if (/^(?:zsh|bash|sh|fish|nu|csh|tcsh|ksh)$/i.test(t)) return true;
+  return false;
+}
+
 export function createMobileTerminalSessionId(workspaceId: string) {
-  const suffix = Math.random().toString(36).slice(2, 10);
+  const suffix = randomIdFragment(8);
   return `${workspaceId}:mobile:${Date.now().toString(36)}:${suffix}`;
 }
 
@@ -23,7 +48,7 @@ export function createLocalTerminalEntry(
   existingEntries: MobileTerminalEntry[],
 ): MobileTerminalEntry {
   return {
-    id: `${workspaceId}:mobile-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+    id: `${workspaceId}:mobile-${Date.now()}-${randomIdFragment(5)}`,
     workspaceId,
     label: `Terminal ${existingEntries.length + 1}`,
     sessionId: createMobileTerminalSessionId(workspaceId),
@@ -47,10 +72,19 @@ export function appendLocalTerminalEntry(
   };
 }
 
-/** Short label for the top tab strip (keeps chrome compact). */
+/**
+ * Short label for the top tab strip (keeps chrome compact).
+ * Prefer the dynamic command title; only surface OSC when it is non-empty and
+ * not shell host/cwd noise. Empty strings must not block fallbacks (`??` alone
+ * treats `""` as present).
+ */
 export function terminalTabLabel(entry: Pick<MobileTerminalEntry, "dynamicTitle" | "label" | "oscTitle">): string {
-  const raw = (entry.oscTitle ?? entry.dynamicTitle ?? entry.label).trim();
-  if (!raw) return "Terminal";
+  const osc = entry.oscTitle?.trim() ?? "";
+  const usableOsc = osc && !isLikelyNoisyOscTitle(osc) ? osc : "";
+  const raw =
+    [entry.dynamicTitle, usableOsc, entry.label]
+      .map((value) => value?.trim())
+      .find((value) => value) ?? "Terminal";
   if (raw.length <= 22) return raw;
   return `${raw.slice(0, 20)}…`;
 }


### PR DESCRIPTION
## Summary

Finishes the basic mobile path for multi-terminal workspaces: computer/server terminal candidates (including anything that would be split panes on desktop) are exposed as a **flat, horizontally scrollable tab strip at the top** of the workspace terminal surface. Exactly one terminal renderer is active at a time; **New terminal** adds a tab and selects it. Auth/pair → computers → projects/workspaces listing and create-workspace remain on the existing routes (no second product model).

Key pieces:
- `TerminalTabStrip` — top tabs (+ new), iOS glass chrome
- Pure helpers: `createLocalTerminalEntry`, `appendLocalTerminalEntry`, `terminalTabLabel`
- Unit coverage for flatten/select/new-active/label

## Related Issue

APP-025 mobile basic flow (terminal multi-tab UX).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] Additional checks (describe below)

```bash
bun --filter @atmos/mobile test
# 57 pass, 0 fail

bun --filter @atmos/mobile typecheck
# exit 0
```

Native iOS sim launch not available in this environment (no `apps/mobile/ios` prebuild). Static structure checks confirm top tab strip, single WebView, onboarding login/QR, computer list, workspace list/create routes.

## Checklist

- [ ] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a flat, horizontally scrollable terminal tab strip at the top of the mobile workspace to support multiple terminals. New terminals append as tabs and are selected immediately. Supports APP-025 (mobile basic flow for multi-terminal UX).

- **Bug Fixes**
  - Generate local terminal session and entry IDs with `crypto.getRandomValues`.
  - Tab labels prefer dynamic command titles, ignore noisy OSC titles, and truncate if too long.
  - Active tab reliably scrolls into view after tab or viewport layout.

<sup>Written for commit fa6da1a876350f7583c5982a14b4d038608a89b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added terminal tabs for viewing, selecting, and creating local terminals.
  * Terminal tabs display meaningful titles, including dynamic and OSC-provided names.
  * Active tabs automatically remain visible, with accessible labels and responsive light/dark styling.
  * Added platform-specific tab presentation for iOS and Android.
* **Bug Fixes**
  * Improved terminal guidance to reference the new tab interface.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->