### PR TITLE
feat(core-service): base attention summary on terminal transcript

### DIFF
--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -300,6 +300,7 @@ async fn register_idle_session_cleanup_job(
 async fn register_attention_summary_job(
     jobs: Arc<LocalScheduler>,
     agent_hooks_service: Arc<core_service::AgentHooksService>,
+    terminal_service: Arc<core_service::TerminalService>,
 ) {
     if let Err(error) = jobs
         .set_interval_job(
@@ -313,8 +314,9 @@ async fn register_attention_summary_job(
             RetryPolicy::none(),
             move || {
                 let agent_hooks_service = Arc::clone(&agent_hooks_service);
+                let terminal_service = Arc::clone(&terminal_service);
                 async move {
-                    tick_attention_auto_summary(agent_hooks_service).await;
+                    tick_attention_auto_summary(agent_hooks_service, terminal_service).await;
                     Ok(())
                 }
             },
@@ -328,7 +330,10 @@ async fn register_attention_summary_job(
     }
 }
 
-async fn tick_attention_auto_summary(agent_hooks_service: Arc<core_service::AgentHooksService>) {
+async fn tick_attention_auto_summary(
+    agent_hooks_service: Arc<core_service::AgentHooksService>,
+    terminal_service: Arc<core_service::TerminalService>,
+) {
     let settings = read_attention_summary_settings();
     if !settings.enabled {
         return;
@@ -344,9 +349,16 @@ async fn tick_attention_auto_summary(agent_hooks_service: Arc<core_service::Agen
             continue;
         };
         let service = Arc::clone(&agent_hooks_service);
+        let terminal = Arc::clone(&terminal_service);
         let settings = settings.clone();
         tokio::spawn(async move {
-            match core_service::generate_attention_summary(&latch, &settings).await {
+            match core_service::generate_attention_summary(
+                &latch,
+                &settings,
+                Some(terminal.as_ref()),
+            )
+            .await
+            {
                 Ok(payload) => {
                     let _ = service.complete_attention_summary(
                         &latch.stable_pane_id,
@@ -807,6 +819,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let project_service_for_startup = Arc::clone(&app_state.project_service);
     let agent_hooks_for_startup = Arc::clone(&app_state.agent_hooks_service);
+    let terminal_service_for_startup = Arc::clone(&app_state.terminal_service);
 
     let mut app = Router::new()
         .route("/healthz", get(|| async { StatusCode::OK }))
@@ -884,7 +897,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     register_idle_session_cleanup_job(Arc::clone(&jobs), Arc::clone(&agent_hooks_for_startup))
         .await;
-    register_attention_summary_job(Arc::clone(&jobs), agent_hooks_for_startup).await;
+    register_attention_summary_job(
+        Arc::clone(&jobs),
+        agent_hooks_for_startup,
+        terminal_service_for_startup,
+    )
+    .await;
 
     // Serve with graceful shutdown — ensures PTY resources are cleaned up
     // when the process receives SIGTERM/SIGINT (e.g., during hot-reload).

--- a/crates/core-service/src/lib.rs
+++ b/crates/core-service/src/lib.rs
@@ -56,10 +56,11 @@ pub use service::notification::NotificationService;
 pub use service::project::ProjectService;
 pub use service::review::ReviewService;
 pub use service::terminal::{
-    AttachSessionParams, CaptureSideContextParams, CapturedSideContext, CreateSessionParams,
-    CreateSimpleSessionParams, SessionDetail, SessionType, TerminalKind, TerminalMessage,
-    TerminalResponse, TerminalService, TerminalSideChatRecord, TerminalSideChatStatus,
-    UpsertTerminalSideChatParams,
+    AttachSessionParams, CapturePanePlainTextParams, CaptureSideContextParams,
+    CapturedPanePlainText, CapturedSideContext, CreateSessionParams, CreateSimpleSessionParams,
+    SessionDetail, SessionType, TerminalKind, TerminalMessage, TerminalResponse, TerminalService,
+    TerminalSideChatRecord, TerminalSideChatStatus, TranscriptBudget, UpsertTerminalSideChatParams,
+    process_captured_pane_text, select_transcript, strip_ansi_and_controls,
 };
 pub use service::terminal_overview::build_terminal_overview_active_sessions_json;
 pub use service::test::TestService;

--- a/crates/core-service/src/service/agent_hooks/attention_summary_generate.rs
+++ b/crates/core-service/src/service/agent_hooks/attention_summary_generate.rs
@@ -2,7 +2,12 @@
 //!
 //! Spawns a one-shot agent-cli (preferred, same path as automations) or falls
 //! back to the default LLM provider. Never attaches to the original pane.
+//!
+//! Primary context is the pane's plain terminal transcript (same capture path
+//! as `/side` and `/spawn`). Optional supplement: relative paths of changed
+//! files in the project (no diffs).
 
+use std::collections::BTreeSet;
 use std::path::Path;
 use std::process::Command;
 use std::time::Duration;
@@ -17,14 +22,27 @@ use super::AgentAttentionLatch;
 use crate::error::{Result, ServiceError};
 use crate::service::automation::{resolve_automation_agent_with_config, AutomationAgentRunConfig};
 use crate::service::llm_text_generation::generate_text;
+use crate::service::terminal::{
+    CapturePanePlainTextParams, TerminalService, TranscriptBudget,
+};
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(180);
-const MAX_CONTEXT_CHARS: usize = 12_000;
+const MAX_TERMINAL_CONTEXT_BYTES: u32 = 12_000;
+const MAX_CHANGED_FILES: usize = 80;
+const MAX_CHANGED_FILES_SECTION_CHARS: usize = 2_000;
 const GIT_TIMEOUT: Duration = Duration::from_secs(8);
+/// Attention captures: fewer lines than side chat; recent turn is enough.
+const ATTENTION_CAPTURE_APPROX_LINES: i32 = 4_000;
+const ATTENTION_MAX_RAW_BYTES: usize = 64_000;
 
 const SYSTEM_PROMPT: &str = r#"You are Atmos attention-summary helper.
-A coding agent finished a turn and the user has not acknowledged it yet.
-Summarize what was recently done and suggest concise next steps.
+An agent finished a turn in a terminal and the user has not acknowledged it yet.
+Summarize what the agent recently did in that terminal session and suggest concise next steps.
+
+Primary evidence is the terminal transcript (conversation + command output).
+Changed file paths are optional signals only — do not invent work from them alone.
+The user may not be coding; summarize whatever the transcript shows (Q&A, debug, shell work, etc.).
+
 Respond with ONLY a single JSON object (no markdown fences) matching:
 {
   "summary": "one sentence",
@@ -32,24 +50,22 @@ Respond with ONLY a single JSON object (no markdown fences) matching:
   "can_close_session": true
 }
 Rules:
-- summary: one clear sentence about recent work (max ~160 chars).
-- next_steps: 2-4 short imperative actions the user might take next.
+- summary: one clear sentence about what happened in the recent terminal turn (max ~160 chars).
+- next_steps: 2-4 short imperative actions the user might take next, grounded in the transcript.
 - can_close_session: true only if work looks complete with no obvious unfinished blockers.
 - Prefer the user's language if the context is clearly non-English; otherwise English.
+- Do not invent file edits, commits, or outcomes not supported by the transcript or file list.
 "#;
 
 /// Run headless summary generation for a sticky task-complete latch.
 pub async fn generate_attention_summary(
     latch: &AgentAttentionLatch,
     settings: &AttentionSummarySettings,
+    terminal: Option<&TerminalService>,
 ) -> Result<AttentionSummaryPayload> {
-    // Git status/log/diff use std::process — keep them off the Tokio worker.
-    let latch_for_context = latch.clone();
-    let context = tokio::task::spawn_blocking(move || build_context_block(&latch_for_context))
-        .await
-        .unwrap_or_default();
+    let context = build_context_block(latch, terminal).await;
     let prompt = format!(
-        "Pane: {}\nSession: {}\nTool: {}\nRaised at: {}\nProject: {}\n\nRecent work context:\n{}",
+        "Pane: {}\nSession: {}\nTool: {}\nRaised at: {}\nProject: {}\n\n{}",
         latch.stable_pane_id,
         latch.session_id,
         latch
@@ -62,7 +78,7 @@ pub async fn generate_attention_summary(
             .as_deref()
             .unwrap_or("(unknown project path)"),
         if context.trim().is_empty() {
-            "(no git/terminal context available — infer cautiously)"
+            "(no terminal transcript or changed-file list available — infer cautiously)"
         } else {
             context.as_str()
         }
@@ -144,40 +160,136 @@ fn resolve_summary_provider(settings: &AttentionSummarySettings) -> Result<Resol
     Ok(provider)
 }
 
-fn build_context_block(latch: &AgentAttentionLatch) -> String {
-    let Some(project_path) = latch
+async fn build_context_block(
+    latch: &AgentAttentionLatch,
+    terminal: Option<&TerminalService>,
+) -> String {
+    let mut sections = Vec::new();
+
+    if let Some(text) = capture_terminal_transcript(latch, terminal).await {
+        if !text.trim().is_empty() {
+            sections.push(format!("## Terminal transcript\n{text}"));
+        }
+    }
+
+    let project_path = latch
         .project_path
         .as_deref()
         .map(str::trim)
         .filter(|s| !s.is_empty())
-    else {
-        return String::new();
-    };
-    let path = Path::new(project_path);
-    if !path.is_dir() {
-        return format!("Project path is not a directory: {project_path}");
-    }
+        .map(Path::new)
+        .filter(|p| p.is_dir());
 
-    let mut sections = Vec::new();
-
-    if let Some(status) = run_git_capture(path, &["status", "--short", "--branch"]) {
-        if !status.trim().is_empty() {
-            sections.push(format!("## git status\n{}", trim_chars(&status, 4_000)));
-        }
-    }
-    if let Some(log) = run_git_capture(path, &["log", "-8", "--oneline", "--decorate"]) {
-        if !log.trim().is_empty() {
-            sections.push(format!("## recent commits\n{}", trim_chars(&log, 2_000)));
-        }
-    }
-    if let Some(diff) = run_git_capture(path, &["diff", "--stat", "HEAD"]) {
-        if !diff.trim().is_empty() {
-            sections.push(format!("## diff stat\n{}", trim_chars(&diff, 3_000)));
+    if let Some(path) = project_path {
+        let path_buf = path.to_path_buf();
+        let files = tokio::task::spawn_blocking(move || list_changed_relative_paths(&path_buf))
+            .await
+            .unwrap_or_default();
+        if !files.is_empty() {
+            let list = format_changed_files(&files);
+            sections.push(format!("## Changed files (relative paths)\n{list}"));
         }
     }
 
-    let joined = sections.join("\n\n");
-    trim_chars(&joined, MAX_CONTEXT_CHARS)
+    sections.join("\n\n")
+}
+
+async fn capture_terminal_transcript(
+    latch: &AgentAttentionLatch,
+    terminal: Option<&TerminalService>,
+) -> Option<String> {
+    let terminal = terminal?;
+    let workspace_id = latch.context_id.trim();
+    if workspace_id.is_empty() {
+        return None;
+    }
+    let window_name = tmux_window_name_from_latch(latch)?;
+    let budget = TranscriptBudget::attention_summary(MAX_TERMINAL_CONTEXT_BYTES as usize);
+
+    match terminal
+        .capture_pane_plain_text(CapturePanePlainTextParams {
+            workspace_id: workspace_id.to_string(),
+            project_name: None,
+            workspace_name: None,
+            source_session_id: None,
+            source_tmux_window_name: window_name.to_string(),
+            max_text_bytes: Some(MAX_TERMINAL_CONTEXT_BYTES),
+            approx_lines: Some(ATTENTION_CAPTURE_APPROX_LINES),
+            max_raw_bytes: Some(ATTENTION_MAX_RAW_BYTES),
+            head_prefix_bytes: Some(budget.head_prefix_bytes),
+        })
+        .await
+    {
+        Ok(captured) => {
+            if captured.text.trim().is_empty() {
+                None
+            } else {
+                Some(captured.text)
+            }
+        }
+        Err(error) => {
+            warn!(
+                pane = %latch.stable_pane_id,
+                window = %window_name,
+                "Attention summary terminal capture failed: {error}"
+            );
+            None
+        }
+    }
+}
+
+/// `stable_pane_id` is `{context_id}:{tmux_window_name}`.
+fn tmux_window_name_from_latch(latch: &AgentAttentionLatch) -> Option<&str> {
+    let id = latch.stable_pane_id.trim();
+    let (_ctx, window) = id.split_once(':')?;
+    let window = window.trim();
+    if window.is_empty() {
+        None
+    } else {
+        Some(window)
+    }
+}
+
+/// Relative paths only — no diffs, no status codes, no commit log.
+fn list_changed_relative_paths(project_path: &Path) -> Vec<String> {
+    let mut paths = BTreeSet::new();
+
+    // Tracked + staged + unstaged vs HEAD.
+    if let Some(out) = run_git_capture(project_path, &["diff", "--name-only", "HEAD"]) {
+        for line in out.lines() {
+            let path = line.trim();
+            if !path.is_empty() {
+                paths.insert(path.to_string());
+            }
+        }
+    }
+    // Untracked files.
+    if let Some(out) = run_git_capture(
+        project_path,
+        &["ls-files", "--others", "--exclude-standard"],
+    ) {
+        for line in out.lines() {
+            let path = line.trim();
+            if !path.is_empty() {
+                paths.insert(path.to_string());
+            }
+        }
+    }
+
+    paths.into_iter().take(MAX_CHANGED_FILES).collect()
+}
+
+fn format_changed_files(files: &[String]) -> String {
+    let mut out = String::new();
+    for path in files {
+        let line = format!("- {path}\n");
+        if out.len() + line.len() > MAX_CHANGED_FILES_SECTION_CHARS {
+            out.push_str("- … (truncated)\n");
+            break;
+        }
+        out.push_str(&line);
+    }
+    out
 }
 
 fn run_git_capture(cwd: &Path, args: &[&str]) -> Option<String> {
@@ -332,5 +444,27 @@ mod tests {
     fn parse_rejects_missing_summary() {
         let err = parse_summary_payload(r#"{"next_steps":["x"]}"#).unwrap_err();
         assert!(err.to_string().contains("summary"));
+    }
+
+    #[test]
+    fn window_name_from_stable_pane() {
+        let latch = AgentAttentionLatch {
+            stable_pane_id: "ws-guid:main".into(),
+            context_id: "ws-guid".into(),
+            reason: super::super::AgentAttentionReason::TaskComplete,
+            session_id: "s1".into(),
+            tool: None,
+            project_path: None,
+            raised_at: "t".into(),
+        };
+        assert_eq!(tmux_window_name_from_latch(&latch), Some("main"));
+    }
+
+    #[test]
+    fn format_changed_files_lists_paths() {
+        let text = format_changed_files(&["src/a.rs".into(), "README.md".into()]);
+        assert!(text.contains("- src/a.rs"));
+        assert!(text.contains("- README.md"));
+        assert!(!text.contains("diff"));
     }
 }

--- a/crates/core-service/src/service/agent_hooks/attention_summary_generate.rs
+++ b/crates/core-service/src/service/agent_hooks/attention_summary_generate.rs
@@ -13,7 +13,8 @@ use std::process::Command;
 use std::time::Duration;
 
 use llm::{
-    FileLlmConfigStore, GenerateTextRequest, ProviderKind, ResolvedLlmProvider, ResponseFormat,
+    render_prompt_template, FileLlmConfigStore, GenerateTextRequest, ProviderKind,
+    ResolvedLlmProvider, ResponseFormat,
 };
 use tracing::{info, warn};
 
@@ -35,27 +36,13 @@ const GIT_TIMEOUT: Duration = Duration::from_secs(8);
 const ATTENTION_CAPTURE_APPROX_LINES: i32 = 4_000;
 const ATTENTION_MAX_RAW_BYTES: usize = 64_000;
 
-const SYSTEM_PROMPT: &str = r#"You are Atmos attention-summary helper.
-An agent finished a turn in a terminal and the user has not acknowledged it yet.
-Summarize what the agent recently did in that terminal session and suggest concise next steps.
+const SYSTEM_PROMPT_TEMPLATE: &str =
+    include_str!("../../../../../prompt/attention-summary/attention-summary-system.md");
+const USER_PROMPT_TEMPLATE: &str =
+    include_str!("../../../../../prompt/attention-summary/attention-summary-user.md");
 
-Primary evidence is the terminal transcript (conversation + command output).
-Changed file paths are optional signals only — do not invent work from them alone.
-The user may not be coding; summarize whatever the transcript shows (Q&A, debug, shell work, etc.).
-
-Respond with ONLY a single JSON object (no markdown fences) matching:
-{
-  "summary": "one sentence",
-  "next_steps": ["short action 1", "short action 2"],
-  "can_close_session": true
-}
-Rules:
-- summary: one clear sentence about what happened in the recent terminal turn (max ~160 chars).
-- next_steps: 2-4 short imperative actions the user might take next, grounded in the transcript.
-- can_close_session: true only if work looks complete with no obvious unfinished blockers.
-- Prefer the user's language if the context is clearly non-English; otherwise English.
-- Do not invent file edits, commits, or outcomes not supported by the transcript or file list.
-"#;
+const EMPTY_CONTEXT_FALLBACK: &str =
+    "(no terminal transcript or changed-file list available — infer cautiously)";
 
 /// Run headless summary generation for a sticky task-complete latch.
 pub async fn generate_attention_summary(
@@ -64,25 +51,31 @@ pub async fn generate_attention_summary(
     terminal: Option<&TerminalService>,
 ) -> Result<AttentionSummaryPayload> {
     let context = build_context_block(latch, terminal).await;
-    let prompt = format!(
-        "Pane: {}\nSession: {}\nTool: {}\nRaised at: {}\nProject: {}\n\n{}",
-        latch.stable_pane_id,
-        latch.session_id,
-        latch
-            .tool
-            .map(|t| t.to_string())
-            .unwrap_or_else(|| "unknown".into()),
-        latch.raised_at,
-        latch
-            .project_path
-            .as_deref()
-            .unwrap_or("(unknown project path)"),
-        if context.trim().is_empty() {
-            "(no terminal transcript or changed-file list available — infer cautiously)"
-        } else {
-            context.as_str()
-        }
+    let tool = latch
+        .tool
+        .map(|t| t.to_string())
+        .unwrap_or_else(|| "unknown".into());
+    let project_path = latch
+        .project_path
+        .as_deref()
+        .unwrap_or("(unknown project path)");
+    let context_body = if context.trim().is_empty() {
+        EMPTY_CONTEXT_FALLBACK
+    } else {
+        context.as_str()
+    };
+    let prompt = render_prompt_template(
+        USER_PROMPT_TEMPLATE,
+        &[
+            ("stable_pane_id", latch.stable_pane_id.as_str()),
+            ("session_id", latch.session_id.as_str()),
+            ("tool", tool.as_str()),
+            ("raised_at", latch.raised_at.as_str()),
+            ("project_path", project_path),
+            ("context", context_body),
+        ],
     );
+    let system = SYSTEM_PROMPT_TEMPLATE.trim().to_string();
 
     let provider = resolve_summary_provider(settings)?;
     info!(
@@ -94,7 +87,7 @@ pub async fn generate_attention_summary(
     );
 
     let request = GenerateTextRequest {
-        system: Some(SYSTEM_PROMPT.to_string()),
+        system: Some(system),
         prompt,
         temperature: Some(0.2),
         max_output_tokens: Some(provider.max_output_tokens.unwrap_or(1024).min(2048)),
@@ -466,5 +459,27 @@ mod tests {
         assert!(text.contains("- src/a.rs"));
         assert!(text.contains("- README.md"));
         assert!(!text.contains("diff"));
+    }
+
+    #[test]
+    fn prompt_templates_render_with_placeholders() {
+        assert!(SYSTEM_PROMPT_TEMPLATE.contains("attention-summary helper"));
+        assert!(SYSTEM_PROMPT_TEMPLATE.contains("can_close_session"));
+
+        let rendered = render_prompt_template(
+            USER_PROMPT_TEMPLATE,
+            &[
+                ("stable_pane_id", "ws:main"),
+                ("session_id", "sess-1"),
+                ("tool", "claude-code"),
+                ("raised_at", "t0"),
+                ("project_path", "/tmp/proj"),
+                ("context", "## Terminal transcript\nhello"),
+            ],
+        );
+        assert!(rendered.contains("Pane: ws:main"));
+        assert!(rendered.contains("Tool: claude-code"));
+        assert!(rendered.contains("## Terminal transcript\nhello"));
+        assert!(!rendered.contains("${"));
     }
 }

--- a/crates/core-service/src/service/terminal.rs
+++ b/crates/core-service/src/service/terminal.rs
@@ -24,16 +24,21 @@ mod management;
 mod mouse_mode_watch;
 mod run_log_tee;
 mod runtime;
+mod text_capture;
 mod types;
 
 use mouse_mode_watch::{pane_watch_key, MouseModeWatchRegistry};
 use run_log_tee::is_run_window_name as run_window_name_matches;
 pub use run_log_tee::{is_run_window_name, latest_log_path, RunLogTee};
 use runtime::{run_control_mode_tmux_session, run_simple_pty_session};
+pub use text_capture::{
+    process_captured_pane_text, select_transcript, strip_ansi_and_controls, TranscriptBudget,
+};
 pub use types::{
-    AttachSessionParams, CaptureSideContextParams, CapturedSideContext, CreateSessionParams,
-    CreateSimpleSessionParams, SessionDetail, SessionType, TerminalKind, TerminalMessage,
-    TerminalResponse, TerminalSideChatRecord, TerminalSideChatStatus, UpsertTerminalSideChatParams,
+    AttachSessionParams, CapturePanePlainTextParams, CaptureSideContextParams,
+    CapturedPanePlainText, CapturedSideContext, CreateSessionParams, CreateSimpleSessionParams,
+    SessionDetail, SessionType, TerminalKind, TerminalMessage, TerminalResponse,
+    TerminalSideChatRecord, TerminalSideChatStatus, UpsertTerminalSideChatParams,
 };
 use types::{SessionCommand, SessionHandle};
 

--- a/crates/core-service/src/service/terminal/management.rs
+++ b/crates/core-service/src/service/terminal/management.rs
@@ -9,24 +9,26 @@ use tracing::{debug, info, warn};
 use crate::error::{Result, ServiceError};
 
 use super::runtime::apply_utf8_env_to_tmux_command;
+use super::text_capture::{
+    count_lines, process_captured_pane_text, DEFAULT_CAPTURE_APPROX_LINES,
+    DEFAULT_HEAD_PREFIX_BYTES, DEFAULT_MAX_RAW_CAPTURE_BYTES, DEFAULT_PROMPT_BUDGET_BYTES,
+    MAX_PROMPT_BUDGET_BYTES, MIN_PROMPT_BUDGET_BYTES, TranscriptBudget,
+};
 use super::{
-    CaptureSideContextParams, CapturedSideContext, SessionCommand, SessionDetail, SessionHandle,
-    TerminalService, TerminalSideChatRecord, TerminalSideChatStatus, UpsertTerminalSideChatParams,
+    CapturePanePlainTextParams, CaptureSideContextParams, CapturedPanePlainText,
+    CapturedSideContext, SessionCommand, SessionDetail, SessionHandle, TerminalService,
+    TerminalSideChatRecord, TerminalSideChatStatus, UpsertTerminalSideChatParams,
 };
 
-const DEFAULT_SIDE_PROMPT_BYTES: usize = 98_304;
-const MIN_SIDE_PROMPT_BYTES: usize = 8_192;
-const MAX_SIDE_PROMPT_BYTES: usize = 131_072;
-const RAW_SIDE_CAPTURE_BYTES: usize = 524_288;
-const SIDE_CAPTURE_APPROX_LINES: i32 = 12_000;
-const SIDE_CONTEXT_PREFIX_BYTES: usize = 8_192;
-
 impl TerminalService {
-    /// Capture bounded plain tmux text for `/side` prompt construction.
-    pub async fn capture_side_context(
+    /// Capture bounded plain tmux text for any consumer (side chat, /spawn, attention, …).
+    ///
+    /// Uses `capture-pane` without `-e` (cells, not SGR), then strips residual ANSI and
+    /// windows the transcript to the requested byte budget.
+    pub async fn capture_pane_plain_text(
         &self,
-        params: CaptureSideContextParams,
-    ) -> Result<CapturedSideContext> {
+        params: CapturePanePlainTextParams,
+    ) -> Result<CapturedPanePlainText> {
         let workspace_id = params.workspace_id.trim().to_string();
         if workspace_id.is_empty() {
             return Err(ServiceError::Validation("workspace_id is required".into()));
@@ -39,11 +41,27 @@ impl TerminalService {
             ));
         }
 
-        let prompt_budget_bytes = params
-            .max_prompt_bytes
+        // Generic API: soft bounds only. Side-chat wrapper applies the stricter 8k–128k clamp.
+        let text_budget_bytes = params
+            .max_text_bytes
             .map(|value| value as usize)
-            .unwrap_or(DEFAULT_SIDE_PROMPT_BYTES)
-            .clamp(MIN_SIDE_PROMPT_BYTES, MAX_SIDE_PROMPT_BYTES);
+            .unwrap_or(DEFAULT_PROMPT_BUDGET_BYTES)
+            .clamp(1, MAX_PROMPT_BUDGET_BYTES);
+        let approx_lines = params
+            .approx_lines
+            .unwrap_or(DEFAULT_CAPTURE_APPROX_LINES)
+            .clamp(1, 50_000);
+        let max_raw_bytes = params
+            .max_raw_bytes
+            .unwrap_or(DEFAULT_MAX_RAW_CAPTURE_BYTES)
+            .max(text_budget_bytes);
+        let head_prefix_bytes = params
+            .head_prefix_bytes
+            .unwrap_or(DEFAULT_HEAD_PREFIX_BYTES);
+        let budget = TranscriptBudget {
+            max_text_bytes: text_budget_bytes,
+            head_prefix_bytes,
+        };
 
         let primary_tmux_session = self
             .resolve_tmux_session_name(
@@ -75,21 +93,14 @@ impl TerminalService {
                 )?
             };
 
-        let raw_full = self.tmux_engine.capture_pane_text(
-            &tmux_session,
-            tmux_window_index,
-            SIDE_CAPTURE_APPROX_LINES,
-        )?;
-        let omitted_older_bytes = raw_full.len().saturating_sub(RAW_SIDE_CAPTURE_BYTES);
-        let raw = byte_suffix(&raw_full, RAW_SIDE_CAPTURE_BYTES);
-        let captured_lines = count_lines(&raw);
-        let mut selected = select_side_context_text(&raw, prompt_budget_bytes);
-        selected.omitted_older_bytes = selected
-            .omitted_older_bytes
-            .saturating_add(omitted_older_bytes);
+        let raw_full =
+            self.tmux_engine
+                .capture_pane_text(&tmux_session, tmux_window_index, approx_lines)?;
+        let selected = process_captured_pane_text(&raw_full, max_raw_bytes, budget);
+        let captured_lines = count_lines(&selected.text);
         let captured_bytes = selected.text.len();
 
-        Ok(CapturedSideContext {
+        Ok(CapturedPanePlainText {
             workspace_id,
             project_name: params.project_name,
             workspace_name: params.workspace_name,
@@ -98,12 +109,41 @@ impl TerminalService {
             tmux_window_index,
             captured_lines,
             captured_bytes: captured_bytes as u32,
-            prompt_budget_bytes: prompt_budget_bytes as u32,
+            text_budget_bytes: text_budget_bytes as u32,
             omitted_older_bytes: selected.omitted_older_bytes as u32,
             omitted_middle_bytes: selected.omitted_middle_bytes as u32,
-            truncated_bytes: selected.truncated_bytes,
+            truncated_bytes: selected.truncated,
             text: selected.text,
         })
+    }
+
+    /// Capture bounded plain tmux text for `/side` and `/spawn` prompt construction.
+    ///
+    /// Thin wrapper over [`Self::capture_pane_plain_text`] with side-chat budgets.
+    pub async fn capture_side_context(
+        &self,
+        params: CaptureSideContextParams,
+    ) -> Result<CapturedSideContext> {
+        let max_prompt_bytes = params
+            .max_prompt_bytes
+            .map(|value| value as usize)
+            .unwrap_or(DEFAULT_PROMPT_BUDGET_BYTES)
+            .clamp(MIN_PROMPT_BUDGET_BYTES, MAX_PROMPT_BUDGET_BYTES)
+            as u32;
+        let captured = self
+            .capture_pane_plain_text(CapturePanePlainTextParams {
+                workspace_id: params.workspace_id,
+                project_name: params.project_name,
+                workspace_name: params.workspace_name,
+                source_session_id: params.source_session_id,
+                source_tmux_window_name: params.source_tmux_window_name,
+                max_text_bytes: Some(max_prompt_bytes),
+                approx_lines: None,
+                max_raw_bytes: None,
+                head_prefix_bytes: None,
+            })
+            .await?;
+        Ok(captured.into())
     }
 
     async fn resolve_active_session_capture_target(
@@ -1016,13 +1056,6 @@ struct LiveSideChatWindow {
     metadata: TmuxWindowAtmosMetadata,
 }
 
-struct SelectedSideContextText {
-    text: String,
-    omitted_older_bytes: usize,
-    omitted_middle_bytes: usize,
-    truncated_bytes: bool,
-}
-
 fn model_to_side_chat_record(model: terminal_side_chat::Model) -> Result<TerminalSideChatRecord> {
     let status = TerminalSideChatStatus::try_from(model.status.as_str())
         .map_err(ServiceError::Validation)?;
@@ -1069,74 +1102,6 @@ fn validate_bright_color(value: &str) -> Result<()> {
         ));
     }
     Ok(())
-}
-
-fn count_lines(text: &str) -> u32 {
-    if text.is_empty() {
-        0
-    } else {
-        text.matches('\n').count() as u32 + 1
-    }
-}
-
-fn select_side_context_text(text: &str, budget: usize) -> SelectedSideContextText {
-    if text.len() <= budget {
-        return SelectedSideContextText {
-            text: text.to_string(),
-            omitted_older_bytes: 0,
-            omitted_middle_bytes: 0,
-            truncated_bytes: false,
-        };
-    }
-
-    let marker_overhead = 128usize;
-    let prefix_budget = SIDE_CONTEXT_PREFIX_BYTES.min(budget / 4).max(1024);
-    let tail_budget = budget
-        .saturating_sub(prefix_budget + marker_overhead)
-        .max(1024);
-    let prefix = byte_prefix(text, prefix_budget);
-    let tail = byte_suffix(text, tail_budget);
-    let omitted_middle_bytes = text
-        .len()
-        .saturating_sub(prefix.len())
-        .saturating_sub(tail.len());
-    let marker = format!(
-        "\n\n[... omitted {} bytes from the middle of the terminal transcript ...]\n\n",
-        omitted_middle_bytes
-    );
-    let mut selected = format!("{prefix}{marker}{tail}");
-    if selected.len() > budget {
-        selected = byte_suffix(&selected, budget);
-    }
-
-    SelectedSideContextText {
-        text: selected,
-        omitted_older_bytes: 0,
-        omitted_middle_bytes,
-        truncated_bytes: true,
-    }
-}
-
-fn byte_prefix(text: &str, max_bytes: usize) -> String {
-    if text.len() <= max_bytes {
-        return text.to_string();
-    }
-    let mut end = max_bytes.min(text.len());
-    while end > 0 && !text.is_char_boundary(end) {
-        end -= 1;
-    }
-    text[..end].to_string()
-}
-
-fn byte_suffix(text: &str, max_bytes: usize) -> String {
-    if text.len() <= max_bytes {
-        return text.to_string();
-    }
-    let mut start = text.len().saturating_sub(max_bytes);
-    while start < text.len() && !text.is_char_boundary(start) {
-        start += 1;
-    }
-    text[start..].to_string()
 }
 
 fn fallback_side_chat_color(side_chat_id: &str) -> String {

--- a/crates/core-service/src/service/terminal/run_log_tee.rs
+++ b/crates/core-service/src/service/terminal/run_log_tee.rs
@@ -14,6 +14,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use chrono::Utc;
 use tracing::debug;
 
+// Shared with side chat / attention summary / any plain-text terminal readers.
+pub use super::text_capture::strip_ansi_and_controls;
+
 const RUN_LOGS_REL: &str = ".atmos/run-logs";
 const ARCHIVE_REL: &str = "archive";
 const MAX_LATEST_BYTES: u64 = 8 * 1024 * 1024;
@@ -49,98 +52,6 @@ pub fn run_logs_dir(project_root: &Path) -> PathBuf {
 
 pub fn latest_log_path(project_root: &Path, window_name: &str) -> PathBuf {
     run_logs_dir(project_root).join(format!("{}.latest.log", sanitize_window_name(window_name)))
-}
-
-pub fn strip_ansi_and_controls(input: &str) -> String {
-    let bytes = input.as_bytes();
-    let mut out = String::with_capacity(input.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        let b = bytes[i];
-        if b == 0x1b {
-            i += 1;
-            if i >= bytes.len() {
-                break;
-            }
-            match bytes[i] {
-                b'[' => {
-                    i += 1;
-                    while i < bytes.len() {
-                        let c = bytes[i];
-                        i += 1;
-                        if (0x40..=0x7e).contains(&c) {
-                            break;
-                        }
-                    }
-                }
-                b']' => {
-                    i += 1;
-                    while i < bytes.len() {
-                        let c = bytes[i];
-                        i += 1;
-                        if c == 0x07 {
-                            break;
-                        }
-                        if c == 0x1b && i < bytes.len() && bytes[i] == b'\\' {
-                            i += 1;
-                            break;
-                        }
-                    }
-                }
-                b'P' | b'X' | b'^' | b'_' => {
-                    i += 1;
-                    while i < bytes.len() {
-                        if bytes[i] == 0x1b {
-                            i += 1;
-                            if i < bytes.len() && bytes[i] == b'\\' {
-                                i += 1;
-                                break;
-                            }
-                        } else {
-                            i += 1;
-                        }
-                    }
-                }
-                b'(' | b')' | b'*' | b'+' => {
-                    // charset designation: ESC ( B etc.
-                    i += 1;
-                    if i < bytes.len() {
-                        i += 1;
-                    }
-                }
-                _ => {
-                    // Single-char ESC sequences
-                    i += 1;
-                }
-            }
-            continue;
-        }
-        // Keep tab and newline; drop other C0 controls and DEL.
-        if b == b'\n' || b == b'\t' || b == b'\r' {
-            if b == b'\r' {
-                // Normalize CR to nothing if followed by LF; else treat as newline.
-                if i + 1 < bytes.len() && bytes[i + 1] == b'\n' {
-                    i += 1;
-                    continue;
-                }
-                out.push('\n');
-            } else {
-                out.push(b as char);
-            }
-            i += 1;
-            continue;
-        }
-        if b < 0x20 || b == 0x7f {
-            i += 1;
-            continue;
-        }
-        // UTF-8: take valid leading bytes as chars via lossy slice walk
-        let ch = input[i..].chars().next().unwrap_or('\u{FFFD}');
-        let len = ch.len_utf8();
-        out.push(ch);
-        i += len;
-    }
-    out
 }
 
 fn utc_stamp_for_archive() -> String {

--- a/crates/core-service/src/service/terminal/text_capture.rs
+++ b/crates/core-service/src/service/terminal/text_capture.rs
@@ -1,0 +1,321 @@
+//! Shared plain-text terminal capture helpers.
+//!
+//! Used by side chat /spawn context, attention auto-summary, run-log tee, and any
+//! other feature that needs readable terminal content without ANSI noise.
+
+/// Default budget for side-chat style prompt seeding (~96 KiB).
+pub const DEFAULT_PROMPT_BUDGET_BYTES: usize = 98_304;
+pub const MIN_PROMPT_BUDGET_BYTES: usize = 8_192;
+pub const MAX_PROMPT_BUDGET_BYTES: usize = 131_072;
+
+/// How much raw `capture-pane` text to keep before budgeting (prevents huge history).
+pub const DEFAULT_MAX_RAW_CAPTURE_BYTES: usize = 524_288;
+/// Approximate scrollback lines requested from tmux (`capture-pane -S -N`).
+pub const DEFAULT_CAPTURE_APPROX_LINES: i32 = 12_000;
+/// Head-of-transcript bytes kept when mid-section is omitted (side-chat default).
+pub const DEFAULT_HEAD_PREFIX_BYTES: usize = 8_192;
+
+/// How to window a long transcript into a prompt-sized budget.
+#[derive(Debug, Clone, Copy)]
+pub struct TranscriptBudget {
+    /// Max UTF-8 bytes in the selected text (marker included when truncated).
+    pub max_text_bytes: usize,
+    /// Bytes kept from the start of the transcript when mid is omitted.
+    /// `0` means tail-only (prefer recent output).
+    pub head_prefix_bytes: usize,
+}
+
+impl TranscriptBudget {
+    pub fn side_chat(max_text_bytes: usize) -> Self {
+        Self {
+            max_text_bytes: max_text_bytes.clamp(MIN_PROMPT_BUDGET_BYTES, MAX_PROMPT_BUDGET_BYTES),
+            head_prefix_bytes: DEFAULT_HEAD_PREFIX_BYTES,
+        }
+    }
+
+    /// Attention auto-summary: emphasize recent agent turn, keep a tiny head for titles.
+    pub fn attention_summary(max_text_bytes: usize) -> Self {
+        let max_text_bytes = max_text_bytes.clamp(2_048, 32_768);
+        Self {
+            max_text_bytes,
+            // Small head for session banner / cwd; bulk is the recent tail.
+            head_prefix_bytes: 1_024.min(max_text_bytes / 8).max(256),
+        }
+    }
+
+    pub fn tail_only(max_text_bytes: usize) -> Self {
+        Self {
+            max_text_bytes: max_text_bytes.max(1),
+            head_prefix_bytes: 0,
+        }
+    }
+}
+
+/// Result of selecting a budgeted slice from captured terminal text.
+#[derive(Debug, Clone)]
+pub struct SelectedTranscript {
+    pub text: String,
+    pub omitted_older_bytes: usize,
+    pub omitted_middle_bytes: usize,
+    pub truncated: bool,
+}
+
+/// Strip ANSI CSI/OSC/DCS sequences and most C0 controls for LLM / log use.
+///
+/// Keeps `\n` and `\t`; normalizes lone `\r` to `\n` and drops `\r` before `\n`.
+pub fn strip_ansi_and_controls(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = String::with_capacity(input.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == 0x1b {
+            i += 1;
+            if i >= bytes.len() {
+                break;
+            }
+            match bytes[i] {
+                b'[' => {
+                    i += 1;
+                    while i < bytes.len() {
+                        let c = bytes[i];
+                        i += 1;
+                        if (0x40..=0x7e).contains(&c) {
+                            break;
+                        }
+                    }
+                }
+                b']' => {
+                    i += 1;
+                    while i < bytes.len() {
+                        let c = bytes[i];
+                        i += 1;
+                        if c == 0x07 {
+                            break;
+                        }
+                        if c == 0x1b && i < bytes.len() && bytes[i] == b'\\' {
+                            i += 1;
+                            break;
+                        }
+                    }
+                }
+                b'P' | b'X' | b'^' | b'_' => {
+                    i += 1;
+                    while i < bytes.len() {
+                        if bytes[i] == 0x1b {
+                            i += 1;
+                            if i < bytes.len() && bytes[i] == b'\\' {
+                                i += 1;
+                                break;
+                            }
+                        } else {
+                            i += 1;
+                        }
+                    }
+                }
+                b'(' | b')' | b'*' | b'+' => {
+                    // charset designation: ESC ( B etc.
+                    i += 1;
+                    if i < bytes.len() {
+                        i += 1;
+                    }
+                }
+                _ => {
+                    // Single-char ESC sequences
+                    i += 1;
+                }
+            }
+            continue;
+        }
+        // Keep tab and newline; drop other C0 controls and DEL.
+        if b == b'\n' || b == b'\t' || b == b'\r' {
+            if b == b'\r' {
+                // Normalize CR to nothing if followed by LF; else treat as newline.
+                if i + 1 < bytes.len() && bytes[i + 1] == b'\n' {
+                    i += 1;
+                    continue;
+                }
+                out.push('\n');
+            } else {
+                out.push(b as char);
+            }
+            i += 1;
+            continue;
+        }
+        if b < 0x20 || b == 0x7f {
+            i += 1;
+            continue;
+        }
+        // UTF-8: take valid leading bytes as chars via lossy slice walk
+        let ch = input[i..].chars().next().unwrap_or('\u{FFFD}');
+        let len = ch.len_utf8();
+        out.push(ch);
+        i += len;
+    }
+    out
+}
+
+/// Count lines in text (empty → 0; otherwise 1 + newline count).
+pub fn count_lines(text: &str) -> u32 {
+    if text.is_empty() {
+        0
+    } else {
+        text.matches('\n').count() as u32 + 1
+    }
+}
+
+pub fn byte_prefix(text: &str, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
+        return text.to_string();
+    }
+    let mut end = max_bytes.min(text.len());
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    text[..end].to_string()
+}
+
+pub fn byte_suffix(text: &str, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
+        return text.to_string();
+    }
+    let mut start = text.len().saturating_sub(max_bytes);
+    while start < text.len() && !text.is_char_boundary(start) {
+        start += 1;
+    }
+    text[start..].to_string()
+}
+
+/// Select a head+tail (or tail-only) window within `budget`.
+pub fn select_transcript(text: &str, budget: TranscriptBudget) -> SelectedTranscript {
+    let max_bytes = budget.max_text_bytes.max(1);
+    if text.len() <= max_bytes {
+        return SelectedTranscript {
+            text: text.to_string(),
+            omitted_older_bytes: 0,
+            omitted_middle_bytes: 0,
+            truncated: false,
+        };
+    }
+
+    if budget.head_prefix_bytes == 0 {
+        return SelectedTranscript {
+            text: byte_suffix(text, max_bytes),
+            omitted_older_bytes: text.len().saturating_sub(max_bytes),
+            omitted_middle_bytes: 0,
+            truncated: true,
+        };
+    }
+
+    let marker_overhead = 128usize;
+    let prefix_budget = budget
+        .head_prefix_bytes
+        .min(max_bytes / 4)
+        .max(256)
+        .min(max_bytes.saturating_sub(marker_overhead + 256));
+    let tail_budget = max_bytes
+        .saturating_sub(prefix_budget + marker_overhead)
+        .max(256);
+    let prefix = byte_prefix(text, prefix_budget);
+    let tail = byte_suffix(text, tail_budget);
+    let omitted_middle_bytes = text
+        .len()
+        .saturating_sub(prefix.len())
+        .saturating_sub(tail.len());
+    let marker = format!(
+        "\n\n[... omitted {omitted_middle_bytes} bytes from the middle of the terminal transcript ...]\n\n"
+    );
+    let mut selected = format!("{prefix}{marker}{tail}");
+    if selected.len() > max_bytes {
+        selected = byte_suffix(&selected, max_bytes);
+    }
+
+    SelectedTranscript {
+        text: selected,
+        omitted_older_bytes: 0,
+        omitted_middle_bytes,
+        truncated: true,
+    }
+}
+
+/// Normalize raw tmux capture into prompt-safe text within budgets.
+///
+/// 1. Keep the newest `max_raw_bytes` of the capture (drop older scrollback).
+/// 2. Strip ANSI / control sequences.
+/// 3. Window into `budget` with optional head+tail selection.
+pub fn process_captured_pane_text(
+    raw_full: &str,
+    max_raw_bytes: usize,
+    budget: TranscriptBudget,
+) -> SelectedTranscript {
+    let max_raw_bytes = max_raw_bytes.max(1);
+    let omitted_older_bytes = raw_full.len().saturating_sub(max_raw_bytes);
+    let raw = byte_suffix(raw_full, max_raw_bytes);
+    let plain = strip_ansi_and_controls(&raw);
+    let mut selected = select_transcript(&plain, budget);
+    selected.omitted_older_bytes = selected
+        .omitted_older_bytes
+        .saturating_add(omitted_older_bytes);
+    selected
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_ansi_color() {
+        let raw = "\x1b[31merror\x1b[0m hello\n";
+        let out = strip_ansi_and_controls(raw);
+        assert_eq!(out, "error hello\n");
+        assert!(!out.contains('\x1b'));
+    }
+
+    #[test]
+    fn select_fits_without_truncation() {
+        let selected = select_transcript("short", TranscriptBudget::tail_only(100));
+        assert_eq!(selected.text, "short");
+        assert!(!selected.truncated);
+    }
+
+    #[test]
+    fn select_tail_only_keeps_end() {
+        let text = "a".repeat(100) + "TAIL";
+        let selected = select_transcript(&text, TranscriptBudget::tail_only(10));
+        assert!(selected.text.ends_with("TAIL"));
+        assert!(selected.truncated);
+        assert!(selected.omitted_older_bytes > 0);
+    }
+
+    #[test]
+    fn select_head_tail_omits_middle() {
+        let text = format!("{}MID{}", "H".repeat(2_000), "T".repeat(2_000));
+        let selected = select_transcript(
+            &text,
+            TranscriptBudget {
+                max_text_bytes: 1_200,
+                head_prefix_bytes: 400,
+            },
+        );
+        assert!(selected.truncated);
+        assert!(selected.omitted_middle_bytes > 0);
+        assert!(selected.text.starts_with('H'));
+        assert!(selected.text.ends_with('T'));
+        assert!(selected.text.contains("omitted"));
+    }
+
+    #[test]
+    fn process_strips_ansi_and_budgets() {
+        let raw = format!("\x1b[32m{}\x1b[0mEND", "x".repeat(5_000));
+        let selected = process_captured_pane_text(
+            &raw,
+            10_000,
+            TranscriptBudget {
+                max_text_bytes: 500,
+                head_prefix_bytes: 0,
+            },
+        );
+        assert!(selected.text.ends_with("END"));
+        assert!(!selected.text.contains('\x1b'));
+    }
+}

--- a/crates/core-service/src/service/terminal/types.rs
+++ b/crates/core-service/src/service/terminal/types.rs
@@ -246,6 +246,44 @@ pub struct AttachSessionParams {
     pub cwd: Option<String>,
 }
 
+/// Generic plain-text capture of a tmux pane (side chat, /spawn, attention summary, …).
+pub struct CapturePanePlainTextParams {
+    pub workspace_id: String,
+    pub project_name: Option<String>,
+    pub workspace_name: Option<String>,
+    /// Active browser/API terminal session id when known (preferred resolve path).
+    pub source_session_id: Option<String>,
+    /// Tmux window name fallback when no live session handle is available.
+    pub source_tmux_window_name: String,
+    /// Final selected text budget in bytes (after ANSI strip + head/tail window).
+    pub max_text_bytes: Option<u32>,
+    /// Optional scrollback line request for `capture-pane -S`.
+    pub approx_lines: Option<i32>,
+    /// Optional cap on raw capture bytes before selection.
+    pub max_raw_bytes: Option<usize>,
+    /// Bytes kept from the start of the transcript when mid is omitted.
+    /// `None` uses the side-chat default head; `Some(0)` is tail-only.
+    pub head_prefix_bytes: Option<usize>,
+}
+
+/// Result of a generic plain-text pane capture.
+pub struct CapturedPanePlainText {
+    pub workspace_id: String,
+    pub project_name: Option<String>,
+    pub workspace_name: Option<String>,
+    pub tmux_session: String,
+    pub tmux_window_name: String,
+    pub tmux_window_index: u32,
+    pub captured_lines: u32,
+    pub captured_bytes: u32,
+    pub text_budget_bytes: u32,
+    pub omitted_older_bytes: u32,
+    pub omitted_middle_bytes: u32,
+    pub truncated_bytes: bool,
+    pub text: String,
+}
+
+/// Side-chat /spawn capture params (thin alias over the generic API defaults).
 pub struct CaptureSideContextParams {
     pub workspace_id: String,
     pub project_name: Option<String>,
@@ -269,6 +307,26 @@ pub struct CapturedSideContext {
     pub omitted_middle_bytes: u32,
     pub truncated_bytes: bool,
     pub text: String,
+}
+
+impl From<CapturedPanePlainText> for CapturedSideContext {
+    fn from(value: CapturedPanePlainText) -> Self {
+        Self {
+            workspace_id: value.workspace_id,
+            project_name: value.project_name,
+            workspace_name: value.workspace_name,
+            tmux_session: value.tmux_session,
+            tmux_window_name: value.tmux_window_name,
+            tmux_window_index: value.tmux_window_index,
+            captured_lines: value.captured_lines,
+            captured_bytes: value.captured_bytes,
+            prompt_budget_bytes: value.text_budget_bytes,
+            omitted_older_bytes: value.omitted_older_bytes,
+            omitted_middle_bytes: value.omitted_middle_bytes,
+            truncated_bytes: value.truncated_bytes,
+            text: value.text,
+        }
+    }
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/prompt/attention-summary/attention-summary-system.md
+++ b/prompt/attention-summary/attention-summary-system.md
@@ -1,0 +1,20 @@
+You are Atmos attention-summary helper.
+An agent finished a turn in a terminal and the user has not acknowledged it yet.
+Summarize what the agent recently did in that terminal session and suggest concise next steps.
+
+Primary evidence is the terminal transcript (conversation + command output).
+Changed file paths are optional signals only — do not invent work from them alone.
+The user may not be coding; summarize whatever the transcript shows (Q&A, debug, shell work, etc.).
+
+Respond with ONLY a single JSON object (no markdown fences) matching:
+{
+  "summary": "one sentence",
+  "next_steps": ["short action 1", "short action 2"],
+  "can_close_session": true
+}
+Rules:
+- summary: one clear sentence about what happened in the recent terminal turn (max ~160 chars).
+- next_steps: 2-4 short imperative actions the user might take next, grounded in the transcript.
+- can_close_session: true only if work looks complete with no obvious unfinished blockers.
+- Prefer the user's language if the context is clearly non-English; otherwise English.
+- Do not invent file edits, commits, or outcomes not supported by the transcript or file list.

--- a/prompt/attention-summary/attention-summary-user.md
+++ b/prompt/attention-summary/attention-summary-user.md
@@ -1,0 +1,7 @@
+Pane: ${stable_pane_id}
+Session: ${session_id}
+Tool: ${tool}
+Raised at: ${raised_at}
+Project: ${project_path}
+
+${context}


### PR DESCRIPTION
## Summary

- Extract shared plain-text pane capture (`text_capture` + `capture_pane_plain_text`) with ANSI stripping and budgeted head/tail selection for side chat, `/spawn`, and attention auto-summary.
- Rewire attention auto-summary to use the terminal transcript as primary context; supplement with relative changed-file paths only (no git log/diff).
- Move attention-summary system/user prompts under `prompt/attention-summary/` and assemble via `include_str!` + `render_prompt_template`, matching git-commit and workspace todo patterns.
- Wire the attention summary job to `TerminalService` so pane capture can resolve the sticky latch window.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] `cargo test -p core-service --lib text_capture`
- [x] `cargo test -p core-service --lib attention_summary` / `attention_summary_generate`
- [x] `cargo check -p api`

## Checklist

- [ ] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attention auto-summaries now use the terminal transcript as the main context, with ANSI-stripped, budgeted head/tail capture shared with side chat and `/spawn`. Prompts are templated, and the job now uses `TerminalService`; we only include changed file paths (no git log/diff).

- **New Features**
  - Base attention summaries on the pane’s plain-text transcript (shared capture path with side chat and `/spawn`).
  - Include only relative changed-file paths as optional context (no commit log/diff).
  - Template system/user prompts under `prompt/attention-summary/` via `include_str!` + `render_prompt_template`.

- **Refactors**
  - Extract shared text capture to `terminal::text_capture` (ANSI stripping, head/tail selection, budgets) and export helpers.
  - Add `capture_pane_plain_text` and use it in attention generation; expose `TranscriptBudget` and selection utilities.
  - Wire the attention-summary job to `TerminalService` and update API scheduler to pass it into `generate_attention_summary`.

<sup>Written for commit b2be241d837c440d5e5b1d1c46215f70c2c8ab5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Attention summaries now incorporate recent terminal activity and relevant changed project files.
  - Summaries provide grounded next-step recommendations and indicate whether a session appears complete.
  - Added support for configurable terminal transcript capture, including text cleanup and intelligent truncation.

- **Improvements**
  - Attention-summary prompts now use structured templates for more consistent results.
  - Large terminal histories are selectively condensed to preserve the most relevant context.
  - ANSI formatting and control characters are removed from captured terminal text for clearer summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->