### PR TITLE
feat(landing,docs): add PostHog web analytics

### DIFF
--- a/apps/docs/.env.example
+++ b/apps/docs/.env.example
@@ -1,0 +1,3 @@
+# PostHog web analytics (optional — app no-ops when unset)
+# NEXT_PUBLIC_POSTHOG_KEY=phc_...
+# NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -10,6 +10,15 @@
 - **Build**: `bun build`
 - **Typecheck**: `bun run types:check` (Fumadocs MDX checks + TypeScript)
 
+### PostHog (optional)
+
+Set public env vars in Cloudflare Pages (or `.env.local` for local testing):
+
+- `NEXT_PUBLIC_POSTHOG_KEY` — project API key (required to enable analytics)
+- `NEXT_PUBLIC_POSTHOG_HOST` — ingestion host (defaults to `https://us.i.posthog.com`)
+
+When the key is unset, PostHog is not initialized and the app builds/runs normally.
+
 ---
 
 ## Tech Stack

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -24,6 +24,7 @@
     "fumadocs-ui": "16.8.12",
     "lucide-react": "^0.562.0",
     "next": "16.3.0",
+    "posthog-js": "^1.415.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "tailwind-merge": "^3.4.0"

--- a/apps/docs/src/app/[lang]/layout.tsx
+++ b/apps/docs/src/app/[lang]/layout.tsx
@@ -1,4 +1,5 @@
 import { DocsRootProvider } from '@/components/docs-root-provider';
+import { PostHogProvider } from '@/components/posthog-provider';
 import { i18n } from '@/lib/i18n';
 import { Inter } from 'next/font/google';
 
@@ -18,17 +19,19 @@ export default async function LangLayout({
   return (
     <html lang={lang} className={inter.className} suppressHydrationWarning>
       <body className="flex min-h-screen flex-col">
-        <DocsRootProvider
-          i18n={{
-            locale: lang,
-            locales: i18n.languages.map((l) => ({
-              locale: l,
-              name: l === 'zh' ? '中文' : 'English',
-            })),
-          }}
-        >
-          {children}
-        </DocsRootProvider>
+        <PostHogProvider>
+          <DocsRootProvider
+            i18n={{
+              locale: lang,
+              locales: i18n.languages.map((l) => ({
+                locale: l,
+                name: l === 'zh' ? '中文' : 'English',
+              })),
+            }}
+          >
+            {children}
+          </DocsRootProvider>
+        </PostHogProvider>
       </body>
     </html>
   );

--- a/apps/docs/src/components/posthog-provider.tsx
+++ b/apps/docs/src/components/posthog-provider.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { isPostHogEnabled, posthogHost, posthogKey } from "@/lib/posthog";
+import posthog from "posthog-js";
+import { usePathname, useSearchParams } from "next/navigation";
+import { Suspense, useEffect } from "react";
+
+let initialized = false;
+
+function initPostHog() {
+  if (!posthogKey || initialized) return;
+
+  initialized = true;
+  posthog.init(posthogKey, {
+    api_host: posthogHost,
+    capture_pageview: false,
+    capture_pageleave: true,
+    person_profiles: "identified_only",
+    disable_session_recording: true,
+  });
+}
+
+function PostHogPageView() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    initPostHog();
+    if (!isPostHogEnabled() || !pathname) return;
+
+    const search = searchParams?.toString();
+    const url = `${window.location.origin}${pathname}${search ? `?${search}` : ""}`;
+
+    posthog.capture("$pageview", {
+      $current_url: url,
+    });
+  }, [pathname, searchParams]);
+
+  return null;
+}
+
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    initPostHog();
+  }, []);
+
+  if (!isPostHogEnabled()) {
+    return children;
+  }
+
+  return (
+    <>
+      <Suspense fallback={null}>
+        <PostHogPageView />
+      </Suspense>
+      {children}
+    </>
+  );
+}

--- a/apps/docs/src/lib/posthog.ts
+++ b/apps/docs/src/lib/posthog.ts
@@ -1,0 +1,8 @@
+export const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+export const posthogHost =
+  process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com";
+
+export function isPostHogEnabled(): boolean {
+  return Boolean(posthogKey);
+}

--- a/apps/landing/.env.example
+++ b/apps/landing/.env.example
@@ -1,0 +1,3 @@
+# PostHog web analytics (optional — app no-ops when unset)
+# NEXT_PUBLIC_POSTHOG_KEY=phc_...
+# NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/apps/landing/.gitignore
+++ b/apps/landing/.gitignore
@@ -22,6 +22,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/apps/landing/AGENTS.md
+++ b/apps/landing/AGENTS.md
@@ -10,6 +10,15 @@
 - **Build**: `bun build`
 - **Start**: `bun start`
 
+### PostHog (optional)
+
+Set public env vars in Vercel (or `.env.local` for local testing):
+
+- `NEXT_PUBLIC_POSTHOG_KEY` — project API key (required to enable analytics)
+- `NEXT_PUBLIC_POSTHOG_HOST` — ingestion host (defaults to `https://us.i.posthog.com`)
+
+When the key is unset, PostHog is not initialized and the app builds/runs normally.
+
 ---
 
 ## 📁 Directory Structure

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -28,6 +28,7 @@
     "next": "16.3.0",
     "next-intl": "^4.7.0",
     "next-themes": "^0.4.6",
+    "posthog-js": "^1.415.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",

--- a/apps/landing/src/app/[locale]/layout.tsx
+++ b/apps/landing/src/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import { NextIntlClientProvider } from "next-intl";
 import { getMessages, getTranslations, setRequestLocale } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { routing } from "@atmos/i18n/routing";
+import { PostHogProvider } from "@/components/providers/posthog-provider";
 import { ThemeProvider } from "@/components/providers/theme-provider";
 import { TooltipProvider } from "@workspace/ui/components/ui/tooltip";
 import Header from "@/components/layout/header";
@@ -70,19 +71,21 @@ export default async function LocaleLayout({ children, params }: Props) {
       <body
         className={`${GeistSans.variable} ${geistMono.variable} ${GeistSans.className} antialiased`}
       >
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="system"
-          enableSystem
-          disableTransitionOnChange
-        >
-          <NextIntlClientProvider messages={messages}>
-            <TooltipProvider>
-              <Header />
-              {children}
-            </TooltipProvider>
-          </NextIntlClientProvider>
-        </ThemeProvider>
+        <PostHogProvider>
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="system"
+            enableSystem
+            disableTransitionOnChange
+          >
+            <NextIntlClientProvider messages={messages}>
+              <TooltipProvider>
+                <Header />
+                {children}
+              </TooltipProvider>
+            </NextIntlClientProvider>
+          </ThemeProvider>
+        </PostHogProvider>
       </body>
     </html>
   );

--- a/apps/landing/src/components/providers/posthog-provider.tsx
+++ b/apps/landing/src/components/providers/posthog-provider.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { isPostHogEnabled, posthogHost, posthogKey } from "@/lib/posthog";
+import posthog from "posthog-js";
+import { usePathname, useSearchParams } from "next/navigation";
+import { Suspense, useEffect } from "react";
+
+let initialized = false;
+
+function initPostHog() {
+  if (!posthogKey || initialized) return;
+
+  initialized = true;
+  posthog.init(posthogKey, {
+    api_host: posthogHost,
+    capture_pageview: false,
+    capture_pageleave: true,
+    person_profiles: "identified_only",
+    disable_session_recording: true,
+  });
+}
+
+function PostHogPageView() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    initPostHog();
+    if (!isPostHogEnabled() || !pathname) return;
+
+    const search = searchParams?.toString();
+    const url = `${window.location.origin}${pathname}${search ? `?${search}` : ""}`;
+
+    posthog.capture("$pageview", {
+      $current_url: url,
+    });
+  }, [pathname, searchParams]);
+
+  return null;
+}
+
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    initPostHog();
+  }, []);
+
+  if (!isPostHogEnabled()) {
+    return children;
+  }
+
+  return (
+    <>
+      <Suspense fallback={null}>
+        <PostHogPageView />
+      </Suspense>
+      {children}
+    </>
+  );
+}

--- a/apps/landing/src/lib/posthog.ts
+++ b/apps/landing/src/lib/posthog.ts
@@ -1,0 +1,8 @@
+export const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+export const posthogHost =
+  process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com";
+
+export function isPostHogEnabled(): boolean {
+  return Boolean(posthogKey);
+}

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "apps/desktop-electron": {
       "name": "desktop-electron",
-      "version": "2026.8.10",
+      "version": "2026.8.11",
       "dependencies": {
         "koffi": "^3.1.2",
       },
@@ -50,6 +50,7 @@
         "fumadocs-ui": "16.8.12",
         "lucide-react": "^0.562.0",
         "next": "16.3.0",
+        "posthog-js": "^1.415.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "tailwind-merge": "^3.4.0",
@@ -88,6 +89,7 @@
         "next": "16.3.0",
         "next-intl": "^4.7.0",
         "next-themes": "^0.4.6",
+        "posthog-js": "^1.415.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
@@ -1312,6 +1314,12 @@
 
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
+    "@posthog/browser-common": ["@posthog/browser-common@0.5.0", "", { "dependencies": { "@posthog/core": "^1.47.0", "@posthog/types": "^1.402.2" } }, "sha512-8DaxVZS1bQPbA514RePurLNbYjei3P4jhnC206DwVv5XThmZM3QdlsXenI2ujE3pLbgQ79hYn9o1Kda8I3WK/Q=="],
+
+    "@posthog/core": ["@posthog/core@1.47.0", "", { "dependencies": { "@posthog/types": "^1.402.2" } }, "sha512-LW62V+9yx7G7mLd+EYpwW0PiaPZI8XRJ1tLuhw+9fXHpugLp8XQD5JuCQ2kIXvoUfyx1DpKfGQY3dUnzMOIn7Q=="],
+
+    "@posthog/types": ["@posthog/types@1.402.3", "", {}, "sha512-nnqKIGUqggeNbCZg6of/hYN+4shYZUoPFkILIIpYq0p9HDX8PgOrnrtBAUH8kr1MOmDh2nm+fY5Ceks7A5y6BQ=="],
+
     "@radix-ui/number": ["@radix-ui/number@1.1.3", "", {}, "sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.7", "", {}, "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q=="],
@@ -2520,7 +2528,7 @@
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
-    "dompurify": ["dompurify@3.4.12", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg=="],
+    "dompurify": ["dompurify@3.4.13", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
@@ -3588,11 +3596,13 @@
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
+    "posthog-js": ["posthog-js@1.415.6", "", { "dependencies": { "@posthog/browser-common": "^0.5.0", "@posthog/core": "^1.47.0", "@posthog/types": "^1.402.3", "core-js": "^3.49.0", "dompurify": "^3.4.13", "fflate": "^0.4.8", "preact": "^10.29.3", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.3.0", "web-vitals-soft-navs": "npm:web-vitals@6.0.0" } }, "sha512-zOvUooIDyQEz+uS8zwmS229cMdGSqJVeC+1C1PEozUulxPcCR41EWpHtffWpv8t/yRzoR4tk43i6Xa5N9QnOtQ=="],
+
     "postject": ["postject@1.0.0-alpha.6", "", { "dependencies": { "commander": "^9.4.0" }, "bin": { "postject": "dist/cli.js" } }, "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A=="],
 
     "postprocessing": ["postprocessing@6.39.3", "", { "peerDependencies": { "three": ">= 0.168.0 < 0.186.0" } }, "sha512-h5H1iuN96aRkU06CzJ8d/FqFe3Qs2bI7LiGHTzOI5T5mQqjzovi2t1EkRHb8qkHgoD9cTJDb4uA30AkSxsFB7A=="],
 
-    "preact": ["preact@11.0.0-beta.0", "", {}, "sha512-IcODoASASYwJ9kxz7+MJeiJhvLriwSb4y4mHIyxdgaRZp6kPUud7xytrk/6GZw8U3y6EFJaRb5wi9SrEK+8+lg=="],
+    "preact": ["preact@10.29.8", "", { "peerDependencies": { "preact-render-to-string": ">=5" }, "optionalPeers": ["preact-render-to-string"] }, "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q=="],
 
     "preact-render-to-string": ["preact-render-to-string@6.6.5", "", { "peerDependencies": { "preact": ">=10 || >= 11.0.0-0" } }, "sha512-O6MHzYNIKYaiSX3bOw0gGZfEbOmlIDtDfWwN1JJdc/T3ihzRT6tGGSEWE088dWrEDGa1u7101q+6fzQnO9XCPA=="],
 
@@ -3659,6 +3669,8 @@
     "qrcode": ["qrcode@1.5.4", "", { "dependencies": { "dijkstrajs": "^1.0.1", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg=="],
 
     "qrcode-generator": ["qrcode-generator@2.0.4", "", {}, "sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g=="],
+
+    "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
 
     "query-string": ["query-string@7.1.3", "", { "dependencies": { "decode-uri-component": "^0.2.2", "filter-obj": "^1.1.0", "split-on-first": "^1.0.0", "strict-uri-encode": "^2.0.0" } }, "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg=="],
 
@@ -4262,6 +4274,10 @@
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
+    "web-vitals": ["web-vitals@5.3.0", "", {}, "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g=="],
+
+    "web-vitals-soft-navs": ["web-vitals@6.0.0", "", {}, "sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA=="],
+
     "web-worker": ["web-worker@1.5.0", "", {}, "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw=="],
 
     "webcrypto-core": ["webcrypto-core@1.9.2", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/json-schema": "^1.1.12", "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q=="],
@@ -4411,6 +4427,8 @@
     "@next/eslint-plugin-next/@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
     "@pierre/diffs/shiki": ["shiki@4.3.1", "", { "dependencies": { "@shikijs/core": "4.3.1", "@shikijs/engine-javascript": "4.3.1", "@shikijs/engine-oniguruma": "4.3.1", "@shikijs/langs": "4.3.1", "@shikijs/themes": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw=="],
+
+    "@pierre/trees/preact": ["preact@11.0.0-beta.0", "", {}, "sha512-IcODoASASYwJ9kxz7+MJeiJhvLriwSb4y4mHIyxdgaRZp6kPUud7xytrk/6GZw8U3y6EFJaRb5wi9SrEK+8+lg=="],
 
     "@poppinss/colors/kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
@@ -4634,6 +4652,8 @@
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
+    "mermaid/dompurify": ["dompurify@3.4.12", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg=="],
+
     "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
 
     "metro/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
@@ -4677,6 +4697,8 @@
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
+    "posthog-js/fflate": ["fflate@0.4.9", "", {}, "sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw=="],
 
     "postject/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds PostHog web analytics to the marketing landing site (`apps/landing`) and documentation site (`apps/docs`).

Both apps now mount a client-side `PostHogProvider` that:
- Initializes `posthog-js` once when `NEXT_PUBLIC_POSTHOG_KEY` is set
- Tracks SPA pageviews on route changes (`usePathname` / `useSearchParams`), including `[locale]` and `[lang]` routes
- Enables autocapture and pageleave by default
- Leaves session replay disabled
- No-ops safely when the key is missing (dev/CI builds without env vars)

## Environment variables

Set these in deploy targets (no secrets are committed to the repo):

| Variable | Required | Default | Deploy target |
|----------|----------|---------|---------------|
| `NEXT_PUBLIC_POSTHOG_KEY` | Yes (to enable analytics) | — | Vercel (landing), Cloudflare Pages (docs) |
| `NEXT_PUBLIC_POSTHOG_HOST` | No | `https://us.i.posthog.com` | Same |

Local testing: copy `.env.example` to `.env.local` in each app and set the key.

## Changes

- `posthog-js` dependency added to `apps/landing` and `apps/docs`
- `PostHogProvider` + small `lib/posthog.ts` config helper in each app
- Provider mounted in `apps/landing/src/app/[locale]/layout.tsx` and `apps/docs/src/app/[lang]/layout.tsx`
- Setup notes in each app's `AGENTS.md` and `.env.example`

## Validation

- [x] `bun run build` in `apps/landing` (PostHog env unset)
- [x] `bun run build` in `apps/docs` (PostHog env unset)
- [ ] `just lint` (not run — analytics-only wiring)

## Type of Change

- [x] New feature
- [x] Documentation

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cddf51cc-296d-4451-93a7-24d62246b737?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cddf51cc-296d-4451-93a7-24d62246b737&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add PostHog analytics to `apps/landing` and `apps/docs` with SPA pageview tracking and page-leave events. Analytics is optional and safely no-ops when the key is missing, so dev/CI builds are unaffected.

- **New Features**
  - Client `PostHogProvider` in both apps; initializes `posthog-js` once when `NEXT_PUBLIC_POSTHOG_KEY` is set.
  - Tracks SPA pageviews on route changes (includes `[locale]` / `[lang]`).
  - Autocapture on; session replay off; page-leave capture on.
  - Adds `.env.example` and setup notes; mounts provider in each app’s root layout.

- **Migration**
  - Set `NEXT_PUBLIC_POSTHOG_KEY` in deploy envs to enable analytics.
  - Optional: `NEXT_PUBLIC_POSTHOG_HOST` (defaults to `https://us.i.posthog.com`).
  - Deploy targets: Vercel (`landing`), Cloudflare Pages (`docs`). For local, use `.env.local`.

<sup>Written for commit 6f0911127d60b7c1ddd140ca28bf7e0d405a5fab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

