### PR TITLE
ci(docs): inject PostHog env vars in Pages build workflow

### DIFF
--- a/.github/workflows/deploy-docs-pages.yml
+++ b/.github/workflows/deploy-docs-pages.yml
@@ -47,6 +47,8 @@ jobs:
       - name: Build docs for Pages
         env:
           NEXT_PUBLIC_SITE_URL: https://docs.atmos.land
+          NEXT_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+          NEXT_PUBLIC_POSTHOG_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST }}
         run: bun run build:docs:pages
 
       - name: Deploy Pages site


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pass `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST` from GitHub repository variables into the docs Cloudflare Pages build step, matching the landing Pages workflow.

## Related Issue

Follow-up to docs PostHog provider (#222) — enables analytics in production Pages deploys when repo vars are set.

## Type of Change

- [x] Chore / tooling

## Validation

- [x] Workflow YAML only; mirrors existing `deploy-landing-pages.yml` pattern
- [ ] CI will validate on merge

## Checklist

- [x] I followed repository conventions and AGENTS.md guidance
- [ ] No app code changes — docs PostHog provider already merged in #222
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c2973af-3849-4891-9aab-9b3d2c77dcbb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c2973af-3849-4891-9aab-9b3d2c77dcbb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inject `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST` into the docs Cloudflare Pages build to enable PostHog analytics in production, matching the landing Pages workflow.

- **Migration**
  - Set `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST` as GitHub repository variables; builds will pick them up automatically.

<sup>Written for commit 4967a602d2a22b2a0082402b574c4477db8e6cf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documentation site builds now include the configured analytics key and host settings, enabling analytics functionality on published documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->