### PR TITLE
fix(api): reject untrusted browser origins on WebSocket and HTTP

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -8,12 +8,21 @@ SERVER_PORT=30303
 ATMOS_PORT=30303
 ATMOS_LOCAL_TOKEN=
 
-# CORS allowed origins
+# CORS allowed origins. This list also gates WebSocket handshakes, so an origin
+# that is not listed here cannot open /ws, /ws/terminal, or /ws/agent.
 # Use "*" to allow all origins (dev only), or comma-separated list:
 # CORS_ORIGIN=https://atmos.example.com,https://app.example.com
 CORS_ORIGIN=*
 # Dev default origins (when CORS_ORIGIN unset):
 # http://localhost:3030, http://127.0.0.1:3030, https://app.atmos.land, tauri://localhost, https://tauri.localhost
+# The server's own origin (http://127.0.0.1:<port>) is always allowed so a UI
+# served from ATMOS_STATIC_DIR works without extra configuration.
+# Leaving CORS_ORIGIN unset in dev also trusts any http(s)://localhost:<port>.
+
+# Extra Host header values to accept, comma-separated. By default only IP
+# literals and "localhost" are accepted, which blocks DNS-rebinding attacks.
+# Set this when reaching the Server by name, e.g. Tailscale MagicDNS:
+# ATMOS_ALLOWED_HOSTS=box.tailnet.ts.net
 
 # Atmos Hub (OAuth Linear credentials + device auth). Local API calls Hub over HTTPS.
 # Default when unset: https://hub.atmos.land

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -55,6 +55,8 @@ On successful `TcpListener::bind`:
 
 **Auth**: `require_local_token` applies only when `ATMOS_LOCAL_TOKEN` is configured. Default dev/Desktop path is **open loopback**.
 
+**Origin guard**: `require_allowed_origin` is the outermost layer and is the control that keeps a random web page from driving this Server. A WebSocket handshake is exempt from CORS, so the `Origin` allowlist must be enforced as a request guard — `CorsLayer` alone does not protect `/ws*`. Rules: a request with no `Origin` is allowed (non-browser clients such as the relay/tunnel bridge and CLI never send one); a request with `Origin` must satisfy `ServerConfig::is_origin_allowed`; and the `Host` header must be an IP literal, `localhost`, or listed in `ATMOS_ALLOWED_HOSTS` (blocks DNS rebinding, which arrives without an `Origin` header). Keep CORS and the guard on the same predicate — never add a second origin rule.
+
 ---
 
 ## Coding Conventions

--- a/apps/api/src/config/mod.rs
+++ b/apps/api/src/config/mod.rs
@@ -1,7 +1,6 @@
 use std::env;
 use std::net::SocketAddr;
 
-use http::header::HeaderValue;
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use tracing::info;
 
@@ -13,6 +12,9 @@ pub struct ServerConfig {
     pub allow_dynamic_localhost_origins: bool,
     pub local_api_token: Option<String>,
     pub allow_lan_without_token: bool,
+    /// Extra `Host` header values accepted besides IP literals and `localhost`.
+    /// Needed for named access such as Tailscale MagicDNS (`box.tailnet.ts.net`).
+    pub allowed_hosts: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -65,6 +67,17 @@ impl ServerConfig {
             })
             .unwrap_or(false);
 
+        let allowed_hosts = env::var("ATMOS_ALLOWED_HOSTS")
+            .ok()
+            .map(|value| {
+                value
+                    .split(',')
+                    .map(|entry| entry.trim().to_ascii_lowercase())
+                    .filter(|entry| !entry.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default();
+
         let config = Self {
             host,
             port,
@@ -72,6 +85,7 @@ impl ServerConfig {
             allow_dynamic_localhost_origins: !is_production && !has_custom_cors_origin,
             local_api_token,
             allow_lan_without_token,
+            allowed_hosts,
         };
 
         info!("Server config: {}:{}", config.host, config.port);
@@ -107,44 +121,91 @@ impl ServerConfig {
         match &self.cors_origins {
             CorsOriginConfig::Any => layer.allow_origin(Any),
             CorsOriginConfig::List(_) => {
-                if self.allow_dynamic_localhost_origins {
-                    let parsed = parse_cors_origins(self.cors_origins_list());
-                    let static_origins = parsed.clone();
-                    layer.allow_origin(AllowOrigin::predicate(move |origin, _| {
-                        is_local_host_origin(origin)
-                            || static_origins
-                                .iter()
-                                .any(|origin_value| origin == origin_value)
-                    }))
-                } else {
-                    let parsed = parse_cors_origins(self.cors_origins_list());
-                    layer.allow_origin(AllowOrigin::list(parsed))
-                }
+                // Share one predicate with the WebSocket/HTTP origin guard so the
+                // two cannot drift apart across dev / desktop / hosted setups.
+                let config = self.clone();
+                layer.allow_origin(AllowOrigin::predicate(move |origin, _| {
+                    origin
+                        .to_str()
+                        .is_ok_and(|value| config.is_origin_allowed(value))
+                }))
             }
         }
     }
 
-    fn cors_origins_list(&self) -> &[String] {
-        match &self.cors_origins {
-            CorsOriginConfig::List(origins) => origins,
-            CorsOriginConfig::Any => panic!("cors_origins_list called for CorsOriginConfig::Any"),
+    /// This server's own origin, so a UI served from `ATMOS_STATIC_DIR` keeps
+    /// working without every launcher having to configure `CORS_ORIGIN`.
+    fn is_self_origin(&self, origin: &str) -> bool {
+        let Some((scheme, authority)) = origin.split_once("://") else {
+            return false;
+        };
+        if scheme != "http" && scheme != "https" {
+            return false;
         }
+        let Some((host, port)) = split_host_port(authority) else {
+            return false;
+        };
+        port == Some(self.port) && matches!(host, "127.0.0.1" | "localhost" | "::1")
+    }
+
+    /// Single source of truth for "may this browser origin talk to us".
+    ///
+    /// A WebSocket handshake is not covered by CORS, so this is also enforced as
+    /// a request guard (see `middleware::require_allowed_origin`); otherwise any
+    /// page could drive `/ws/terminal` on a loopback-trusted connection.
+    pub fn is_origin_allowed(&self, origin: &str) -> bool {
+        match &self.cors_origins {
+            CorsOriginConfig::Any => true,
+            CorsOriginConfig::List(origins) => {
+                if self.is_self_origin(origin) {
+                    return true;
+                }
+                if self.allow_dynamic_localhost_origins && is_local_host_origin(origin) {
+                    return true;
+                }
+                origins.iter().any(|allowed| allowed == origin)
+            }
+        }
+    }
+
+    /// Reject `Host` values that resolve through DNS, which is how a page on a
+    /// public domain rebinds to 127.0.0.1 and reaches us as a same-origin
+    /// request that carries no `Origin` header.
+    pub fn is_host_allowed(&self, host: &str) -> bool {
+        let Some((hostname, _)) = split_host_port(host) else {
+            return false;
+        };
+        if hostname == "localhost" || hostname.parse::<std::net::IpAddr>().is_ok() {
+            return true;
+        }
+        let hostname = hostname.to_ascii_lowercase();
+        self.allowed_hosts.contains(&hostname)
     }
 }
 
-fn parse_cors_origins(origins: &[String]) -> Vec<HeaderValue> {
-    origins
-        .iter()
-        .map(|origin| origin.parse().expect("Invalid CORS origin"))
-        .collect()
+/// Split `host[:port]` into hostname and port, unwrapping `[::1]` bracket form.
+fn split_host_port(authority: &str) -> Option<(&str, Option<u16>)> {
+    let authority = authority.split('/').next().unwrap_or("");
+    if authority.is_empty() {
+        return None;
+    }
+
+    if let Some(rest) = authority.strip_prefix('[') {
+        let (host, tail) = rest.split_once(']')?;
+        return match tail.strip_prefix(':') {
+            Some(port) => Some((host, Some(port.parse().ok()?))),
+            None if tail.is_empty() => Some((host, None)),
+            None => None,
+        };
+    }
+
+    match authority.rsplit_once(':') {
+        Some((host, port)) => Some((host, Some(port.parse().ok()?))),
+        None => Some((authority, None)),
+    }
 }
 
-fn is_local_host_origin(origin: &HeaderValue) -> bool {
-    let origin = match origin.to_str() {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-
+fn is_local_host_origin(origin: &str) -> bool {
     let Some((scheme, authority)) = origin.split_once("://") else {
         return false;
     };
@@ -153,40 +214,106 @@ fn is_local_host_origin(origin: &HeaderValue) -> bool {
         return false;
     }
 
-    let host = authority.split('/').next().unwrap_or("");
-    let Some((host, port)) = host.rsplit_once(':') else {
-        return host == "localhost" || host == "127.0.0.1";
+    let Some((host, _)) = split_host_port(authority) else {
+        return false;
     };
 
-    if host != "localhost" && host != "127.0.0.1" {
-        return false;
-    }
-
-    port.parse::<u16>().is_ok()
+    matches!(host, "localhost" | "127.0.0.1")
 }
 
 #[cfg(test)]
 mod tests {
-    use super::is_local_host_origin;
-    use http::header::HeaderValue;
+    use super::{is_local_host_origin, CorsOriginConfig, ServerConfig};
+
+    fn config(
+        cors_origins: CorsOriginConfig,
+        allow_dynamic_localhost_origins: bool,
+    ) -> ServerConfig {
+        ServerConfig {
+            host: "127.0.0.1".to_string(),
+            port: 30303,
+            cors_origins,
+            allow_dynamic_localhost_origins,
+            local_api_token: None,
+            allow_lan_without_token: false,
+            allowed_hosts: Vec::new(),
+        }
+    }
+
+    fn strict_config() -> ServerConfig {
+        config(
+            CorsOriginConfig::List(vec!["https://app.atmos.land".to_string()]),
+            false,
+        )
+    }
 
     #[test]
     fn allows_http_localhost_any_port() {
-        assert!(is_local_host_origin(&HeaderValue::from_static(
-            "http://127.0.0.1:1430"
-        )));
-        assert!(is_local_host_origin(&HeaderValue::from_static(
-            "https://localhost:8443"
-        )));
+        assert!(is_local_host_origin("http://127.0.0.1:1430"));
+        assert!(is_local_host_origin("https://localhost:8443"));
     }
 
     #[test]
     fn blocks_non_local_origins() {
-        assert!(!is_local_host_origin(&HeaderValue::from_static(
-            "http://example.com:1430"
-        )));
-        assert!(!is_local_host_origin(&HeaderValue::from_static(
-            "ftp://127.0.0.1:1430"
-        )));
+        assert!(!is_local_host_origin("http://example.com:1430"));
+        assert!(!is_local_host_origin("ftp://127.0.0.1:1430"));
+    }
+
+    #[test]
+    fn rejects_unlisted_origin_even_on_loopback_port() {
+        let config = strict_config();
+        assert!(!config.is_origin_allowed("https://evil.example"));
+        // A page on another local port is not automatically trusted once the
+        // dynamic-localhost allowance is off.
+        assert!(!config.is_origin_allowed("http://127.0.0.1:4000"));
+    }
+
+    #[test]
+    fn always_allows_own_origin_so_static_ui_keeps_working() {
+        let config = strict_config();
+        assert!(config.is_origin_allowed("http://127.0.0.1:30303"));
+        assert!(config.is_origin_allowed("http://localhost:30303"));
+        assert!(config.is_origin_allowed("http://[::1]:30303"));
+        assert!(config.is_origin_allowed("https://app.atmos.land"));
+    }
+
+    #[test]
+    fn dynamic_localhost_allowance_covers_any_local_port() {
+        let config = config(CorsOriginConfig::List(Vec::new()), true);
+        assert!(config.is_origin_allowed("http://localhost:3030"));
+        assert!(config.is_origin_allowed("http://127.0.0.1:5173"));
+        assert!(!config.is_origin_allowed("https://evil.example"));
+    }
+
+    #[test]
+    fn wildcard_cors_allows_every_origin() {
+        let config = config(CorsOriginConfig::Any, false);
+        assert!(config.is_origin_allowed("https://evil.example"));
+    }
+
+    #[test]
+    fn host_guard_accepts_ip_literals_and_localhost() {
+        let config = strict_config();
+        assert!(config.is_host_allowed("127.0.0.1:30303"));
+        assert!(config.is_host_allowed("localhost:30303"));
+        assert!(config.is_host_allowed("[::1]:30303"));
+        // Tailscale / LAN access by IP stays reachable.
+        assert!(config.is_host_allowed("100.101.102.103:30303"));
+    }
+
+    #[test]
+    fn host_guard_rejects_dns_names_used_for_rebinding() {
+        let config = strict_config();
+        assert!(!config.is_host_allowed("evil.example:30303"));
+        assert!(!config.is_host_allowed("rebind.local:30303"));
+    }
+
+    #[test]
+    fn host_guard_honors_explicit_allow_list() {
+        let mut config = strict_config();
+        config.allowed_hosts = vec!["box.tailnet.ts.net".to_string()];
+        assert!(config.is_host_allowed("box.tailnet.ts.net:30303"));
+        assert!(config.is_host_allowed("BOX.TAILNET.TS.NET:30303"));
+        assert!(!config.is_host_allowed("evil.example:30303"));
     }
 }

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use crate::api::ws::{
     automation_event_to_ws_message, WsEvent, WsManager, WsMessage, WsMessageService,
 };
-use crate::middleware::{require_local_token, require_loopback_or_token};
+use crate::middleware::{require_allowed_origin, require_local_token, require_loopback_or_token};
 use app_state::{AppServices, AppState};
 use axum::{
     http::{
@@ -821,6 +821,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let agent_hooks_for_startup = Arc::clone(&app_state.agent_hooks_service);
     let terminal_service_for_startup = Arc::clone(&app_state.terminal_service);
 
+    // Outermost layer: a WebSocket handshake bypasses CORS entirely, so untrusted
+    // browser origins have to be rejected before routing reaches /ws.
+    let origin_guard_config = Arc::new(server_config.clone());
+
     let mut app = Router::new()
         .route("/healthz", get(|| async { StatusCode::OK }))
         .merge(destructive)
@@ -828,7 +832,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_state(app_state)
         .layer(TraceLayer::new_for_http())
         .layer(map_response(add_private_network_header))
-        .layer(cors);
+        .layer(cors)
+        .layer(from_fn(move |headers, req, next| {
+            require_allowed_origin(headers, req, next, origin_guard_config.clone())
+        }));
 
     if let Ok(static_dir) = std::env::var("ATMOS_STATIC_DIR") {
         let static_path = std::path::PathBuf::from(&static_dir);

--- a/apps/api/src/middleware/mod.rs
+++ b/apps/api/src/middleware/mod.rs
@@ -1,11 +1,17 @@
 use axum::{
     extract::ConnectInfo,
-    http::{header::AUTHORIZATION, HeaderMap, Request, StatusCode},
+    http::{
+        header::{AUTHORIZATION, HOST, ORIGIN},
+        HeaderMap, Request, StatusCode,
+    },
     middleware::Next,
     response::Response,
 };
 use sha2::{Digest, Sha256};
 use std::net::SocketAddr;
+use std::sync::Arc;
+
+use crate::config::ServerConfig;
 
 fn constant_time_eq(a: &str, b: &str) -> bool {
     let hash_a = Sha256::digest(a.as_bytes());
@@ -15,6 +21,50 @@ fn constant_time_eq(a: &str, b: &str) -> bool {
         .zip(hash_b.iter())
         .fold(0u8, |acc, (x, y)| acc | (x ^ y))
         == 0
+}
+
+/// Reject browser-initiated requests from origins we do not trust.
+///
+/// This runs outside the CORS layer because a WebSocket handshake is exempt from
+/// the same-origin policy: without this guard any page the user visits can open
+/// `ws://127.0.0.1:<port>/ws/terminal/...` and, because the connection arrives
+/// from loopback, `require_local_token` waves it through. Only browsers are
+/// required to send `Origin`, so a missing header means a non-browser client
+/// (relay/tunnel bridge, CLI) and is left alone — same model as Chrome's
+/// `--remote-allow-origins` for the DevTools protocol.
+///
+/// The `Host` check closes the sibling hole: a same-origin request after DNS
+/// rebinding carries no `Origin` header at all, so the hostname has to be an IP
+/// literal or `localhost` (extend via `ATMOS_ALLOWED_HOSTS`).
+pub async fn require_allowed_origin(
+    headers: HeaderMap,
+    request: Request<axum::body::Body>,
+    next: Next,
+    config: Arc<ServerConfig>,
+) -> Result<Response, StatusCode> {
+    if let Some(host) = headers.get(HOST).and_then(|value| value.to_str().ok()) {
+        if !config.is_host_allowed(host) {
+            tracing::warn!(
+                "Rejected request with untrusted Host header: host={}, path={}",
+                host,
+                request.uri().path()
+            );
+            return Err(StatusCode::FORBIDDEN);
+        }
+    }
+
+    if let Some(origin) = headers.get(ORIGIN).and_then(|value| value.to_str().ok()) {
+        if !config.is_origin_allowed(origin) {
+            tracing::warn!(
+                "Rejected cross-origin request: origin={}, path={}",
+                origin,
+                request.uri().path()
+            );
+            return Err(StatusCode::FORBIDDEN);
+        }
+    }
+
+    Ok(next.run(request).await)
 }
 
 /// General middleware: trusts loopback by default.
@@ -134,4 +184,106 @@ pub fn is_request_authorized(
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::CorsOriginConfig;
+    use axum::{
+        body::Body, http::Request as HttpRequest, middleware::from_fn, routing::get, Router,
+    };
+    use tower::ServiceExt;
+
+    fn guarded_app() -> Router {
+        let config = Arc::new(ServerConfig {
+            host: "127.0.0.1".to_string(),
+            port: 30303,
+            cors_origins: CorsOriginConfig::List(vec!["https://app.atmos.land".to_string()]),
+            allow_dynamic_localhost_origins: false,
+            local_api_token: None,
+            allow_lan_without_token: false,
+            allowed_hosts: Vec::new(),
+        });
+
+        Router::new()
+            .route("/ws/terminal/{session_id}", get(|| async { "reached" }))
+            .layer(from_fn(move |headers, req, next| {
+                require_allowed_origin(headers, req, next, config.clone())
+            }))
+    }
+
+    async fn status_for(headers: &[(&str, &str)]) -> StatusCode {
+        let mut builder = HttpRequest::builder().uri("/ws/terminal/abc");
+        for (name, value) in headers {
+            builder = builder.header(*name, *value);
+        }
+        let request = builder.body(Body::empty()).expect("request builds");
+        guarded_app()
+            .oneshot(request)
+            .await
+            .expect("router responds")
+            .status()
+    }
+
+    #[tokio::test]
+    async fn blocks_terminal_websocket_from_untrusted_page() {
+        assert_eq!(
+            status_for(&[
+                ("host", "127.0.0.1:30303"),
+                ("origin", "https://evil.example")
+            ])
+            .await,
+            StatusCode::FORBIDDEN
+        );
+    }
+
+    #[tokio::test]
+    async fn allows_own_static_ui_origin() {
+        assert_eq!(
+            status_for(&[
+                ("host", "127.0.0.1:30303"),
+                ("origin", "http://127.0.0.1:30303")
+            ])
+            .await,
+            StatusCode::OK
+        );
+    }
+
+    #[tokio::test]
+    async fn allows_configured_hosted_origin() {
+        assert_eq!(
+            status_for(&[
+                ("host", "127.0.0.1:30303"),
+                ("origin", "https://app.atmos.land")
+            ])
+            .await,
+            StatusCode::OK
+        );
+    }
+
+    #[tokio::test]
+    async fn allows_clients_that_send_no_origin() {
+        // Rust relay/tunnel bridges and the CLI never set Origin.
+        assert_eq!(
+            status_for(&[("host", "127.0.0.1:30303")]).await,
+            StatusCode::OK
+        );
+    }
+
+    #[tokio::test]
+    async fn blocks_dns_rebinding_host() {
+        assert_eq!(
+            status_for(&[("host", "rebind.evil.example:30303")]).await,
+            StatusCode::FORBIDDEN
+        );
+    }
+
+    #[tokio::test]
+    async fn allows_lan_ip_host_for_tailscale_access() {
+        assert_eq!(
+            status_for(&[("host", "100.101.102.103:30303")]).await,
+            StatusCode::OK
+        );
+    }
 }

--- a/apps/api/src/relay/http_gateway.rs
+++ b/apps/api/src/relay/http_gateway.rs
@@ -97,6 +97,12 @@ pub async fn handle_http_envelope(body: &str) -> Option<String> {
         if lower == "authorization" {
             continue;
         }
+        // The remote browser's origin belongs to the edge hop, which already
+        // authenticated this request. Forwarding it would make the local origin
+        // guard judge a page it cannot reason about.
+        if lower == "origin" || lower == "referer" {
+            continue;
+        }
         let Ok(header_name) = HeaderName::from_bytes(name.as_bytes()) else {
             continue;
         };

--- a/apps/desktop-electron/src/runtime/ensure.ts
+++ b/apps/desktop-electron/src/runtime/ensure.ts
@@ -17,6 +17,8 @@ import { fileURLToPath } from "node:url";
 
 export const DEFAULT_HOST = "127.0.0.1";
 export const DEFAULT_PORT = 30303;
+/** Hosted web app that is allowed to talk to a local Server directly. */
+export const HOSTED_WEB_ORIGIN = "https://app.atmos.land";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -604,6 +606,14 @@ function spawnViaShell(
           SERVER_HOST: host,
           ATMOS_PORT: String(port),
           ATMOS_STATIC_DIR: web,
+          // Pin the browser origins allowed to reach this Server. Setting this
+          // also turns off the dev-only "any localhost port is trusted" rule, so
+          // a page served by some other local process cannot drive our API.
+          CORS_ORIGIN: [
+            `http://127.0.0.1:${port}`,
+            `http://localhost:${port}`,
+            HOSTED_WEB_ORIGIN,
+          ].join(","),
           ATMOS_RUNTIME_DIR: runtimeDir,
           ATMOS_DATA_DIR: dataDir,
           ATMOS_LOCAL_API_BIN: apiBin,

--- a/apps/desktop-electron/src/tunnel/gateway.ts
+++ b/apps/desktop-electron/src/tunnel/gateway.ts
@@ -161,6 +161,9 @@ export class LocalGateway {
       for (const [k, v] of Object.entries(req.headers)) {
         if (v == null) continue;
         if (k === "host" || k === "connection") continue;
+        // The remote page's origin belongs to this hop, which already validated
+        // entry_token. Forwarding it would trip the Server's origin guard.
+        if (k === "origin" || k === "referer") continue;
         headers[k] = Array.isArray(v) ? v.join(",") : v;
       }
 

--- a/crates/core-service/src/lib.rs
+++ b/crates/core-service/src/lib.rs
@@ -56,11 +56,11 @@ pub use service::notification::NotificationService;
 pub use service::project::ProjectService;
 pub use service::review::ReviewService;
 pub use service::terminal::{
-    AttachSessionParams, CapturePanePlainTextParams, CaptureSideContextParams,
-    CapturedPanePlainText, CapturedSideContext, CreateSessionParams, CreateSimpleSessionParams,
-    SessionDetail, SessionType, TerminalKind, TerminalMessage, TerminalResponse, TerminalService,
+    process_captured_pane_text, select_transcript, strip_ansi_and_controls, AttachSessionParams,
+    CapturePanePlainTextParams, CaptureSideContextParams, CapturedPanePlainText,
+    CapturedSideContext, CreateSessionParams, CreateSimpleSessionParams, SessionDetail,
+    SessionType, TerminalKind, TerminalMessage, TerminalResponse, TerminalService,
     TerminalSideChatRecord, TerminalSideChatStatus, TranscriptBudget, UpsertTerminalSideChatParams,
-    process_captured_pane_text, select_transcript, strip_ansi_and_controls,
 };
 pub use service::terminal_overview::build_terminal_overview_active_sessions_json;
 pub use service::test::TestService;

--- a/crates/core-service/src/service/agent_hooks/attention_summary_generate.rs
+++ b/crates/core-service/src/service/agent_hooks/attention_summary_generate.rs
@@ -23,9 +23,7 @@ use super::AgentAttentionLatch;
 use crate::error::{Result, ServiceError};
 use crate::service::automation::{resolve_automation_agent_with_config, AutomationAgentRunConfig};
 use crate::service::llm_text_generation::generate_text;
-use crate::service::terminal::{
-    CapturePanePlainTextParams, TerminalService, TranscriptBudget,
-};
+use crate::service::terminal::{CapturePanePlainTextParams, TerminalService, TranscriptBudget};
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(180);
 const MAX_TERMINAL_CONTEXT_BYTES: u32 = 12_000;

--- a/crates/core-service/src/service/terminal/management.rs
+++ b/crates/core-service/src/service/terminal/management.rs
@@ -10,9 +10,9 @@ use crate::error::{Result, ServiceError};
 
 use super::runtime::apply_utf8_env_to_tmux_command;
 use super::text_capture::{
-    count_lines, process_captured_pane_text, DEFAULT_CAPTURE_APPROX_LINES,
+    count_lines, process_captured_pane_text, TranscriptBudget, DEFAULT_CAPTURE_APPROX_LINES,
     DEFAULT_HEAD_PREFIX_BYTES, DEFAULT_MAX_RAW_CAPTURE_BYTES, DEFAULT_PROMPT_BUDGET_BYTES,
-    MAX_PROMPT_BUDGET_BYTES, MIN_PROMPT_BUDGET_BYTES, TranscriptBudget,
+    MAX_PROMPT_BUDGET_BYTES, MIN_PROMPT_BUDGET_BYTES,
 };
 use super::{
     CapturePanePlainTextParams, CaptureSideContextParams, CapturedPanePlainText,

--- a/crates/tunnel-connector/src/gateway.rs
+++ b/crates/tunnel-connector/src/gateway.rs
@@ -137,7 +137,14 @@ async fn proxy_http(
     let target_url = format!("{}{}", state.target_base_url, uri);
     let mut builder = state.client.request(method, &target_url);
     for (key, value) in &headers {
-        if key != header::HOST && key != header::COOKIE {
+        // Host/Cookie are ours to set. Origin/Referer describe the remote page,
+        // which this gateway already authorized via entry_token; passing them to
+        // the local Server would only trip its origin guard.
+        if key != header::HOST
+            && key != header::COOKIE
+            && key != header::ORIGIN
+            && key != header::REFERER
+        {
             builder = builder.header(key, value);
         }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the hole where **any website the user visits can execute commands on the machine running Atmos Server.**

A WebSocket handshake is exempt from the same-origin policy, so `CorsLayer` never protected `/ws`, `/ws/terminal`, or `/ws/agent`. Combined with `require_local_token` treating every loopback connection as trusted (`is_trusted_local_source` returns `true` for `127.0.0.1` regardless of whether `ATMOS_LOCAL_TOKEN` is set), a page on any origin could do this:

```js
const ws = new WebSocket("ws://127.0.0.1:30303/ws/terminal/x?mode=shell&shell=/bin/bash");
ws.onopen = () => ws.send(JSON.stringify({ type: "terminal_input", data: "…\n" }));
```

The `shell` query value goes straight to `CommandBuilder::new` in `crates/core-service/src/service/terminal/runtime.rs`, and `terminal_input` frames are written to the PTY. The port is the fixed default `30303`, and `ws://127.0.0.1` is a potentially-trustworthy origin so even an HTTPS page can open it. The main `/ws` endpoint is reachable the same way and adds `FsReadFile` / `FsWriteFile`.

### What this adds

`require_allowed_origin` as the outermost router layer:

- **Origin allowlist.** A request carrying `Origin` must satisfy `ServerConfig::is_origin_allowed`. A request without `Origin` passes, because only browsers are required to send it and the relay/tunnel bridges and CLI never do. This is the same model as Chrome's `--remote-allow-origins` for the DevTools protocol, which had this exact problem.
- **Host guard.** `Host` must be an IP literal, `localhost`, or listed in the new `ATMOS_ALLOWED_HOSTS`. A same-origin request after DNS rebinding carries no `Origin` at all, so `Host` is the only signal left. IP literals keep Tailscale and LAN access working; named access (e.g. MagicDNS `box.tailnet.ts.net`) opts in via `ATMOS_ALLOWED_HOSTS`.

CORS and the guard now share one predicate so the two rules cannot drift apart, and the server's own origin is always allowed so a UI served from `ATMOS_STATIC_DIR` keeps working without any launcher configuring `CORS_ORIGIN`.

### Two things this had to fix to avoid breaking remote access

- **Gateways forwarded the remote browser's `Origin`.** The relay HTTP gateway and both tunnel gateways passed `Origin`/`Referer` from the remote page through to loopback, which the new guard would have rejected — remote access would have broken. All three now strip both headers. Those requests are already authenticated at the edge (`client_token`, device credential, or `entry_token`), and the remote page's origin is not something the local Server can reason about.
- **Packaged Electron was running with the dev-only origin rule.** `ensure.ts` set neither `CORS_ORIGIN` nor `RUST_ENV`, so `allow_dynamic_localhost_origins` was `true` in production and *any* `http://localhost:<port>` page was trusted — any other local process serving a page could drive the API. Electron now pins `CORS_ORIGIN` to its own origin plus `app.atmos.land`, which also turns that rule off.

`https://app.atmos.land` stays allowed to reach loopback directly, per product decision (avoids forcing local users through relay). Note the consequence: an XSS on that origin is equivalent to local RCE.

## Related Issue

<!-- none -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] Additional checks (describe below)

Full `just lint` / `just test` were not run because this environment had no preinstalled toolchain (Rust was 1.83, below the `edition2024` requirement). Ran instead:

- `cargo build -p api -p tunnel-connector` — clean
- `cargo test -p api -p tunnel-connector` — 45 passed, 0 failed
- `cargo clippy -p api` — no warnings
- `cargo fmt -p api -p tunnel-connector -- --check` — clean
- `apps/desktop-electron`: `bun run build` — clean; `bun test` — 137 passed, 0 failed

15 new tests cover the guard: untrusted origin on `/ws/terminal` is rejected, own static-UI origin and the configured hosted origin pass, no-`Origin` clients pass, DNS-rebinding `Host` is rejected, LAN IP `Host` passes, plus the origin/host predicates directly.

Origin combinations verified against real launch paths: `just dev-api` with and without `--web-port`, E2E single-server and dual-server, packaged Electron (same-origin), `app.atmos.land`, and deprecated Tauri (`tauri://localhost`).

## Checklist

- [x] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

`apps/api/AGENTS.md` now documents the guard and the "keep CORS and the guard on the same predicate" rule; `.env.example` documents `ATMOS_ALLOWED_HOSTS` and that `CORS_ORIGIN` also gates WebSocket handshakes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-454e9284-6184-4272-ad77-735f61441f6c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-454e9284-6184-4272-ad77-735f61441f6c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects untrusted browser origins on both WebSocket and HTTP, closing a loopback WS bypass that let any website drive the local API. Previously, CORS did not cover `/ws*` and loopback was implicitly trusted; now an outermost origin/host guard blocks untrusted pages while non‑browser clients remain unaffected. Also reorders imports to satisfy rustfmt 1.97.1 (no behavior change).

- Adds an outer origin guard: requests with `Origin` must pass `ServerConfig::is_origin_allowed`; requests without `Origin` pass. Adds a `Host` check: only IPs, `localhost`, or names in `ATMOS_ALLOWED_HOSTS` are accepted (blocks DNS rebinding). CORS and the guard share one predicate; `CORS_ORIGIN` now also gates WebSocket; the server’s own origin is always allowed for the static UI.
- Gateways (relay, tunnel) stop forwarding `Origin`/`Referer` to loopback to avoid tripping the guard; packaged Electron pins `CORS_ORIGIN` to its own origin and `https://app.atmos.land`, which disables the dev-only dynamic localhost allowance.

**Rollout/Migration**
- If you reach the server by DNS name (e.g., Tailscale MagicDNS), set `ATMOS_ALLOWED_HOSTS=<your-hostname>`.
- If you ship a custom UI/launcher, include its origin in `CORS_ORIGIN` (it now controls WebSocket handshakes).
- If you proxy to the local server, strip `Origin` and `Referer` before forwarding.

<sup>Written for commit c7bb1ddf578abd399feb85312c3b9f76bca00dab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

