### PR TITLE
fix(agent-hooks): keep need-attention summary after focusing Terminal

### DIFF
--- a/apps/api/src/api/hooks/mod.rs
+++ b/apps/api/src/api/hooks/mod.rs
@@ -268,6 +268,10 @@ struct ClearAttentionBody {
     /// late dismiss cannot wipe a newer turn that landed after the client acted.
     #[serde(default)]
     not_after: Option<String>,
+    /// When true, also drop auto-summary chrome (explicit Dismiss / send / pane
+    /// destroy). Focus-ack omits this so the user can still read the recap.
+    #[serde(default)]
+    dismiss_summary: bool,
 }
 
 async fn clear_attention(
@@ -285,30 +289,9 @@ async fn clear_attention(
         .as_deref()
         .map(str::trim)
         .filter(|s| !s.is_empty());
-    let cleared = if let Some(cutoff) = not_after {
-        if ids.len() == 1 {
-            state
-                .agent_hooks_service
-                .clear_attention_for_pane_not_after(ids[0].as_str(), cutoff)
-        } else {
-            // Multi-id guarded clear: reuse single-id path per id.
-            let mut all = Vec::new();
-            for id in &ids {
-                all.extend(
-                    state
-                        .agent_hooks_service
-                        .clear_attention_for_pane_not_after(id.as_str(), cutoff),
-                );
-            }
-            all
-        }
-    } else if ids.len() == 1 {
-        state
-            .agent_hooks_service
-            .clear_attention_for_pane(ids[0].as_str())
-    } else {
-        state.agent_hooks_service.clear_attention_matching_ids(&ids)
-    };
+    let cleared = state
+        .agent_hooks_service
+        .clear_attention_matching_ids_not_after(&ids, not_after, body.dismiss_summary);
     Json(serde_json::json!({ "cleared": cleared }))
 }
 

--- a/apps/web/src/api/rest-api.ts
+++ b/apps/web/src/api/rest-api.ts
@@ -667,6 +667,8 @@ export const agentHooksApi = {
     stablePaneIds?: string[];
     /** RFC3339: only clear latches raised at or before this (dismiss race guard). */
     notAfter?: string;
+    /** Also drop auto-summary chrome. Focus-ack omits this; Dismiss / send set it. */
+    dismissSummary?: boolean;
   }): Promise<{ cleared: string[] }> => {
     return fetchHooksApi<{ cleared: string[] }>('/hooks/attention/clear', {
       method: 'POST',
@@ -674,6 +676,7 @@ export const agentHooksApi = {
         stable_pane_id: input.stablePaneId,
         stable_pane_ids: input.stablePaneIds,
         not_after: input.notAfter,
+        dismiss_summary: input.dismissSummary === true ? true : undefined,
       }),
     });
   },

--- a/apps/web/src/features/agent/store/agent-attention-store.test.ts
+++ b/apps/web/src/features/agent/store/agent-attention-store.test.ts
@@ -4,12 +4,17 @@ import {
   setAgentPaneAcknowledgedHandler,
   useAgentAttentionStore,
 } from "./agent-attention-store";
+import { useAgentAttentionSummaryStore } from "./agent-attention-summary-store";
 
 beforeEach(() => {
   useAgentAttentionStore.setState({
     panes: new Map(),
     filterMode: false,
     focusedStablePaneId: null,
+    revision: 0,
+  });
+  useAgentAttentionSummaryStore.setState({
+    panes: new Map(),
     revision: 0,
   });
   setAgentPaneAcknowledgedHandler(null);
@@ -60,6 +65,29 @@ describe("agent-attention-store", () => {
     useAgentAttentionStore.getState().notifyPaneFocused("ws-1:main");
     expect(ack).toHaveBeenCalledTimes(1);
     expect(ack).toHaveBeenCalledWith("ws-1:main");
+  });
+
+  test("notifyPaneFocused keeps auto-summary chrome", () => {
+    useAgentAttentionSummaryStore.getState().upsert({
+      stablePaneId: "ws-1:main",
+      contextId: "ws-1",
+      sessionId: "ws-1:main",
+      status: "ready",
+      summary: "Shipped the recap.",
+      nextSteps: ["Open the PR"],
+      startedAt: Date.now(),
+    });
+    const store = useAgentAttentionStore.getState();
+    store.raise({
+      stablePaneId: "ws-1:main",
+      contextId: "ws-1",
+      reason: "task_complete",
+    });
+    store.notifyPaneFocused("ws-1:main");
+    expect(store.hasPaneAttention("ws-1:main")).toBe(false);
+    expect(
+      useAgentAttentionSummaryStore.getState().getPane("ws-1:main")?.summary,
+    ).toBe("Shipped the recap.");
   });
 
   test("notifyPaneFocused clears attention when focus key matches sessionId alias", () => {

--- a/apps/web/src/features/agent/store/agent-attention-store.ts
+++ b/apps/web/src/features/agent/store/agent-attention-store.ts
@@ -5,7 +5,6 @@ import {
   agentHooksApi,
   type AgentAttentionLatchDto,
 } from "@/api/rest-api";
-import { useAgentAttentionSummaryStore } from "@/features/agent/store/agent-attention-summary-store";
 
 export type AttentionReason = "permission_request" | "task_complete";
 
@@ -206,8 +205,6 @@ export const useAgentAttentionStore = create<AgentAttentionStore>((set, get) => 
       const filterMode = panes.size === 0 ? false : state.filterMode;
       return { panes, filterMode, revision: state.revision + 1 };
     });
-    // Keep auto-summary chrome in sync with local acknowledge.
-    useAgentAttentionSummaryStore.getState().clearPane(stablePaneId);
   },
 
   clearMatchingSessionIds: (ids) => {

--- a/apps/web/src/features/agent/store/agent-attention-summary-store.test.ts
+++ b/apps/web/src/features/agent/store/agent-attention-summary-store.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { dismissAttentionSummaryChrome, useAgentAttentionSummaryStore } from "./agent-attention-summary-store";
+import { useAgentAttentionStore } from "./agent-attention-store";
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  useAgentAttentionStore.setState({
+    panes: new Map(),
+    filterMode: false,
+    focusedStablePaneId: null,
+    revision: 0,
+  });
+  useAgentAttentionSummaryStore.setState({
+    panes: new Map(),
+    revision: 0,
+  });
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ cleared: ["ws-1:main"] }), {
+      headers: { "Content-Type": "application/json" },
+      status: 200,
+    })) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("dismissAttentionSummaryChrome", () => {
+  test("clears local summary and latch", () => {
+    useAgentAttentionStore.getState().raise({
+      stablePaneId: "ws-1:main",
+      contextId: "ws-1",
+      reason: "task_complete",
+    });
+    useAgentAttentionSummaryStore.getState().upsert({
+      stablePaneId: "ws-1:main",
+      contextId: "ws-1",
+      sessionId: "ws-1:main",
+      status: "ready",
+      summary: "While you were away",
+      nextSteps: [],
+      startedAt: Date.now(),
+    });
+
+    dismissAttentionSummaryChrome("ws-1:main");
+
+    expect(useAgentAttentionStore.getState().hasPaneAttention("ws-1:main")).toBe(false);
+    expect(useAgentAttentionSummaryStore.getState().getPane("ws-1:main")).toBeNull();
+  });
+
+  test("no-ops when neither latch nor summary exists", () => {
+    const attentionRev = useAgentAttentionStore.getState().revision;
+    const summaryRev = useAgentAttentionSummaryStore.getState().revision;
+    dismissAttentionSummaryChrome("ws-1:main");
+    expect(useAgentAttentionStore.getState().revision).toBe(attentionRev);
+    expect(useAgentAttentionSummaryStore.getState().revision).toBe(summaryRev);
+  });
+});

--- a/apps/web/src/features/agent/store/agent-attention-summary-store.test.ts
+++ b/apps/web/src/features/agent/store/agent-attention-summary-store.test.ts
@@ -56,4 +56,86 @@ describe("dismissAttentionSummaryChrome", () => {
     expect(useAgentAttentionStore.getState().revision).toBe(attentionRev);
     expect(useAgentAttentionSummaryStore.getState().revision).toBe(summaryRev);
   });
+
+  test("clears attention keyed by session alias", () => {
+    useAgentAttentionStore.getState().raise({
+      stablePaneId: "agent-session-uuid",
+      contextId: "ws-1",
+      reason: "task_complete",
+      sessionId: "ws-1:main",
+    });
+    useAgentAttentionSummaryStore.getState().upsert({
+      stablePaneId: "ws-1:main",
+      contextId: "ws-1",
+      sessionId: "agent-session-uuid",
+      status: "ready",
+      summary: "While you were away",
+      nextSteps: [],
+      startedAt: Date.now(),
+    });
+
+    dismissAttentionSummaryChrome("ws-1:main");
+
+    expect(useAgentAttentionStore.getState().hasPaneAttention("agent-session-uuid")).toBe(false);
+    expect(useAgentAttentionSummaryStore.getState().getPane("ws-1:main")).toBeNull();
+  });
+
+  test("restores this pane when dismiss fails even if another pane advanced the store", async () => {
+    let rejectFetch!: (error: Error) => void;
+    let fetchStarted!: () => void;
+    const fetchReady = new Promise<void>((resolve) => {
+      fetchStarted = resolve;
+    });
+    globalThis.fetch = (() => {
+      fetchStarted();
+      return new Promise((_, reject) => {
+        rejectFetch = reject as (error: Error) => void;
+      });
+    }) as typeof fetch;
+
+    useAgentAttentionStore.getState().raise({
+      stablePaneId: "ws-1:main",
+      contextId: "ws-1",
+      reason: "task_complete",
+    });
+    useAgentAttentionSummaryStore.getState().upsert({
+      stablePaneId: "ws-1:main",
+      contextId: "ws-1",
+      sessionId: "ws-1:main",
+      status: "ready",
+      summary: "Keep me if the request fails",
+      nextSteps: [],
+      startedAt: Date.now(),
+    });
+
+    dismissAttentionSummaryChrome("ws-1:main");
+    expect(useAgentAttentionSummaryStore.getState().getPane("ws-1:main")).toBeNull();
+
+    useAgentAttentionStore.getState().raise({
+      stablePaneId: "ws-2:other",
+      contextId: "ws-2",
+      reason: "task_complete",
+    });
+    useAgentAttentionSummaryStore.getState().upsert({
+      stablePaneId: "ws-2:other",
+      contextId: "ws-2",
+      sessionId: "ws-2:other",
+      status: "ready",
+      summary: "unrelated pane",
+      nextSteps: [],
+      startedAt: Date.now(),
+    });
+
+    await fetchReady;
+    rejectFetch(new Error("network"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(
+      useAgentAttentionSummaryStore.getState().getPane("ws-1:main")?.summary,
+    ).toBe("Keep me if the request fails");
+    expect(useAgentAttentionStore.getState().hasPaneAttention("ws-1:main")).toBe(true);
+    expect(
+      useAgentAttentionSummaryStore.getState().getPane("ws-2:other")?.summary,
+    ).toBe("unrelated pane");
+  });
 });

--- a/apps/web/src/features/agent/store/agent-attention-summary-store.ts
+++ b/apps/web/src/features/agent/store/agent-attention-summary-store.ts
@@ -6,7 +6,10 @@ import {
   type AgentAttentionSummaryDto,
   type AttentionSummaryStatusDto,
 } from "@/api/rest-api";
-import { useAgentAttentionStore } from "@/features/agent/store/agent-attention-store";
+import {
+  type PaneAttention,
+  useAgentAttentionStore,
+} from "@/features/agent/store/agent-attention-store";
 
 export type AttentionSummaryStatus = AttentionSummaryStatusDto;
 
@@ -160,10 +163,11 @@ export function dismissAttentionSummaryChrome(stablePaneId: string): void {
 
   const attentionStore = useAgentAttentionStore.getState();
   const summaryStore = useAgentAttentionSummaryStore.getState();
-  const latch = attentionStore.panes.get(id);
+  const prevAttentionList = collectMatchingAttention(attentionStore.panes, id);
   const prevSummary = summaryStore.panes.get(id) ?? null;
-  if (!latch && !prevSummary) return;
-  const prevAttention = latch ?? null;
+  if (prevAttentionList.length === 0 && !prevSummary) return;
+
+  const latch = prevAttentionList[0];
   const notAfter = latch?.raisedAt
     ? new Date(latch.raisedAt).toISOString()
     : prevSummary?.startedAt
@@ -171,10 +175,7 @@ export function dismissAttentionSummaryChrome(stablePaneId: string): void {
       : undefined;
 
   summaryStore.clearPane(id);
-  attentionStore.clearPane(id);
-
-  const attentionRevAfterClear = useAgentAttentionStore.getState().revision;
-  const summaryRevAfterClear = useAgentAttentionSummaryStore.getState().revision;
+  attentionStore.clearMatchingSessionIds([id]);
 
   void agentHooksApi
     .clearAttention({ stablePaneId: id, notAfter, dismissSummary: true })
@@ -183,26 +184,58 @@ export function dismissAttentionSummaryChrome(stablePaneId: string): void {
         "[AgentAttentionSummaryStore] Failed to dismiss summary:",
         error,
       );
-      const attentionNow = useAgentAttentionStore.getState();
-      const summaryNow = useAgentAttentionSummaryStore.getState();
-      if (
-        attentionNow.revision !== attentionRevAfterClear ||
-        summaryNow.revision !== summaryRevAfterClear
-      ) {
-        return;
-      }
-      if (!attentionNow.panes.has(id) && prevAttention) {
-        attentionNow.raise({
-          stablePaneId: prevAttention.stablePaneId,
-          contextId: prevAttention.contextId,
-          reason: prevAttention.reason,
-          sessionId: prevAttention.sessionId,
-          tool: prevAttention.tool,
-          raisedAt: prevAttention.raisedAt,
-        });
-      }
-      if (!summaryNow.panes.has(id) && prevSummary) {
-        useAgentAttentionSummaryStore.getState().upsert(prevSummary);
-      }
+      restoreDismissedAttentionSummary(id, prevAttentionList, prevSummary);
     });
+}
+
+function collectMatchingAttention(
+  panes: Map<string, PaneAttention>,
+  id: string,
+): PaneAttention[] {
+  const matched: PaneAttention[] = [];
+  for (const [key, pane] of panes) {
+    if (key === id || pane.sessionId === id) {
+      matched.push(pane);
+    }
+  }
+  return matched;
+}
+
+function restoreDismissedAttentionSummary(
+  id: string,
+  prevAttentionList: readonly PaneAttention[],
+  prevSummary: PaneAttentionSummary | null,
+): void {
+  const attentionNow = useAgentAttentionStore.getState();
+  const summaryNow = useAgentAttentionSummaryStore.getState();
+  // Restore per-pane, not by global revision — another pane can bump either
+  // store while this request is in flight.
+  const currentMatches = collectMatchingAttention(attentionNow.panes, id);
+  const newestCurrentRaisedAt = currentMatches.reduce(
+    (best, pane) => Math.max(best, pane.raisedAt),
+    0,
+  );
+  const prevRaisedAt = prevAttentionList.reduce(
+    (best, pane) => Math.max(best, pane.raisedAt),
+    prevSummary?.startedAt ?? 0,
+  );
+  const newerTurnTookOver =
+    newestCurrentRaisedAt > 0 && newestCurrentRaisedAt > prevRaisedAt;
+
+  if (currentMatches.length === 0) {
+    for (const prev of prevAttentionList) {
+      attentionNow.raise({
+        stablePaneId: prev.stablePaneId,
+        contextId: prev.contextId,
+        reason: prev.reason,
+        sessionId: prev.sessionId,
+        tool: prev.tool,
+        raisedAt: prev.raisedAt,
+      });
+    }
+  }
+
+  if (!newerTurnTookOver && !summaryNow.panes.has(id) && prevSummary) {
+    useAgentAttentionSummaryStore.getState().upsert(prevSummary);
+  }
 }

--- a/apps/web/src/features/agent/store/agent-attention-summary-store.ts
+++ b/apps/web/src/features/agent/store/agent-attention-summary-store.ts
@@ -6,6 +6,7 @@ import {
   type AgentAttentionSummaryDto,
   type AttentionSummaryStatusDto,
 } from "@/api/rest-api";
+import { useAgentAttentionStore } from "@/features/agent/store/agent-attention-store";
 
 export type AttentionSummaryStatus = AttentionSummaryStatusDto;
 
@@ -147,4 +148,61 @@ export async function hydrateAttentionSummariesFromServer(): Promise<void> {
       error,
     );
   }
+}
+
+/**
+ * Explicit Dismiss / composer send / pane destroy. Focus-ack must not call this
+ * — the recap stays until the user has actually consumed it.
+ */
+export function dismissAttentionSummaryChrome(stablePaneId: string): void {
+  const id = stablePaneId?.trim();
+  if (!id) return;
+
+  const attentionStore = useAgentAttentionStore.getState();
+  const summaryStore = useAgentAttentionSummaryStore.getState();
+  const latch = attentionStore.panes.get(id);
+  const prevSummary = summaryStore.panes.get(id) ?? null;
+  if (!latch && !prevSummary) return;
+  const prevAttention = latch ?? null;
+  const notAfter = latch?.raisedAt
+    ? new Date(latch.raisedAt).toISOString()
+    : prevSummary?.startedAt
+      ? new Date(prevSummary.startedAt).toISOString()
+      : undefined;
+
+  summaryStore.clearPane(id);
+  attentionStore.clearPane(id);
+
+  const attentionRevAfterClear = useAgentAttentionStore.getState().revision;
+  const summaryRevAfterClear = useAgentAttentionSummaryStore.getState().revision;
+
+  void agentHooksApi
+    .clearAttention({ stablePaneId: id, notAfter, dismissSummary: true })
+    .catch((error) => {
+      console.warn(
+        "[AgentAttentionSummaryStore] Failed to dismiss summary:",
+        error,
+      );
+      const attentionNow = useAgentAttentionStore.getState();
+      const summaryNow = useAgentAttentionSummaryStore.getState();
+      if (
+        attentionNow.revision !== attentionRevAfterClear ||
+        summaryNow.revision !== summaryRevAfterClear
+      ) {
+        return;
+      }
+      if (!attentionNow.panes.has(id) && prevAttention) {
+        attentionNow.raise({
+          stablePaneId: prevAttention.stablePaneId,
+          contextId: prevAttention.contextId,
+          reason: prevAttention.reason,
+          sessionId: prevAttention.sessionId,
+          tool: prevAttention.tool,
+          raisedAt: prevAttention.raisedAt,
+        });
+      }
+      if (!summaryNow.panes.has(id) && prevSummary) {
+        useAgentAttentionSummaryStore.getState().upsert(prevSummary);
+      }
+    });
 }

--- a/apps/web/src/features/agent/store/agent-hooks-store.ts
+++ b/apps/web/src/features/agent/store/agent-hooks-store.ts
@@ -258,10 +258,6 @@ export const useAgentHooksStore = create<AgentHooksStore>((set, get) => ({
         const { stable_pane_ids } = data as { stable_pane_ids?: string[] };
         if (!stable_pane_ids?.length) return;
         useAgentAttentionStore.getState().clearMatchingSessionIds(stable_pane_ids);
-        // Backend also clears summaries, but keep client in sync if events reorder.
-        useAgentAttentionSummaryStore
-          .getState()
-          .clearMatchingIds(stable_pane_ids);
       },
     );
 

--- a/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
+++ b/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
@@ -98,10 +98,9 @@ import {
 import { useTerminalRichInputSettingsStore } from "@/features/settings/store/terminal-rich-input-settings-store";
 import {
   selectPaneAttentionSummary,
+  dismissAttentionSummaryChrome,
   useAgentAttentionSummaryStore,
 } from "@/features/agent/store/agent-attention-summary-store";
-import { useAgentAttentionStore } from "@/features/agent/store/agent-attention-store";
-import { agentHooksApi } from "@/api/rest-api";
 import { AttentionSummaryPanel } from "./AttentionSummaryPanel";
 
 import "./TerminalAgentInputOverlay.css";
@@ -1026,6 +1025,7 @@ export const TerminalAgentInputOverlay = React.forwardRef<
         } else {
           await runSideChat(prompt, contextAgent.agent, contextAgent.runConfig, selectedContexts);
         }
+        if (stablePaneId) dismissAttentionSummaryChrome(stablePaneId);
         return;
       }
 
@@ -1050,6 +1050,7 @@ export const TerminalAgentInputOverlay = React.forwardRef<
         setPromptContexts([]);
         setMentionPopover(null);
         setSlashPopover(null);
+        if (stablePaneId) dismissAttentionSummaryChrome(stablePaneId);
         return;
       }
       const isMultiLine = trimmedExpandedText.includes("\n");
@@ -1076,6 +1077,7 @@ export const TerminalAgentInputOverlay = React.forwardRef<
       setPromptContexts([]);
       setMentionPopover(null);
       setSlashPopover(null);
+      if (stablePaneId) dismissAttentionSummaryChrome(stablePaneId);
     } catch (error) {
       console.error("Failed to submit terminal agent input:", error);
     } finally {
@@ -1101,6 +1103,7 @@ export const TerminalAgentInputOverlay = React.forwardRef<
     runSideChat,
     runSpawn,
     shouldShowSideChatAgentSelector,
+    stablePaneId,
     submitMode,
     text,
   ]);
@@ -1197,63 +1200,7 @@ export const TerminalAgentInputOverlay = React.forwardRef<
               }}
               onDismiss={() => {
                 if (!stablePaneId) return;
-                // Capture observed latch time so a late clear cannot wipe a newer turn.
-                const attentionStore = useAgentAttentionStore.getState();
-                const summaryStore = useAgentAttentionSummaryStore.getState();
-                const latch = attentionStore.panes.get(stablePaneId);
-                const prevSummary = summaryStore.panes.get(stablePaneId) ?? null;
-                const prevAttention = latch ?? null;
-                const notAfter = latch?.raisedAt
-                  ? new Date(latch.raisedAt).toISOString()
-                  : attentionSummary?.startedAt
-                    ? new Date(attentionSummary.startedAt).toISOString()
-                    : undefined;
-                // Optimistic local clear, then persist via attention-clear so
-                // refresh hydration cannot resurrect the dismissed summary.
-                summaryStore.clearPane(stablePaneId);
-                attentionStore.clearPane(stablePaneId);
-                // Snapshot revisions *after* optimistic clear. If a WS clear /
-                // raise advances either store while the request is in flight,
-                // we must not roll back over that authoritative update.
-                const attentionRevAfterClear =
-                  useAgentAttentionStore.getState().revision;
-                const summaryRevAfterClear =
-                  useAgentAttentionSummaryStore.getState().revision;
-                void agentHooksApi
-                  .clearAttention({ stablePaneId, notAfter })
-                  .catch((error) => {
-                    console.warn(
-                      "[TerminalAgentInputOverlay] Failed to clear attention on dismiss:",
-                      error,
-                    );
-                    const attentionNow = useAgentAttentionStore.getState();
-                    const summaryNow = useAgentAttentionSummaryStore.getState();
-                    if (
-                      attentionNow.revision !== attentionRevAfterClear ||
-                      summaryNow.revision !== summaryRevAfterClear
-                    ) {
-                      // Focus ack, another clear, or a newer raise already
-                      // mutated local state — leave it alone.
-                      return;
-                    }
-                    if (!attentionNow.panes.has(stablePaneId) && prevAttention) {
-                      attentionNow.raise({
-                        stablePaneId: prevAttention.stablePaneId,
-                        contextId: prevAttention.contextId,
-                        reason: prevAttention.reason,
-                        sessionId: prevAttention.sessionId,
-                        tool: prevAttention.tool,
-                        raisedAt: prevAttention.raisedAt,
-                      });
-                    }
-                    if (!summaryNow.panes.has(stablePaneId) && prevSummary) {
-                      // raise() does not restore summary chrome; re-upsert only
-                      // when the store is still at the post-dismiss revision.
-                      useAgentAttentionSummaryStore
-                        .getState()
-                        .upsert(prevSummary);
-                    }
-                  });
+                dismissAttentionSummaryChrome(stablePaneId);
               }}
             />
           </div>

--- a/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
+++ b/apps/web/src/features/terminal/components/TerminalAgentInputOverlay.tsx
@@ -932,7 +932,8 @@ export const TerminalAgentInputOverlay = React.forwardRef<
     await onStartSideChat(prompt, agent, sanitizeRunConfig(runConfig), contexts);
     const flyTarget = await resolveSideChatFlyTarget(getSideChatFlyTargetClientPoint);
     startSuccessfulSubmitAnimation(prompt, flyTarget);
-  }, [getSideChatFlyTargetClientPoint, onStartSideChat, startSuccessfulSubmitAnimation]);
+    if (stablePaneId) dismissAttentionSummaryChrome(stablePaneId);
+  }, [getSideChatFlyTargetClientPoint, onStartSideChat, stablePaneId, startSuccessfulSubmitAnimation]);
 
   const runSpawn = React.useCallback(async (
     prompt: string,
@@ -943,7 +944,8 @@ export const TerminalAgentInputOverlay = React.forwardRef<
     if (!onSpawn) return;
     await onSpawn(prompt, agent, sanitizeRunConfig(runConfig), contexts);
     startSuccessfulSubmitAnimation(prompt);
-  }, [onSpawn, startSuccessfulSubmitAnimation]);
+    if (stablePaneId) dismissAttentionSummaryChrome(stablePaneId);
+  }, [onSpawn, stablePaneId, startSuccessfulSubmitAnimation]);
 
   const handleSideChatRunConfigChange = React.useCallback(
     (agentId: string, value: TerminalAgentRunConfigInput | null) => {
@@ -1025,7 +1027,6 @@ export const TerminalAgentInputOverlay = React.forwardRef<
         } else {
           await runSideChat(prompt, contextAgent.agent, contextAgent.runConfig, selectedContexts);
         }
-        if (stablePaneId) dismissAttentionSummaryChrome(stablePaneId);
         return;
       }
 

--- a/apps/web/src/features/terminal/components/TerminalGrid.tsx
+++ b/apps/web/src/features/terminal/components/TerminalGrid.tsx
@@ -15,7 +15,7 @@ import { cn } from "@workspace/ui";
 import type { TerminalRef } from "./Terminal";
 import type { TerminalPaneAgent } from "../types/index";
 import { isPathLikeTitle } from "./terminal-title";
-import { systemApi } from "@/api/rest-api";
+import { agentHooksApi, systemApi } from "@/api/rest-api";
 import { useTerminalStore, FIXED_TERMINAL_TAB_VALUE } from "@/features/terminal/store/use-terminal-store";
 import { useTerminalSplitPrefsStore } from "@/features/settings/store/terminal-split-prefs-store";
 import { resolveDefaultSplitAgent } from "@/features/terminal/lib/terminal-split-prefs";
@@ -48,6 +48,7 @@ import { useTerminalGridCanvasPins } from "../hooks/use-terminal-grid-canvas-pin
 import { useTerminalGridHotkeys } from "../hooks/use-terminal-grid-hotkeys";
 import { useContestedCliOwners } from "../hooks/use-contested-cli-owners";
 import { useAgentAttentionStore } from "@/features/agent/store/agent-attention-store";
+import { useAgentAttentionSummaryStore } from "@/features/agent/store/agent-attention-summary-store";
 import { useAgentHooksStore } from "@/features/agent/store/agent-hooks-store";
 import {
   toPendingTerminalRun,
@@ -418,6 +419,12 @@ export const TerminalGrid = React.forwardRef<TerminalGridHandle, TerminalGridPro
     if (!windowName || !workspaceId) return;
     const stablePaneId = `${workspaceId}:${windowName}`;
     useAgentAttentionStore.getState().clearPane(stablePaneId);
+    useAgentAttentionSummaryStore.getState().clearPane(stablePaneId);
+    void agentHooksApi
+      .clearAttention({ stablePaneId, dismissSummary: true })
+      .catch((error) => {
+        console.warn("[TerminalGrid] Failed to dismiss attention summary on pane close:", error);
+      });
     void useAgentHooksStore.getState().removeSession(stablePaneId);
   }, [workspaceId]);
 

--- a/crates/core-service/src/lib.rs
+++ b/crates/core-service/src/lib.rs
@@ -56,11 +56,11 @@ pub use service::notification::NotificationService;
 pub use service::project::ProjectService;
 pub use service::review::ReviewService;
 pub use service::terminal::{
-    AttachSessionParams, CapturePanePlainTextParams, CaptureSideContextParams,
-    CapturedPanePlainText, CapturedSideContext, CreateSessionParams, CreateSimpleSessionParams,
-    SessionDetail, SessionType, TerminalKind, TerminalMessage, TerminalResponse, TerminalService,
+    process_captured_pane_text, select_transcript, strip_ansi_and_controls, AttachSessionParams,
+    CapturePanePlainTextParams, CaptureSideContextParams, CapturedPanePlainText,
+    CapturedSideContext, CreateSessionParams, CreateSimpleSessionParams, SessionDetail,
+    SessionType, TerminalKind, TerminalMessage, TerminalResponse, TerminalService,
     TerminalSideChatRecord, TerminalSideChatStatus, TranscriptBudget, UpsertTerminalSideChatParams,
-    process_captured_pane_text, select_transcript, strip_ansi_and_controls,
 };
 pub use service::terminal_overview::build_terminal_overview_active_sessions_json;
 pub use service::test::TestService;

--- a/crates/core-service/src/service/agent_hooks.rs
+++ b/crates/core-service/src/service/agent_hooks.rs
@@ -289,8 +289,9 @@ impl AgentHooksService {
         self.clear_child_tracking(session_id);
         if removed {
             self.broadcast_sessions_cleared(vec![session_id.to_string()]);
-            // Explicit session dismiss drops the latch but keeps auto-summary
-            // chrome (focus-ack / idle dismiss is how the user gets to read it).
+            // Removing the session row drops the latch but keeps auto-summary
+            // chrome — the pane may still exist, so the user can still read the
+            // recap. Only explicit Dismiss / send / pane destroy drop it.
             self.clear_attention_matching_ids(&[session_id.to_string()]);
         }
         removed

--- a/crates/core-service/src/service/agent_hooks.rs
+++ b/crates/core-service/src/service/agent_hooks.rs
@@ -289,7 +289,8 @@ impl AgentHooksService {
         self.clear_child_tracking(session_id);
         if removed {
             self.broadcast_sessions_cleared(vec![session_id.to_string()]);
-            // Explicit session dismiss also drops sticky attention for that id.
+            // Explicit session dismiss drops the latch but keeps auto-summary
+            // chrome (focus-ack / idle dismiss is how the user gets to read it).
             self.clear_attention_matching_ids(&[session_id.to_string()]);
         }
         removed
@@ -334,10 +335,11 @@ impl AgentHooksService {
             );
             self.broadcast_sessions_cleared(removed.clone());
         }
-        // Pane is gone — drop sticky attention for this pane and session aliases.
+        // Pane is gone — drop sticky attention and auto-summary for this pane
+        // and session aliases.
         let mut attention_ids = removed.clone();
         attention_ids.push(stable_pane_id.to_string());
-        self.clear_attention_matching_ids(&attention_ids);
+        self.clear_attention_and_summaries_matching_ids(&attention_ids);
         removed
     }
 
@@ -893,11 +895,81 @@ mod tests {
             AgentHookState::Running,
             None,
             &ctx,
-            StateUpdateKind::Progress,
+            StateUpdateKind::NewTurn,
         );
+        service.update_state(
+            "ws-1:win",
+            AgentToolType::Cursor,
+            AgentHookState::Idle,
+            None,
+            &ctx,
+            StateUpdateKind::TerminalIdle,
+        );
+        let (_, _, gen) = service.begin_attention_summary("ws-1:win").expect("begin");
+        let _ = service.complete_attention_summary(
+            "ws-1:win",
+            gen,
+            AttentionSummaryPayload {
+                summary: "done".into(),
+                next_steps: vec![],
+                can_close_session: true,
+            },
+        );
+        assert!(!service.get_all_attention().is_empty());
+        assert!(service.get_attention_summary("ws-1:win").is_some());
+
         let removed = service.clear_sessions_for_stable_pane("ws-1:win");
         assert_eq!(removed, vec!["ws-1:win".to_string()]);
         assert!(service.get_all_sessions().is_empty());
+        assert!(service.get_all_attention().is_empty());
+        assert!(service.get_all_attention_summaries().is_empty());
+    }
+
+    #[test]
+    fn remove_session_drops_latch_but_keeps_summary() {
+        let service = AgentHooksService::new();
+        let ctx = AtmosContext {
+            pane_id: Some("ws-1:win".into()),
+            context_id: Some("ws-1".into()),
+            ..AtmosContext::default()
+        };
+        service.update_state(
+            "ws-1:win",
+            AgentToolType::Cursor,
+            AgentHookState::Running,
+            None,
+            &ctx,
+            StateUpdateKind::NewTurn,
+        );
+        service.update_state(
+            "ws-1:win",
+            AgentToolType::Cursor,
+            AgentHookState::Idle,
+            None,
+            &ctx,
+            StateUpdateKind::TerminalIdle,
+        );
+        let (_, _, gen) = service.begin_attention_summary("ws-1:win").expect("begin");
+        let _ = service.complete_attention_summary(
+            "ws-1:win",
+            gen,
+            AttentionSummaryPayload {
+                summary: "keep me".into(),
+                next_steps: vec![],
+                can_close_session: true,
+            },
+        );
+        assert!(service.remove_session("ws-1:win"));
+        assert!(service.get_all_sessions().is_empty());
+        assert!(service.get_all_attention().is_empty());
+        assert_eq!(
+            service
+                .get_attention_summary("ws-1:win")
+                .unwrap()
+                .summary
+                .as_deref(),
+            Some("keep me")
+        );
     }
 
     #[test]

--- a/crates/core-service/src/service/agent_hooks/attention.rs
+++ b/crates/core-service/src/service/agent_hooks/attention.rs
@@ -175,6 +175,8 @@ impl AgentHooksService {
     }
 
     /// Clear sticky attention for a focused/acknowledged pane (and session aliases).
+    /// Does not drop auto-summary chrome — focusing the pane is how the user
+    /// *sees* "while you were away".
     pub fn clear_attention_for_pane(&self, stable_pane_id: &str) -> Vec<String> {
         let pane_id = stable_pane_id.trim();
         if pane_id.is_empty() {
@@ -194,18 +196,28 @@ impl AgentHooksService {
         if pane_id.is_empty() {
             return Vec::new();
         }
-        self.clear_attention_matching_ids_not_after(&[pane_id.to_string()], Some(not_after))
+        self.clear_attention_matching_ids_not_after(&[pane_id.to_string()], Some(not_after), false)
     }
 
     /// Clear latches whose map key or stored `session_id` matches any of `ids`.
+    /// Leaves auto-summaries in place unless `dismiss_summary` is set.
     pub fn clear_attention_matching_ids(&self, ids: &[String]) -> Vec<String> {
-        self.clear_attention_matching_ids_not_after(ids, None)
+        self.clear_attention_matching_ids_not_after(ids, None, false)
     }
 
-    fn clear_attention_matching_ids_not_after(
+    /// Pane/session destroy: drop both the latch and any auto-summary chrome.
+    pub fn clear_attention_and_summaries_matching_ids(&self, ids: &[String]) -> Vec<String> {
+        self.clear_attention_matching_ids_not_after(ids, None, true)
+    }
+
+    /// Acknowledge a pane. When `dismiss_summary` is true, also drop the
+    /// auto-summary (explicit Dismiss / send / pane destroy). Focus-ack
+    /// passes false so the user can still read the recap.
+    pub fn clear_attention_matching_ids_not_after(
         &self,
         ids: &[String],
         not_after: Option<&str>,
+        dismiss_summary: bool,
     ) -> Vec<String> {
         let id_set: HashSet<&str> = ids
             .iter()
@@ -252,29 +264,28 @@ impl AgentHooksService {
             to_clear
         };
 
-        // Drop summary chrome for cleared panes. When not_after guards skipped a
-        // newer latch, leave its summary alone (to_clear won't include it).
-        // Also drop orphan summaries for the requested ids only when we are not
-        // guarded, or when no newer latch remains for that id.
-        let mut summary_ids = cleared.clone();
-        if not_after_ts.is_none() {
-            summary_ids.extend(ids.iter().cloned());
-        } else {
-            // For guarded clears: also drop orphan summaries for requested ids
-            // that currently have no latch (dismiss of a finished summary whose
-            // latch was already gone).
-            let attention = self.attention.read();
-            for id in &id_set {
-                if !attention.contains_key(*id)
-                    && !attention
-                        .values()
-                        .any(|latch| latch.session_id.as_str() == *id)
-                {
-                    summary_ids.push((*id).to_string());
+        if dismiss_summary {
+            // Drop summary chrome for cleared panes. When not_after guards skipped
+            // a newer latch, leave its summary alone (to_clear won't include it).
+            // Also drop orphan summaries (latch already gone after a focus-ack)
+            // when no newer latch remains for that id.
+            let mut summary_ids = cleared.clone();
+            if not_after_ts.is_none() {
+                summary_ids.extend(ids.iter().cloned());
+            } else {
+                let attention = self.attention.read();
+                for id in &id_set {
+                    if !attention.contains_key(*id)
+                        && !attention
+                            .values()
+                            .any(|latch| latch.session_id.as_str() == *id)
+                    {
+                        summary_ids.push((*id).to_string());
+                    }
                 }
             }
+            self.clear_attention_summaries_matching_ids(&summary_ids);
         }
-        self.clear_attention_summaries_matching_ids(&summary_ids);
 
         if !cleared.is_empty() {
             self.broadcast_attention_cleared(cleared.clone());
@@ -511,13 +522,18 @@ mod tests {
                 can_close_session: true,
             },
         );
-        // Remove latch without going through clear (simulate orphan).
+        // Remove latch without going through clear (simulate focus-ack already
+        // dropped the latch while the recap is still showing).
         service.test_remove_attention_latch_only("ws-1:main");
         assert!(service.get_attention_summary("ws-1:main").is_some());
 
-        // Clear by pane id must still drop the orphan summary.
+        // Focus-style clear must keep the orphan recap.
         let cleared = service.clear_attention_for_pane("ws-1:main");
         assert!(cleared.is_empty());
+        assert!(service.get_attention_summary("ws-1:main").is_some());
+
+        // Explicit dismiss drops the orphan summary.
+        service.clear_attention_matching_ids_not_after(&["ws-1:main".to_string()], None, true);
         assert!(service.get_attention_summary("ws-1:main").is_none());
     }
 
@@ -569,5 +585,86 @@ mod tests {
         assert!(cleared.is_empty());
         assert_eq!(service.get_all_attention().len(), 1);
         assert_eq!(service.get_all_attention()[0].raised_at, new_raised);
+    }
+
+    #[test]
+    fn dismiss_summary_not_after_skips_newer_turn() {
+        let service = AgentHooksService::new();
+        let ctx = ctx_with_pane("ws-1:main");
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Running,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::NewTurn,
+        );
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Idle,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::TerminalIdle,
+        );
+        let old_raised = service.get_all_attention()[0].raised_at.clone();
+        let (_, _, gen) = service
+            .begin_attention_summary("ws-1:main")
+            .expect("begin first");
+        let _ = service.complete_attention_summary(
+            "ws-1:main",
+            gen,
+            AttentionSummaryPayload {
+                summary: "old turn".into(),
+                next_steps: vec![],
+                can_close_session: true,
+            },
+        );
+
+        // Newer turn replaces the latch and drops the old summary.
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Running,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::NewTurn,
+        );
+        service.update_state(
+            "ws-1:main",
+            AgentToolType::ClaudeCode,
+            AgentHookState::Idle,
+            Some("/tmp/p".into()),
+            &ctx,
+            StateUpdateKind::TerminalIdle,
+        );
+        let (_, _, gen2) = service
+            .begin_attention_summary("ws-1:main")
+            .expect("begin second");
+        let _ = service.complete_attention_summary(
+            "ws-1:main",
+            gen2,
+            AttentionSummaryPayload {
+                summary: "new turn".into(),
+                next_steps: vec![],
+                can_close_session: false,
+            },
+        );
+
+        // Late dismiss of the old recap must not wipe the newer latch or summary.
+        service.clear_attention_matching_ids_not_after(
+            &["ws-1:main".to_string()],
+            Some(&old_raised),
+            true,
+        );
+        assert_eq!(service.get_all_attention().len(), 1);
+        assert_eq!(
+            service
+                .get_attention_summary("ws-1:main")
+                .unwrap()
+                .summary
+                .as_deref(),
+            Some("new turn")
+        );
     }
 }

--- a/crates/core-service/src/service/agent_hooks/attention_summary.rs
+++ b/crates/core-service/src/service/agent_hooks/attention_summary.rs
@@ -286,14 +286,11 @@ impl AgentHooksService {
         // Hold attention.read across the summaries write so a concurrent
         // `raise_attention` cannot insert a replacement latch and leave us
         // completing the previous generation against the new turn.
+        // Latch may already be gone (user focused the pane while summarizing);
+        // still apply the result so they can read it. Generation token is the
+        // guard against a newer turn — `raise_attention` drops the row first.
         let updated = {
-            let attention = self.attention.read();
-            if !attention.contains_key(pane_id) {
-                drop(attention);
-                self.clear_attention_summaries_matching_ids(&[pane_id.to_string()]);
-                return None;
-            }
-
+            let _attention = self.attention.read();
             let mut summaries = self.summaries.write();
             let entry = summaries.get_mut(pane_id)?;
             if entry.generation != generation {
@@ -334,13 +331,7 @@ impl AgentHooksService {
         }
 
         let updated = {
-            let attention = self.attention.read();
-            if !attention.contains_key(pane_id) {
-                drop(attention);
-                self.clear_attention_summaries_matching_ids(&[pane_id.to_string()]);
-                return None;
-            }
-
+            let _attention = self.attention.read();
             let mut summaries = self.summaries.write();
             let entry = summaries.get_mut(pane_id)?;
             if entry.generation != generation {
@@ -499,8 +490,16 @@ mod tests {
         assert_eq!(ready.next_steps.len(), 2);
         assert_eq!(ready.can_close_session, Some(true));
 
-        // Clear attention also drops summary.
+        // Focus-ack clears the latch but keeps the recap for the user to read.
         service.clear_attention_for_pane("ws-1:main");
+        assert!(service.get_all_attention().is_empty());
+        assert_eq!(
+            service.get_attention_summary("ws-1:main").unwrap().status,
+            AttentionSummaryStatus::Ready
+        );
+
+        // Explicit dismiss drops the summary.
+        service.clear_attention_matching_ids_not_after(&["ws-1:main".to_string()], None, true);
         assert!(service.get_all_attention_summaries().is_empty());
     }
 
@@ -566,5 +565,39 @@ mod tests {
         let due = service.attention_due_for_summary(Duration::from_secs(0));
         assert_eq!(due.len(), 1);
         assert!(service.get_attention_summary("ws-1:main").is_none());
+    }
+
+    #[test]
+    fn complete_after_focus_ack_still_lands_ready() {
+        let service = AgentHooksService::new();
+        raise_task_complete(&service, "ws-1:main");
+        let (_, _, gen) = service.begin_attention_summary("ws-1:main").expect("begin");
+        service.clear_attention_for_pane("ws-1:main");
+        assert!(service.get_all_attention().is_empty());
+        assert_eq!(
+            service.get_attention_summary("ws-1:main").unwrap().status,
+            AttentionSummaryStatus::Summarizing
+        );
+
+        let ready = service
+            .complete_attention_summary(
+                "ws-1:main",
+                gen,
+                AttentionSummaryPayload {
+                    summary: "Finished while the user was opening the pane.".into(),
+                    next_steps: vec!["Review the diff".into()],
+                    can_close_session: false,
+                },
+            )
+            .expect("complete after focus-ack");
+        assert_eq!(ready.status, AttentionSummaryStatus::Ready);
+        assert_eq!(
+            service
+                .get_attention_summary("ws-1:main")
+                .unwrap()
+                .summary
+                .as_deref(),
+            Some("Finished while the user was opening the pane.")
+        );
     }
 }

--- a/crates/core-service/src/service/agent_hooks/attention_summary_generate.rs
+++ b/crates/core-service/src/service/agent_hooks/attention_summary_generate.rs
@@ -23,9 +23,7 @@ use super::AgentAttentionLatch;
 use crate::error::{Result, ServiceError};
 use crate::service::automation::{resolve_automation_agent_with_config, AutomationAgentRunConfig};
 use crate::service::llm_text_generation::generate_text;
-use crate::service::terminal::{
-    CapturePanePlainTextParams, TerminalService, TranscriptBudget,
-};
+use crate::service::terminal::{CapturePanePlainTextParams, TerminalService, TranscriptBudget};
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(180);
 const MAX_TERMINAL_CONTEXT_BYTES: u32 = 12_000;

--- a/crates/core-service/src/service/terminal/management.rs
+++ b/crates/core-service/src/service/terminal/management.rs
@@ -10,9 +10,9 @@ use crate::error::{Result, ServiceError};
 
 use super::runtime::apply_utf8_env_to_tmux_command;
 use super::text_capture::{
-    count_lines, process_captured_pane_text, DEFAULT_CAPTURE_APPROX_LINES,
+    count_lines, process_captured_pane_text, TranscriptBudget, DEFAULT_CAPTURE_APPROX_LINES,
     DEFAULT_HEAD_PREFIX_BYTES, DEFAULT_MAX_RAW_CAPTURE_BYTES, DEFAULT_PROMPT_BUDGET_BYTES,
-    MAX_PROMPT_BUDGET_BYTES, MIN_PROMPT_BUDGET_BYTES, TranscriptBudget,
+    MAX_PROMPT_BUDGET_BYTES, MIN_PROMPT_BUDGET_BYTES,
 };
 use super::{
     CapturePanePlainTextParams, CaptureSideContextParams, CapturedPanePlainText,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Need-attention auto-summary (“While you were away”) was tied to the sticky attention latch. Clicking Terminal to come back immediately cleared both the latch **and** the recap, so the user never saw it.

This splits the two lifetimes:

- **Focus / 3s auto-clear / idle session dismiss**: still clear the latch (bell, sidebar filter, pane ring). Summary stays.
- **Dismiss button / composer send / pane destroy / new turn**: drop the summary.

`POST /hooks/attention/clear` now accepts `dismiss_summary` (default `false`). Completing an in-flight summary still lands `Ready` after a focus-ack, so a user who opens the pane while summarizing still gets the recap.

Follow-up commit also:

- Fixes CI `cargo fmt --all` import order
- Restores a failed dismiss per pane (not via global store revision)
- Clears session-id attention aliases on dismiss
- Dismisses the recap after picker-based `/side` and `/spawn` sends

## Related Issue

N/A — follow-up to unattended need-attention auto-summary.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [x] `cargo test -p core-service --lib service::agent_hooks` (86 passed)
- [x] `bun test` attention store suites (18 passed)
- [x] `cargo check -p api`
- [x] `cargo +stable fmt --all -- --check`
- [ ] `just test`
- [ ] `just fmt`

## Checklist

- [ ] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55fd8e39-796f-4ef7-8141-07c764d3a35a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55fd8e39-796f-4ef7-8141-07c764d3a35a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the “While you were away” auto-summary visible after focusing a Terminal. Previously focus cleared both the attention latch and the recap; now focus clears only the latch. The recap persists until Dismiss, composer send, pane destroy, or a new turn.

- API: `POST /hooks/attention/clear` accepts `dismiss_summary` (default false). Focus acks omit it; Dismiss/send/pane destroy set it. `not_after` continues to guard against wiping newer turns.
- Web: Adds `dismissAttentionSummaryChrome` to clear latch and recap on explicit dismiss, send, and pane close. Restores the recap per pane if the request fails. Side/spawn sends (including picker-based) now dismiss the recap.
- Backend: Splits latch vs summary lifecycles. `clear_attention_matching_ids_not_after` takes `dismiss_summary` and only drops summaries when true. `remove_session` drops the latch but keeps the recap; pane destroy drops both. Completing a summary after a focus-ack still lands Ready. Clears session-id attention aliases on dismiss.
- Migration: Callers that intend to dismiss the recap must pass `dismiss_summary: true` (or `dismissSummary: true` via the client). Focus acknowledgments should not set it.

<sup>Written for commit 044263e80e78d807e6ab715210216605165afe0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dismissing attention summaries separately from acknowledging them.
  * Focusing a pane now clears its attention indicator while preserving available summary content.
  * Explicit dismissal, pane removal, and session cleanup now remove associated summaries when appropriate.
  * Summary dismissal safely restores state if the request fails.

* **Bug Fixes**
  * Preserved in-progress summary results after attention is acknowledged.
  * Improved cleanup of summaries associated with removed panes and sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->