### PR TITLE
fix(token-usage): 把发布放进分享并拆出排行榜

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -634,7 +634,6 @@
         }
       },
       "publish": {
-        "trigger": "Publish",
         "title": "Publish page",
         "description": "Share a link on atmos.land. Updates overwrite the same page.",
         "signInHint": "Sign in to publish a Token Usage page.",
@@ -647,7 +646,6 @@
         },
         "xPlaceholder": "username",
         "githubPlaceholder": "username",
-        "includeCost": "Include estimated cost",
         "copyLink": "Copy link",
         "copied": "Copied",
         "publish": "Publish",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -634,7 +634,6 @@
         }
       },
       "publish": {
-        "trigger": "发布",
         "title": "发布页面",
         "description": "用 atmos.land 链接分享。更新会覆盖同一页。",
         "signInHint": "登录后即可发布 Token Usage 页面。",
@@ -647,7 +646,6 @@
         },
         "xPlaceholder": "用户名",
         "githubPlaceholder": "用户名",
-        "includeCost": "包含估算费用",
         "copyLink": "复制链接",
         "copied": "已复制",
         "publish": "发布",

--- a/apps/web/src/app-shell/TokenUsagePage.tsx
+++ b/apps/web/src/app-shell/TokenUsagePage.tsx
@@ -17,7 +17,6 @@ import { useTokenUsageQuery } from "@/features/quota-usage/hooks/use-token-usage
 import { TokenUsageSharePopover } from "@/app-shell/TokenUsageShareDialog";
 import { TokenUsageCookieConsentBanner } from "@/app-shell/TokenUsageCookieConsentBanner";
 import { TokenUsageOverviewView } from "@/features/token-usage/TokenUsageOverviewView";
-import { TokenUsagePublishControls } from "@/features/token-usage/TokenUsagePublishControls";
 
 /** i18n keys under `tokenUsageDialog.loading.tips` — fun status lines while overview loads. */
 const TOKEN_USAGE_LOADING_TIP_KEYS = [
@@ -227,20 +226,15 @@ export function TokenUsagePage() {
             loading={loading}
             captureTargetRef={captureTargetRef}
             toolbarEnd={
-              <div className="flex items-center gap-0.5">
-                <TokenUsagePublishControls
-                  overview={overview}
-                  disabled={loading || !overview}
-                />
-                <TokenUsageSharePopover
-                  captureTargetRef={captureTargetRef}
-                  locale={locale}
-                  isDark={isDark}
-                  totalTokens={overview?.summary.total_tokens ?? 0}
-                  totalCost={overview?.summary.total_cost_usd ?? null}
-                  disabled={loading || !overview}
-                />
-              </div>
+              <TokenUsageSharePopover
+                captureTargetRef={captureTargetRef}
+                locale={locale}
+                isDark={isDark}
+                totalTokens={overview?.summary.total_tokens ?? 0}
+                totalCost={overview?.summary.total_cost_usd ?? null}
+                overview={overview}
+                disabled={loading || !overview}
+              />
             }
           />
         </div>

--- a/apps/web/src/app-shell/TokenUsageShareDialog.tsx
+++ b/apps/web/src/app-shell/TokenUsageShareDialog.tsx
@@ -37,6 +37,8 @@ import {
   formatCompactNumber,
   formatCurrencyCompact,
 } from "@/app-shell/token-usage-dialog-utils";
+import type { TokenUsageOverviewResponse } from "@/api/ws/token-usage-api";
+import { TokenUsagePublishControls } from "@/features/token-usage/TokenUsagePublishControls";
 
 type TokenUsageSharePopoverProps = {
   captureTargetRef: React.RefObject<HTMLElement | null>;
@@ -44,6 +46,7 @@ type TokenUsageSharePopoverProps = {
   isDark: boolean;
   totalTokens: number;
   totalCost: number | null;
+  overview?: TokenUsageOverviewResponse | null;
   disabled?: boolean;
 };
 
@@ -61,7 +64,7 @@ const SOCIALS: Array<{
 /** Compact ~16:9 preview — image fills the box (object-cover). */
 const PREVIEW_FRAME_H = 168;
 const ACTIONS_ROW_H = 44;
-const POPOVER_W = 300;
+const POPOVER_W = 320;
 
 export function TokenUsageSharePopover({
   captureTargetRef,
@@ -69,6 +72,7 @@ export function TokenUsageSharePopover({
   isDark,
   totalTokens,
   totalCost,
+  overview = null,
   disabled,
 }: TokenUsageSharePopoverProps) {
   const t = useTranslations("appShell.tokenUsageDialog.share");
@@ -81,6 +85,7 @@ export function TokenUsageSharePopover({
   const previewUrlRef = React.useRef<string | null>(null);
   /** True while lightbox is open or was opened from this popover — keep popover open. */
   const lightboxActiveRef = React.useRef(false);
+  const nestedDialogOpenRef = React.useRef(false);
 
   const notify = React.useCallback(
     (title: string, type: "success" | "error" | "info" = "info") => {
@@ -278,8 +283,11 @@ export function TokenUsageSharePopover({
 
   const handlePopoverOpenChange = React.useCallback(
     (next: boolean) => {
-      // While the full-size preview is open (or just closing), do not dismiss the popover.
-      if (!next && (lightboxOpen || lightboxActiveRef.current)) {
+      // While the full-size preview or nested sign-in dialog is open, keep the popover.
+      if (
+        !next &&
+        (lightboxOpen || lightboxActiveRef.current || nestedDialogOpenRef.current)
+      ) {
         return;
       }
       setOpen(next);
@@ -337,24 +345,37 @@ export function TokenUsageSharePopover({
           side="bottom"
           sideOffset={8}
           className={cn(
-            "overflow-hidden rounded-[20px] border-border/70 p-0 shadow-[0_20px_60px_-28px_rgba(15,23,42,0.35)]",
+            "max-h-[min(80vh,720px)] overflow-y-auto rounded-[20px] border-border/70 p-0 shadow-[0_20px_60px_-28px_rgba(15,23,42,0.35)]",
           )}
           style={{ width: POPOVER_W, maxWidth: "calc(100vw - 1.5rem)" }}
           {...{ [SHARE_CAPTURE_EXCLUDE_ATTR]: "" }}
           onOpenAutoFocus={(event) => event.preventDefault()}
           onCloseAutoFocus={(event) => event.preventDefault()}
           onPointerDownOutside={(event) => {
-            if (lightboxOpen || isDialogSurface(event.target)) {
+            if (
+              lightboxOpen ||
+              nestedDialogOpenRef.current ||
+              isDialogSurface(event.target)
+            ) {
               event.preventDefault();
             }
           }}
           onFocusOutside={(event) => {
-            if (lightboxOpen || lightboxActiveRef.current) {
+            if (
+              lightboxOpen ||
+              lightboxActiveRef.current ||
+              nestedDialogOpenRef.current ||
+              isDialogSurface(event.target)
+            ) {
               event.preventDefault();
             }
           }}
           onInteractOutside={(event) => {
-            if (lightboxOpen || isDialogSurface(event.target)) {
+            if (
+              lightboxOpen ||
+              nestedDialogOpenRef.current ||
+              isDialogSurface(event.target)
+            ) {
               event.preventDefault();
             }
           }}
@@ -442,6 +463,15 @@ export function TokenUsageSharePopover({
               <Download className="size-3.5 opacity-90" aria-hidden />
             </Button>
           </div>
+
+          <TokenUsagePublishControls
+            overview={overview}
+            disabled={disabled}
+            onDialogOpenChange={(next) => {
+              nestedDialogOpenRef.current = next;
+              if (next) setOpen(true);
+            }}
+          />
         </PopoverContent>
       </Popover>
 

--- a/apps/web/src/app/tok/page.tsx
+++ b/apps/web/src/app/tok/page.tsx
@@ -42,7 +42,9 @@ export default function TokPage() {
   const [profile, setProfile] = React.useState<PublicTokData | null | undefined>(
     route.kind === "home" ? null : undefined,
   );
-  const [boards, setBoards] = React.useState<PublicLeaderboards | null>(null);
+  const [boards, setBoards] = React.useState<PublicLeaderboards | null | undefined>(
+    route.kind === "leaderboard" ? undefined : null,
+  );
 
   React.useEffect(() => {
     if (route.kind === "home") {
@@ -63,13 +65,9 @@ export default function TokPage() {
         return;
       }
 
-      const [page, nextBoards] = await Promise.all([
-        fetchPublicTok(route.handle, k),
-        fetchPublicLeaderboards(),
-      ]);
+      const page = await fetchPublicTok(route.handle, k);
       if (cancelled) return;
       setProfile(page);
-      setBoards(nextBoards);
     })();
 
     return () => {
@@ -112,7 +110,6 @@ export default function TokPage() {
       xUsername={profile.x_username}
       generatedAt={profile.generated_at}
       payload={profile.snapshot}
-      leaderboards={boards}
     />
   );
 }

--- a/apps/web/src/features/token-usage/PublicTokPage.tsx
+++ b/apps/web/src/features/token-usage/PublicTokPage.tsx
@@ -5,8 +5,6 @@ import { GithubIcon, XIcon } from "@workspace/ui";
 import { useLocale, useTranslations } from "next-intl";
 
 import { TokenUsageOverviewView } from "@/features/token-usage/TokenUsageOverviewView";
-import { PublicTokLeaderboards } from "@/features/token-usage/PublicTokLeaderboards";
-import type { PublicLeaderboards } from "@/features/token-usage/fetch-public-tok";
 import type { TokenUsageSharePayload } from "@/features/token-usage/token-usage-share-payload";
 
 export type PublicTokPageProps = {
@@ -16,7 +14,6 @@ export type PublicTokPageProps = {
   xUsername: string | null;
   generatedAt: number;
   payload: TokenUsageSharePayload;
-  leaderboards?: PublicLeaderboards | null;
 };
 
 function formatGeneratedDate(ts: number, locale: string) {
@@ -38,7 +35,6 @@ export function PublicTokPage({
   xUsername,
   generatedAt,
   payload,
-  leaderboards,
 }: PublicTokPageProps) {
   const t = useTranslations("appShell.tokenUsageDialog.publicPage");
   const locale = useLocale();
@@ -105,12 +101,6 @@ export function PublicTokPage({
       </div>
 
       <TokenUsageOverviewView payload={payload} hideCostToggle={!payload.summary.total_cost_usd} />
-
-      {leaderboards ? (
-        <div className="pt-2">
-          <PublicTokLeaderboards data={leaderboards} />
-        </div>
-      ) : null}
 
       <footer className="mx-auto flex w-full max-w-[1100px] justify-end px-4 pb-8 sm:px-5">
         <p className="text-right text-[11px] text-muted-foreground">

--- a/apps/web/src/features/token-usage/TokenUsagePublishControls.tsx
+++ b/apps/web/src/features/token-usage/TokenUsagePublishControls.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Link2, Loader2, LogIn } from "lucide-react";
+import { Loader2, LogIn } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { AuthView } from "@daveyplate/better-auth-ui";
@@ -12,10 +12,9 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
-  Input,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
   cn,
 } from "@workspace/ui";
 
@@ -39,24 +38,67 @@ type Visibility = "off" | "public" | "unlisted";
 export function TokenUsagePublishControls({
   overview,
   disabled,
+  onDialogOpenChange,
 }: {
   overview: TokenUsageOverviewResponse | null;
   disabled?: boolean;
+  onDialogOpenChange?: (open: boolean) => void;
 }) {
   if (!hubConfigured()) return null;
   return (
     <HubAuthUIProvider>
-      <PublishBody overview={overview} disabled={disabled} />
+      <PublishBody
+        overview={overview}
+        disabled={disabled}
+        onDialogOpenChange={onDialogOpenChange}
+      />
     </HubAuthUIProvider>
+  );
+}
+
+function PrefixedField({
+  prefix,
+  value,
+  onChange,
+  placeholder,
+  disabled,
+  "aria-label": ariaLabel,
+}: {
+  prefix: string;
+  value: string;
+  onChange: (next: string) => void;
+  placeholder: string;
+  disabled?: boolean;
+  "aria-label": string;
+}) {
+  return (
+    <InputGroup className="h-8">
+      <InputGroupAddon
+        align="inline-start"
+        className="h-8 shrink-0 whitespace-nowrap pl-2.5 pr-0 text-[11px] font-normal text-muted-foreground"
+      >
+        {prefix}
+      </InputGroupAddon>
+      <InputGroupInput
+        aria-label={ariaLabel}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        disabled={disabled}
+        className="h-8 min-w-0 pl-0 text-xs"
+      />
+    </InputGroup>
   );
 }
 
 function PublishBody({
   overview,
   disabled,
+  onDialogOpenChange,
 }: {
   overview: TokenUsageOverviewResponse | null;
   disabled?: boolean;
+  onDialogOpenChange?: (open: boolean) => void;
 }) {
   const t = useTranslations("appShell.tokenUsageDialog.publish");
   const signInT = useTranslations("settings.accountSection");
@@ -88,17 +130,23 @@ function PublishBody({
   const signedIn = Boolean(sessionQuery.data?.user?.id || meQuery.data?.user_id);
   const page: HubUsagePage | null = pageQuery.data ?? null;
 
-  const [open, setOpen] = React.useState(false);
   const [signInOpen, setSignInOpen] = React.useState(false);
   const [handle, setHandle] = React.useState("");
   const [visibility, setVisibility] = React.useState<Visibility>("public");
   const [github, setGithub] = React.useState("");
   const [x, setX] = React.useState("");
-  const [includeCost, setIncludeCost] = React.useState(false);
   const [busy, setBusy] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const [secretOnce, setSecretOnce] = React.useState<string | null>(null);
   const [copied, setCopied] = React.useState(false);
+
+  const setSignInDialog = React.useCallback(
+    (open: boolean) => {
+      setSignInOpen(open);
+      onDialogOpenChange?.(open);
+    },
+    [onDialogOpenChange],
+  );
 
   React.useEffect(() => {
     if (!page) return;
@@ -106,7 +154,6 @@ function PublishBody({
     if (page.visibility) setVisibility(page.visibility === "off" ? "public" : page.visibility);
     setGithub(page.github_username ?? "");
     setX(page.x_username ?? "");
-    setIncludeCost(page.include_cost);
   }, [page]);
 
   const claimed = Boolean(page?.handle_claimed && page.handle);
@@ -136,11 +183,11 @@ function PublishBody({
     setBusy(true);
     setError(null);
     try {
-      const snapshot = mapOverviewToSharePayload(overview, { includeCost });
+      const snapshot = mapOverviewToSharePayload(overview, { includeCost: true });
       const result = await hubPutUsagePage({
         handle: claimed ? undefined : handle,
         visibility,
-        include_cost: includeCost,
+        include_cost: true,
         github_username: github,
         x_username: x,
         snapshot,
@@ -184,173 +231,139 @@ function PublishBody({
 
   return (
     <>
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <Button
-            type="button"
-            size="sm"
-            variant="ghost"
-            className="h-8 gap-1.5 px-2.5 text-xs"
-            disabled={disabled}
-          >
-            <Link2 className="size-3.5" />
-            {t("trigger")}
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent align="end" className="z-[70] w-80 space-y-3">
-          {!signedIn ? (
-            <div className="space-y-3">
-              <p className="text-sm text-muted-foreground">{t("signInHint")}</p>
-              <Button
-                type="button"
-                size="sm"
-                className="h-8 gap-1.5"
-                onClick={() => setSignInOpen(true)}
-              >
-                <LogIn className="size-3.5" />
-                {signInT("signIn")}
-              </Button>
+      <div className="space-y-3 border-t border-border/70 px-3 py-3">
+        {!signedIn ? (
+          <div className="space-y-3">
+            <p className="text-sm font-medium">{t("title")}</p>
+            <p className="text-xs text-muted-foreground">{t("signInHint")}</p>
+            <Button
+              type="button"
+              size="sm"
+              className="h-8 gap-1.5"
+              onClick={() => setSignInDialog(true)}
+            >
+              <LogIn className="size-3.5" />
+              {signInT("signIn")}
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <p className="text-sm font-medium">{t("title")}</p>
+              <p className="text-xs text-muted-foreground">{t("description")}</p>
             </div>
-          ) : (
-            <div className="space-y-3">
-              <div className="space-y-1">
-                <p className="text-sm font-medium">{t("title")}</p>
-                <p className="text-xs text-muted-foreground">{t("description")}</p>
-              </div>
 
-              <label className="block space-y-1">
-                <span className="text-[11px] text-muted-foreground">
-                  {t("handleLabel")}
-                </span>
-                <div className="flex items-center gap-1 rounded-md border border-border px-2">
-                  <span className="shrink-0 text-[11px] text-muted-foreground">
-                    atmos.land/tok/@
-                  </span>
-                  <Input
-                    value={handle}
-                    onChange={(e) => setHandle(e.target.value)}
-                    placeholder={t("handlePlaceholder")}
-                    disabled={claimed || busy}
-                    className="h-8 border-0 px-0 shadow-none focus-visible:ring-0"
-                  />
-                </div>
-                {claimed ? (
-                  <p className="text-[11px] text-muted-foreground">{t("handleLocked")}</p>
-                ) : null}
-              </label>
-
-              <div className="flex gap-1">
-                {(["public", "unlisted"] as const).map((id) => (
-                  <button
-                    key={id}
-                    type="button"
-                    className={cn(
-                      "h-7 rounded-full px-2.5 text-[11px]",
-                      visibility === id
-                        ? "bg-foreground text-background"
-                        : "bg-muted text-muted-foreground",
-                    )}
-                    onClick={() => setVisibility(id)}
-                  >
-                    {t(`visibility.${id}`)}
-                  </button>
-                ))}
-              </div>
-
-              <label className="block space-y-1">
-                <span className="text-[11px] text-muted-foreground">x.com/</span>
-                <Input
-                  value={x}
-                  onChange={(e) => setX(e.target.value)}
-                  placeholder={t("xPlaceholder")}
-                  disabled={busy}
-                  className="h-8"
-                />
-              </label>
-              <label className="block space-y-1">
-                <span className="text-[11px] text-muted-foreground">github.com/</span>
-                <Input
-                  value={github}
-                  onChange={(e) => setGithub(e.target.value)}
-                  placeholder={t("githubPlaceholder")}
-                  disabled={busy}
-                  className="h-8"
-                />
-              </label>
-
-              <label className="flex items-center gap-2 text-xs">
-                <input
-                  type="checkbox"
-                  checked={includeCost}
-                  onChange={(e) => setIncludeCost(e.target.checked)}
-                  disabled={busy}
-                />
-                {t("includeCost")}
-              </label>
-
-              {shareUrl ? (
-                <div className="space-y-1">
-                  <p className="break-all text-[11px] text-muted-foreground">{shareUrl}</p>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    className="h-7 text-xs"
-                    onClick={() => void copyUrl(shareUrl)}
-                  >
-                    {copied ? t("copied") : t("copyLink")}
-                  </Button>
-                </div>
-              ) : visibility === "unlisted" && live ? (
-                <p className="text-[11px] text-muted-foreground">
-                  {t("unlistedNeedsSecret")}
-                </p>
+            <div className="space-y-1">
+              <PrefixedField
+                prefix="atmos.land/tok/@"
+                value={handle}
+                onChange={setHandle}
+                placeholder={t("handlePlaceholder")}
+                disabled={claimed || busy}
+                aria-label={t("handleLabel")}
+              />
+              {claimed ? (
+                <p className="text-[11px] text-muted-foreground">{t("handleLocked")}</p>
               ) : null}
+            </div>
 
-              {error ? <p className="text-xs text-destructive">{error}</p> : null}
+            <div className="flex gap-1">
+              {(["public", "unlisted"] as const).map((id) => (
+                <button
+                  key={id}
+                  type="button"
+                  className={cn(
+                    "h-7 rounded-full px-2.5 text-[11px]",
+                    visibility === id
+                      ? "bg-foreground text-background"
+                      : "bg-muted text-muted-foreground",
+                  )}
+                  onClick={() => setVisibility(id)}
+                >
+                  {t(`visibility.${id}`)}
+                </button>
+              ))}
+            </div>
 
-              <div className="flex flex-wrap items-center gap-2">
+            <PrefixedField
+              prefix="x.com/"
+              value={x}
+              onChange={setX}
+              placeholder={t("xPlaceholder")}
+              disabled={busy}
+              aria-label={t("xPlaceholder")}
+            />
+            <PrefixedField
+              prefix="github.com/"
+              value={github}
+              onChange={setGithub}
+              placeholder={t("githubPlaceholder")}
+              disabled={busy}
+              aria-label={t("githubPlaceholder")}
+            />
+
+            {shareUrl ? (
+              <div className="space-y-1">
+                <p className="break-all text-[11px] text-muted-foreground">{shareUrl}</p>
                 <Button
                   type="button"
                   size="sm"
-                  className="h-8"
-                  disabled={busy || !overview || (!claimed && handle.trim().length < 3)}
-                  onClick={() => void publish()}
+                  variant="outline"
+                  className="h-7 text-xs"
+                  onClick={() => void copyUrl(shareUrl)}
                 >
-                  {busy ? <Loader2 className="size-3.5 animate-spin" /> : null}
-                  {live ? t("update") : t("publish")}
+                  {copied ? t("copied") : t("copyLink")}
                 </Button>
-                {live ? (
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="ghost"
-                    className="h-8"
-                    disabled={busy}
-                    onClick={() => void turnOff()}
-                  >
-                    {t("turnOff")}
-                  </Button>
-                ) : null}
-                {visibility === "unlisted" && live ? (
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="ghost"
-                    className="h-8"
-                    disabled={busy}
-                    onClick={() => void rotate()}
-                  >
-                    {t("rotateSecret")}
-                  </Button>
-                ) : null}
               </div>
-            </div>
-          )}
-        </PopoverContent>
-      </Popover>
+            ) : visibility === "unlisted" && live ? (
+              <p className="text-[11px] text-muted-foreground">
+                {t("unlistedNeedsSecret")}
+              </p>
+            ) : null}
 
-      <Dialog open={signInOpen} onOpenChange={setSignInOpen}>
+            {error ? <p className="text-xs text-destructive">{error}</p> : null}
+
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                size="sm"
+                className="h-8"
+                disabled={disabled || busy || !overview || (!claimed && handle.trim().length < 3)}
+                onClick={() => void publish()}
+              >
+                {busy ? <Loader2 className="size-3.5 animate-spin" /> : null}
+                {live ? t("update") : t("publish")}
+              </Button>
+              {live ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  className="h-8"
+                  disabled={busy}
+                  onClick={() => void turnOff()}
+                >
+                  {t("turnOff")}
+                </Button>
+              ) : null}
+              {visibility === "unlisted" && live ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  className="h-8"
+                  disabled={busy}
+                  onClick={() => void rotate()}
+                >
+                  {t("rotateSecret")}
+                </Button>
+              ) : null}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <Dialog open={signInOpen} onOpenChange={setSignInDialog}>
         <DialogContent
           className="z-[70] w-full max-w-sm gap-0 overflow-hidden border-none bg-transparent p-0 shadow-none sm:max-w-sm"
           overlayClassName="z-[70]"

--- a/apps/web/src/features/token-usage/__tests__/token-usage-public-share-static.test.ts
+++ b/apps/web/src/features/token-usage/__tests__/token-usage-public-share-static.test.ts
@@ -21,7 +21,7 @@ describe("APP-061 static wiring", () => {
     expect(page).toContain("https://github.com/");
     expect(page).toContain("https://atmos.land");
     expect(page).toContain("overflow-y-auto");
-    expect(page).toContain("PublicTokLeaderboards");
+    expect(page).not.toContain("PublicTokLeaderboards");
     expect(page).toContain("leaderboardLink");
     expect(page).toContain("/tok/leaderboard");
     const boards = read(
@@ -34,11 +34,15 @@ describe("APP-061 static wiring", () => {
     expect(page).toContain("generatedByPrefix");
     expect(page).not.toContain("TokenUsageCookieConsentBanner");
     expect(page).not.toContain("TokenUsageSharePopover");
+    const tok = read("apps/web/src/app/tok/page.tsx");
+    expect(tok).not.toContain("leaderboards={");
+    expect(tok).toContain("fetchPublicLeaderboards");
   });
 
   it("local page keeps PNG, consent, and does not auto-upload", () => {
     const local = read("apps/web/src/app-shell/TokenUsagePage.tsx");
     expect(local).toContain("TokenUsageSharePopover");
+    expect(local).not.toContain("TokenUsagePublishControls");
     expect(local).toContain("TokenUsageCookieConsentBanner");
     expect(local).toContain("TokenUsageOverviewView");
     expect(local).toContain("tokenUsageApi.getOverview");
@@ -51,8 +55,16 @@ describe("APP-061 static wiring", () => {
       "apps/web/src/features/token-usage/TokenUsagePublishControls.tsx",
     );
     expect(publish).toContain("https://atmos.land/tok/@");
+    expect(publish).toContain("atmos.land/tok/@");
+    expect(publish).toContain("InputGroup");
+    expect(publish).toContain("include_cost: true");
+    expect(publish).toContain("{ includeCost: true }");
+    expect(publish).not.toContain("setIncludeCost");
+    expect(publish).not.toContain("PopoverTrigger");
+    const share = read("apps/web/src/app-shell/TokenUsageShareDialog.tsx");
+    expect(share).toContain("TokenUsagePublishControls");
     const hub = read("packages/hub/src/usage-page.ts");
-    expect(hub).toContain('https://atmos.land');
+    expect(hub).toContain("https://atmos.land");
     expect(hub).toContain("/tok/@");
   });
 

--- a/specs/APP/APP-061_token-usage-public-share/TECH.md
+++ b/specs/APP/APP-061_token-usage-public-share/TECH.md
@@ -350,6 +350,15 @@ Each step 1–6 is mergeable without the rewrite.
 - **Tradeoff**: Snapshot on `user_profiles` vs `usage_shares`. **Choose profile** so handle + socials + blob are one row.
 - **Rollback**: `usage_visibility=off` or revert Worker route; local Token Usage unaffected.
 
+<!-- updated 2026-08-15: publish lives in the PNG share popover; UI always sends cost; leaderboard is /tok/leaderboard only -->
+
+## Implementation delta (2026-08-15)
+
+- Publish UI is **inside the Token Usage share popover**, not a second toolbar button/popover.
+- Handle / X / GitHub fields are one fused control: fixed prefix + editable username (no nested input chrome).
+- The in-app publish action always sends `include_cost: true` with the snapshot. Hub still accepts `include_cost` for older clients.
+- Public `/tok/@handle` is the share page only. Leaderboards render on `/tok/leaderboard` (bare `/tok` still redirects there). A header link on the share page points at the leaderboard; the board is not embedded under the snapshot.
+
 ## Dependencies & compatibility
 
 - Depends on APP-056 Hub auth + `requireUser`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Token Usage 发布不再单独占一个工具栏按钮/popover，改进行现有分享菜单。

- 发布表单放在分享 popover 里（PNG 社交分享下面）
- Handle / X / GitHub 用融合字段：左侧固定路径 + 右侧用户名，不再套一层独立输入框
- 发布时始终带上 cost，去掉「包含估算费用」勾选
- `/tok/@handle` 分享页不再在底部嵌入排行榜；排行榜仍在独立的 `/tok/leaderboard`（分享页顶部保留链接）

## Related Issue

N/A（跟进 APP-061 发布/分享 UX）

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [x] `just test` (targeted)
- [ ] `just fmt`
- [x] Additional checks (describe below)

- `bun test apps/web/src/features/token-usage/__tests__/token-usage-public-share-static.test.ts apps/web/src/features/token-usage/__tests__/token-usage-share-payload.test.ts` — 9 pass
- `cd apps/web && bun run typecheck` — pass
- Manual: `/tok/@preview` footer is Generated-by-Atmos only; ranking table is on `/tok/leaderboard`

## Checklist

- [x] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a005fd-1647-7120-bd72-e9e32a630938?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a005fd-1647-7120-bd72-e9e32a630938&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Token Usage publish into the existing share popover and removes the extra publish button. Previously publish had its own popover with an optional cost toggle and the share page embedded the leaderboard; now publish is in the share menu, cost is always included, and `\`/tok/@handle\`` links to but does not embed the leaderboard at `\`/tok/leaderboard\``. Aligns with APP-061 publish/share UX.

- Integrates `TokenUsagePublishControls` into `TokenUsageSharePopover`; removes the publish trigger from `TokenUsagePage`.
- Fuses handle/X/GitHub inputs with fixed prefixes; drops i18n keys `publish.trigger` and `publish.includeCost`; always sends `include_cost: true`.
- Keeps the popover open during preview or auth; makes content scrollable and slightly wider.
- Stops fetching/rendering `PublicTokLeaderboards` on `\`/tok/@handle\``; loads boards only on `\`/tok/leaderboard\``; updates tests and tech notes accordingly.

<sup>Written for commit d0afcd6101f1c7bec8d7fac3bdd712acfe9285d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

