### PR TITLE
refactor: address daily quality findings for 2026-08-16

### DIFF
--- a/apps/web/src/features/automations/components/AutomationSetup.tsx
+++ b/apps/web/src/features/automations/components/AutomationSetup.tsx
@@ -3,11 +3,6 @@
 import React from "react";
 import { useTranslations } from "next-intl";
 import { Button, Label, TooltipProvider } from "@workspace/ui";
-import { useAppRouter } from "@/shared/hooks/use-app-router";
-import {
-  useRegisteredAppNavigationGuard,
-  type AppNavigationTarget,
-} from "@/shared/hooks/app-navigation-intercept";
 import { ArrowLeft, Brain, ChevronDown, LoaderCircle, Sparkles } from "lucide-react";
 import { AgentIcon } from "@/features/agent/components/AgentIcon";
 import {
@@ -34,6 +29,7 @@ import {
   updateAutomationWithGithubRoute,
 } from "@/features/automations/lib/github-route-lifecycle";
 import { useAutomationSetupForm } from "@/features/automations/hooks/use-automation-setup-form";
+import { useAutomationSetupLeaveGuard } from "@/features/automations/hooks/use-automation-setup-leave-guard";
 import { useGithubTriggerSetup } from "@/features/automations/hooks/use-github-trigger-setup";
 import type {
   AutomationAgentCapability,
@@ -100,7 +96,6 @@ export function AutomationSetup({
   onUpdate: (request: AutomationUpdateRequest) => Promise<AutomationDetail>;
 }) {
   const t = useTranslations("automation.setup");
-  const router = useAppRouter();
   const composerRef = React.useRef<ComposerHandle | null>(null);
   const {
     attachments,
@@ -404,99 +399,19 @@ export function AutomationSetup({
       workspaceGuid,
     ],
   );
-  const baselineRef = React.useRef<string | null>(null);
-  const [leaveDialogOpen, setLeaveDialogOpen] = React.useState(false);
-  const pendingLeaveRef = React.useRef<{
-    discard: () => void;
-    afterSave: () => void;
-  } | null>(null);
-  const bypassNavRef = React.useRef(false);
-  const isDirtyRef = React.useRef(false);
-  const allowPopStateLeaveRef = React.useRef(false);
-
-  React.useEffect(() => {
-    if (!ready) return;
-    if (mode === "create" && !agentId) return;
-    if (baselineRef.current === null) {
-      baselineRef.current = setupSnapshot;
-    }
-  }, [agentId, mode, ready, setupSnapshot]);
-
-  const isDirty =
-    baselineRef.current !== null && baselineRef.current !== setupSnapshot;
-  isDirtyRef.current = isDirty;
-
-  const requestLeave = React.useCallback(
-    (actions: { discard: () => void; afterSave?: () => void }) => {
-      if (!isDirtyRef.current) {
-        actions.discard();
-        return;
-      }
-      pendingLeaveRef.current = {
-        discard: actions.discard,
-        afterSave: actions.afterSave ?? (() => undefined),
-      };
-      setLeaveDialogOpen(true);
-    },
-    [],
-  );
-
-  const resumeNavigation = React.useCallback(
-    (target: AppNavigationTarget) => {
-      bypassNavRef.current = true;
-      if (target.kind === "replace") {
-        router.replace(target.path);
-      } else {
-        router.push(target.path);
-      }
-      bypassNavRef.current = false;
-    },
-    [router],
-  );
-
-  const navigationGuard = React.useCallback(
-    (target: AppNavigationTarget) => {
-      if (bypassNavRef.current || !isDirtyRef.current) {
-        return false;
-      }
-      requestLeave({
-        discard: () => resumeNavigation(target),
-        afterSave: () => resumeNavigation(target),
-      });
-      return true;
-    },
-    [requestLeave, resumeNavigation],
-  );
-  useRegisteredAppNavigationGuard(navigationGuard);
-
-  React.useEffect(() => {
-    if (!isDirty) return;
-    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      event.preventDefault();
-      event.returnValue = "";
-    };
-    window.addEventListener("beforeunload", handleBeforeUnload);
-    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
-  }, [isDirty]);
-
-  React.useEffect(() => {
-    if (!isDirty) return;
-    window.history.pushState({ automationSetupGuard: true }, "", window.location.href);
-    const handlePopState = () => {
-      if (allowPopStateLeaveRef.current || !isDirtyRef.current) {
-        return;
-      }
-      window.history.pushState({ automationSetupGuard: true }, "", window.location.href);
-      requestLeave({
-        discard: () => {
-          allowPopStateLeaveRef.current = true;
-          window.history.back();
-        },
-      });
-    };
-    window.addEventListener("popstate", handlePopState);
-    return () => window.removeEventListener("popstate", handlePopState);
-  }, [isDirty, requestLeave]);
+  const {
+    leaveDialogOpen,
+    requestLeave,
+    clearDirtyBaseline,
+    handleStay,
+    handleDiscard,
+    handleSaveAndLeave: runSaveAndLeave,
+  } = useAutomationSetupLeaveGuard({
+    ready,
+    mode,
+    agentId,
+    setupSnapshot,
+  });
 
   const saveAutomation = async () => {
     setSubmitError(null);
@@ -590,8 +505,7 @@ export function AutomationSetup({
         setInstructions(savedAutomation.instructions);
         setMemory(savedAutomation.memory ?? "");
         composerRef.current?.setText(savedAutomation.instructions);
-        baselineRef.current = null;
-        isDirtyRef.current = false;
+        clearDirtyBaseline();
       }
       clearAttachments();
       return Boolean(savedAutomation);
@@ -612,33 +526,6 @@ export function AutomationSetup({
 
   const handleBack = () => {
     requestLeave({ discard: onCancel });
-  };
-
-  const handleStay = () => {
-    setLeaveDialogOpen(false);
-    pendingLeaveRef.current = null;
-  };
-
-  const handleDiscard = () => {
-    const pending = pendingLeaveRef.current;
-    isDirtyRef.current = false;
-    baselineRef.current = setupSnapshot;
-    setLeaveDialogOpen(false);
-    pendingLeaveRef.current = null;
-    pending?.discard();
-  };
-
-  const handleSaveAndLeave = async () => {
-    const pending = pendingLeaveRef.current;
-    const saved = await saveAutomation();
-    if (!saved) {
-      setLeaveDialogOpen(false);
-      pendingLeaveRef.current = null;
-      return;
-    }
-    setLeaveDialogOpen(false);
-    pendingLeaveRef.current = null;
-    pending?.afterSave();
   };
 
   const handleGithubStartSetup = React.useCallback(() => {
@@ -987,7 +874,7 @@ export function AutomationSetup({
           onStay={handleStay}
           onDiscard={handleDiscard}
           onSave={() => {
-            void handleSaveAndLeave();
+            void runSaveAndLeave(saveAutomation);
           }}
         />
       </div>

--- a/apps/web/src/features/automations/hooks/use-automation-setup-leave-guard.ts
+++ b/apps/web/src/features/automations/hooks/use-automation-setup-leave-guard.ts
@@ -1,0 +1,166 @@
+"use client";
+
+import React from "react";
+import {
+  useRegisteredAppNavigationGuard,
+  type AppNavigationTarget,
+} from "@/shared/hooks/app-navigation-intercept";
+import { useAppRouter } from "@/shared/hooks/use-app-router";
+
+type LeaveActions = {
+  discard: () => void;
+  afterSave?: () => void;
+};
+
+/**
+ * Dirty-form leave protection for automation setup:
+ * baseline snapshot, in-app nav guard, beforeunload, and popstate confirm.
+ */
+export function useAutomationSetupLeaveGuard({
+  ready,
+  mode,
+  agentId,
+  setupSnapshot,
+}: {
+  ready: boolean;
+  mode: "create" | "edit";
+  agentId: string;
+  setupSnapshot: string;
+}) {
+  const router = useAppRouter();
+  const baselineRef = React.useRef<string | null>(null);
+  const [leaveDialogOpen, setLeaveDialogOpen] = React.useState(false);
+  const pendingLeaveRef = React.useRef<{
+    discard: () => void;
+    afterSave: () => void;
+  } | null>(null);
+  const bypassNavRef = React.useRef(false);
+  const isDirtyRef = React.useRef(false);
+  const allowPopStateLeaveRef = React.useRef(false);
+
+  React.useEffect(() => {
+    if (!ready) return;
+    if (mode === "create" && !agentId) return;
+    if (baselineRef.current === null) {
+      baselineRef.current = setupSnapshot;
+    }
+  }, [agentId, mode, ready, setupSnapshot]);
+
+  const isDirty =
+    baselineRef.current !== null && baselineRef.current !== setupSnapshot;
+  isDirtyRef.current = isDirty;
+
+  const requestLeave = React.useCallback((actions: LeaveActions) => {
+    if (!isDirtyRef.current) {
+      actions.discard();
+      return;
+    }
+    pendingLeaveRef.current = {
+      discard: actions.discard,
+      afterSave: actions.afterSave ?? (() => undefined),
+    };
+    setLeaveDialogOpen(true);
+  }, []);
+
+  const resumeNavigation = React.useCallback(
+    (target: AppNavigationTarget) => {
+      bypassNavRef.current = true;
+      if (target.kind === "replace") {
+        router.replace(target.path);
+      } else {
+        router.push(target.path);
+      }
+      bypassNavRef.current = false;
+    },
+    [router],
+  );
+
+  const navigationGuard = React.useCallback(
+    (target: AppNavigationTarget) => {
+      if (bypassNavRef.current || !isDirtyRef.current) {
+        return false;
+      }
+      requestLeave({
+        discard: () => resumeNavigation(target),
+        afterSave: () => resumeNavigation(target),
+      });
+      return true;
+    },
+    [requestLeave, resumeNavigation],
+  );
+  useRegisteredAppNavigationGuard(navigationGuard);
+
+  React.useEffect(() => {
+    if (!isDirty) return;
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [isDirty]);
+
+  React.useEffect(() => {
+    if (!isDirty) return;
+    window.history.pushState({ automationSetupGuard: true }, "", window.location.href);
+    const handlePopState = () => {
+      if (allowPopStateLeaveRef.current || !isDirtyRef.current) {
+        return;
+      }
+      window.history.pushState({ automationSetupGuard: true }, "", window.location.href);
+      requestLeave({
+        discard: () => {
+          allowPopStateLeaveRef.current = true;
+          window.history.back();
+        },
+      });
+    };
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, [isDirty, requestLeave]);
+
+  const clearDirtyBaseline = React.useCallback(() => {
+    baselineRef.current = null;
+    isDirtyRef.current = false;
+  }, []);
+
+  const handleStay = React.useCallback(() => {
+    setLeaveDialogOpen(false);
+    pendingLeaveRef.current = null;
+  }, []);
+
+  const handleDiscard = React.useCallback(() => {
+    const pending = pendingLeaveRef.current;
+    isDirtyRef.current = false;
+    baselineRef.current = setupSnapshot;
+    setLeaveDialogOpen(false);
+    pendingLeaveRef.current = null;
+    pending?.discard();
+  }, [setupSnapshot]);
+
+  const handleSaveAndLeave = React.useCallback(
+    async (save: () => Promise<boolean>) => {
+      const pending = pendingLeaveRef.current;
+      const saved = await save();
+      if (!saved) {
+        setLeaveDialogOpen(false);
+        pendingLeaveRef.current = null;
+        return;
+      }
+      setLeaveDialogOpen(false);
+      pendingLeaveRef.current = null;
+      pending?.afterSave();
+    },
+    [],
+  );
+
+  return {
+    isDirty,
+    leaveDialogOpen,
+    requestLeave,
+    clearDirtyBaseline,
+    handleStay,
+    handleDiscard,
+    handleSaveAndLeave,
+  };
+}

--- a/apps/web/src/features/git/components/GitHistoryPanel.tsx
+++ b/apps/web/src/features/git/components/GitHistoryPanel.tsx
@@ -17,33 +17,22 @@ import React, {
   useState,
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { useTranslations, useLocale } from "next-intl";
-import { fromUnixTime, format } from "date-fns";
-import { enUS, zhCN } from "date-fns/locale";
+import { useTranslations } from "next-intl";
 import {
   CaseSensitive,
-  Check,
   ChevronLeft,
   ChevronRight,
-  Cloud,
-  Copy,
-  GitBranch,
   LoaderCircle,
   RotateCcw,
-  Tag,
 } from "lucide-react";
 import {
   Button,
   InputGroup,
   InputGroupButton,
   InputGroupInput,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
 } from "@workspace/ui";
 import { cn } from "@/shared/lib/utils";
-import { copyToClipboard } from "@/shared/utils/copy";
-import type { GitHistoryCommit, GitHistoryRef } from "@/api/ws-api-types";
+import type { GitHistoryCommit } from "@/api/ws-api-types";
 import { useGitHistory } from "@/features/git/hooks/use-git-history";
 import { useGitHistoryCenterTabStore } from "@/features/git/store/use-git-history-center-tab";
 import { useGitStatusQuery } from "@/features/git/hooks/use-git-status-query";
@@ -53,16 +42,8 @@ import {
 } from "@/features/task/components/task-github-drawer/TaskGithubDrawerHost";
 import { commitDrawerKey } from "@/features/task/components/task-github-drawer/types";
 import {
-  HISTORY_GRAPH_ROW_OVERLAP,
-  HISTORY_HEADER_HEIGHT,
-  HISTORY_HEAD_RING_PADDING,
-  HISTORY_NODE_RADIUS,
   HISTORY_ROW_HEIGHT,
-  HISTORY_STROKE_WIDTH,
-  GIT_HISTORY_GRAPH_COLORS,
-  historyGraphColor,
   historyGraphWidth,
-  historyLaneX,
   layoutGitHistoryGraph,
 } from "@/features/git/lib/git-history-graph";
 import {
@@ -76,12 +57,14 @@ import {
   type HistoryColumnId,
   type HistoryColumnWidths,
 } from "@/features/git/lib/git-history-columns";
+import { collectGitHistoryMatchIndexes } from "@/features/git/lib/git-history-search";
 import {
-  collectGitHistoryMatchIndexes,
-  splitHighlightedText,
-} from "@/features/git/lib/git-history-search";
+  ColumnResizeHandle,
+  GitHistoryTableHeader,
+} from "@/features/git/components/git-history-table-chrome";
+import { GitHistoryGraphSvg } from "@/features/git/components/git-history-graph-svg";
+import { GitHistoryRow } from "@/features/git/components/git-history-row";
 
-const MAX_VISIBLE_REFS = 3;
 const GIT_HISTORY_ROW_OVERSCAN = 12;
 
 export function GitHistoryPanel({
@@ -452,420 +435,5 @@ export function GitHistoryPanel({
       </div>
       <TaskGithubDrawerHost controllerRef={drawerControllerRef} />
     </div>
-  );
-}
-
-function GitHistoryTableHeader({
-  columns,
-  gridTemplate,
-}: {
-  columns: HistoryColumnWidths;
-  gridTemplate: string;
-}) {
-  const t = useTranslations("git.history");
-  return (
-    <div
-      className="sticky top-0 z-20 grid items-center border-b border-border/50 bg-background text-[10.5px] font-medium text-muted-foreground"
-      style={{
-        height: HISTORY_HEADER_HEIGHT,
-        width: historyTableWidth(columns),
-        gridTemplateColumns: gridTemplate,
-      }}
-    >
-      {HISTORY_RESIZE_COLUMNS.map((id) => (
-        <div key={id} className="min-w-0 px-1.5">
-          <span className="block truncate">{t(`columns.${id}`)}</span>
-        </div>
-      ))}
-      <div className="min-w-0 px-1.5">
-        <span className="block truncate">{t("columns.commit")}</span>
-      </div>
-    </div>
-  );
-}
-
-function ColumnResizeHandle({
-  column,
-  width,
-  left,
-  height,
-  label,
-  onResize,
-}: {
-  column: HistoryColumnId;
-  width: number;
-  left: number;
-  height: number;
-  label: string;
-  onResize: (id: HistoryColumnId, nextWidth: number) => void;
-}) {
-  const drag = useRef<{ x: number; width: number } | null>(null);
-  const [active, setActive] = useState(false);
-
-  return (
-    <div
-      role="separator"
-      aria-orientation="vertical"
-      aria-label={label}
-      tabIndex={0}
-      style={{ left, height: Math.max(height, HISTORY_HEADER_HEIGHT) }}
-      className={cn(
-        "absolute top-0 w-2.5 -translate-x-1/2 cursor-col-resize touch-none select-none",
-        "after:absolute after:inset-y-0 after:left-1/2 after:w-px after:-translate-x-1/2 after:transition-colors",
-        active
-          ? "after:bg-foreground/45"
-          : "after:bg-transparent hover:after:bg-foreground/35",
-      )}
-      onPointerDown={(event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        drag.current = { x: event.clientX, width };
-        setActive(true);
-        event.currentTarget.setPointerCapture(event.pointerId);
-      }}
-      onPointerMove={(event) => {
-        if (!drag.current) return;
-        onResize(column, drag.current.width + event.clientX - drag.current.x);
-      }}
-      onPointerUp={(event) => {
-        drag.current = null;
-        setActive(false);
-        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-          event.currentTarget.releasePointerCapture(event.pointerId);
-        }
-      }}
-      onPointerCancel={() => {
-        drag.current = null;
-        setActive(false);
-      }}
-      onKeyDown={(event) => {
-        if (event.key === "ArrowLeft") {
-          event.preventDefault();
-          onResize(column, width - 16);
-        } else if (event.key === "ArrowRight") {
-          event.preventDefault();
-          onResize(column, width + 16);
-        }
-      }}
-    />
-  );
-}
-
-function GitHistoryGraphSvg({
-  rows,
-  width,
-}: {
-  rows: ReturnType<typeof layoutGitHistoryGraph>["rows"];
-  width: number;
-}) {
-  const height = rows.length * HISTORY_ROW_HEIGHT;
-  const middle = HISTORY_ROW_HEIGHT / 2;
-  const colorCount = GIT_HISTORY_GRAPH_COLORS.length;
-
-  return (
-    <svg
-      aria-hidden
-      className="pointer-events-none absolute top-0 left-0 overflow-visible"
-      width={width}
-      height={height}
-    >
-      {Array.from({ length: colorCount }, (_, colorIndex) => {
-        const d: string[] = [];
-        for (let index = 0; index < rows.length; index++) {
-          const row = rows[index]!;
-          const originY = index * HISTORY_ROW_HEIGHT;
-          for (const segment of row.segments) {
-            if (segment.colorId % colorCount !== colorIndex) continue;
-            const fromX = historyLaneX(segment.fromLane);
-            const toX = historyLaneX(segment.toLane);
-            if (segment.shape === "incoming") {
-              d.push(
-                `M ${fromX} ${originY - HISTORY_GRAPH_ROW_OVERLAP} C ${fromX} ${originY + middle * 0.55}, ${toX} ${originY + middle * 0.55}, ${toX} ${originY + middle}`,
-              );
-            } else if (segment.shape === "outgoing") {
-              d.push(
-                `M ${fromX} ${originY + middle} C ${fromX} ${originY + middle * 1.45}, ${toX} ${originY + middle * 1.45}, ${toX} ${originY + HISTORY_ROW_HEIGHT + HISTORY_GRAPH_ROW_OVERLAP}`,
-              );
-            } else if (segment.fromLane === segment.toLane) {
-              d.push(
-                `M ${fromX} ${originY - HISTORY_GRAPH_ROW_OVERLAP} L ${toX} ${originY + HISTORY_ROW_HEIGHT + HISTORY_GRAPH_ROW_OVERLAP}`,
-              );
-            } else {
-              d.push(
-                `M ${fromX} ${originY - HISTORY_GRAPH_ROW_OVERLAP} C ${fromX} ${originY + middle}, ${toX} ${originY + middle}, ${toX} ${originY + HISTORY_ROW_HEIGHT + HISTORY_GRAPH_ROW_OVERLAP}`,
-              );
-            }
-          }
-        }
-        if (d.length === 0) return null;
-        return (
-          <path
-            key={colorIndex}
-            d={d.join(" ")}
-            fill="none"
-            stroke={historyGraphColor(colorIndex)}
-            strokeWidth={HISTORY_STROKE_WIDTH}
-          />
-        );
-      })}
-    </svg>
-  );
-}
-
-function HighlightedText({
-  text,
-  query,
-  caseSensitive,
-  className,
-}: {
-  text: string;
-  query: string;
-  caseSensitive: boolean;
-  className?: string;
-}) {
-  const parts = splitHighlightedText(text, query, caseSensitive);
-  return (
-    <span className={className}>
-      {parts.map((part, index) =>
-        part.match ? (
-          <mark key={`${part.text}-${index}`} className="rounded-sm bg-info/35 text-foreground">
-            {part.text}
-          </mark>
-        ) : (
-          <React.Fragment key={`${part.text}-${index}`}>{part.text}</React.Fragment>
-        ),
-      )}
-    </span>
-  );
-}
-
-function GitHistoryRow({
-  commit,
-  columns,
-  gridTemplate,
-  nodeLane,
-  nodeColorId,
-  isHead,
-  selected,
-  matched,
-  query,
-  caseSensitive,
-  onSelect,
-}: {
-  commit: GitHistoryCommit;
-  columns: HistoryColumnWidths;
-  gridTemplate: string;
-  nodeLane: number;
-  nodeColorId: number;
-  isHead: boolean;
-  selected: boolean;
-  matched: boolean;
-  query: string;
-  caseSensitive: boolean;
-  onSelect: () => void;
-}) {
-  const t = useTranslations("git.history");
-  const locale = useLocale();
-  const dateLocale = locale.startsWith("zh") ? zhCN : enUS;
-  const [copied, setCopied] = useState(false);
-  const color = historyGraphColor(nodeColorId);
-  const nodeX = historyLaneX(nodeLane);
-  const dateLabel = format(fromUnixTime(commit.timestamp), "d MMM yyyy HH:mm", {
-    locale: dateLocale,
-  });
-  const visibleRefs = commit.refs.slice(0, MAX_VISIBLE_REFS);
-  const hiddenRefCount = Math.max(0, commit.refs.length - visibleRefs.length);
-  const subject = commit.subject.trim() ? commit.subject : t("noSubject");
-
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      aria-pressed={selected}
-      onClick={onSelect}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          onSelect();
-        }
-      }}
-      className={cn(
-        "grid h-9 cursor-pointer items-center border-b border-border/40 text-[11px] hover:bg-muted/40",
-        matched && !selected && "bg-info/10",
-        selected && "bg-muted/50",
-      )}
-      style={{
-        width: historyTableWidth(columns),
-        gridTemplateColumns: gridTemplate,
-      }}
-    >
-      <div className="relative h-full min-w-0">
-        {isHead ? (
-          <span
-            className="absolute rounded-full border bg-background"
-            style={{
-              left: nodeX - HISTORY_NODE_RADIUS - HISTORY_HEAD_RING_PADDING,
-              top:
-                HISTORY_ROW_HEIGHT / 2 -
-                HISTORY_NODE_RADIUS -
-                HISTORY_HEAD_RING_PADDING,
-              width: (HISTORY_NODE_RADIUS + HISTORY_HEAD_RING_PADDING) * 2,
-              height: (HISTORY_NODE_RADIUS + HISTORY_HEAD_RING_PADDING) * 2,
-              borderColor: color,
-            }}
-          />
-        ) : null}
-        <span
-          className="absolute rounded-full"
-          style={{
-            left: nodeX - HISTORY_NODE_RADIUS,
-            top: HISTORY_ROW_HEIGHT / 2 - HISTORY_NODE_RADIUS,
-            width: HISTORY_NODE_RADIUS * 2,
-            height: HISTORY_NODE_RADIUS * 2,
-            backgroundColor: color,
-          }}
-        />
-      </div>
-
-      <div className="flex min-w-0 items-center overflow-hidden px-1.5">
-        {visibleRefs.length > 0 ? (
-          <span className="mr-1.5 flex min-w-0 max-w-[70%] items-center gap-1 overflow-hidden">
-            {visibleRefs.map((reference) => (
-              <HistoryRefBadge
-                key={`${reference.kind}:${reference.label}`}
-                reference={reference}
-                query={query}
-                caseSensitive={caseSensitive}
-              />
-            ))}
-            {hiddenRefCount > 0 ? (
-              <span className="shrink-0 text-[10px] text-muted-foreground">
-                +{hiddenRefCount}
-              </span>
-            ) : null}
-          </span>
-        ) : null}
-        <HighlightedText
-          text={subject}
-          query={query}
-          caseSensitive={caseSensitive}
-          className="min-w-0 flex-1 truncate text-xs text-foreground"
-        />
-      </div>
-
-      <span className="min-w-0 truncate px-1.5 text-[10.5px] text-muted-foreground">
-        {dateLabel}
-      </span>
-      <span className="min-w-0 truncate px-1.5 text-muted-foreground">
-        <HighlightedText
-          text={commit.author_name || t("unknownAuthor")}
-          query={query}
-          caseSensitive={caseSensitive}
-        />
-      </span>
-      <div className="group/hash flex min-w-0 items-center justify-start gap-1 px-1.5 font-mono text-[10.5px] text-muted-foreground">
-        <span className="min-w-0 truncate">
-          {copied ? (
-            <span className="text-info">{t("copied")}</span>
-          ) : (
-            <HighlightedText
-              text={commit.short_hash}
-              query={query}
-              caseSensitive={caseSensitive}
-            />
-          )}
-        </span>
-        <button
-          type="button"
-          aria-label={t("copyHash")}
-          title={t("copyHash")}
-          className={cn(
-            "inline-flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-colors hover:bg-accent hover:text-foreground group-hover/hash:opacity-100",
-            copied && "opacity-100 text-info",
-          )}
-          onClick={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            void copyToClipboard(commit.hash).then((ok) => {
-              if (!ok) return;
-              setCopied(true);
-              window.setTimeout(() => setCopied(false), 1200);
-            });
-          }}
-        >
-          {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function HistoryRefBadge({
-  reference,
-  query,
-  caseSensitive,
-}: {
-  reference: GitHistoryRef;
-  query: string;
-  caseSensitive: boolean;
-}) {
-  const Icon =
-    reference.kind === "branch"
-      ? GitBranch
-      : reference.kind === "tag"
-        ? Tag
-        : Cloud;
-  const tone =
-    reference.kind === "branch"
-      ? "text-info bg-info/10"
-      : reference.kind === "tag"
-        ? "text-warning bg-warning/10"
-        : "text-muted-foreground bg-muted/60";
-  const labelRef = useRef<HTMLSpanElement>(null);
-  const [truncated, setTruncated] = useState(false);
-  const [tooltipOpen, setTooltipOpen] = useState(false);
-
-  useLayoutEffect(() => {
-    const label = labelRef.current;
-    if (!label) return;
-    const measure = () => {
-      const nextTruncated = label.scrollWidth > label.clientWidth + 1;
-      setTruncated(nextTruncated);
-      if (!nextTruncated) setTooltipOpen(false);
-    };
-    measure();
-    const observer = new ResizeObserver(measure);
-    observer.observe(label);
-    return () => observer.disconnect();
-  }, [caseSensitive, query, reference.label]);
-
-  return (
-    <Tooltip
-      open={truncated ? tooltipOpen : false}
-      onOpenChange={(next) => {
-        if (truncated) setTooltipOpen(next);
-      }}
-    >
-      <TooltipTrigger asChild>
-        <span
-          className={cn(
-            "inline-flex min-w-0 max-w-56 items-center gap-0.5 rounded-sm px-1 py-0.5 text-[10px]",
-            tone,
-          )}
-        >
-          <Icon className="size-2.5 shrink-0" />
-          <span ref={labelRef} className="truncate">
-            <HighlightedText
-              text={reference.label}
-              query={query}
-              caseSensitive={caseSensitive}
-            />
-          </span>
-        </span>
-      </TooltipTrigger>
-      <TooltipContent side="top" className="max-w-xs break-all">
-        {reference.label}
-      </TooltipContent>
-    </Tooltip>
   );
 }

--- a/apps/web/src/features/git/components/git-history-graph-svg.tsx
+++ b/apps/web/src/features/git/components/git-history-graph-svg.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import {
+  HISTORY_GRAPH_ROW_OVERLAP,
+  HISTORY_ROW_HEIGHT,
+  HISTORY_STROKE_WIDTH,
+  GIT_HISTORY_GRAPH_COLORS,
+  historyGraphColor,
+  historyLaneX,
+  layoutGitHistoryGraph,
+} from "@/features/git/lib/git-history-graph";
+
+export function GitHistoryGraphSvg({
+  rows,
+  width,
+}: {
+  rows: ReturnType<typeof layoutGitHistoryGraph>["rows"];
+  width: number;
+}) {
+  const height = rows.length * HISTORY_ROW_HEIGHT;
+  const middle = HISTORY_ROW_HEIGHT / 2;
+  const colorCount = GIT_HISTORY_GRAPH_COLORS.length;
+
+  return (
+    <svg
+      aria-hidden
+      className="pointer-events-none absolute top-0 left-0 overflow-visible"
+      width={width}
+      height={height}
+    >
+      {Array.from({ length: colorCount }, (_, colorIndex) => {
+        const d: string[] = [];
+        for (let index = 0; index < rows.length; index++) {
+          const row = rows[index]!;
+          const originY = index * HISTORY_ROW_HEIGHT;
+          for (const segment of row.segments) {
+            if (segment.colorId % colorCount !== colorIndex) continue;
+            const fromX = historyLaneX(segment.fromLane);
+            const toX = historyLaneX(segment.toLane);
+            if (segment.shape === "incoming") {
+              d.push(
+                `M ${fromX} ${originY - HISTORY_GRAPH_ROW_OVERLAP} C ${fromX} ${originY + middle * 0.55}, ${toX} ${originY + middle * 0.55}, ${toX} ${originY + middle}`,
+              );
+            } else if (segment.shape === "outgoing") {
+              d.push(
+                `M ${fromX} ${originY + middle} C ${fromX} ${originY + middle * 1.45}, ${toX} ${originY + middle * 1.45}, ${toX} ${originY + HISTORY_ROW_HEIGHT + HISTORY_GRAPH_ROW_OVERLAP}`,
+              );
+            } else if (segment.fromLane === segment.toLane) {
+              d.push(
+                `M ${fromX} ${originY - HISTORY_GRAPH_ROW_OVERLAP} L ${toX} ${originY + HISTORY_ROW_HEIGHT + HISTORY_GRAPH_ROW_OVERLAP}`,
+              );
+            } else {
+              d.push(
+                `M ${fromX} ${originY - HISTORY_GRAPH_ROW_OVERLAP} C ${fromX} ${originY + middle}, ${toX} ${originY + middle}, ${toX} ${originY + HISTORY_ROW_HEIGHT + HISTORY_GRAPH_ROW_OVERLAP}`,
+              );
+            }
+          }
+        }
+        if (d.length === 0) return null;
+        return (
+          <path
+            key={colorIndex}
+            d={d.join(" ")}
+            fill="none"
+            stroke={historyGraphColor(colorIndex)}
+            strokeWidth={HISTORY_STROKE_WIDTH}
+          />
+        );
+      })}
+    </svg>
+  );
+}
+

--- a/apps/web/src/features/git/components/git-history-row.tsx
+++ b/apps/web/src/features/git/components/git-history-row.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import React, { useLayoutEffect, useRef, useState } from "react";
+import { useTranslations, useLocale } from "next-intl";
+import { fromUnixTime, format } from "date-fns";
+import { enUS, zhCN } from "date-fns/locale";
+import { Check, Cloud, Copy, GitBranch, Tag } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@workspace/ui";
+import { cn } from "@/shared/lib/utils";
+import { copyToClipboard } from "@/shared/utils/copy";
+import type { GitHistoryCommit, GitHistoryRef } from "@/api/ws-api-types";
+import {
+  HISTORY_HEAD_RING_PADDING,
+  HISTORY_NODE_RADIUS,
+  HISTORY_ROW_HEIGHT,
+  historyGraphColor,
+  historyLaneX,
+} from "@/features/git/lib/git-history-graph";
+import {
+  historyTableWidth,
+  type HistoryColumnWidths,
+} from "@/features/git/lib/git-history-columns";
+import { splitHighlightedText } from "@/features/git/lib/git-history-search";
+
+const MAX_VISIBLE_REFS = 3;
+
+export function HighlightedText({
+  text,
+  query,
+  caseSensitive,
+  className,
+}: {
+  text: string;
+  query: string;
+  caseSensitive: boolean;
+  className?: string;
+}) {
+  const parts = splitHighlightedText(text, query, caseSensitive);
+  return (
+    <span className={className}>
+      {parts.map((part, index) =>
+        part.match ? (
+          <mark key={`${part.text}-${index}`} className="rounded-sm bg-info/35 text-foreground">
+            {part.text}
+          </mark>
+        ) : (
+          <React.Fragment key={`${part.text}-${index}`}>{part.text}</React.Fragment>
+        ),
+      )}
+    </span>
+  );
+}
+
+export function GitHistoryRow({
+  commit,
+  columns,
+  gridTemplate,
+  nodeLane,
+  nodeColorId,
+  isHead,
+  selected,
+  matched,
+  query,
+  caseSensitive,
+  onSelect,
+}: {
+  commit: GitHistoryCommit;
+  columns: HistoryColumnWidths;
+  gridTemplate: string;
+  nodeLane: number;
+  nodeColorId: number;
+  isHead: boolean;
+  selected: boolean;
+  matched: boolean;
+  query: string;
+  caseSensitive: boolean;
+  onSelect: () => void;
+}) {
+  const t = useTranslations("git.history");
+  const locale = useLocale();
+  const dateLocale = locale.startsWith("zh") ? zhCN : enUS;
+  const [copied, setCopied] = useState(false);
+  const color = historyGraphColor(nodeColorId);
+  const nodeX = historyLaneX(nodeLane);
+  const dateLabel = format(fromUnixTime(commit.timestamp), "d MMM yyyy HH:mm", {
+    locale: dateLocale,
+  });
+  const visibleRefs = commit.refs.slice(0, MAX_VISIBLE_REFS);
+  const hiddenRefCount = Math.max(0, commit.refs.length - visibleRefs.length);
+  const subject = commit.subject.trim() ? commit.subject : t("noSubject");
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-pressed={selected}
+      onClick={onSelect}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onSelect();
+        }
+      }}
+      className={cn(
+        "grid h-9 cursor-pointer items-center border-b border-border/40 text-[11px] hover:bg-muted/40",
+        matched && !selected && "bg-info/10",
+        selected && "bg-muted/50",
+      )}
+      style={{
+        width: historyTableWidth(columns),
+        gridTemplateColumns: gridTemplate,
+      }}
+    >
+      <div className="relative h-full min-w-0">
+        {isHead ? (
+          <span
+            className="absolute rounded-full border bg-background"
+            style={{
+              left: nodeX - HISTORY_NODE_RADIUS - HISTORY_HEAD_RING_PADDING,
+              top:
+                HISTORY_ROW_HEIGHT / 2 -
+                HISTORY_NODE_RADIUS -
+                HISTORY_HEAD_RING_PADDING,
+              width: (HISTORY_NODE_RADIUS + HISTORY_HEAD_RING_PADDING) * 2,
+              height: (HISTORY_NODE_RADIUS + HISTORY_HEAD_RING_PADDING) * 2,
+              borderColor: color,
+            }}
+          />
+        ) : null}
+        <span
+          className="absolute rounded-full"
+          style={{
+            left: nodeX - HISTORY_NODE_RADIUS,
+            top: HISTORY_ROW_HEIGHT / 2 - HISTORY_NODE_RADIUS,
+            width: HISTORY_NODE_RADIUS * 2,
+            height: HISTORY_NODE_RADIUS * 2,
+            backgroundColor: color,
+          }}
+        />
+      </div>
+
+      <div className="flex min-w-0 items-center overflow-hidden px-1.5">
+        {visibleRefs.length > 0 ? (
+          <span className="mr-1.5 flex min-w-0 max-w-[70%] items-center gap-1 overflow-hidden">
+            {visibleRefs.map((reference) => (
+              <HistoryRefBadge
+                key={`${reference.kind}:${reference.label}`}
+                reference={reference}
+                query={query}
+                caseSensitive={caseSensitive}
+              />
+            ))}
+            {hiddenRefCount > 0 ? (
+              <span className="shrink-0 text-[10px] text-muted-foreground">
+                +{hiddenRefCount}
+              </span>
+            ) : null}
+          </span>
+        ) : null}
+        <HighlightedText
+          text={subject}
+          query={query}
+          caseSensitive={caseSensitive}
+          className="min-w-0 flex-1 truncate text-xs text-foreground"
+        />
+      </div>
+
+      <span className="min-w-0 truncate px-1.5 text-[10.5px] text-muted-foreground">
+        {dateLabel}
+      </span>
+      <span className="min-w-0 truncate px-1.5 text-muted-foreground">
+        <HighlightedText
+          text={commit.author_name || t("unknownAuthor")}
+          query={query}
+          caseSensitive={caseSensitive}
+        />
+      </span>
+      <div className="group/hash flex min-w-0 items-center justify-start gap-1 px-1.5 font-mono text-[10.5px] text-muted-foreground">
+        <span className="min-w-0 truncate">
+          {copied ? (
+            <span className="text-info">{t("copied")}</span>
+          ) : (
+            <HighlightedText
+              text={commit.short_hash}
+              query={query}
+              caseSensitive={caseSensitive}
+            />
+          )}
+        </span>
+        <button
+          type="button"
+          aria-label={t("copyHash")}
+          title={t("copyHash")}
+          className={cn(
+            "inline-flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-colors hover:bg-accent hover:text-foreground group-hover/hash:opacity-100",
+            copied && "opacity-100 text-info",
+          )}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            void copyToClipboard(commit.hash).then((ok) => {
+              if (!ok) return;
+              setCopied(true);
+              window.setTimeout(() => setCopied(false), 1200);
+            });
+          }}
+        >
+          {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function HistoryRefBadge({
+  reference,
+  query,
+  caseSensitive,
+}: {
+  reference: GitHistoryRef;
+  query: string;
+  caseSensitive: boolean;
+}) {
+  const Icon =
+    reference.kind === "branch"
+      ? GitBranch
+      : reference.kind === "tag"
+        ? Tag
+        : Cloud;
+  const tone =
+    reference.kind === "branch"
+      ? "text-info bg-info/10"
+      : reference.kind === "tag"
+        ? "text-warning bg-warning/10"
+        : "text-muted-foreground bg-muted/60";
+  const labelRef = useRef<HTMLSpanElement>(null);
+  const [truncated, setTruncated] = useState(false);
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+
+  useLayoutEffect(() => {
+    const label = labelRef.current;
+    if (!label) return;
+    const measure = () => {
+      const nextTruncated = label.scrollWidth > label.clientWidth + 1;
+      setTruncated(nextTruncated);
+      if (!nextTruncated) setTooltipOpen(false);
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(label);
+    return () => observer.disconnect();
+  }, [caseSensitive, query, reference.label]);
+
+  return (
+    <Tooltip
+      open={truncated ? tooltipOpen : false}
+      onOpenChange={(next) => {
+        if (truncated) setTooltipOpen(next);
+      }}
+    >
+      <TooltipTrigger asChild>
+        <span
+          className={cn(
+            "inline-flex min-w-0 max-w-56 items-center gap-0.5 rounded-sm px-1 py-0.5 text-[10px]",
+            tone,
+          )}
+        >
+          <Icon className="size-2.5 shrink-0" />
+          <span ref={labelRef} className="truncate">
+            <HighlightedText
+              text={reference.label}
+              query={query}
+              caseSensitive={caseSensitive}
+            />
+          </span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-xs break-all">
+        {reference.label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/features/git/components/git-history-table-chrome.tsx
+++ b/apps/web/src/features/git/components/git-history-table-chrome.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import { cn } from "@/shared/lib/utils";
+import { HISTORY_HEADER_HEIGHT } from "@/features/git/lib/git-history-graph";
+import {
+  HISTORY_RESIZE_COLUMNS,
+  historyTableWidth,
+  type HistoryColumnId,
+  type HistoryColumnWidths,
+} from "@/features/git/lib/git-history-columns";
+
+export function GitHistoryTableHeader({
+  columns,
+  gridTemplate,
+}: {
+  columns: HistoryColumnWidths;
+  gridTemplate: string;
+}) {
+  const t = useTranslations("git.history");
+  return (
+    <div
+      className="sticky top-0 z-20 grid items-center border-b border-border/50 bg-background text-[10.5px] font-medium text-muted-foreground"
+      style={{
+        height: HISTORY_HEADER_HEIGHT,
+        width: historyTableWidth(columns),
+        gridTemplateColumns: gridTemplate,
+      }}
+    >
+      {HISTORY_RESIZE_COLUMNS.map((id) => (
+        <div key={id} className="min-w-0 px-1.5">
+          <span className="block truncate">{t(`columns.${id}`)}</span>
+        </div>
+      ))}
+      <div className="min-w-0 px-1.5">
+        <span className="block truncate">{t("columns.commit")}</span>
+      </div>
+    </div>
+  );
+}
+
+export function ColumnResizeHandle({
+  column,
+  width,
+  left,
+  height,
+  label,
+  onResize,
+}: {
+  column: HistoryColumnId;
+  width: number;
+  left: number;
+  height: number;
+  label: string;
+  onResize: (id: HistoryColumnId, nextWidth: number) => void;
+}) {
+  const drag = useRef<{ x: number; width: number } | null>(null);
+  const [active, setActive] = useState(false);
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={label}
+      tabIndex={0}
+      style={{ left, height: Math.max(height, HISTORY_HEADER_HEIGHT) }}
+      className={cn(
+        "absolute top-0 w-2.5 -translate-x-1/2 cursor-col-resize touch-none select-none",
+        "after:absolute after:inset-y-0 after:left-1/2 after:w-px after:-translate-x-1/2 after:transition-colors",
+        active
+          ? "after:bg-foreground/45"
+          : "after:bg-transparent hover:after:bg-foreground/35",
+      )}
+      onPointerDown={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        drag.current = { x: event.clientX, width };
+        setActive(true);
+        event.currentTarget.setPointerCapture(event.pointerId);
+      }}
+      onPointerMove={(event) => {
+        if (!drag.current) return;
+        onResize(column, drag.current.width + event.clientX - drag.current.x);
+      }}
+      onPointerUp={(event) => {
+        drag.current = null;
+        setActive(false);
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        }
+      }}
+      onPointerCancel={() => {
+        drag.current = null;
+        setActive(false);
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "ArrowLeft") {
+          event.preventDefault();
+          onResize(column, width - 16);
+        } else if (event.key === "ArrowRight") {
+          event.preventDefault();
+          onResize(column, width + 16);
+        }
+      }}
+    />
+  );
+}
+

--- a/apps/web/src/features/git/lib/__tests__/git-history-panel.structural.test.ts
+++ b/apps/web/src/features/git/lib/__tests__/git-history-panel.structural.test.ts
@@ -12,6 +12,15 @@ function read(rel: string) {
   return readFileSync(join(root, rel), "utf8");
 }
 
+function readHistoryUi() {
+  return [
+    read("apps/web/src/features/git/components/GitHistoryPanel.tsx"),
+    read("apps/web/src/features/git/components/git-history-table-chrome.tsx"),
+    read("apps/web/src/features/git/components/git-history-graph-svg.tsx"),
+    read("apps/web/src/features/git/components/git-history-row.tsx"),
+  ].join("\n");
+}
+
 describe("git history panel structural", () => {
   it("keeps match-case inside the search field and drops the toolbar divider", () => {
     const src = read("apps/web/src/features/git/components/GitHistoryPanel.tsx");
@@ -39,7 +48,7 @@ describe("git history panel structural", () => {
   });
 
   it("renders a table header and a hover copy control on the hash", () => {
-    const src = read("apps/web/src/features/git/components/GitHistoryPanel.tsx");
+    const src = readHistoryUi();
     expect(src).toContain("GitHistoryTableHeader");
     expect(src).toContain("t(`columns.${id}`)");
     expect(src).toContain('t("columns.commit")');
@@ -62,7 +71,7 @@ describe("git history panel structural", () => {
   });
 
   it("allows longer ref labels and tooltips only when truncated", () => {
-    const src = read("apps/web/src/features/git/components/GitHistoryPanel.tsx");
+    const src = read("apps/web/src/features/git/components/git-history-row.tsx");
     expect(src).toContain("max-w-56");
     expect(src).not.toContain("max-w-28");
     expect(src).toContain("open={truncated ? tooltipOpen : false}");
@@ -85,6 +94,16 @@ describe("git history panel structural", () => {
     );
     expect(drawer).toContain("openCommit: (entry: Extract<TaskGithubDrawerEntry, { kind: \"commit\" }>) => void");
     expect(drawer).toContain("CommitDetailView");
+  });
+
+  it("splits graph chrome, SVG, and rows out of the panel shell", () => {
+    const panel = read("apps/web/src/features/git/components/GitHistoryPanel.tsx");
+    expect(panel).toContain('from "@/features/git/components/git-history-table-chrome"');
+    expect(panel).toContain('from "@/features/git/components/git-history-graph-svg"');
+    expect(panel).toContain('from "@/features/git/components/git-history-row"');
+    expect(panel).not.toContain("function GitHistoryGraphSvg");
+    expect(panel).not.toContain("function GitHistoryRow");
+    expect(panel).not.toContain("function ColumnResizeHandle");
   });
 });
 

--- a/apps/web/src/features/skills/components/SkillsView.tsx
+++ b/apps/web/src/features/skills/components/SkillsView.tsx
@@ -42,6 +42,7 @@ import {
   type SkillMarketItem,
 } from "../lib/market-data";
 import {
+  buildSkillDetailUrl,
   buildSkillListUrl,
   countCategoryItems,
   filterMarketCategories,
@@ -264,25 +265,19 @@ export const SkillsView: React.FC = () => {
   );
 
   const handleOpenInstalledSkill = (skill: SkillInfo) => {
-    const searchParams = new URLSearchParams();
-    if (activeTab !== "installed") {
-      searchParams.set("tab", activeTab);
-    }
-    if (scopeFilter !== "all") {
-      searchParams.set("filter", scopeFilter);
-    }
-    if (projectsParam) {
-      searchParams.set("projects", projectsParam);
-    }
-    if (query.trim()) {
-      searchParams.set("q", query.trim());
-    }
-    searchParams.set("scope", skill.scope);
-    searchParams.set("skillId", skill.id);
     // Paint the detail page immediately with list data; URL + full payload follow.
     openDetail(skill);
     queueMicrotask(() => {
-      router.push(`/skills?${searchParams.toString()}`);
+      router.push(
+        buildSkillDetailUrl({
+          activeTab,
+          filter: scopeFilter,
+          projects: projectsParam,
+          query,
+          skillScope: skill.scope,
+          skillId: skill.id,
+        }),
+      );
     });
   };
 

--- a/apps/web/src/features/skills/lib/skills-view-utils.ts
+++ b/apps/web/src/features/skills/lib/skills-view-utils.ts
@@ -58,6 +58,31 @@ export function buildSkillListUrl({
   return search ? `/skills?${search}` : "/skills";
 }
 
+/** List filters + installed skill identity for push-detail deep links. */
+export function buildSkillDetailUrl({
+  activeTab,
+  filter,
+  projects,
+  query,
+  skillScope,
+  skillId,
+}: {
+  activeTab: SkillsTab;
+  filter: ScopeFilter;
+  projects: string;
+  query: string;
+  skillScope: string;
+  skillId: string;
+}) {
+  const listUrl = buildSkillListUrl({ activeTab, filter, projects, query });
+  const searchParams = new URLSearchParams(
+    listUrl.includes("?") ? listUrl.split("?", 1)[1] : "",
+  );
+  searchParams.set("scope", skillScope);
+  searchParams.set("skillId", skillId);
+  return `/skills?${searchParams.toString()}`;
+}
+
 export function filterMarketCategories(categories: SkillMarketCategory[], query: string) {
   if (!query) {
     return categories;

--- a/automations/review/quality/result/2026-08/08-16_score-79_RESULT.md
+++ b/automations/review/quality/result/2026-08/08-16_score-79_RESULT.md
@@ -153,4 +153,6 @@ Git History 后端 parse + 前端纯 layout + infinite query + 虚拟化方向�
 ## 11. 结果提交与推送
 
 - 修复分支：`grokbuild/quality-fix/2026-08-16`
-- 修复与结果将同 PR 推送；详见 PR URL（创建后回填）。
+- 修复提交：`6160d7d0c`（及后续 report URL 补全提交）
+- PR URL：https://github.com/AruNi-01/atmos/pull/246
+- Label：`GrokBuild`

--- a/automations/review/quality/result/2026-08/08-16_score-79_RESULT.md
+++ b/automations/review/quality/result/2026-08/08-16_score-79_RESULT.md
@@ -1,0 +1,156 @@
+# Atmos main 每日代码质量评分（2026-08-16）
+
+## 1. 审查范围
+
+- 昨日时间窗口：2026-08-16 00:00:00 到 2026-08-16 23:59:59（UTC+8 / Asia/Shanghai）。
+- 分支：`main`（窗口内 tip 约 `3e7b89525` docs(landing) changelog；后续日间 tip 已前进到 `fdac12e4f`）。
+- 排除：无「仅 quality result 归档」提交；merge 提交本身不单独评分，按其中业务/代码提交审查。
+- 审查方式：以 **Git Graph History（#242）**、**Launchpad / Automations / Skills / Workspace Script（#241）**、Changes 工具栏与 bulk confirm、Token Usage share 收口、desktop-use 退出清理为主线。
+- 用户主工作区在无关 feature 分支且有未提交改动；修复在独立 worktree `grokbuild/quality-fix/2026-08-16`。
+
+被审查提交（代表性，窗口内约 44 条非 merge 业务/代码提交）：
+
+| Hash | Author | Message |
+| --- | --- | --- |
+| `750fab75b` | AruNi_Lu | fix(token-usage): fold publish into share popover (#240) |
+| `3b1451c8f`…`e5c054814` | AarynLu | Launchpad UI / settings underlay / automations memory+filters / skills / workspace script / token-usage polish（#241 合入） |
+| `f8389e229` | Cursor Agent | feat(git): open topological history graph in a center tab |
+| `2f06e6a48` / `7c214ac9d` | Cursor Agent | history prefetch + @tanstack/react-virtual |
+| `c18f78fbc` | AarynLu | feat(git): add resizable Graph History columns |
+| `995ea6ac2`…`d5e72f9ca` | Cursor Agent | Changes toolbar scoped bulk actions + destructive confirm dialog |
+| `1a5d5e115` | AarynLu | feat(web): add Changes list/tree view and tighten chrome |
+| `d282d0081` | AarynLu | feat(ui): share overlay close chrome across drawers |
+| `c5f80a48e` | AarynLu | fix(desktop-use): stop host on quit and hide vendor process name |
+| `621110fc4` / `2ca6d303e` / `571eb9810` | Cursor Agent | desktop 2026.8.16 release + serve-sim packing fixes |
+| `3e7b89525` | AarynLu | docs(landing): changelog for 2026.8.15 / 2026.8.16 |
+
+日合计业务改动量大（git history 单功能约 40+ files；automations 单提交 +3.7k/−1.0k；launchpad 相关多提交叠加）。
+
+## 2. 一份好代码应该是什么样
+
+本日标准看「大功能是否沿既有分层落地，以及枢纽文件是否被继续放大」。Git History 应把 parse / layout / query / 虚拟列表 / 行渲染边界画清；Automations 应把 filter 纯逻辑、leave 守卫、表单 IO 分开；Launchpad 页应把 tabs/filter/push 细节交给子组件，而不是在一个 View 里重写 URL 拼装。新增体积可以大，但长度必须换来可定位的模块，而不是单文件堆叠。
+
+## 3. 评分方法
+
+- 100 分制：设计与分层 30、可读性与复杂度 25、体量与内聚 20、可维护性与复用 15、工程卫生 10。
+- 高/中/低约扣 8–15 / 3–7 / 1–2；只计当日引入/放大问题。
+- 体量阈值：单文件 500+ 中风险、800+ 高风险信号；单组件 250+ 中风险（与结构恶化同时出现才扣分）。
+
+## 4. 总分
+
+总分：**79/100**。总体判断：**良好**。
+
+Git History 后端 parse + 前端纯 layout + infinite query + 虚拟化方向正确，且带测试与 MIT 归因；Automations 过滤器纯模块/测试也是加分。扣分集中在当日固化/放大的超大 UI 枢纽：`GitHistoryPanel`、`AutomationSetup`、`TokenUsageShareDialog`、`use-automation-page-state`。
+
+## 5. 分项评分
+
+| 维度 | 得分 | 扣分原因 |
+| --- | ---: | --- |
+| 设计与分层 | 25/30 | 正向：`history.rs` parse/refs；`git-history-graph.ts` / columns / search 纯模块；WS infinite query；filters 纯函数 + tests；workspace-script-dialog 纯 helper + DOM 测；desktop-use lifecycle/host-branding 抽出。扣分：`AutomationSetup` 仍是 composer + github + memory + dirty-leave 的总装车间（leave 守卫当日放大）；`use-automation-page-state` 继续做 URL+action 上帝 hook。 |
+| 可读性与复杂度 | 19/25 | Git History 面板内搜索/列宽/虚拟列表/SVG 切片交织，主组件约 370 行状态+渲染；TokenUsage share 的 capture / blob / lightbox / nested open 状态机难扫读；Automation leave 的 pushState+popstate+nav guard 正确但密度高。 |
+| 体量与内聚 | 13/20 | 当日固化/放大：`GitHistoryPanel` ~871（resizable 单提交 +532）、`AutomationSetup` 809→996、`TokenUsageShareDialog` ~727、`use-automation-page-state` ~736。正向：filter menus / memory editor / run drawer / SkillsFilterMenu / script helpers 有拆出。 |
+| 可维护性与复用 | 13/15 | 正向：overlay close chrome 共享；history columns 单测；stage-all 路径统一 re-export；TokenUsage icons/chips 抽出。扣分：`SkillsView.handleOpenInstalledSkill` 手写 URL 参数，与已有 `buildSkillListUrl` 平行。 |
+| 工程卫生 | 9/10 | 正向：Comet MIT NOTICE、图布局/search/columns 单测、e2e 调整、rustfmt/clippy 跟进、destructive bulk 确认对话框。扣 1：部分提交 message 非 conventional（如 “Restyle changes toolbar…”）。 |
+
+## 6. 主要问题清单
+
+### 中：`GitHistoryPanel.tsx` ~871 行混合 shell / 列 resize / SVG / 行 / badge
+
+- 提交：`f8389e229`、`7c214ac9d`、`c18f78fbc` 等
+- 文件：`apps/web/src/features/git/components/GitHistoryPanel.tsx`
+- 问题：纯 layout/search/columns 已外提，但 UI 仍单文件承载 TableHeader、ColumnResizeHandle、GitHistoryGraphSvg、GitHistoryRow、HistoryRefBadge 与主面板编排；resizable 提交进一步抬高体积。
+- 为什么是质量问题：改行复制按钮或 resize 手柄会与搜索/prefetch 逻辑同 diff，审查与回归面过大。
+- 优化建议：拆 `git-history-table-chrome.tsx`（header+resize）、`git-history-graph-svg.tsx`、`git-history-row.tsx`（含 highlight/badge）；`GitHistoryPanel` 只保留 query/虚拟列表/选择/drawer 编排。
+
+### 中：`AutomationSetup.tsx` 809→996，dirty-leave 守卫与表单总装同居
+
+- 提交：`f50c35a94`（memory / unsaved dialog / 表单扩张）
+- 文件：`apps/web/src/features/automations/components/AutomationSetup.tsx`
+- 问题：`setupSnapshot` 基线、`useRegisteredAppNavigationGuard`、`beforeunload`、`popstate` 二次 pushState、leave dialog 动作与 save/create/update/github 路径同文件；SetupControls 体积下沉到 Setup。
+- 为什么是质量问题：改「是否脏」判定或浏览器后退拦截必须加载整份 setup 表单。
+- 优化建议：抽 `use-automation-setup-leave-guard.ts`（baseline + requestLeave + 三类拦截 + dialog 动作）；Setup 只调用 `requestLeave` / `clearDirtyBaseline`。
+
+### 中：`use-automation-page-state.ts` ~736 上帝 hook
+
+- 提交：`f50c35a94`（list/run filter URL 状态接入）
+- 文件：`apps/web/src/features/automations/hooks/use-automation-page-state.ts`
+- 问题：page view URL、list/run filters、detail 加载、definition actions（run/pause/resume/delete）、toggle、cancel run、continue terminal、memory save 同 hook 返回。
+- 为什么是质量问题：改 run filter 会与 delete github route 生命周期 diff 纠缠。
+- 优化建议：中期拆 `use-automation-definition-actions.ts` 与 filter URL 绑定；本次优先保证 filter 纯逻辑已在 `automation-*-filters.ts`（已完成部分）。
+
+### 中：`TokenUsageShareDialog.tsx` / `TokenUsageSharePopover` ~727 行状态机
+
+- 提交：`750fab75b`、`86c8006bd`
+- 文件：`apps/web/src/app-shell/TokenUsageShareDialog.tsx`
+- 问题：publish/share 双 tab 高度动画、capture blob、preview URL revoke、lightbox 与 nested dialog 保活 popover、social share 路径同组件。
+- 为什么是质量问题：改 capture 失败恢复策略必须读完整 share UX。
+- 优化建议：抽 `use-token-usage-share-capture.ts`（blob/preview/revoke/ensureBlob）与 `SharePublishPanels` 文件；popover 只做 tab + 动作按钮编排。
+
+### 低：`SkillsView` 详情 URL 与 `buildSkillListUrl` 平行拼装
+
+- 提交：`0d5dc6a9c`
+- 文件：`apps/web/src/features/skills/components/SkillsView.tsx`、`apps/web/src/features/skills/lib/skills-view-utils.ts`
+- 问题：`handleOpenInstalledSkill` 手写 tab/filter/projects/q，与 list back 使用的 `buildSkillListUrl` 规则重复。
+- 优化建议：新增 `buildSkillDetailUrl`（list 参数 + scope/skillId），两边共用。
+
+## 7. 正向观察
+
+- **Git History 分层**：`crates/core-engine/src/git/history.rs` 有界字段/ref 排序 + 单测；前端 layout 与 search 可单测；Zed 分页常量与 prefetch 边界清晰；虚拟列表只切片绘制 SVG。
+- **Comet MIT 归因**：NOTICE + 文件头注释到位。
+- **Automations 过滤**：`automation-list-filters.ts` / `automation-run-filters.ts` + 组件侧 tests；Run drawer / Memory editor 独立组件。
+- **Workspace Script Dialog**：phases / trust / env insert 有 `workspace-script-dialog.ts` 与 DOM 测。
+- **Skills**：tabs 子组件 + `SkillsFilterMenu` + push transition 注释说明时序。
+- **Changes 工具栏**：destructive bulk 走 Dialog 确认，busy 状态收敛。
+- **共享 drawer 关闭 chrome**：`packages/ui` drawer + structural test。
+- **desktop-use**：quit 停 host、vendor 进程名隐藏，lifecycle/host-branding 分文件。
+
+## 8. Review 建议
+
+1. Graph History：大仓 2k+ commit 时 layout 全量 memo 成本；列宽拖动与虚拟行对齐。
+2. History 搜索：SHA 前缀 vs 文本匹配；match 跳转与 prefetch 竞态。
+3. Automation dirty leave：浏览器后退 / in-app nav / beforeunload 三路径是否一致。
+4. Changes bulk discard/trash：确认文案与实际作用域（tracked vs untracked）。
+5. Token share capture：暗色背景、popover 关闭后 lightbox 是否仍持有 blob。
+6. Skills push detail：冷开 URL vs list 点击 open 是否双重动画。
+
+## 9. 自动修复与 PR
+
+总分 79 < 90，已触发自动修复。
+
+### 修复摘要
+
+1. **Git History UI 拆分**
+   - `git-history-table-chrome.tsx`：`GitHistoryTableHeader` + `ColumnResizeHandle`
+   - `git-history-graph-svg.tsx`：`GitHistoryGraphSvg`
+   - `git-history-row.tsx`：`GitHistoryRow` + highlight + ref badge
+   - `GitHistoryPanel.tsx`：871 → **~439**（编排 + 搜索 + 虚拟列表）
+   - 更新 structural test，覆盖拆分后多文件契约
+
+2. **Automation leave 守卫抽出**
+   - 新增 `use-automation-setup-leave-guard.ts`（baseline / nav guard / beforeunload / popstate / dialog 动作）
+   - `AutomationSetup.tsx`：996 → **~883**，保存成功走 `clearDirtyBaseline()`
+
+3. **Skills URL 复用**
+   - `buildSkillDetailUrl` 复用 list 参数规则
+   - `SkillsView.handleOpenInstalledSkill` 改为调用 helper
+
+### 验证
+
+- `bun test`：`git-history-panel.structural` + columns/graph/search：**21 pass**
+- `git diff --check`：通过
+- 全量 `bun run typecheck`（worktree 依赖链接不完整）存在大量与本次无关的缺失类型错误；本次引入的 `GitHistoryCommit` 缺 import 已补齐
+
+### 剩余风险
+
+- `TokenUsageSharePopover` 状态机未在本 PR 拆出（风险面大、与视觉动画耦合）。
+- `use-automation-page-state` 仍偏大，未拆 definition actions。
+- AutomationSetup 表单/composer/github 总装仍重，仅移出 leave 守卫。
+
+## 10. 结果文件
+
+- `automations/review/quality/result/2026-08/08-16_score-79_RESULT.md`
+
+## 11. 结果提交与推送
+
+- 修复分支：`grokbuild/quality-fix/2026-08-16`
+- 修复与结果将同 PR 推送；详见 PR URL（创建后回填）。


### PR DESCRIPTION
## Summary

Daily Atmos main quality review for **2026-08-16 (UTC+8)** scored **79/100** (良好), triggering auto-fix.

This PR addresses the highest-impact design quality findings from that day:

1. **Git History panel split** — extract table chrome (header + column resize), graph SVG, and row/badge modules so `GitHistoryPanel` stays an orchestration shell (~871 → ~439 lines).
2. **Automation setup leave-guard hook** — move dirty baseline, in-app nav guard, `beforeunload`, and `popstate` confirm out of `AutomationSetup` into `use-automation-setup-leave-guard.ts` (~996 → ~883).
3. **Skills detail URL helper** — add `buildSkillDetailUrl` reusing list filter params; stop hand-rolling search params in `SkillsView`.
4. **Archive** the quality report at `automations/review/quality/result/2026-08/08-16_score-79_RESULT.md`.

### Original score drivers

| Severity | Issue |
| --- | --- |
| 中 | `GitHistoryPanel.tsx` ~871 mixed shell / resize / SVG / row |
| 中 | `AutomationSetup` dirty-leave guard co-located with form total assembly |
| 中 | `use-automation-page-state` god-hook (not fully split this PR) |
| 中 | `TokenUsageSharePopover` capture state machine (deferred; high animation coupling) |
| 低 | Skills detail URL parallel assembly |

## Related Issue

N/A — daily quality automation.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] Additional checks (describe below)

- `bun test` on git-history structural + columns/graph/search: **21 pass**
- `git diff --check`: pass
- Full web `typecheck` in isolated worktree is noisy due incomplete workspace deps; fixed missing `GitHistoryCommit` import introduced by the split

## Checklist

- [ ] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

### Remaining risk

- Token Usage share popover state machine not extracted.
- Automation page-state definition actions still in one hook.
- AutomationSetup still large (composer + github + memory form).

---

### Agent
Generated by **Grok Build** · Atmos daily quality review automation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors Git History UI and Automation Setup leave protection to shrink large components and improve testability without changing UX. Replaces manual Skills detail URL assembly with a helper to keep list and detail links consistent.

- Split the Git History panel into `git-history-table-chrome` (header + `ColumnResizeHandle`), `git-history-graph-svg` (SVG), and `git-history-row` (row, highlights, ref badges); `GitHistoryPanel` now orchestrates layout, search, and virtualization. Structural tests now read from the split files.
- Extract dirty-form leave logic from `AutomationSetup` into `use-automation-setup-leave-guard` (baseline, in-app nav guard, `beforeunload`, and `popstate`). `AutomationSetup` calls `requestLeave` and resets with `clearDirtyBaseline()` after successful save; prompts remain the same.
- Add `buildSkillDetailUrl` and switch `SkillsView` to use it, reusing list filter params for detail links.
- Archive the 2026-08-16 quality report.

- If you extend Git History UI, import `GitHistoryTableHeader`/`ColumnResizeHandle`, `GitHistoryGraphSvg`, and `GitHistoryRow` from their new modules rather than `GitHistoryPanel`.

<sup>Written for commit 6160d7d0c9334a3808be4c1f3ab77f4817d9dc2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

