### PR TITLE
refactor: address daily quality findings for 2026-08-17

### DIFF
--- a/apps/web/src/app-shell/CenterStage.tsx
+++ b/apps/web/src/app-shell/CenterStage.tsx
@@ -117,6 +117,7 @@ import {
 } from "@/app-shell/center-pane/CenterPaneGrid";
 import { useCenterPaneLayoutStore } from "@/app-shell/center-pane/center-pane-layout-store";
 import {
+  buildTabToPaneIdMap,
   collectActiveTabIds,
   createDefaultLayout,
   isEmptyPane,
@@ -125,14 +126,8 @@ import {
   OVERVIEW_TAB_ID,
 } from "@/app-shell/center-pane/center-pane-layout";
 import { useCenterPaneSlotBoxes } from "@/app-shell/center-pane/use-center-pane-slot-boxes";
-import {
-  collectSavedSurfaces,
-  isToolSurfaceKind,
-  materializeSavedLayout,
-  resolveSurfaceTabId,
-  snapshotCenterLayout,
-  type CenterSurfaceKind,
-} from "@/app-shell/center-pane/center-pane-saved-layout";
+import { snapshotCenterLayout } from "@/app-shell/center-pane/center-pane-saved-layout";
+import { prepareSavedCenterLayout } from "@/app-shell/center-pane/apply-saved-center-layout";
 import { useCenterPaneSavedLayoutStore } from "@/app-shell/center-pane/center-pane-saved-layout-store";
 import {
   buildDefaultEmptyPaneActions,
@@ -2234,15 +2229,8 @@ const CenterStage: React.FC = () => {
   }, [isMultiPane, resolvedPaneLayout]);
   const tabToPaneId = React.useMemo(() => {
     if (!isMultiPane) return null;
-    const map: Record<string, string> = {};
-    for (const pane of resolvedPaneLayout.panes) {
-      for (const tabId of pane.tabIds) {
-        map[tabId] = pane.id;
-      }
-      map[pane.activeTabId] = pane.id;
-    }
-    return map;
-  }, [isMultiPane, resolvedPaneLayout.panes]);
+    return buildTabToPaneIdMap(resolvedPaneLayout);
+  }, [isMultiPane, resolvedPaneLayout]);
 
   const handleSplitRight = React.useCallback(() => {
     if (!renderContextId) return;
@@ -2297,40 +2285,16 @@ const CenterStage: React.FC = () => {
       const saved = useCenterPaneSavedLayoutStore.getState().getById(layoutId);
       if (!saved) return;
 
-      const surfaces = collectSavedSurfaces(saved);
-      let browserTabValue: string | null = null;
-
-      for (const surface of surfaces) {
-        if (surface === "browser") {
-          const existing = browserTabs[0]?.value ?? null;
-          if (existing) {
-            browserTabValue = existing;
-          } else {
-            const tab = openBrowserCenterTab(renderContextId);
-            browserTabValue = tab.value;
-            requestBrowserContextUrlFocus(tab.browserContextId);
-          }
-          continue;
-        }
-        if (surface === "simulator") {
-          openSimulatorTab(renderContextId);
-          continue;
-        }
-        if (surface === "git-history") {
-          openGitHistoryTab(renderContextId);
-          continue;
-        }
-        if (isToolSurfaceKind(surface)) {
-          openToolTab(renderContextId, surface);
-          continue;
-        }
-        // overview / terminal / wiki / github: opened via URL tab selection below
-      }
-
-      const resolveTabId = (kind: CenterSurfaceKind) =>
-        resolveSurfaceTabId(kind, { browserTabId: browserTabValue });
-
-      const liveLayout = materializeSavedLayout(saved, resolveTabId);
+      const { liveLayout } = prepareSavedCenterLayout({
+        contextId: renderContextId,
+        saved,
+        existingBrowserTabValue: browserTabs[0]?.value ?? null,
+        openBrowserTab: () => openBrowserCenterTab(renderContextId),
+        focusBrowserUrl: requestBrowserContextUrlFocus,
+        openSimulatorTab,
+        openGitHistoryTab,
+        openToolTab,
+      });
       setCenterPaneLayout(renderContextId, liveLayout);
 
       const focused =

--- a/apps/web/src/app-shell/__tests__/center-pane-layout.test.ts
+++ b/apps/web/src/app-shell/__tests__/center-pane-layout.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   closePane,
+  buildTabToPaneIdMap,
   collectActiveTabIds,
   createDefaultLayout,
   DEFAULT_PANE_ID,
@@ -262,5 +263,20 @@ describe("center-pane-layout", () => {
     expect(reconciled).toBe(layout);
     const opened = openTabOnFocusedPane(layout, "terminal");
     expect(opened).toBe(layout);
+  });
+});
+
+describe("buildTabToPaneIdMap", () => {
+  it("maps owned tabs and active tabs to pane ids", () => {
+    let layout = createDefaultLayout(["overview", "terminal"], "overview");
+    layout = splitPane(layout, { direction: "right" });
+    const secondaryId = layout.panes.find((p) => p.id !== DEFAULT_PANE_ID)?.id;
+    expect(secondaryId).toBeDefined();
+    layout = focusPane(layout, secondaryId!);
+    layout = openTabOnFocusedPane(layout, "changes");
+    const map = buildTabToPaneIdMap(layout);
+    expect(map.overview).toBe(DEFAULT_PANE_ID);
+    expect(map.changes).toBe(secondaryId);
+    expect(Object.values(map).every((id) => layout.panes.some((p) => p.id === id))).toBe(true);
   });
 });

--- a/apps/web/src/app-shell/center-pane/apply-saved-center-layout.ts
+++ b/apps/web/src/app-shell/center-pane/apply-saved-center-layout.ts
@@ -1,0 +1,70 @@
+import type { CenterSurfaceKind, SavedCenterLayout } from "@/app-shell/center-pane/center-pane-saved-layout";
+import {
+  collectSavedSurfaces,
+  isToolSurfaceKind,
+  materializeSavedLayout,
+  resolveSurfaceTabId,
+} from "@/app-shell/center-pane/center-pane-saved-layout";
+import type { CenterToolTabValue } from "@/app-shell/center-tool-tabs";
+
+export type ApplySavedCenterLayoutDeps = {
+  contextId: string;
+  saved: SavedCenterLayout;
+  existingBrowserTabValue: string | null;
+  openBrowserTab: () => { value: string; browserContextId: string };
+  focusBrowserUrl: (browserContextId: string) => void;
+  openSimulatorTab: (contextId: string) => void;
+  openGitHistoryTab: (contextId: string) => void;
+  openToolTab: (contextId: string, surface: CenterToolTabValue) => void;
+};
+
+/**
+ * Ensure saved multi-pane surfaces exist, then materialize a live layout.
+ * Browser tabs are reused when present; other tool surfaces are opened as needed.
+ */
+export function prepareSavedCenterLayout(deps: ApplySavedCenterLayoutDeps) {
+  const {
+    contextId,
+    saved,
+    existingBrowserTabValue,
+    openBrowserTab,
+    focusBrowserUrl,
+    openSimulatorTab,
+    openGitHistoryTab,
+    openToolTab,
+  } = deps;
+
+  const surfaces = collectSavedSurfaces(saved);
+  let browserTabValue: string | null = existingBrowserTabValue;
+
+  for (const surface of surfaces) {
+    if (surface === "browser") {
+      if (!browserTabValue) {
+        const tab = openBrowserTab();
+        browserTabValue = tab.value;
+        focusBrowserUrl(tab.browserContextId);
+      }
+      continue;
+    }
+    if (surface === "simulator") {
+      openSimulatorTab(contextId);
+      continue;
+    }
+    if (surface === "git-history") {
+      openGitHistoryTab(contextId);
+      continue;
+    }
+    if (isToolSurfaceKind(surface)) {
+      openToolTab(contextId, surface);
+      continue;
+    }
+  }
+
+  const resolveTabId = (kind: CenterSurfaceKind) =>
+    resolveSurfaceTabId(kind, { browserTabId: browserTabValue });
+
+  return {
+    liveLayout: materializeSavedLayout(saved, resolveTabId),
+    browserTabValue,
+  };
+}

--- a/apps/web/src/app-shell/center-pane/center-pane-layout.ts
+++ b/apps/web/src/app-shell/center-pane/center-pane-layout.ts
@@ -294,6 +294,21 @@ export function pruneEmptySecondaryPanes(
 }
 
 /** All active tab ids across panes (unique, focus order first). */
+
+/** Map every tab id owned by a pane to that pane id (active tab wins last write). */
+export function buildTabToPaneIdMap(
+  layout: CenterPaneLayout,
+): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const pane of layout.panes) {
+    for (const tabId of pane.tabIds) {
+      map[tabId] = pane.id;
+    }
+    map[pane.activeTabId] = pane.id;
+  }
+  return map;
+}
+
 export function collectActiveTabIds(layout: CenterPaneLayout): string[] {
   const focused = getFocusedPane(layout).activeTabId;
   const ids: string[] = [];

--- a/apps/web/src/features/terminal/components/TerminalSplitView.tsx
+++ b/apps/web/src/features/terminal/components/TerminalSplitView.tsx
@@ -31,6 +31,7 @@ import {
   type TerminalSplitBox,
 } from "@/features/terminal/lib/terminal-layout-tree";
 import {
+  capturePanePreview,
   dragPreviewGrabOffset,
   scaleTerminalDragPreview,
 } from "@/features/terminal/lib/terminal-pane-drag-preview";
@@ -340,149 +341,7 @@ function pointerFromDragEvent(event: {
   delta: { x: number; y: number };
 }): { x: number; y: number } | null {
   const start = getEventCoordinates(event.activatorEvent);
-  if (!start) return null;
-  return { x: start.x + event.delta.x, y: start.y + event.delta.y };
-}
-
-function capturePanePreview(el: HTMLElement): {
-  width: number;
-  height: number;
-  title: string;
-  toolbarHtml: string;
-  snapshotUrl: string | null;
-  left: number;
-  top: number;
-} {
-  const rect = el.getBoundingClientRect();
-  const title =
-    el.querySelector(".terminal-title-primary")?.textContent?.trim() ||
-    el.querySelector(".terminal-pane-title")?.textContent?.trim() ||
-    "";
-  const toolbar =
-    el.querySelector<HTMLElement>(".terminal-pane-toolbar-left") ??
-    el.querySelector<HTMLElement>(".terminal-title-row");
-  return {
-    width: rect.width,
-    height: rect.height,
-    title,
-    toolbarHtml: toolbar?.innerHTML ?? "",
-    snapshotUrl: captureTerminalSnapshot(el),
-    left: rect.left,
-    top: rect.top,
-  };
-}
-
-function captureTerminalSnapshot(root: HTMLElement): string | null {
-  const host =
-    root.querySelector<HTMLElement>(".atmos-terminal") ??
-    root.querySelector<HTMLElement>(".xterm-screen") ??
-    root.querySelector<HTMLElement>(".xterm") ??
-    root;
-  const canvases = Array.from(host.querySelectorAll("canvas")).filter((src) => {
-    return src.width >= 16 && src.height >= 16;
-  });
-  if (canvases.length === 0) return paintTerminalRowsSnapshot(host);
-
-  const hostRect = host.getBoundingClientRect();
-  const width = Math.max(1, Math.round(hostRect.width));
-  const height = Math.max(1, Math.round(hostRect.height));
-  const scale = Math.min(2, window.devicePixelRatio || 1);
-  const canvas = document.createElement("canvas");
-  canvas.width = Math.round(width * scale);
-  canvas.height = Math.round(height * scale);
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return paintTerminalRowsSnapshot(host);
-  ctx.scale(scale, scale);
-  ctx.fillStyle = "#09090b";
-  ctx.fillRect(0, 0, width, height);
-
-  let painted = false;
-  for (const src of canvases) {
-    try {
-      const srcRect = src.getBoundingClientRect();
-      ctx.drawImage(
-        src,
-        srcRect.left - hostRect.left,
-        srcRect.top - hostRect.top,
-        Math.max(1, srcRect.width),
-        Math.max(1, srcRect.height),
-      );
-      painted = true;
-    } catch {
-      // WebGL/tainted canvas — try the next layer.
-    }
-  }
-
-  if (!painted || isMostlyBlankCanvas(ctx, canvas.width, canvas.height)) {
-    return paintTerminalRowsSnapshot(host);
-  }
-  try {
-    return canvas.toDataURL("image/jpeg", 0.84);
-  } catch {
-    return paintTerminalRowsSnapshot(host);
-  }
-}
-
-function isMostlyBlankCanvas(
-  ctx: CanvasRenderingContext2D,
-  width: number,
-  height: number,
-): boolean {
-  if (width <= 0 || height <= 0) return true;
-  const samples: Array<[number, number]> = [
-    [2, 2],
-    [Math.floor(width / 2), Math.floor(height / 2)],
-    [Math.max(0, width - 3), 2],
-    [2, Math.max(0, height - 3)],
-    [Math.floor(width / 4), Math.floor(height / 3)],
-  ];
-  try {
-    for (const [x, y] of samples) {
-      const pixel = ctx.getImageData(x, y, 1, 1).data;
-      if ((pixel[0] ?? 0) > 20 || (pixel[1] ?? 0) > 20 || (pixel[2] ?? 0) > 20) {
-        return false;
-      }
-    }
-    const stripW = Math.min(width, 72);
-    const strip = ctx.getImageData(0, Math.floor(height / 3), stripW, 1).data;
-    for (let i = 0; i < strip.length; i += 4) {
-      if ((strip[i] ?? 0) > 20 || (strip[i + 1] ?? 0) > 20 || (strip[i + 2] ?? 0) > 20) {
-        return false;
-      }
-    }
-  } catch {
-    return false;
-  }
-  return true;
-}
-
-function paintTerminalRowsSnapshot(host: HTMLElement): string | null {
-  const rows = host.querySelectorAll(".xterm-rows > div");
-  if (rows.length === 0) return null;
-  const width = 440;
-  const lineHeight = 16;
-  const height = Math.min(320, Math.max(lineHeight * 8, rows.length * lineHeight));
-  const canvas = document.createElement("canvas");
-  canvas.width = width;
-  canvas.height = height;
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return null;
-  ctx.fillStyle = "#09090b";
-  ctx.fillRect(0, 0, width, height);
-  ctx.font = "12px ui-monospace, SFMono-Regular, Menlo, monospace";
-  ctx.fillStyle = "#d4d4d8";
-  let y = 14;
-  rows.forEach((row) => {
-    if (y > height) return;
-    const text = row.textContent ?? "";
-    if (text.trim().length === 0) {
-      y += lineHeight;
-      return;
-    }
-    ctx.fillText(text.slice(0, 80), 8, y, width - 16);
-    y += lineHeight;
-  });
-  try {
+  if (!stay {
     return canvas.toDataURL("image/jpeg", 0.84);
   } catch {
     return null;

--- a/apps/web/src/features/terminal/lib/terminal-pane-drag-preview.ts
+++ b/apps/web/src/features/terminal/lib/terminal-pane-drag-preview.ts
@@ -28,3 +28,148 @@ export function scaleTerminalDragPreview(
 export function dragPreviewGrabOffset(width: number): { x: number; y: number } {
   return { x: Math.round(Math.max(1, width) / 2), y: 0 };
 }
+
+export function capturePanePreview(el: HTMLElement): {
+  width: number;
+  height: number;
+  title: string;
+  toolbarHtml: string;
+  snapshotUrl: string | null;
+  left: number;
+  top: number;
+} {
+  const rect = el.getBoundingClientRect();
+  const title =
+    el.querySelector(".terminal-title-primary")?.textContent?.trim() ||
+    el.querySelector(".terminal-pane-title")?.textContent?.trim() ||
+    "";
+  const toolbar =
+    el.querySelector<HTMLElement>(".terminal-pane-toolbar-left") ??
+    el.querySelector<HTMLElement>(".terminal-title-row");
+  return {
+    width: rect.width,
+    height: rect.height,
+    title,
+    toolbarHtml: toolbar?.innerHTML ?? "",
+    snapshotUrl: captureTerminalSnapshot(el),
+    left: rect.left,
+    top: rect.top,
+  };
+}
+
+function captureTerminalSnapshot(root: HTMLElement): string | null {
+  const host =
+    root.querySelector<HTMLElement>(".atmos-terminal") ??
+    root.querySelector<HTMLElement>(".xterm-screen") ??
+    root.querySelector<HTMLElement>(".xterm") ??
+    root;
+  const canvases = Array.from(host.querySelectorAll("canvas")).filter((src) => {
+    return src.width >= 16 && src.height >= 16;
+  });
+  if (canvases.length === 0) return paintTerminalRowsSnapshot(host);
+
+  const hostRect = host.getBoundingClientRect();
+  const width = Math.max(1, Math.round(hostRect.width));
+  const height = Math.max(1, Math.round(hostRect.height));
+  const scale = Math.min(2, window.devicePixelRatio || 1);
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.round(width * scale);
+  canvas.height = Math.round(height * scale);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return paintTerminalRowsSnapshot(host);
+  ctx.scale(scale, scale);
+  ctx.fillStyle = "#09090b";
+  ctx.fillRect(0, 0, width, height);
+
+  let painted = false;
+  for (const src of canvases) {
+    try {
+      const srcRect = src.getBoundingClientRect();
+      ctx.drawImage(
+        src,
+        srcRect.left - hostRect.left,
+        srcRect.top - hostRect.top,
+        Math.max(1, srcRect.width),
+        Math.max(1, srcRect.height),
+      );
+      painted = true;
+    } catch {
+      // WebGL/tainted canvas — try the next layer.
+    }
+  }
+
+  if (!painted || isMostlyBlankCanvas(ctx, canvas.width, canvas.height)) {
+    return paintTerminalRowsSnapshot(host);
+  }
+  try {
+    return canvas.toDataURL("image/jpeg", 0.84);
+  } catch {
+    return paintTerminalRowsSnapshot(host);
+  }
+}
+
+function isMostlyBlankCanvas(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+): boolean {
+  if (width <= 0 || height <= 0) return true;
+  const samples: Array<[number, number]> = [
+    [2, 2],
+    [Math.floor(width / 2), Math.floor(height / 2)],
+    [Math.max(0, width - 3), 2],
+    [2, Math.max(0, height - 3)],
+    [Math.floor(width / 4), Math.floor(height / 3)],
+  ];
+  try {
+    for (const [x, y] of samples) {
+      const pixel = ctx.getImageData(x, y, 1, 1).data;
+      if ((pixel[0] ?? 0) > 20 || (pixel[1] ?? 0) > 20 || (pixel[2] ?? 0) > 20) {
+        return false;
+      }
+    }
+    const stripW = Math.min(width, 72);
+    const strip = ctx.getImageData(0, Math.floor(height / 3), stripW, 1).data;
+    for (let i = 0; i < strip.length; i += 4) {
+      if ((strip[i] ?? 0) > 20 || (strip[i + 1] ?? 0) > 20 || (strip[i + 2] ?? 0) > 20) {
+        return false;
+      }
+    }
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+function paintTerminalRowsSnapshot(host: HTMLElement): string | null {
+  const rows = host.querySelectorAll(".xterm-rows > div");
+  if (rows.length === 0) return null;
+  const width = 440;
+  const lineHeight = 16;
+  const height = Math.min(320, Math.max(lineHeight * 8, rows.length * lineHeight));
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+  ctx.fillStyle = "#09090b";
+  ctx.fillRect(0, 0, width, height);
+  ctx.font = "12px ui-monospace, SFMono-Regular, Menlo, monospace";
+  ctx.fillStyle = "#d4d4d8";
+  let y = 14;
+  rows.forEach((row) => {
+    if (y > height) return;
+    const text = row.textContent ?? "";
+    if (text.trim().length === 0) {
+      y += lineHeight;
+      return;
+    }
+    ctx.fillText(text.slice(0, 80), 8, y, width - 16);
+    y += lineHeight;
+  });
+  try {
+    return canvas.toDataURL("image/jpeg", 0.84);
+  } catch {
+    return null;
+  }
+}

--- a/automations/review/quality/result/2026-08/08-17_score-76_RESULT.md
+++ b/automations/review/quality/result/2026-08/08-17_score-76_RESULT.md
@@ -1,0 +1,127 @@
+# Atmos main 每日代码质量评分（2026-08-17）
+
+## 1. 审查范围
+
+- 昨日时间窗口：2026-08-17 00:00:00 到 2026-08-17 23:59:59（UTC+8 / Asia/Shanghai）。
+- 分支：`main`（窗口 tip `5eb227423`；审查时 origin/main 已前进到含后续小修）。
+- 排除：`2b30d5bd1` docs: link quality report to PR #246（仅 quality result）。
+- 计入正向：`6160d7d0c` refactor: address daily quality findings for 2026-08-16（含真实代码拆分）。
+- 审查方式：以 **multi-pane CenterStage**、**APP-062 PT Design 包**、**Terminal pane DnD**、**Launchpad long-press reorder**、brand mark 为主线。
+- 用户工作区有未提交改动；修复在独立 worktree `grokbuild/quality-fix/2026-08-17`。
+
+被审查提交（代表性，窗口内约 48 条非 merge 业务/代码提交）：
+
+| Hash | Author | Message |
+| --- | --- | --- |
+| `4cc44c2ea` | AarynLu | feat(web): multi-pane center stage and retire right sidebar |
+| `abb73913f`…`5eb227423` | AarynLu | PT Design package / MCP / collab / relay DO / agent bridge（多提交迭代） |
+| `d356d688a` | AarynLu | feat(web): drag terminal panes and restyle title chrome |
+| `fd867516c` | AarynLu | feat(web): Launchpad long-press reorder with durable layout |
+| `61b0731d7` / `130fea06e` | AarynLu | brand squircle + app mark PNG across UI |
+| `461980af2` | AarynLu | feat(landing): proxy APP-061 /tok share URLs via Pages Functions |
+| `6160d7d0c` | AarynLu | refactor: address daily quality findings for 2026-08-16 |
+
+## 2. 一份好代码应该是什么样
+
+本日标准看「壳层枢纽是否继续吞掉编排」与「新包是否画清浏览器/Node 边界」。Multi-pane 应把 layout 纯函数与 Stage 编排切开；PT Design 应保持 embed 不拖 `node:fs`/Ink/MCP；Terminal DnD 应把 canvas 抓帧预览与 split 交互拆开。体积可以大，但不能把可单测的映射/落盘/预览逻辑继续堆进 2k+ 行组件。
+
+## 3. 评分方法
+
+- 100 分制：设计与分层 30、可读性与复杂度 25、体量与内聚 20、可维护性与复用 15、工程卫生 10。
+- 高/中/低约扣 8–15 / 3–7 / 1–2；只计当日引入/放大问题。
+
+## 4. 总分
+
+总分：**76/100**。总体判断：**良好**。
+
+PT Design 包边界与 apply-gate、center-pane-layout 纯模块是高质量绿场；扣分主要来自 `CenterStage` 在已有巨大体积上再吞 multi-pane 编排（~2209→~2708），以及新建 `TerminalSplitView` 把 DnD + canvas 预览捆在一起。
+
+## 5. 分项评分
+
+| 维度 | 得分 | 扣分原因 |
+| --- | ---: | --- |
+| 设计与分层 | 24/30 | 正向：`@atmos/pt-design` browser `index` vs `headless`；isolation test 禁止 Ink/`node:fs`；`apply-gate` 单 token 消 echo；`center-pane-layout.ts` + saved-layout 可单测；Launchpad items 抽到 settings lib。扣分：multi-pane 接线/存盘 apply 仍落在 `CenterStage`；`PtDesignApp` 同时编 session、collab、library、board echo。 |
+| 可读性与复杂度 | 18/25 | CenterStage 恢复 tab / deferred context / multi-pane exclusive openTab 注释多但仍难扫；Terminal 拖拽 ghost 含 canvas 采样与 blank 检测；PT Design board onChange ↔ session ↔ persist 时序依赖多 ref。 |
+| 体量与内聚 | 12/20 | `CenterStage` ~2708（当日 +~500）；`CenterStageTabBar` ~1445；新 `TerminalSplitView` ~691；`PtDesignApp` ~566、`ExcalidrawBoard` ~463。正向：RightSidebar 删除；layout/saved-layout 模块；catalog templates 偏数据表。 |
+| 可维护性与复用 | 13/15 | 正向：前日质量拆分合入；launchpad-items；scene-bridge / fingerprint；Pages Functions tok proxy 独立。扣分：CenterStage 多处重复 `openTab(...)` 样板；apply-saved 表面打开逻辑曾内联在 Stage。 |
+| 工程卫生 | 9/10 | 正向：大量 pt-design 单测、isolation、debounce persist、MCP/CLI 错误面修补。扣 1：同日多次「unblock bundle / node:fs」修复说明初版边界曾漏。 |
+
+## 6. 主要问题清单
+
+### 高：`CenterStage.tsx` ~2708，multi-pane 继续放大神组件
+
+- 提交：`4cc44c2ea`（+595/−110 于该文件）
+- 文件：`apps/web/src/app-shell/CenterStage.tsx`
+- 问题：虽抽出 `center-pane-layout*`，但 hydrate/ensure、split、pane tab change、save/apply saved layout、slot boxes、与 URL/openTab 的 exclusive 附着仍堆在 Stage；与既有 restore/deferred/GitHub/browser 编排同居。
+- 为什么是质量问题：改「空窗格 split」或「应用已存布局」必须打开 2700+ 行文件，与 terminal 关闭队列等无关逻辑同 diff。
+- 优化建议：把 saved-layout 表面物化抽到 `apply-saved-center-layout.ts`；`tab→pane` 映射进 `buildTabToPaneIdMap`；中期再把 multi-pane store 接线收到 `use-center-pane-stage.ts`。
+
+### 中：`TerminalSplitView.tsx` ~691 混合 DnD 与 canvas 抓帧
+
+- 提交：`d356d688a`
+- 文件：`apps/web/src/features/terminal/components/TerminalSplitView.tsx`
+- 问题：PointerSensor 停靠、ghost portal、以及 `captureTerminalSnapshot` / blank canvas / xterm rows 回退同文件。
+- 为什么是质量问题：改预览 JPEG 质量或 blank 检测会触碰 split 百分比与 dock 命中逻辑。
+- 优化建议：把 capture* 迁入已有 `terminal-pane-drag-preview.ts`（与 scale/grabOffset 同模块）。
+
+### 中：`PtDesignApp.tsx` ~566 编排放大（collab + library + echo）
+
+- 提交：`24bbfda10`、`abb73913f` 等
+- 文件：`packages/pt-design/src/embed/PtDesignApp.tsx`
+- 问题：apply-gate、persist debouncer、remote elements、library save/open、share 同组件；多 ref（loading/echo/applyGate/broadcast）交叉。
+- 为什么是质量问题：改 library 落盘路径需理解整条 board 同步环。
+- 优化建议：中期抽 `use-pt-design-library` 与 `use-pt-design-board-sync`；保持 apply-gate 纯模块（已有）。
+
+### 低：Launchpad UI 仍偏厚（~477）尽管 items 已外提
+
+- 提交：`fd867516c`
+- 文件：`apps/web/src/app-shell/LeftSidebarLaunchpad.tsx`、`apps/web/src/features/settings/lib/launchpad-items.ts`
+- 问题：long-press reorder / durable layout 增加交互，数据映射已较好抽出。
+- 优化建议：把 reorder 手势状态收到 `use-launchpad-reorder.ts`，组件专注渲染。
+
+## 7. 正向观察
+
+- **PT Design 包边界**：browser barrel 不导出 document/MCP/CLI；isolation 测试守门；headless 另入口。
+- **apply-gate**：programmatic `updateScene` 与 onChange echo 用单 token 对齐，有测试迭代（consume one token）。
+- **center-pane-layout**：纯函数 + 充实单测；删除 RightSidebar 收缩壳层表面积。
+- **Launchpad items**：settings lib + store 测试，顺序持久化路径清楚。
+- **前日质量修复合入**：Git History UI 拆分与 automation leave-guard 当日落地。
+- **工程跟进**：Ink/`node:fs` 出 embed、debounce persist、MCP stdio 错误面、collab host hostname 比较。
+
+## 8. Review 建议
+
+1. Multi-pane：URL `?tab=` 是否仍会偷焦点；Overview 是否永绑 primary。
+2. Saved layout apply：browser/simulator/git-history 表面是否幂等复用。
+3. PT Design：collab 远端写与 local persist 是否双写；apply-gate 漏 token 导致回环。
+4. Terminal DnD：WebGL canvas 抓帧失败时 ghost 是否可读。
+5. Launchpad long-press：与普通点击打开是否冲突。
+
+## 9. 自动修复与 PR
+
+总分 76 < 90，已触发自动修复。
+
+### 修复摘要
+
+1. **`terminal-pane-drag-preview.ts`**：迁入 `capturePanePreview` / canvas / rows 回退；`TerminalSplitView` ~697→~556。
+2. **`apply-saved-center-layout.ts`**：`prepareSavedCenterLayout` 物化已存布局表面；`CenterStage` 调用收口。
+3. **`buildTabToPaneIdMap`**：纯函数 + 单测；Stage 用 memo 包一层。
+
+### 验证
+
+- `bun test` `center-pane-layout.test.ts`：**24 pass**
+- `git diff --check`：通过
+
+### 剩余风险
+
+- `CenterStage` 仍 ~2737，未抽完整 `use-center-pane-stage`。
+- `PtDesignApp` 未拆 library/board-sync。
+- Launchpad reorder 手势未抽 hook。
+
+## 10. 结果文件
+
+- `automations/review/quality/result/2026-08/08-17_score-76_RESULT.md`
+
+## 11. 结果提交与推送
+
+- 修复分支：`grokbuild/quality-fix/2026-08-17`
+- PR URL：创建后回填。

--- a/automations/review/quality/result/2026-08/08-17_score-76_RESULT.md
+++ b/automations/review/quality/result/2026-08/08-17_score-76_RESULT.md
@@ -100,6 +100,8 @@ PT Design 包边界与 apply-gate、center-pane-layout 纯模块是高质量绿�
 
 总分 76 < 90，已触发自动修复。
 
+- PR：https://github.com/AruNi-01/atmos/pull/247
+
 ### 修复摘要
 
 1. **`terminal-pane-drag-preview.ts`**：迁入 `capturePanePreview` / canvas / rows 回退；`TerminalSplitView` ~697→~556。
@@ -124,4 +126,6 @@ PT Design 包边界与 apply-gate、center-pane-layout 纯模块是高质量绿�
 ## 11. 结果提交与推送
 
 - 修复分支：`grokbuild/quality-fix/2026-08-17`
-- PR URL：创建后回填。
+- 修复提交：`330d94955`
+- PR URL：https://github.com/AruNi-01/atmos/pull/247
+- Label：`GrokBuild`


### PR DESCRIPTION
## Summary

Daily Atmos main quality review for **2026-08-17 (UTC+8)** scored **76/100** (良好), triggering auto-fix.

This PR addresses the highest-impact findings from that day:

1. **Terminal drag preview** — move canvas/xterm capture helpers into `terminal-pane-drag-preview.ts`; slim `TerminalSplitView` (~697 → ~556).
2. **Saved multi-pane layout apply** — extract `prepareSavedCenterLayout` so surface opening + materialize no longer live inline in `CenterStage`.
3. **`buildTabToPaneIdMap`** — pure helper + unit test for tab→pane ownership map.
4. **Archive** `automations/review/quality/result/2026-08/08-17_score-76_RESULT.md`.

### Original score drivers

| Severity | Issue |
| --- | --- |
| 高 | `CenterStage.tsx` ~2708 amplified by multi-pane orchestration |
| 中 | `TerminalSplitView` mixed DnD + canvas capture |
| 中 | `PtDesignApp` collab/library/echo orchestration (deferred) |
| 低 | Launchpad reorder UI thickness (deferred) |

## Related Issue

N/A — daily quality automation.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] Additional checks

- `bun test` `apps/web/src/app-shell/__tests__/center-pane-layout.test.ts`: **24 pass**
- `git diff --check`: pass

## Checklist

- [ ] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

### Remaining risk

- `CenterStage` still ~2737; full `use-center-pane-stage` not extracted.
- `PtDesignApp` library/board-sync not split.
- Launchpad reorder gesture not extracted.

---

### Agent
Generated by **Grok Build** · Atmos daily quality review automation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors terminal drag-preview capture and saved layout apply into focused helpers to reduce component size and improve testability. No behavior changes expected; terminal drag ghosts and saved center layout restore should behave as before.

- Terminal drag preview: `capturePanePreview` and canvas/xterm fallbacks moved to `features/terminal/lib/terminal-pane-drag-preview.ts`; `TerminalSplitView` now imports these helpers. Check ghost fidelity and WebGL fallback.
- Saved multi-pane layout apply: `prepareSavedCenterLayout` (`app-shell/center-pane/apply-saved-center-layout.ts`) now opens required surfaces and materializes the layout. Confirm it reuses an existing browser tab (focuses URL) or creates one, and opens simulator/git-history/tool tabs once.
- Tab-to-pane mapping: `buildTabToPaneIdMap` added to `center-pane-layout.ts` and used in `CenterStage`. Unit tests added; verify active tab precedence and completeness.
- Housekeeping: archives the 2026‑08‑17 quality report. No migration actions required.

<sup>Written for commit 330d94955e3d174ea210b782d5021ef58445755f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

