### PR TITLE
fix(web): stop React 185 loop from sidebar workspace job ids

### DIFF
--- a/apps/web/src/app-shell/LeftSidebar.tsx
+++ b/apps/web/src/app-shell/LeftSidebar.tsx
@@ -496,8 +496,12 @@ const LeftSidebar: React.FC<LeftSidebarProps> = () => {
     const startCreating = useWorkspaceCreationStore((s) => s.startCreating);
     const bindWorkspace = useWorkspaceCreationStore((s) => s.bindWorkspace);
     const failCreating = useWorkspaceCreationStore((s) => s.failCreating);
-    const openingWorkspaceIds = useWorkspaceCreationStore((s) =>
-      s.jobs.map((job) => job.workspaceId).filter((id): id is string => Boolean(id)),
+    // useShallow: mapping jobs to ids returns a new array each call. React 19
+    // useSyncExternalStore treats that as a changed snapshot and loops (error #185).
+    const openingWorkspaceIds = useWorkspaceCreationStore(
+      useShallow((s) =>
+        s.jobs.map((job) => job.workspaceId).filter((id): id is string => Boolean(id)),
+      ),
     );
 
     // One-shot: onboarding/import asks the sidebar to highlight a project without

--- a/apps/web/src/app-shell/__tests__/left-sidebar-workspace-jobs.test.ts
+++ b/apps/web/src/app-shell/__tests__/left-sidebar-workspace-jobs.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("left sidebar workspace create jobs", () => {
+  test("shallow-compares derived opening workspace ids so React 19 does not loop", () => {
+    const source = readFileSync(join(import.meta.dir, "../LeftSidebar.tsx"), "utf8");
+    expect(source).toContain("useShallow((s) =>");
+    expect(source).toContain("s.jobs.map((job) => job.workspaceId)");
+    expect(source).not.toMatch(
+      /const openingWorkspaceIds = useWorkspaceCreationStore\(\s*\(s\) =>\s*s\.jobs\.map/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Opening Atmos crashed with minified React error #185 (maximum update depth exceeded).
- Left sidebar derived `openingWorkspaceIds` with `jobs.map(...)`, which returns a new array on every Zustand snapshot. React 19's `useSyncExternalStore` treats that as a changed store and re-renders forever.
- Compare those ids with `useShallow` so an empty (or unchanged) id list is stable.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] `bun test src/app-shell/__tests__/left-sidebar-workspace-jobs.test.ts`

## Checklist

- [ ] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops a React 19 “maximum update depth exceeded” loop by stabilizing the left sidebar’s derived opening workspace IDs. Previously, mapping `jobs` produced a new array on every store snapshot and `useSyncExternalStore` re-rendered indefinitely; now the selector uses shallow comparison so unchanged IDs do not trigger updates.

- Wraps the `openingWorkspaceIds` selector in `useShallow((s) => s.jobs.map(...).filter(...))` to keep the array stable across snapshots.
- Adds a test that asserts the shallow selector is present to prevent regressions.
- No UI or API changes; fixes the crash on app open.

<sup>Written for commit ffb59824b2a8740c98af35b2c093c8ac6bbfade7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

