### PR TITLE
feat(web): scope Token Usage by Atmos Computer

### DIFF
--- a/apps/api/src/api/system/computer.rs
+++ b/apps/api/src/api/system/computer.rs
@@ -6,11 +6,12 @@ use axum::extract::State;
 use axum::http::HeaderMap;
 use axum::Json;
 use runtime_manager::{
-    clear_computer_client_settings, clear_server_identity, computer_client_settings_path,
-    default_relay_url, local_computer_display_name, local_computer_display_name_opt,
-    normalize_relay_url, read_computer_client_settings, read_runtime_manifest,
-    read_server_identity, register_computer, resolve_relay_proxy_auth, resolved_relay_url,
-    write_computer_client_settings, ComputerClientSettings, COMPUTER_CLIENT_SETTINGS_VERSION,
+    app_device_id, clear_computer_client_settings, clear_server_identity,
+    computer_client_settings_path, default_relay_url, local_computer_display_name,
+    local_computer_display_name_opt, normalize_relay_url, read_computer_client_settings,
+    read_runtime_manifest, read_server_identity, register_computer, resolve_relay_proxy_auth,
+    resolved_relay_url, write_computer_client_settings, ComputerClientSettings,
+    COMPUTER_CLIENT_SETTINGS_VERSION,
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -45,6 +46,7 @@ pub async fn get_computer_status(
         "relay_connected": relay_connected,
         "relay_last_error": relay_last_error,
         "server_id": identity.as_ref().map(|i| i.server_id.clone()),
+        "app_device_id": app_device_id().ok(),
         "relay_url": identity
             .as_ref()
             .and_then(|i| i.relay_url.clone())
@@ -90,6 +92,7 @@ pub async fn get_runtime_info(
 
     Ok(Json(ApiResponse::success(json!({
         "api_version": env!("CARGO_PKG_VERSION"),
+        "app_device_id": app_device_id().ok(),
         "runtime_manifest": manifest_json,
         "registration_meta": identity.as_ref().and_then(|i| i.registration_meta.clone()),
         "relay": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -629,6 +629,14 @@
         "loadOverviewFallback": "Failed to load token usage overview",
         "loadOverviewTitle": "Failed to load token usage"
       },
+      "computerScope": {
+        "allComputers": "All computers",
+        "loadOtherError": "Could not reach this Computer.",
+        "missedComputer": "{name} was not included",
+        "missedBanner": "Some Computers could not be reached. Totals are only for machines that answered.",
+        "noneReached": "Could not reach any Computer.",
+        "aggregatedTooltip": "Aggregated from {count} computers"
+      },
       "browserCookie": {
         "title": "Include signed-in web usage",
         "note": "Atmos found {products} on this computer. To add dashboard token usage, Atmos Server will ask Keychain Access to decrypt the matching browser cookie. Keys stay local and are used only to read usage data.",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -629,6 +629,14 @@
         "loadOverviewFallback": "加载 Token 用量概览失败",
         "loadOverviewTitle": "加载 Token 用量失败"
       },
+      "computerScope": {
+        "allComputers": "全部 Computer",
+        "loadOtherError": "无法连接到这台 Computer。",
+        "missedComputer": "未计入 {name}",
+        "missedBanner": "有的 Computer 没连上，合计只包含已扫到的机器。",
+        "noneReached": "没有任何 Computer 可以连接。",
+        "aggregatedTooltip": "来自 {count} 台 Computer 的合计"
+      },
       "browserCookie": {
         "title": "包含已登录网页用量",
         "note": "检测到本机安装了 {products}。若要把对应控制台的 token 用量算进来，Atmos Server 会向钥匙串申请权限，用于解密浏览器里的登录 Cookie。密钥只留在本机，且仅用于读取用量。",

--- a/apps/web/src/api/query/__tests__/query-keys.test.ts
+++ b/apps/web/src/api/query/__tests__/query-keys.test.ts
@@ -141,6 +141,29 @@ describe("queryKeys", () => {
     ]);
   });
 
+  test("scoped token usage overview is isolated from the workbench computer key", () => {
+    expect(queryKeys.computer.tokenUsageOverview(scope)).toEqual([
+      "atmos",
+      "computer",
+      "local",
+      2,
+      3,
+      "tokenUsage",
+      "overview",
+      { year: null, since: null, until: null, clients: null, groupBy: null },
+    ]);
+    expect(queryKeys.tokenUsage.scopedOverview(relayScope, "all")).toEqual([
+      "atmos",
+      "relay",
+      "https://relay.atmos.land",
+      1,
+      "tokenUsage",
+      "overview",
+      "all",
+      { year: null, since: null, until: null, clients: null, groupBy: null },
+    ]);
+  });
+
   test("public GitHub user card is not scoped to a computer", () => {
     expect(queryKeys.publicGithub.userCard("octocat")).toEqual([
       "atmos",

--- a/apps/web/src/api/query/query-keys.ts
+++ b/apps/web/src/api/query/query-keys.ts
@@ -546,6 +546,32 @@ export const queryKeys = {
     root: (scope: RelayQueryScope) =>
       ["atmos", "relay", scope.relayUrl, scope.authRevision] as const,
   },
+  tokenUsage: {
+    scopedOverview: (
+      scope: RelayQueryScope,
+      usageKey: string,
+      filters?: {
+        year?: string | null;
+        since?: string | null;
+        until?: string | null;
+        clients?: string[] | null;
+        groupBy?: string | null;
+      },
+    ) =>
+      [
+        ...queryKeys.relay.root(scope),
+        "tokenUsage",
+        "overview",
+        usageKey,
+        {
+          year: filters?.year ?? null,
+          since: filters?.since ?? null,
+          until: filters?.until ?? null,
+          clients: filters?.clients ?? null,
+          groupBy: filters?.groupBy ?? null,
+        },
+      ] as const,
+  },
   /** Unauthenticated GitHub REST (share/leaderboard hover cards). */
   publicGithub: {
     userCard: (login: string) =>

--- a/apps/web/src/api/rest-api.ts
+++ b/apps/web/src/api/rest-api.ts
@@ -313,6 +313,7 @@ export interface RegistrationMetaResponse {
 
 export interface RuntimeInfoResponse {
   api_version: string;
+  app_device_id?: string | null;
   registration_meta?: RegistrationMetaResponse | Record<string, unknown> | null;
   runtime_manifest: {
     source: string;

--- a/apps/web/src/api/ws/token-usage-api.ts
+++ b/apps/web/src/api/ws/token-usage-api.ts
@@ -109,6 +109,8 @@ export interface TokenUsageOverviewResponse {
   generated_at: number;
   partial_warnings: string[];
   browser_cookie_access?: BrowserCookieAccessResponse[];
+  /** Unique Computers that contributed to this overview (client merge only). */
+  computer_count?: number;
 }
 
 export interface TokenUsageUpdateResponse {

--- a/apps/web/src/app-shell/TokenUsagePage.tsx
+++ b/apps/web/src/app-shell/TokenUsagePage.tsx
@@ -4,19 +4,35 @@ import * as React from "react";
 import { Activity } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { TerminalLoader, cn } from "@workspace/ui";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLocale, useTranslations } from "next-intl";
 import { useTheme } from "next-themes";
+import { isPlausibleDeviceCredential } from "@atmos/relay-client";
 
 import type { TokenUsageOverviewResponse } from "@/api/ws/token-usage-api";
 import { tokenUsageApi } from "@/api/ws/token-usage-api";
 import { permissionAccessApi } from "@/api/ws/permission-access-api";
 import { queryKeys } from "@/api/query/query-keys";
-import { useComputerQueryScope } from "@/api/query/query-scope";
+import {
+  useComputerQueryScope,
+  useRelayQueryScope,
+} from "@/api/query/query-scope";
 import { useTokenUsageQuery } from "@/features/quota-usage/hooks/use-token-usage-query";
 import { TokenUsageSharePopover } from "@/app-shell/TokenUsageShareDialog";
 import { TokenUsageCookieConsentBanner } from "@/app-shell/TokenUsageCookieConsentBanner";
 import { TokenUsageOverviewView } from "@/features/token-usage/TokenUsageOverviewView";
+import { TokenUsageComputerSelect } from "@/features/token-usage/TokenUsageComputerSelect";
+import { fetchLocalComputerStatus } from "@/features/connection/lib/atmos-computer-local";
+import { useAtmosComputerStore } from "@/features/connection/lib/atmos-computer-store";
+import { fetchAllComputersTokenUsageLive } from "@/features/token-usage/lib/fetch-all-token-usage";
+import { fetchRemoteTokenUsageOverviewFromRelay } from "@/features/token-usage/lib/fetch-remote-token-usage";
+import {
+  ALL_COMPUTERS_VALUE,
+  currentUniqueComputer,
+  shouldShowComputerSelect,
+  uniqueComputers,
+  type LocalDeviceInput,
+} from "@/features/token-usage/lib/unique-computers";
 
 /** i18n keys under `tokenUsageDialog.loading.tips` — fun status lines while overview loads. */
 const TOKEN_USAGE_LOADING_TIP_KEYS = [
@@ -99,20 +115,126 @@ export function TokenUsagePage() {
   const captureTargetRef = React.useRef<HTMLDivElement>(null);
   const queryClient = useQueryClient();
   const scope = useComputerQueryScope();
+  const relayScope = useRelayQueryScope();
   const t = useTranslations("appShell.tokenUsageDialog");
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme !== "light";
   const locale = useLocale();
+  const accessToken = useAtmosComputerStore((s) => s.accessToken);
+  const computers = useAtmosComputerStore((s) => s.computers);
+  const connectionMode = useAtmosComputerStore((s) => s.connectionMode);
+  const localServerId = useAtmosComputerStore((s) => s.localServerId);
+  const selectedServerId = useAtmosComputerStore((s) => s.selectedServerId);
+  const localComputerDisplayName = useAtmosComputerStore(
+    (s) => s.localComputerDisplayName,
+  );
+  const signedIn = isPlausibleDeviceCredential(accessToken);
+  const [loopbackDevice, setLoopbackDevice] = React.useState<LocalDeviceInput>(null);
+  const [usageSelection, setUsageSelection] = React.useState<string | null>(null);
+  const fallbackLocalDevice = React.useMemo<LocalDeviceInput>(
+    () => ({
+      serverId: localServerId,
+      appDeviceId: null,
+      displayName: localComputerDisplayName || "Computer",
+    }),
+    [localComputerDisplayName, localServerId],
+  );
+  const localDevice: LocalDeviceInput =
+    connectionMode === "relay" ? null : (loopbackDevice ?? fallbackLocalDevice);
+
+  React.useEffect(() => {
+    if (connectionMode === "relay") return;
+    let cancelled = false;
+    void fetchLocalComputerStatus()
+      .then((status) => {
+        if (cancelled) return;
+        setLoopbackDevice({
+          serverId: status.server_id,
+          appDeviceId: status.app_device_id ?? null,
+          displayName: status.computer_name || localComputerDisplayName || "Computer",
+        });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setLoopbackDevice({
+          serverId: localServerId,
+          appDeviceId: null,
+          displayName: localComputerDisplayName || "Computer",
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [connectionMode, localComputerDisplayName, localServerId]);
+
+  const currentServerId =
+    connectionMode === "relay" ? selectedServerId : localServerId;
+  const devices = React.useMemo(
+    () => uniqueComputers(computers, localDevice, currentServerId),
+    [computers, currentServerId, localDevice],
+  );
+  const currentDevice = currentUniqueComputer(devices);
+  const showSelect = shouldShowComputerSelect({
+    signedIn,
+    uniqueCount: devices.length,
+  });
+  const selectedKey =
+    usageSelection === ALL_COMPUTERS_VALUE ||
+    (usageSelection != null && devices.some((device) => device.key === usageSelection))
+      ? usageSelection
+      : (currentDevice?.key ?? ALL_COMPUTERS_VALUE);
+  const isAll = showSelect && selectedKey === ALL_COMPUTERS_VALUE;
+  const selectedDevice = devices.find((device) => device.key === selectedKey) ?? null;
+  const isCurrentScope = !showSelect || selectedDevice?.isCurrent === true;
+  const scopedUsageKey = isAll
+    ? `${ALL_COMPUTERS_VALUE}:${[...devices.map((device) => device.key)].sort().join(",")}`
+    : selectedKey;
 
   const tokenUsageQuery = useTokenUsageQuery({ year: null });
-  const overview: TokenUsageOverviewResponse | null = tokenUsageQuery.data ?? null;
-  const loading = tokenUsageQuery.isLoading && !tokenUsageQuery.data;
-  const error = tokenUsageQuery.isError
-    ? tokenUsageQuery.error instanceof Error
-      ? tokenUsageQuery.error.message
+  const scopedQuery = useQuery({
+    queryKey: queryKeys.tokenUsage.scopedOverview(relayScope, scopedUsageKey, {
+      year: null,
+      since: null,
+      until: null,
+      clients: null,
+      groupBy: null,
+    }),
+    enabled: showSelect && !isCurrentScope,
+    staleTime: 60_000,
+    queryFn: async () => {
+      if (isAll) {
+        return fetchAllComputersTokenUsageLive(
+          devices,
+          fetchRemoteTokenUsageOverviewFromRelay,
+          (name) => t("computerScope.missedComputer", { name }),
+        );
+      }
+      if (!selectedDevice?.serverId) {
+        throw new Error(t("computerScope.loadOtherError"));
+      }
+      return fetchRemoteTokenUsageOverviewFromRelay(selectedDevice.serverId);
+    },
+  });
+  const activeQuery = isCurrentScope ? tokenUsageQuery : scopedQuery;
+  const overview: TokenUsageOverviewResponse | null = activeQuery.data ?? null;
+  const loading = activeQuery.isLoading && !activeQuery.data;
+  const fullPageLoading = isCurrentScope && loading;
+  const error = activeQuery.isError
+    ? activeQuery.error instanceof Error
+      ? activeQuery.error.message === "none-reached"
+        ? t("computerScope.noneReached")
+        : isCurrentScope
+          ? activeQuery.error.message
+          : isAll
+            ? t("computerScope.noneReached")
+            : t("computerScope.loadOtherError")
       : t("errors.loadOverviewFallback")
     : null;
   const [consentBusy, setConsentBusy] = React.useState(false);
+  const missedWarnings =
+    isAll && overview
+      ? overview.partial_warnings.filter((line) => line.trim().length > 0)
+      : [];
 
   const applyOverview = React.useCallback(
     (next: TokenUsageOverviewResponse) => {
@@ -190,7 +312,7 @@ export function TokenUsagePage() {
         }}
       />
 
-      {loading ? (
+      {fullPageLoading ? (
         <div
           className="relative z-[1] flex min-h-0 flex-1 items-center justify-center p-12 select-none"
           role="status"
@@ -224,20 +346,41 @@ export function TokenUsagePage() {
               </div>
             </div>
           ) : null}
+          {missedWarnings.length > 0 ? (
+            <div className="mx-auto mt-4 max-w-[1100px] rounded-2xl border border-amber-500/25 bg-amber-500/10 px-4 py-3 text-xs text-amber-800 dark:text-amber-200">
+              <div className="font-medium">{t("computerScope.missedBanner")}</div>
+              <ul className="mt-1 list-disc space-y-0.5 pl-4">
+                {missedWarnings.map((line) => (
+                  <li key={line}>{line}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
           <TokenUsageOverviewView
             overview={overview}
             loading={loading}
             captureTargetRef={captureTargetRef}
             toolbarEnd={
-              <TokenUsageSharePopover
-                captureTargetRef={captureTargetRef}
-                locale={locale}
-                isDark={isDark}
-                totalTokens={overview?.summary.total_tokens ?? 0}
-                totalCost={overview?.summary.total_cost_usd ?? null}
-                overview={overview}
-                disabled={loading || !overview}
-              />
+              <div className="flex items-center gap-1">
+                {showSelect ? (
+                  <TokenUsageComputerSelect
+                    value={selectedKey}
+                    onValueChange={setUsageSelection}
+                    devices={devices}
+                    allLabel={t("computerScope.allComputers")}
+                    isDark={isDark}
+                  />
+                ) : null}
+                <TokenUsageSharePopover
+                  captureTargetRef={captureTargetRef}
+                  locale={locale}
+                  isDark={isDark}
+                  totalTokens={overview?.summary.total_tokens ?? 0}
+                  totalCost={overview?.summary.total_cost_usd ?? null}
+                  overview={overview}
+                  disabled={loading || !overview}
+                />
+              </div>
             }
           />
         </div>
@@ -249,7 +392,7 @@ export function TokenUsagePage() {
       >
         <div className="pointer-events-auto">
           <TokenUsageCookieConsentBanner
-            items={overview?.browser_cookie_access}
+            items={isCurrentScope ? overview?.browser_cookie_access : undefined}
             busy={consentBusy}
             onAllow={(providerIds) => {
               void handleCookieConsent(providerIds, true);

--- a/apps/web/src/app-shell/__tests__/token-usage-computer-scope.test.ts
+++ b/apps/web/src/app-shell/__tests__/token-usage-computer-scope.test.ts
@@ -1,0 +1,33 @@
+// @ts-expect-error bun:test is available at runtime but not in tsconfig types
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("Token Usage Computer scope chrome", () => {
+  const pageSource = readFileSync(
+    join(import.meta.dirname, "../TokenUsagePage.tsx"),
+    "utf8",
+  );
+
+  it("places the Computer select immediately left of Share", () => {
+    const selectAt = pageSource.indexOf("<TokenUsageComputerSelect");
+    const shareAt = pageSource.indexOf("<TokenUsageSharePopover");
+    expect(selectAt).toBeGreaterThan(0);
+    expect(shareAt).toBeGreaterThan(selectAt);
+  });
+
+  it("does not switch the workbench Computer from Token Usage", () => {
+    expect(pageSource).not.toContain("createHostedRemoteSession");
+    expect(pageSource).not.toContain("setSelectedServerId");
+    expect(pageSource).not.toContain("setConnectionMode");
+  });
+
+  it("gates cookie consent to the current Computer scope", () => {
+    expect(pageSource).toContain("isCurrentScope ? overview?.browser_cookie_access");
+  });
+
+  it("shares the displayed overview rather than the workbench cache only", () => {
+    expect(pageSource).toContain("totalTokens={overview?.summary.total_tokens");
+    expect(pageSource).toContain("overview={overview}");
+  });
+});

--- a/apps/web/src/features/connection/lib/atmos-computer-local.ts
+++ b/apps/web/src/features/connection/lib/atmos-computer-local.ts
@@ -21,6 +21,7 @@ export interface LocalComputerStatus {
   /** Last relay connect failure from the local API, if any. */
   relay_last_error?: string | null;
   server_id: string | null;
+  app_device_id?: string | null;
   relay_url: string;
   relay_ws_url: string | null;
   shell_env?: ShellEnvInfo;
@@ -176,6 +177,7 @@ export async function loadLocalComputerStatus(
     relay_connected: false,
     relay_last_error: null,
     server_id: knownServerId ?? null,
+    app_device_id: null,
     relay_url: DEFAULT_RELAY,
     relay_ws_url: null,
     shell_env: overview?.shell_env,

--- a/apps/web/src/features/token-usage/HandleComputerCount.tsx
+++ b/apps/web/src/features/token-usage/HandleComputerCount.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  cn,
+} from "@workspace/ui";
+import { useTranslations } from "next-intl";
+
+export function HandleComputerCount({
+  count,
+  className,
+}: {
+  count?: number | null;
+  className?: string;
+}) {
+  const t = useTranslations("appShell.tokenUsageDialog.computerScope");
+  if (count == null || count <= 1) return null;
+  const label = t("aggregatedTooltip", { count });
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <sup
+          className={cn(
+            "relative z-20 ml-0.5 cursor-default align-super text-[0.65em] font-medium tabular-nums text-muted-foreground",
+            className,
+          )}
+          aria-label={label}
+        >
+          {count}
+        </sup>
+      </TooltipTrigger>
+      <TooltipContent side="top">{label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/features/token-usage/PublicTokLeaderboards.tsx
+++ b/apps/web/src/features/token-usage/PublicTokLeaderboards.tsx
@@ -19,6 +19,7 @@ import { GeistPixelSquare } from "geist/font/pixel";
 import LogoSvg from "@workspace/ui/components/logo-svg";
 import { GithubUserHoverCard } from "@/features/github/components/GithubUserHoverCard";
 
+import { HandleComputerCount } from "@/features/token-usage/HandleComputerCount";
 import type {
   PublicLeaderboardEntry,
   PublicLeaderboards,
@@ -308,7 +309,10 @@ function LeaderRow({
       <td className="py-1.5 pl-1 group-hover:bg-muted/60">
         <span className="flex min-w-0 items-center gap-2">
           <Avatar handle={row.handle} url={row.avatar_url} />
-          <span className="min-w-0 truncate">@{row.handle}</span>
+          <span className="inline-flex min-w-0 items-baseline">
+            <span className="truncate">@{row.handle}</span>
+            <HandleComputerCount count={row.computer_count} />
+          </span>
         </span>
       </td>
       <td className="py-1.5 pl-2 text-left text-xs group-hover:bg-muted/60">

--- a/apps/web/src/features/token-usage/PublicTokPage.tsx
+++ b/apps/web/src/features/token-usage/PublicTokPage.tsx
@@ -7,6 +7,7 @@ import { XIcon } from "@workspace/ui";
 import { useLocale, useTranslations } from "next-intl";
 
 import { GithubUserHoverCard } from "@/features/github/components/GithubUserHoverCard";
+import { HandleComputerCount } from "@/features/token-usage/HandleComputerCount";
 import { TokenUsageOverviewView } from "@/features/token-usage/TokenUsageOverviewView";
 import type { TokenUsageSharePayload } from "@/features/token-usage/token-usage-share-payload";
 
@@ -72,7 +73,10 @@ export function PublicTokPage({
         <header className="flex items-center justify-between gap-3">
           <div className="flex min-w-0 items-center gap-2.5">
             {avatar}
-            <span className="truncate text-sm font-medium">@{handle}</span>
+            <span className="inline-flex min-w-0 items-baseline text-sm font-medium">
+              <span className="truncate">@{handle}</span>
+              <HandleComputerCount count={payload.summary.computer_count} />
+            </span>
           </div>
           <div className="flex shrink-0 items-center gap-3">
             {xUsername ? (

--- a/apps/web/src/features/token-usage/TokenUsageComputerSelect.tsx
+++ b/apps/web/src/features/token-usage/TokenUsageComputerSelect.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  cn,
+} from "@workspace/ui";
+import {
+  ALL_COMPUTERS_VALUE,
+  type UniqueComputer,
+} from "@/features/token-usage/lib/unique-computers";
+
+export function TokenUsageComputerSelect({
+  value,
+  onValueChange,
+  devices,
+  allLabel,
+  disabled,
+  isDark,
+}: {
+  value: string;
+  onValueChange: (next: string) => void;
+  devices: UniqueComputer[];
+  allLabel: string;
+  disabled?: boolean;
+  isDark: boolean;
+}) {
+  return (
+    <Select value={value} onValueChange={onValueChange} disabled={disabled}>
+      <SelectTrigger
+        aria-label={allLabel}
+        className={cn(
+          "h-8 w-auto max-w-[12.5rem] rounded-lg border text-xs font-medium",
+          isDark
+            ? "border-white/[0.07] bg-white/[0.04]"
+            : "border-black/[0.08] bg-black/[0.04]",
+        )}
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent align="end">
+        <SelectItem value={ALL_COMPUTERS_VALUE}>{allLabel}</SelectItem>
+        {devices.map((device) => (
+          <SelectItem key={device.key} value={device.key}>
+            {device.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/web/src/features/token-usage/__tests__/token-usage-public-share-static.test.ts
+++ b/apps/web/src/features/token-usage/__tests__/token-usage-public-share-static.test.ts
@@ -33,6 +33,7 @@ describe("APP-061 static wiring", () => {
     expect(page).toContain("TokenUsageOverviewView");
     expect(page).toContain("payload={payload}");
     expect(page).toContain("@{handle}");
+    expect(page).toContain("HandleComputerCount");
     expect(page).toContain("https://x.com/");
     expect(page).toContain("https://github.com/");
     expect(page).toContain("GitHubIcon");
@@ -47,6 +48,7 @@ describe("APP-061 static wiring", () => {
     const boards = read(
       "apps/web/src/features/token-usage/PublicTokLeaderboards.tsx",
     );
+    expect(boards).toContain("HandleComputerCount");
     expect(boards).toContain("Crown");
     expect(boards).toContain("GithubUserHoverCard");
     expect(boards).toContain("GithubCell");

--- a/apps/web/src/features/token-usage/__tests__/token-usage-share-payload.test.ts
+++ b/apps/web/src/features/token-usage/__tests__/token-usage-share-payload.test.ts
@@ -109,6 +109,15 @@ describe("mapOverviewToSharePayload", () => {
     expect(JSON.stringify(payload)).not.toContain("prompt");
     expect(JSON.stringify(payload)).not.toContain("partial_warnings");
     expect(JSON.stringify(payload)).not.toContain("browser_cookie");
+    expect(payload.summary.computer_count).toBeUndefined();
+  });
+
+  it("keeps computer_count when aggregating more than one Computer", () => {
+    const payload = mapOverviewToSharePayload(
+      { ...overviewFixture(), computer_count: 3 },
+      { includeCost: false },
+    );
+    expect(payload.summary.computer_count).toBe(3);
   });
 
   it("omits cost fields when not included", () => {

--- a/apps/web/src/features/token-usage/fetch-public-tok.ts
+++ b/apps/web/src/features/token-usage/fetch-public-tok.ts
@@ -28,6 +28,7 @@ export type PublicLeaderboardEntry = {
   github_username: string | null;
   x_username: string | null;
   value: number;
+  computer_count?: number;
 };
 
 export type PublicLeaderboards = {
@@ -139,6 +140,7 @@ function rankedPreviewRows(values: number[]): PublicLeaderboardEntry[] {
       avatar_url: null,
       ...previewSocials(index, handle),
       value,
+      ...(index % 5 === 0 ? { computer_count: 3 } : {}),
     };
   });
 }

--- a/apps/web/src/features/token-usage/lib/__tests__/fetch-token-usage-scope.test.ts
+++ b/apps/web/src/features/token-usage/lib/__tests__/fetch-token-usage-scope.test.ts
@@ -1,0 +1,156 @@
+// @ts-expect-error bun:test is available at runtime but not in tsconfig types
+import { describe, expect, it } from "bun:test";
+import type { TokenUsageOverviewResponse } from "@/api/ws/token-usage-api";
+import { fetchAllComputersTokenUsage } from "@/features/token-usage/lib/fetch-all-token-usage";
+import { fetchRemoteTokenUsageOverview } from "@/features/token-usage/lib/fetch-remote-token-usage";
+import type { UniqueComputer } from "@/features/token-usage/lib/unique-computers";
+
+function overview(total: number): TokenUsageOverviewResponse {
+  return {
+    query: { group_by: "model" },
+    summary: {
+      total_tokens: total,
+      total_cost_usd: 1,
+      total_messages: 1,
+      active_days: 1,
+      range_start: "2026-01-01",
+      range_end: "2026-01-01",
+      processing_time_ms: 1,
+    },
+    by_client: [],
+    by_model: [],
+    by_day: [
+      {
+        date: "2026-01-01",
+        breakdown: {
+          input_tokens: total,
+          output_tokens: 0,
+          cache_read_tokens: 0,
+          cache_write_tokens: 0,
+          reasoning_tokens: 0,
+          total_tokens: total,
+        },
+        total_tokens: total,
+        total_cost_usd: 1,
+        message_count: 1,
+        by_client: [],
+      },
+    ],
+    by_month: [],
+    available_years: ["2026"],
+    generated_at: 1,
+    partial_warnings: [],
+  };
+}
+
+const laptop: UniqueComputer = {
+  key: "app:aa",
+  serverId: "laptop",
+  label: "Laptop",
+  isCurrent: true,
+};
+const vps: UniqueComputer = {
+  key: "app:bb",
+  serverId: "vps",
+  label: "VPS",
+  isCurrent: false,
+};
+
+describe("fetchRemoteTokenUsageOverview", () => {
+  it("requests a refresh without cookies and disconnects", async () => {
+    const requests: unknown[] = [];
+    let disconnected = false;
+    const result = await fetchRemoteTokenUsageOverview("srv_other", {
+      createClientSession: async (serverId) => {
+        expect(serverId).toBe("srv_other");
+        return { ws_url: "wss://relay.example/ws/client?server_id=srv_other" };
+      },
+      openSession: () => ({
+        connect: async () => undefined,
+        waitUntilConnected: async () => undefined,
+        request: async (_action, data) => {
+          requests.push(data);
+          return overview(9);
+        },
+        disconnect: () => {
+          disconnected = true;
+        },
+      }),
+    });
+    expect(result.summary.total_tokens).toBe(9);
+    expect(requests).toEqual([
+      {
+        refresh: true,
+        try_cookies: false,
+        year: null,
+        since: null,
+        until: null,
+        clients: null,
+        group_by: null,
+      },
+    ]);
+    expect(disconnected).toBe(true);
+  });
+
+  it("disconnects when the request fails", async () => {
+    let disconnected = false;
+    await expect(
+      fetchRemoteTokenUsageOverview("srv_other", {
+        createClientSession: async () => ({ ws_url: "wss://relay.example/ws" }),
+        openSession: () => ({
+          connect: async () => undefined,
+          waitUntilConnected: async () => undefined,
+          request: async () => {
+            throw new Error("offline");
+          },
+          disconnect: () => {
+            disconnected = true;
+          },
+        }),
+      }),
+    ).rejects.toThrow("offline");
+    expect(disconnected).toBe(true);
+  });
+});
+
+describe("fetchAllComputersTokenUsage", () => {
+  it("uses current fetch for the workbench device and remote for others", async () => {
+    const remoteIds: string[] = [];
+    const merged = await fetchAllComputersTokenUsage([laptop, vps], {
+      fetchCurrent: async () => overview(100),
+      fetchRemote: async (serverId) => {
+        remoteIds.push(serverId);
+        return overview(50);
+      },
+      formatMissed: (label) => `${label} was not included`,
+    });
+    expect(remoteIds).toEqual(["vps"]);
+    expect(merged.summary.total_tokens).toBe(150);
+  });
+
+  it("keeps successes and names misses", async () => {
+    const merged = await fetchAllComputersTokenUsage([laptop, vps], {
+      fetchCurrent: async () => overview(40),
+      fetchRemote: async () => {
+        throw new Error("offline");
+      },
+      formatMissed: (label) => `${label} was not included`,
+    });
+    expect(merged.summary.total_tokens).toBe(40);
+    expect(merged.partial_warnings).toContain("VPS was not included");
+  });
+
+  it("errors when every computer fails", async () => {
+    await expect(
+      fetchAllComputersTokenUsage([laptop, vps], {
+        fetchCurrent: async () => {
+          throw new Error("down");
+        },
+        fetchRemote: async () => {
+          throw new Error("down");
+        },
+        formatMissed: (label) => label,
+      }),
+    ).rejects.toThrow("none-reached");
+  });
+});

--- a/apps/web/src/features/token-usage/lib/__tests__/merge-token-usage-overviews.test.ts
+++ b/apps/web/src/features/token-usage/lib/__tests__/merge-token-usage-overviews.test.ts
@@ -1,0 +1,194 @@
+// @ts-expect-error bun:test is available at runtime but not in tsconfig types
+import { describe, expect, it } from "bun:test";
+import type {
+  TokenBreakdownResponse,
+  TokenUsageOverviewResponse,
+} from "@/api/ws/token-usage-api";
+import { mergeTokenUsageOverviews } from "@/features/token-usage/lib/merge-token-usage-overviews";
+
+const zero: TokenBreakdownResponse = {
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_read_tokens: 0,
+  cache_write_tokens: 0,
+  reasoning_tokens: 0,
+  total_tokens: 0,
+};
+
+function overview(
+  partial: Partial<TokenUsageOverviewResponse> & {
+    total_tokens: number;
+    days: string[];
+    active_days?: number;
+    total_cost_usd?: number | null;
+  },
+): TokenUsageOverviewResponse {
+  return {
+    query: { group_by: "model", year: null, since: null, until: null, clients: null },
+    summary: {
+      total_tokens: partial.total_tokens,
+      total_cost_usd: partial.total_cost_usd === undefined ? 1 : partial.total_cost_usd,
+      total_messages: partial.total_tokens / 10,
+      active_days: partial.active_days ?? partial.days.length,
+      range_start: partial.days[0] ?? null,
+      range_end: partial.days.at(-1) ?? null,
+      processing_time_ms: 5,
+    },
+    by_client: [],
+    by_model: [],
+    by_day: partial.days.map((date) => ({
+      date,
+      breakdown: { ...zero, total_tokens: 10 },
+      total_tokens: 10,
+      total_cost_usd: partial.total_cost_usd === undefined ? 0.1 : partial.total_cost_usd,
+      message_count: 1,
+      by_client: [],
+    })),
+    by_month: [],
+    available_years: ["2026"],
+    generated_at: 10,
+    partial_warnings: [],
+    ...partial,
+  };
+}
+
+describe("mergeTokenUsageOverviews", () => {
+  it("sums tokens and unions active days", () => {
+    const merged = mergeTokenUsageOverviews([
+      overview({
+        total_tokens: 100,
+        days: ["2026-01-01", "2026-01-02"],
+        active_days: 2,
+      }),
+      overview({
+        total_tokens: 50,
+        days: ["2026-01-02", "2026-01-03"],
+        active_days: 2,
+      }),
+    ]);
+    expect(merged.summary.total_tokens).toBe(40);
+    expect(merged.by_day.map((d) => d.date)).toEqual([
+      "2026-01-01",
+      "2026-01-02",
+      "2026-01-03",
+    ]);
+    expect(merged.summary.active_days).toBe(3);
+  });
+
+  it("nulls cost when any contributor lacks cost", () => {
+    const merged = mergeTokenUsageOverviews([
+      overview({ total_tokens: 10, days: ["2026-01-01"], total_cost_usd: 1.5 }),
+      overview({ total_tokens: 10, days: ["2026-01-02"], total_cost_usd: null }),
+    ]);
+    expect(merged.summary.total_cost_usd).toBeNull();
+  });
+
+  it("appends missed labels and omits cookie access", () => {
+    const merged = mergeTokenUsageOverviews(
+      [overview({ total_tokens: 10, days: ["2026-01-01"] })],
+      ["VPS was not included"],
+    );
+    expect(merged.partial_warnings).toContain("VPS was not included");
+    expect(merged.browser_cookie_access).toBeUndefined();
+  });
+
+  it("rejects an empty contributor list", () => {
+    expect(() => mergeTokenUsageOverviews([])).toThrow(/zero/i);
+  });
+
+  it("does not double-count the same Cursor cloud account", () => {
+    const laptop = withClients(overview({ total_tokens: 0, days: [] }), {
+      claude: [80, "2026-01-01"],
+      cursor: [100, "2026-01-01"],
+    });
+    const desktop = withClients(overview({ total_tokens: 0, days: [] }), {
+      claude: [20, "2026-01-01"],
+      cursor: [100, "2026-01-01"],
+    });
+    const merged = mergeTokenUsageOverviews([laptop, desktop]);
+    expect(clientTokens(merged, "claude")).toBe(100);
+    expect(clientTokens(merged, "cursor")).toBe(100);
+    expect(merged.summary.total_tokens).toBe(200);
+    expect(merged.computer_count).toBe(2);
+  });
+
+  it("sums Cursor usage from different accounts", () => {
+    const work = withClients(overview({ total_tokens: 0, days: [] }), {
+      cursor: [100, "2026-01-01"],
+    });
+    const personal = withClients(overview({ total_tokens: 0, days: [] }), {
+      cursor: [40, "2026-01-01"],
+    });
+    const merged = mergeTokenUsageOverviews([work, personal]);
+    expect(clientTokens(merged, "cursor")).toBe(140);
+  });
+});
+
+function clientTokens(overview: TokenUsageOverviewResponse, clientId: string): number {
+  return overview.by_client
+    .filter((row) => row.client_id === clientId)
+    .reduce((sum, row) => sum + row.total_tokens, 0);
+}
+
+function withClients(
+  base: TokenUsageOverviewResponse,
+  clients: Record<string, [tokens: number, date: string]>,
+): TokenUsageOverviewResponse {
+  const by_client = Object.entries(clients).map(([client_id, [tokens]]) => ({
+    client_id,
+    total_tokens: tokens,
+    total_cost_usd: 1,
+    message_count: 1,
+    model_count: 1,
+  }));
+  const by_day = Object.values(
+    Object.entries(clients).reduce<Record<string, TokenUsageOverviewResponse["by_day"][number]>>(
+      (days, [client_id, [tokens, date]]) => {
+        const row = {
+          client_id,
+          model_id: "m",
+          provider_id: client_id === "cursor" ? "cursor" : "anthropic",
+          breakdown: {
+            input_tokens: tokens,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+            reasoning_tokens: 0,
+            total_tokens: tokens,
+          },
+          total_tokens: tokens,
+          cost_usd: 1,
+          message_count: 1,
+        };
+        const existing = days[date];
+        if (!existing) {
+          days[date] = {
+            date,
+            breakdown: { ...row.breakdown },
+            total_tokens: tokens,
+            total_cost_usd: 1,
+            message_count: 1,
+            by_client: [row],
+          };
+          return days;
+        }
+        existing.by_client.push(row);
+        existing.total_tokens += tokens;
+        existing.message_count += 1;
+        existing.breakdown.input_tokens += tokens;
+        existing.breakdown.total_tokens += tokens;
+        return days;
+      },
+      {},
+    ),
+  );
+  return {
+    ...base,
+    summary: {
+      ...base.summary,
+      total_tokens: by_client.reduce((sum, row) => sum + row.total_tokens, 0),
+    },
+    by_client,
+    by_day,
+  };
+}

--- a/apps/web/src/features/token-usage/lib/__tests__/unique-computers.test.ts
+++ b/apps/web/src/features/token-usage/lib/__tests__/unique-computers.test.ts
@@ -1,0 +1,113 @@
+// @ts-expect-error bun:test is available at runtime but not in tsconfig types
+import { describe, expect, it } from "bun:test";
+import type { ComputerRow } from "@atmos/relay-client";
+import {
+  ALL_COMPUTERS_VALUE,
+  allComputersFetchTargets,
+  shouldShowComputerSelect,
+  uniqueComputers,
+} from "@/features/token-usage/lib/unique-computers";
+
+const APP_A = "aa".repeat(32);
+const APP_B = "bb".repeat(32);
+
+function row(partial: Partial<ComputerRow> & { server_id: string }): ComputerRow {
+  return {
+    display_name: partial.display_name ?? partial.server_id,
+    revoked: 0,
+    created_at: 1,
+    last_seen_at: null,
+    registration_meta: null,
+    online: false,
+    app_device_id: null,
+    ...partial,
+  };
+}
+
+describe("uniqueComputers", () => {
+  it("collapses two server ids with the same app_device_id", () => {
+    const devices = uniqueComputers(
+      [
+        row({
+          server_id: "old",
+          app_device_id: APP_A,
+          online: false,
+          last_seen_at: 10,
+          created_at: 1,
+        }),
+        row({
+          server_id: "new",
+          app_device_id: APP_A,
+          online: true,
+          last_seen_at: 20,
+          created_at: 2,
+        }),
+      ],
+      null,
+      "new",
+    );
+    expect(devices).toHaveLength(1);
+    expect(devices[0]?.key).toBe(`app:${APP_A}`);
+    expect(devices[0]?.serverId).toBe("new");
+    expect(devices[0]?.isCurrent).toBe(true);
+    expect(allComputersFetchTargets(devices)).toHaveLength(1);
+  });
+
+  it("appends an unregistered local computer", () => {
+    const devices = uniqueComputers(
+      [row({ server_id: "vps", app_device_id: APP_B })],
+      { serverId: null, appDeviceId: APP_A, displayName: "Laptop" },
+      null,
+    );
+    expect(devices).toHaveLength(2);
+    const local = devices.find((d) => d.key.startsWith("local:"));
+    expect(local?.label).toBe("Laptop");
+    expect(local?.serverId).toBeNull();
+    expect(local?.isCurrent).toBe(true);
+  });
+
+  it("does not add a second local when app_device_id already matches the list", () => {
+    const devices = uniqueComputers(
+      [row({ server_id: "old", app_device_id: APP_A, display_name: "Studio" })],
+      { serverId: "new", appDeviceId: APP_A, displayName: "Studio" },
+      "new",
+    );
+    expect(devices).toHaveLength(1);
+    expect(devices[0]?.isCurrent).toBe(true);
+    expect(devices[0]?.key).toBe(`app:${APP_A}`);
+  });
+
+  it("drops revoked rows", () => {
+    const devices = uniqueComputers(
+      [
+        row({ server_id: "dead", revoked: 1, app_device_id: APP_A }),
+        row({ server_id: "live", app_device_id: APP_B }),
+      ],
+      null,
+      "live",
+    );
+    expect(devices.map((d) => d.serverId)).toEqual(["live"]);
+  });
+
+  it("suffixes colliding display names", () => {
+    const devices = uniqueComputers(
+      [
+        row({ server_id: "aaaaaaa1-id", display_name: "Studio", app_device_id: APP_A }),
+        row({ server_id: "bbbbbbb2-id", display_name: "Studio", app_device_id: APP_B }),
+      ],
+      null,
+      "aaaaaaa1-id",
+    );
+    expect(devices.map((d) => d.label).sort()).toEqual([
+      "Studio · aaaaaaa1",
+      "Studio · bbbbbbb2",
+    ]);
+  });
+
+  it("hides the select without sign-in or a second unique machine", () => {
+    expect(shouldShowComputerSelect({ signedIn: false, uniqueCount: 4 })).toBe(false);
+    expect(shouldShowComputerSelect({ signedIn: true, uniqueCount: 1 })).toBe(false);
+    expect(shouldShowComputerSelect({ signedIn: true, uniqueCount: 2 })).toBe(true);
+    expect(ALL_COMPUTERS_VALUE).toBe("all");
+  });
+});

--- a/apps/web/src/features/token-usage/lib/cloud-api-clients.ts
+++ b/apps/web/src/features/token-usage/lib/cloud-api-clients.ts
@@ -1,0 +1,82 @@
+/**
+ * Token Usage clients whose numbers come from a **cloud account API**
+ * (not per-machine session files). Atmos currently enriches Cursor this way
+ * (`crates/token-usage` cursor CSV sync). The same account on two Computers
+ * must not be summed when aggregating.
+ */
+export const CLOUD_API_CLIENT_IDS = new Set(["cursor"]);
+
+export function isCloudApiClient(clientId: string): boolean {
+  return CLOUD_API_CLIENT_IDS.has(clientId.trim().toLowerCase());
+}
+
+const ACCOUNT_MATCH_RATIO = 0.9;
+
+export function clientDailySeries(
+  byDay: Array<{ date: string; by_client: Array<{ client_id: string; total_tokens: number }> }>,
+  clientId: string,
+): Map<string, number> {
+  const series = new Map<string, number>();
+  const needle = clientId.trim().toLowerCase();
+  for (const day of byDay) {
+    let tokens = 0;
+    for (const row of day.by_client) {
+      if (row.client_id.trim().toLowerCase() === needle) {
+        tokens += row.total_tokens;
+      }
+    }
+    if (tokens > 0) series.set(day.date, tokens);
+  }
+  return series;
+}
+
+/** Same cloud account if overlapping days almost always match (shared API export). */
+export function sameCloudAccountSeries(
+  left: Map<string, number>,
+  right: Map<string, number>,
+): boolean {
+  if (left.size === 0 || right.size === 0) return false;
+  const overlap: string[] = [];
+  for (const date of left.keys()) {
+    if (right.has(date)) overlap.push(date);
+  }
+  if (overlap.length === 0) return false;
+  let matches = 0;
+  for (const date of overlap) {
+    if (left.get(date) === right.get(date)) matches += 1;
+  }
+  return matches / overlap.length >= ACCOUNT_MATCH_RATIO;
+}
+
+export function clusterCloudAccountIndices(
+  seriesList: Array<Map<string, number>>,
+): number[][] {
+  const n = seriesList.length;
+  const parent = Array.from({ length: n }, (_, i) => i);
+  const find = (i: number): number => {
+    if (parent[i] === i) return i;
+    parent[i] = find(parent[i]!);
+    return parent[i]!;
+  };
+  const union = (a: number, b: number) => {
+    const pa = find(a);
+    const pb = find(b);
+    if (pa !== pb) parent[pa] = pb;
+  };
+  for (let i = 0; i < n; i += 1) {
+    if (seriesList[i]!.size === 0) continue;
+    for (let j = i + 1; j < n; j += 1) {
+      if (seriesList[j]!.size === 0) continue;
+      if (sameCloudAccountSeries(seriesList[i]!, seriesList[j]!)) union(i, j);
+    }
+  }
+  const groups = new Map<number, number[]>();
+  for (let i = 0; i < n; i += 1) {
+    if (seriesList[i]!.size === 0) continue;
+    const root = find(i);
+    const list = groups.get(root) ?? [];
+    list.push(i);
+    groups.set(root, list);
+  }
+  return [...groups.values()];
+}

--- a/apps/web/src/features/token-usage/lib/fetch-all-token-usage.ts
+++ b/apps/web/src/features/token-usage/lib/fetch-all-token-usage.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { tokenUsageApi, type TokenUsageOverviewResponse } from "@/api/ws/token-usage-api";
+import { mergeTokenUsageOverviews } from "@/features/token-usage/lib/merge-token-usage-overviews";
+import type { UniqueComputer } from "@/features/token-usage/lib/unique-computers";
+import { allComputersFetchTargets } from "@/features/token-usage/lib/unique-computers";
+
+const FANOUT_CONCURRENCY = 3;
+
+export type FetchAllTokenUsageDeps = {
+  fetchCurrent: () => Promise<TokenUsageOverviewResponse>;
+  fetchRemote: (serverId: string) => Promise<TokenUsageOverviewResponse>;
+  formatMissed: (label: string) => string;
+};
+
+async function mapPool<T, R>(
+  items: T[],
+  limit: number,
+  mapper: (item: T) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (next < items.length) {
+      const index = next;
+      next += 1;
+      results[index] = await mapper(items[index]!);
+    }
+  }
+  const workers = Array.from({ length: Math.min(limit, items.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
+
+export async function fetchAllComputersTokenUsage(
+  devices: UniqueComputer[],
+  deps: FetchAllTokenUsageDeps,
+): Promise<TokenUsageOverviewResponse> {
+  const targets = allComputersFetchTargets(devices);
+  if (targets.length === 0) {
+    throw new Error("No computers to scan");
+  }
+
+  type Outcome =
+    | { ok: true; overview: TokenUsageOverviewResponse }
+    | { ok: false; label: string };
+
+  const outcomes = await mapPool(targets, FANOUT_CONCURRENCY, async (device): Promise<Outcome> => {
+    try {
+      if (device.isCurrent) {
+        return { ok: true, overview: await deps.fetchCurrent() };
+      }
+      if (!device.serverId) {
+        return { ok: false, label: device.label };
+      }
+      return { ok: true, overview: await deps.fetchRemote(device.serverId) };
+    } catch {
+      return { ok: false, label: device.label };
+    }
+  });
+
+  const successes = outcomes.flatMap((row) => (row.ok ? [row.overview] : []));
+  const missedLabels = outcomes.flatMap((row) =>
+    row.ok ? [] : [deps.formatMissed(row.label)],
+  );
+
+  if (successes.length === 0) {
+    throw new Error("none-reached");
+  }
+
+  return mergeTokenUsageOverviews(successes, missedLabels);
+}
+
+export async function fetchAllComputersTokenUsageLive(
+  devices: UniqueComputer[],
+  fetchRemote: (serverId: string) => Promise<TokenUsageOverviewResponse>,
+  formatMissed: (label: string) => string,
+): Promise<TokenUsageOverviewResponse> {
+  return fetchAllComputersTokenUsage(devices, {
+    fetchCurrent: () =>
+      tokenUsageApi.getOverview({
+        refresh: true,
+        tryCookies: false,
+        year: null,
+      }),
+    fetchRemote,
+    formatMissed,
+  });
+}

--- a/apps/web/src/features/token-usage/lib/fetch-remote-token-usage.ts
+++ b/apps/web/src/features/token-usage/lib/fetch-remote-token-usage.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { createWsSession } from "@atmos/api-client/ws";
+import { isPlausibleDeviceCredential } from "@atmos/relay-client";
+import type { TokenUsageOverviewResponse } from "@/api/ws/token-usage-api";
+import { getWebRelayClient } from "@/features/connection/lib/create-web-relay-client";
+import { workbenchRelayClientKind } from "@/features/connection/lib/workbench-relay-client-kind";
+import { useAtmosComputerStore } from "@/features/connection/lib/atmos-computer-store";
+
+export const REMOTE_TOKEN_USAGE_CONNECT_WAIT_MS = 15_000;
+export const REMOTE_TOKEN_USAGE_REQUEST_TIMEOUT_MS = 60_000;
+
+export type RemoteTokenUsageSession = {
+  connect: () => Promise<void>;
+  waitUntilConnected: (timeoutMs?: number) => Promise<void>;
+  request: <T>(
+    action: string,
+    data?: unknown,
+    opts?: { timeoutMs?: number },
+  ) => Promise<T>;
+  disconnect: () => void;
+};
+
+export type FetchRemoteTokenUsageDeps = {
+  createClientSession: (serverId: string) => Promise<{ ws_url: string }>;
+  openSession: (wsUrl: string) => RemoteTokenUsageSession;
+};
+
+export async function fetchRemoteTokenUsageOverview(
+  serverId: string,
+  deps: FetchRemoteTokenUsageDeps,
+): Promise<TokenUsageOverviewResponse> {
+  const trimmed = serverId.trim();
+  if (!trimmed) {
+    throw new Error("Computer id is required");
+  }
+
+  const sessionInfo = await deps.createClientSession(trimmed);
+  const session = deps.openSession(sessionInfo.ws_url);
+  try {
+    await session.waitUntilConnected(REMOTE_TOKEN_USAGE_CONNECT_WAIT_MS);
+    return await session.request<TokenUsageOverviewResponse>(
+      "token_usage_overview_get",
+      {
+        refresh: true,
+        try_cookies: false,
+        year: null,
+        since: null,
+        until: null,
+        clients: null,
+        group_by: null,
+      },
+      { timeoutMs: REMOTE_TOKEN_USAGE_REQUEST_TIMEOUT_MS },
+    );
+  } finally {
+    session.disconnect();
+  }
+}
+
+function browserWsPlatform() {
+  return {
+    createWebSocket: (url: string) =>
+      new WebSocket(url) as unknown as import("@atmos/api-client/platform").WebSocketLike,
+  };
+}
+
+export function openRemoteTokenUsageSession(wsUrl: string): RemoteTokenUsageSession {
+  return createWsSession({
+    url: wsUrl,
+    platform: browserWsPlatform(),
+    reconnect: { enabled: false, maxAttempts: 0, exhausted: { type: "stop" } },
+    requestTimeoutMs: REMOTE_TOKEN_USAGE_REQUEST_TIMEOUT_MS,
+    connectWaitMs: REMOTE_TOKEN_USAGE_CONNECT_WAIT_MS,
+  });
+}
+
+export async function fetchRemoteTokenUsageOverviewFromRelay(
+  serverId: string,
+): Promise<TokenUsageOverviewResponse> {
+  const state = useAtmosComputerStore.getState();
+  const credential = state.accessToken.trim();
+  if (!isPlausibleDeviceCredential(credential)) {
+    throw new Error("Sign in to load another Computer");
+  }
+  return fetchRemoteTokenUsageOverview(serverId, {
+    createClientSession: async (id) => {
+      const session = await getWebRelayClient({
+        relayUrl: state.relayUrl,
+        relaySecretKey: state.relaySecretKey,
+      })
+        .withDeviceCredential(credential)
+        .createClientSession(id, { clientKind: workbenchRelayClientKind() });
+      return { ws_url: session.ws_url };
+    },
+    openSession: openRemoteTokenUsageSession,
+  });
+}

--- a/apps/web/src/features/token-usage/lib/merge-token-usage-overviews.ts
+++ b/apps/web/src/features/token-usage/lib/merge-token-usage-overviews.ts
@@ -1,0 +1,335 @@
+import type {
+  ClientTokenUsageResponse,
+  DailyClientTokenUsageResponse,
+  DailyTokenUsageResponse,
+  ModelTokenUsageResponse,
+  MonthlyTokenUsageResponse,
+  TokenBreakdownResponse,
+  TokenUsageOverviewResponse,
+} from "@/api/ws/token-usage-api";
+import {
+  clientDailySeries,
+  clusterCloudAccountIndices,
+  isCloudApiClient,
+} from "@/features/token-usage/lib/cloud-api-clients";
+
+function addBreakdown(
+  into: TokenBreakdownResponse,
+  add: TokenBreakdownResponse,
+): TokenBreakdownResponse {
+  return {
+    input_tokens: into.input_tokens + add.input_tokens,
+    output_tokens: into.output_tokens + add.output_tokens,
+    cache_read_tokens: into.cache_read_tokens + add.cache_read_tokens,
+    cache_write_tokens: into.cache_write_tokens + add.cache_write_tokens,
+    reasoning_tokens: into.reasoning_tokens + add.reasoning_tokens,
+    total_tokens: into.total_tokens + add.total_tokens,
+  };
+}
+
+function addNullableCost(a: number | null, b: number | null): number | null {
+  if (a == null || b == null) return null;
+  return a + b;
+}
+
+function minDate(a: string | null, b: string | null): string | null {
+  if (!a) return b;
+  if (!b) return a;
+  return a < b ? a : b;
+}
+
+function maxDate(a: string | null, b: string | null): string | null {
+  if (!a) return b;
+  if (!b) return a;
+  return a > b ? a : b;
+}
+
+function clientTotal(overview: TokenUsageOverviewResponse, clientId: string): number {
+  return overview.by_client
+    .filter((row) => row.client_id === clientId)
+    .reduce((sum, row) => sum + row.total_tokens, 0);
+}
+
+function cloudWinnerIndices(
+  overviews: TokenUsageOverviewResponse[],
+): (clientId: string, overviewIndex: number) => boolean {
+  const winners = new Map<string, Set<number>>();
+  const clientIds = new Set<string>();
+  for (const overview of overviews) {
+    for (const row of overview.by_client) {
+      if (isCloudApiClient(row.client_id)) clientIds.add(row.client_id);
+    }
+  }
+  for (const clientId of clientIds) {
+    const seriesList = overviews.map((overview) =>
+      clientDailySeries(overview.by_day, clientId),
+    );
+    const allowed = new Set<number>();
+    for (const cluster of clusterCloudAccountIndices(seriesList)) {
+      let winner = cluster[0]!;
+      for (const index of cluster) {
+        if (clientTotal(overviews[index]!, clientId) > clientTotal(overviews[winner]!, clientId)) {
+          winner = index;
+        }
+      }
+      allowed.add(winner);
+    }
+    winners.set(clientId, allowed);
+  }
+  return (clientId, overviewIndex) => {
+    if (!isCloudApiClient(clientId)) return true;
+    return winners.get(clientId)?.has(overviewIndex) ?? false;
+  };
+}
+
+function totalsFromClientDays(
+  rows: DailyClientTokenUsageResponse[],
+): Pick<
+  DailyTokenUsageResponse,
+  "breakdown" | "total_tokens" | "total_cost_usd" | "message_count"
+> {
+  let breakdown: TokenBreakdownResponse = {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    cache_write_tokens: 0,
+    reasoning_tokens: 0,
+    total_tokens: 0,
+  };
+  let totalTokens = 0;
+  let messages = 0;
+  let cost: number | null = 0;
+  for (const row of rows) {
+    breakdown = addBreakdown(breakdown, row.breakdown);
+    totalTokens += row.total_tokens;
+    messages += row.message_count;
+    cost = addNullableCost(cost, row.cost_usd);
+  }
+  return {
+    breakdown,
+    total_tokens: totalTokens,
+    total_cost_usd: cost,
+    message_count: messages,
+  };
+}
+
+export function mergeTokenUsageOverviews(
+  overviews: TokenUsageOverviewResponse[],
+  missedLabels: string[] = [],
+): TokenUsageOverviewResponse {
+  if (overviews.length === 0) {
+    throw new Error("Cannot merge zero token usage overviews");
+  }
+
+  const include = cloudWinnerIndices(overviews);
+
+  const byModel = new Map<string, ModelTokenUsageResponse>();
+  overviews.forEach((overview, overviewIndex) => {
+    for (const row of overview.by_model) {
+      if (!include(row.client_id, overviewIndex)) continue;
+      const key = `${row.client_id}\0${row.provider_id}\0${row.model_id}`;
+      const prev = byModel.get(key);
+      if (!prev) {
+        byModel.set(key, { ...row });
+        continue;
+      }
+      byModel.set(key, {
+        ...prev,
+        input_tokens: prev.input_tokens + row.input_tokens,
+        output_tokens: prev.output_tokens + row.output_tokens,
+        cache_read_tokens: prev.cache_read_tokens + row.cache_read_tokens,
+        cache_write_tokens: prev.cache_write_tokens + row.cache_write_tokens,
+        reasoning_tokens: prev.reasoning_tokens + row.reasoning_tokens,
+        total_tokens: prev.total_tokens + row.total_tokens,
+        cost_usd: addNullableCost(prev.cost_usd, row.cost_usd),
+        message_count: prev.message_count + row.message_count,
+      });
+    }
+  });
+
+  const modelsByClient = new Map<string, Set<string>>();
+  for (const row of byModel.values()) {
+    const models = modelsByClient.get(row.client_id) ?? new Set<string>();
+    models.add(row.model_id);
+    modelsByClient.set(row.client_id, models);
+  }
+
+  const byClient = new Map<string, ClientTokenUsageResponse>();
+  overviews.forEach((overview, overviewIndex) => {
+    for (const row of overview.by_client) {
+      if (!include(row.client_id, overviewIndex)) continue;
+      const prev = byClient.get(row.client_id);
+      if (!prev) {
+        byClient.set(row.client_id, {
+          ...row,
+          model_count: modelsByClient.get(row.client_id)?.size ?? row.model_count,
+        });
+        continue;
+      }
+      byClient.set(row.client_id, {
+        ...prev,
+        total_tokens: prev.total_tokens + row.total_tokens,
+        total_cost_usd: addNullableCost(prev.total_cost_usd, row.total_cost_usd),
+        message_count: prev.message_count + row.message_count,
+        model_count: modelsByClient.get(row.client_id)?.size ?? prev.model_count,
+      });
+    }
+  });
+
+  const byDay = new Map<string, DailyTokenUsageResponse>();
+  const unattributed = new Map<
+    string,
+    Pick<DailyTokenUsageResponse, "breakdown" | "total_tokens" | "total_cost_usd" | "message_count">
+  >();
+  overviews.forEach((overview, overviewIndex) => {
+    for (const day of overview.by_day) {
+      const prev = byDay.get(day.date);
+      const byClientDay = new Map<string, DailyClientTokenUsageResponse>();
+      const seed = prev?.by_client ?? [];
+      for (const row of seed) {
+        byClientDay.set(`${row.client_id}\0${row.provider_id}\0${row.model_id}`, {
+          ...row,
+          breakdown: { ...row.breakdown },
+        });
+      }
+      for (const row of day.by_client) {
+        if (!include(row.client_id, overviewIndex)) continue;
+        const key = `${row.client_id}\0${row.provider_id}\0${row.model_id}`;
+        const existing = byClientDay.get(key);
+        if (!existing) {
+          byClientDay.set(key, {
+            ...row,
+            breakdown: { ...row.breakdown },
+          });
+          continue;
+        }
+        byClientDay.set(key, {
+          ...existing,
+          breakdown: addBreakdown(existing.breakdown, row.breakdown),
+          total_tokens: existing.total_tokens + row.total_tokens,
+          cost_usd: addNullableCost(existing.cost_usd, row.cost_usd),
+          message_count: existing.message_count + row.message_count,
+        });
+      }
+      if (day.by_client.length === 0) {
+        const prevGap = unattributed.get(day.date);
+        unattributed.set(
+          day.date,
+          prevGap
+            ? {
+                breakdown: addBreakdown(prevGap.breakdown, day.breakdown),
+                total_tokens: prevGap.total_tokens + day.total_tokens,
+                total_cost_usd: addNullableCost(prevGap.total_cost_usd, day.total_cost_usd),
+                message_count: prevGap.message_count + day.message_count,
+              }
+            : {
+                breakdown: { ...day.breakdown },
+                total_tokens: day.total_tokens,
+                total_cost_usd: day.total_cost_usd,
+                message_count: day.message_count,
+              },
+        );
+      }
+      const rows = [...byClientDay.values()];
+      const fromRows = totalsFromClientDays(rows);
+      const gap = unattributed.get(day.date);
+      byDay.set(day.date, {
+        date: day.date,
+        by_client: rows,
+        breakdown: gap ? addBreakdown(fromRows.breakdown, gap.breakdown) : fromRows.breakdown,
+        total_tokens: fromRows.total_tokens + (gap?.total_tokens ?? 0),
+        total_cost_usd: gap
+          ? addNullableCost(fromRows.total_cost_usd, gap.total_cost_usd)
+          : fromRows.total_cost_usd,
+        message_count: fromRows.message_count + (gap?.message_count ?? 0),
+      });
+    }
+  });
+
+  const sortedDays = [...byDay.values()].sort((a, b) => a.date.localeCompare(b.date));
+  const byMonth = new Map<string, MonthlyTokenUsageResponse>();
+  for (const day of sortedDays) {
+    const month = day.date.slice(0, 7);
+    if (month.length < 7) continue;
+    const prev = byMonth.get(month);
+    const models = new Set(prev?.models ?? []);
+    for (const row of day.by_client) {
+      if (row.model_id) models.add(row.model_id);
+    }
+    if (!prev) {
+      byMonth.set(month, {
+        month,
+        breakdown: { ...day.breakdown },
+        total_tokens: day.total_tokens,
+        total_cost_usd: day.total_cost_usd,
+        message_count: day.message_count,
+        models: [...models],
+      });
+      continue;
+    }
+    byMonth.set(month, {
+      month,
+      breakdown: addBreakdown(prev.breakdown, day.breakdown),
+      total_tokens: prev.total_tokens + day.total_tokens,
+      total_cost_usd: addNullableCost(prev.total_cost_usd, day.total_cost_usd),
+      message_count: prev.message_count + day.message_count,
+      models: [...models],
+    });
+  }
+
+  let processingTime = 0;
+  let generatedAt = 0;
+  const warnings = new Set<string>();
+  for (const overview of overviews) {
+    processingTime = Math.max(processingTime, overview.summary.processing_time_ms);
+    generatedAt = Math.max(generatedAt, overview.generated_at);
+    for (const warning of overview.partial_warnings) warnings.add(warning);
+  }
+  for (const label of missedLabels) {
+    if (label.trim()) warnings.add(label);
+  }
+
+  const first = overviews[0]!;
+  let totalTokens = 0;
+  let totalMessages = 0;
+  let totalCost: number | null = 0;
+  let rangeStart: string | null = null;
+  let rangeEnd: string | null = null;
+  const years = new Set<string>();
+  for (const day of sortedDays) {
+    totalTokens += day.total_tokens;
+    totalMessages += day.message_count;
+    totalCost = addNullableCost(totalCost, day.total_cost_usd);
+    rangeStart = minDate(rangeStart, day.date);
+    rangeEnd = maxDate(rangeEnd, day.date);
+    if (day.date.length >= 4) years.add(day.date.slice(0, 4));
+  }
+
+  return {
+    query: {
+      ...first.query,
+      year: null,
+      since: null,
+      until: null,
+      clients: null,
+    },
+    summary: {
+      total_tokens: totalTokens,
+      total_cost_usd: totalCost,
+      total_messages: totalMessages,
+      active_days: sortedDays.length,
+      range_start: rangeStart,
+      range_end: rangeEnd,
+      processing_time_ms: processingTime,
+    },
+    by_client: [...byClient.values()],
+    by_model: [...byModel.values()],
+    by_day: sortedDays,
+    by_month: [...byMonth.values()].sort((a, b) => a.month.localeCompare(b.month)),
+    available_years: [...years].sort(),
+    generated_at: generatedAt,
+    partial_warnings: [...warnings],
+    browser_cookie_access: undefined,
+    computer_count: overviews.length,
+  };
+}

--- a/apps/web/src/features/token-usage/lib/unique-computers.ts
+++ b/apps/web/src/features/token-usage/lib/unique-computers.ts
@@ -1,0 +1,140 @@
+import { activeComputers, type ComputerRow } from "@atmos/relay-client";
+
+export const ALL_COMPUTERS_VALUE = "all";
+
+const APP_DEVICE_ID_PATTERN = /^[a-f0-9]{64}$/;
+
+export type DeviceKey = `app:${string}` | `server:${string}` | `local:${string}`;
+
+export type UniqueComputer = {
+  key: DeviceKey;
+  serverId: string | null;
+  label: string;
+  isCurrent: boolean;
+};
+
+export type LocalDeviceInput = {
+  serverId: string | null;
+  appDeviceId: string | null;
+  displayName: string;
+} | null;
+
+function normalizeAppDeviceId(raw: string | null | undefined): string | null {
+  const value = raw?.trim().toLowerCase() ?? "";
+  return APP_DEVICE_ID_PATTERN.test(value) ? value : null;
+}
+
+function deviceKeyForRow(row: ComputerRow): DeviceKey {
+  const appDeviceId = normalizeAppDeviceId(row.app_device_id);
+  if (appDeviceId) return `app:${appDeviceId}`;
+  return `server:${row.server_id}`;
+}
+
+function representativeRank(row: ComputerRow): [number, number, number] {
+  return [
+    row.online ? 1 : 0,
+    row.last_seen_at ?? -1,
+    row.created_at,
+  ];
+}
+
+function pickRepresentative(rows: ComputerRow[]): ComputerRow {
+  return rows.reduce((best, row) => {
+    const a = representativeRank(row);
+    const b = representativeRank(best);
+    if (a[0] !== b[0]) return a[0] > b[0] ? row : best;
+    if (a[1] !== b[1]) return a[1] > b[1] ? row : best;
+    return a[2] >= b[2] ? row : best;
+  });
+}
+
+function fallbackLabel(row: ComputerRow): string {
+  const name = row.display_name?.trim();
+  return name || "Computer";
+}
+
+export function uniqueComputers(
+  computers: ComputerRow[],
+  local: LocalDeviceInput,
+  currentServerId: string | null,
+): UniqueComputer[] {
+  const groups = new Map<DeviceKey, ComputerRow[]>();
+  for (const row of activeComputers(computers)) {
+    const key = deviceKeyForRow(row);
+    const list = groups.get(key);
+    if (list) list.push(row);
+    else groups.set(key, [row]);
+  }
+
+  const localAppId = normalizeAppDeviceId(local?.appDeviceId);
+  const localServerId = local?.serverId?.trim() || null;
+  const currentId = currentServerId?.trim() || null;
+
+  const devices: UniqueComputer[] = [...groups.entries()].map(([key, rows]) => {
+    const representative = pickRepresentative(rows);
+    const isCurrent =
+      rows.some((row) => row.server_id === currentId) ||
+      rows.some((row) => row.server_id === localServerId) ||
+      (localAppId != null && key === `app:${localAppId}`);
+    return {
+      key,
+      serverId: representative.server_id,
+      label: fallbackLabel(representative),
+      isCurrent,
+    };
+  });
+
+  const localMatched =
+    localAppId != null && devices.some((device) => device.key === `app:${localAppId}`);
+  const localServerMatched =
+    localServerId != null &&
+    devices.some((device) => device.serverId === localServerId);
+  if (local && !localMatched && !localServerMatched) {
+    devices.push({
+      key: `local:${localServerId ?? "unregistered"}`,
+      serverId: null,
+      label: local.displayName.trim() || "Computer",
+      isCurrent: true,
+    });
+  }
+
+  const labelCounts = new Map<string, number>();
+  for (const device of devices) {
+    labelCounts.set(device.label, (labelCounts.get(device.label) ?? 0) + 1);
+  }
+  return devices.map((device) => {
+    if ((labelCounts.get(device.label) ?? 0) < 2 || !device.serverId) {
+      return device;
+    }
+    return {
+      ...device,
+      label: `${device.label} · ${device.serverId.slice(0, 8)}`,
+    };
+  });
+}
+
+export function shouldShowComputerSelect(opts: {
+  signedIn: boolean;
+  uniqueCount: number;
+}): boolean {
+  return opts.signedIn && opts.uniqueCount >= 2;
+}
+
+export function currentUniqueComputer(
+  devices: UniqueComputer[],
+): UniqueComputer | null {
+  return devices.find((device) => device.isCurrent) ?? devices[0] ?? null;
+}
+
+export function allComputersFetchTargets(
+  devices: UniqueComputer[],
+): UniqueComputer[] {
+  const seen = new Set<DeviceKey>();
+  const targets: UniqueComputer[] = [];
+  for (const device of devices) {
+    if (seen.has(device.key)) continue;
+    seen.add(device.key);
+    targets.push(device);
+  }
+  return targets;
+}

--- a/apps/web/src/features/token-usage/public-tok-preview.ts
+++ b/apps/web/src/features/token-usage/public-tok-preview.ts
@@ -88,6 +88,7 @@ export function buildPublicTokPreview(): PublicTokData {
         model_count: 12,
         total_cost_usd: Number((total_tokens / 1_200_000).toFixed(2)),
         mix,
+        computer_count: 3,
       },
       by_client: [
         { id: "claude", total_tokens: Math.round(total_tokens * 0.46), message_count: 420 },

--- a/apps/web/src/features/token-usage/token-usage-share-payload.ts
+++ b/apps/web/src/features/token-usage/token-usage-share-payload.ts
@@ -50,6 +50,8 @@ export type TokenUsageSharePayload = {
     model_count: number;
     total_cost_usd?: number;
     mix: TokenUsageShareMix;
+    /** Present when the snapshot is a unique-Computer aggregate (APP-063). */
+    computer_count?: number;
   };
   by_client: TokenUsageShareRankRow[];
   by_model: TokenUsageShareRankRow[];
@@ -238,6 +240,10 @@ export function mapOverviewToSharePayload(
         ? { total_cost_usd: overview.summary.total_cost_usd ?? 0 }
         : {}),
       mix,
+      ...(typeof overview.computer_count === "number" &&
+      overview.computer_count > 1
+        ? { computer_count: Math.floor(overview.computer_count) }
+        : {}),
     },
     by_client,
     by_model,

--- a/crates/runtime-manager/src/device_identity.rs
+++ b/crates/runtime-manager/src/device_identity.rs
@@ -7,9 +7,13 @@ type HmacSha256 = Hmac<Sha256>;
 
 const APP_DEVICE_ID_CONTEXT: &[u8] = b"atmos-device-v1:computer-registration";
 
-pub(crate) fn derive_app_device_id() -> Result<String, String> {
+pub fn app_device_id() -> Result<String, String> {
     let machine_id = machine_uid::get().map_err(|err| format!("machine id unavailable: {err}"))?;
     app_device_id_from_machine_id(&machine_id)
+}
+
+pub(crate) fn derive_app_device_id() -> Result<String, String> {
+    app_device_id()
 }
 
 fn app_device_id_from_machine_id(machine_id: &str) -> Result<String, String> {

--- a/crates/runtime-manager/src/lib.rs
+++ b/crates/runtime-manager/src/lib.rs
@@ -33,6 +33,7 @@ pub use computer_client_settings::{
     COMPUTER_CLIENT_SETTINGS_VERSION,
 };
 pub use computer_name::{local_computer_display_name, local_computer_display_name_opt};
+pub use device_identity::app_device_id;
 pub use identity::{
     clear_server_identity, read_server_identity, relay_identity_path, resolve_server_identity_path,
     server_identity_env_path_override, write_server_identity, ServerIdentity,

--- a/packages/hub/src/usage-leaderboard.ts
+++ b/packages/hub/src/usage-leaderboard.ts
@@ -42,6 +42,7 @@ export type LeaderboardEntry = {
   github_username: string | null;
   x_username: string | null;
   value: number;
+  computer_count?: number;
 };
 
 export type LeaderboardBoard = {
@@ -59,20 +60,28 @@ export type LeaderboardPayload = {
 export function extractShareTotals(
   snapshotJson: string | null | undefined,
   includeCost: boolean,
-): { tokens: number | null; cost: number | null } {
+): { tokens: number | null; cost: number | null; computer_count?: number } {
   if (!snapshotJson) return { tokens: null, cost: null };
   try {
     const parsed = JSON.parse(snapshotJson) as {
-      summary?: { total_tokens?: unknown; total_cost_usd?: unknown };
+      summary?: {
+        total_tokens?: unknown;
+        total_cost_usd?: unknown;
+        computer_count?: unknown;
+      };
     };
     const tokens = parsed.summary?.total_tokens;
     const cost = parsed.summary?.total_cost_usd;
+    const computers = parsed.summary?.computer_count;
     return {
       tokens: typeof tokens === "number" && Number.isFinite(tokens) ? tokens : null,
       cost:
         includeCost && typeof cost === "number" && Number.isFinite(cost)
           ? cost
           : null,
+      ...(typeof computers === "number" && Number.isFinite(computers) && computers > 1
+        ? { computer_count: Math.min(99, Math.floor(computers)) }
+        : {}),
     };
   } catch {
     return { tokens: null, cost: null };
@@ -89,6 +98,7 @@ type RankedRow = {
   github_username: string | null;
   x_username: string | null;
   value: number;
+  computer_count?: number;
 };
 
 function buildBoard(rows: RankedRow[]): LeaderboardBoard {
@@ -106,6 +116,9 @@ function buildBoard(rows: RankedRow[]): LeaderboardBoard {
         github_username: row.github_username,
         x_username: row.x_username,
         value: row.value,
+        ...(row.computer_count && row.computer_count > 1
+          ? { computer_count: row.computer_count }
+          : {}),
       });
     }
   });
@@ -123,6 +136,7 @@ export async function refreshUsageLeaderboards(db: HubDb): Promise<LeaderboardPa
       cost: userProfiles.shareTotalCostUsd,
       claimedAt: userProfiles.handleClaimedAt,
       visibility: userProfiles.usageVisibility,
+      snapshotJson: userProfiles.snapshotJson,
     })
     .from(userProfiles)
     .where(
@@ -138,11 +152,13 @@ export async function refreshUsageLeaderboards(db: HubDb): Promise<LeaderboardPa
 
   for (const row of rows) {
     if (!row.handle || !row.claimedAt) continue;
+    const computerCount = extractShareTotals(row.snapshotJson, false).computer_count;
     const shared = {
       handle: row.handle,
       avatar_url: row.avatarUrl ?? null,
       github_username: row.githubUsername ?? null,
       x_username: row.xUsername ?? null,
+      ...(computerCount ? { computer_count: computerCount } : {}),
     };
     if (typeof row.tokens === "number" && Number.isFinite(row.tokens)) {
       tokenRows.push({ ...shared, value: row.tokens });

--- a/packages/hub/src/usage-page.ts
+++ b/packages/hub/src/usage-page.ts
@@ -240,6 +240,14 @@ export function normalizeSharePayload(
         ...(opts.includeCost
           ? { total_cost_usd: asFiniteNumber(summaryIn.total_cost_usd) }
           : {}),
+        ...(asFiniteNumber(summaryIn.computer_count) > 1
+          ? {
+              computer_count: Math.min(
+                99,
+                Math.floor(asFiniteNumber(summaryIn.computer_count)),
+              ),
+            }
+          : {}),
         mix: {
           input: asFiniteNumber(mixIn.input),
           output: asFiniteNumber(mixIn.output),

--- a/packages/hub/test/usage-page.test.ts
+++ b/packages/hub/test/usage-page.test.ts
@@ -190,6 +190,23 @@ describe("normalizeSharePayload", () => {
     expect(out.snapshot.schema_version).toBe(2);
   });
 
+  test("keeps computer_count on aggregated snapshots", () => {
+    const out = normalizeSharePayload(
+      slimSnapshot({
+        summary: {
+          ...slimSnapshot().summary,
+          computer_count: 4,
+        },
+      }),
+      { includeCost: false },
+    );
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(
+      (out.snapshot.summary as { computer_count?: number }).computer_count,
+    ).toBe(4);
+  });
+
   test("strips cost unless included", () => {
     const without = normalizeSharePayload(
       slimSnapshot({

--- a/packages/relay-client/src/types.ts
+++ b/packages/relay-client/src/types.ts
@@ -11,6 +11,8 @@ export type ComputerRow = {
   last_seen_at: number | null;
   registration_meta: Record<string, unknown> | null;
   online: boolean;
+  /** HMAC of host machine id; null on legacy rows. Same value ⇒ same physical machine. */
+  app_device_id?: string | null;
 };
 
 export type ClientSessionResponse = {

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -48,6 +48,8 @@ const GITHUB_CONTROL_RATE_LIMIT = 60;
 const PT_DESIGN_ROOM_RATE_LIMIT = 60;
 const RATE_WINDOW_SEC = 60;
 const COMPUTER_DEVICE_REGISTRATION_LIMIT = 10;
+/** Live client sessions per user+Computer. Token Usage side sessions must not kick workbench/mobile. */
+const CLIENT_SESSIONS_PER_COMPUTER_LIMIT = 8;
 const DEFAULT_RELAY_ORIGIN = "https://relay.atmos.land";
 /** Minimum device credential length (characters). */
 const MIN_ACCESS_TOKEN_LEN = 32;
@@ -618,7 +620,7 @@ async function handleApi(
       }
 
       const { results } = await env.DB.prepare(
-        `SELECT server_id, display_name, revoked, created_at, last_seen_at, registration_meta
+        `SELECT server_id, display_name, revoked, created_at, last_seen_at, registration_meta, app_device_id
          FROM computers WHERE user_id = ? ORDER BY created_at DESC`,
       )
         .bind(userId)
@@ -629,6 +631,7 @@ async function handleApi(
           created_at: number;
           last_seen_at: number | null;
           registration_meta: string | null;
+          app_device_id: string | null;
         }>();
 
       const computers = (results ?? []).map((c) => ({
@@ -639,6 +642,7 @@ async function handleApi(
         last_seen_at: c.last_seen_at,
         registration_meta: parseRegistrationMeta(c.registration_meta),
         online: c.last_seen_at != null,
+        app_device_id: c.app_device_id ?? null,
       }));
 
       return json({ computers });
@@ -725,11 +729,25 @@ async function handleApi(
       const clientToken = randomBase64Url(32);
       const tokenHash = await secretHash(clientToken);
 
-      await env.DB.prepare(
-        "DELETE FROM client_sessions WHERE server_id = ? AND user_id = ?",
+      const sessionCountRow = await env.DB.prepare(
+        "SELECT COUNT(*) AS count FROM client_sessions WHERE server_id = ? AND user_id = ?",
       )
         .bind(serverId, userId)
-        .run();
+        .first<{ count: number }>();
+      const overflow =
+        (sessionCountRow?.count ?? 0) + 1 - CLIENT_SESSIONS_PER_COMPUTER_LIMIT;
+      if (overflow > 0) {
+        await env.DB.prepare(
+          `DELETE FROM client_sessions WHERE rowid IN (
+             SELECT rowid FROM client_sessions
+             WHERE server_id = ? AND user_id = ?
+             ORDER BY created_at ASC, rowid ASC
+             LIMIT ?
+           )`,
+        )
+          .bind(serverId, userId, overflow)
+          .run();
+      }
 
       await env.DB.prepare(
         "UPDATE computers SET updated_at = ? WHERE server_id = ? AND user_id = ?",

--- a/packages/relay/test/computer-list-and-sessions.test.ts
+++ b/packages/relay/test/computer-list-and-sessions.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("cloudflare:workers", () => ({
+  DurableObject: class {},
+}));
+
+const DEVICE_TOKEN = "a".repeat(32);
+
+function sqlIncludes(sql: string, snippet: string): boolean {
+  return sql.replace(/\s+/g, " ").includes(snippet.replace(/\s+/g, " "));
+}
+
+function computerListEnv(rows: Array<Record<string, unknown>>) {
+  const calls: Array<{ sql: string; args: unknown[]; op?: string }> = [];
+  return {
+    calls,
+    env: {
+      DB: {
+        prepare(sql: string) {
+          return {
+            bind(...args: unknown[]) {
+              const call: { sql: string; args: unknown[]; op?: string } = { sql, args };
+              calls.push(call);
+              return {
+                async first() {
+                  call.op = "first";
+                  if (sql.includes("SELECT device_id, user_id FROM devices")) {
+                    return { device_id: "dev_1", user_id: "user_1" };
+                  }
+                  return null;
+                },
+                async all() {
+                  call.op = "all";
+                  return { results: rows };
+                },
+                async run() {
+                  call.op = "run";
+                  return { meta: { changes: 1 } };
+                },
+              };
+            },
+          };
+        },
+      },
+      SERVER_HUB: {
+        idFromName: () => "server_1",
+        get: () => ({ fetch: async () => new Response(null) }),
+      },
+    },
+  };
+}
+
+function clientSessionEnv(options: { sessionCount?: number } = {}) {
+  const calls: Array<{ sql: string; args: unknown[]; op?: string }> = [];
+  return {
+    calls,
+    env: {
+      DB: {
+        prepare(sql: string) {
+          return {
+            bind(...args: unknown[]) {
+              const call: { sql: string; args: unknown[]; op?: string } = { sql, args };
+              calls.push(call);
+              return {
+                async first() {
+                  call.op = "first";
+                  if (sql.includes("SELECT device_id, user_id FROM devices")) {
+                    return { device_id: "dev_1", user_id: "user_1" };
+                  }
+                  if (sql.includes("SELECT revoked FROM computers")) {
+                    return { revoked: 0 };
+                  }
+                  if (sql.includes("SELECT COUNT(*) AS count FROM client_sessions")) {
+                    return { count: options.sessionCount ?? 0 };
+                  }
+                  return null;
+                },
+                async run() {
+                  call.op = "run";
+                  return { meta: { changes: 1 } };
+                },
+              };
+            },
+          };
+        },
+      },
+      SERVER_HUB: {
+        idFromName: () => "server_1",
+        get: () => ({ fetch: async () => new Response(null) }),
+      },
+    },
+  };
+}
+
+describe("GET /v1/computers app_device_id", () => {
+  test("includes app_device_id on each computer", async () => {
+    const appDeviceId = "ab".repeat(32);
+    const harness = computerListEnv([
+      {
+        server_id: "srv_1",
+        display_name: "Laptop",
+        revoked: 0,
+        created_at: 1,
+        last_seen_at: 2,
+        registration_meta: null,
+        app_device_id: appDeviceId,
+      },
+      {
+        server_id: "srv_2",
+        display_name: "Legacy",
+        revoked: 0,
+        created_at: 1,
+        last_seen_at: null,
+        registration_meta: null,
+        app_device_id: null,
+      },
+    ]);
+    const { default: worker } = await import("../src/index");
+
+    const response = await worker.fetch(
+      new Request("https://relay.atmos.land/v1/computers", {
+        method: "GET",
+        headers: { Authorization: `Bearer ${DEVICE_TOKEN}` },
+      }),
+      harness.env as never,
+      {} as never,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      computers: [
+        {
+          server_id: "srv_1",
+          display_name: "Laptop",
+          revoked: 0,
+          created_at: 1,
+          last_seen_at: 2,
+          registration_meta: null,
+          online: true,
+          app_device_id: appDeviceId,
+        },
+        {
+          server_id: "srv_2",
+          display_name: "Legacy",
+          revoked: 0,
+          created_at: 1,
+          last_seen_at: null,
+          registration_meta: null,
+          online: false,
+          app_device_id: null,
+        },
+      ],
+    });
+    expect(
+      harness.calls.some((c) => c.sql.includes("app_device_id")),
+    ).toBe(true);
+  });
+});
+
+describe("POST client_sessions concurrent rows", () => {
+  test("does not wipe sibling sessions for the same user and computer", async () => {
+    const harness = clientSessionEnv({ sessionCount: 1 });
+    const { default: worker } = await import("../src/index");
+
+    const response = await worker.fetch(
+      new Request("https://relay.atmos.land/v1/computers/srv_1/client_sessions", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${DEVICE_TOKEN}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ client_kind: "web" }),
+      }),
+      harness.env as never,
+      {} as never,
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { client_token?: string; ws_url?: string };
+    expect(body.client_token).toBeTruthy();
+    expect(body.ws_url).toContain("server_id=srv_1");
+
+    const wipeAll = harness.calls.some(
+      (c) =>
+        sqlIncludes(c.sql, "DELETE FROM client_sessions WHERE server_id = ? AND user_id = ?") &&
+        !c.sql.includes("rowid"),
+    );
+    expect(wipeAll).toBe(false);
+    expect(
+      harness.calls.some((c) => c.sql.includes("INSERT INTO client_sessions")),
+    ).toBe(true);
+    expect(
+      harness.calls.some((c) =>
+        sqlIncludes(c.sql, "DELETE FROM client_sessions WHERE rowid IN"),
+      ),
+    ).toBe(false);
+  });
+
+  test("drops the oldest sessions when the per-computer cap is exceeded", async () => {
+    const harness = clientSessionEnv({ sessionCount: 8 });
+    const { default: worker } = await import("../src/index");
+
+    const response = await worker.fetch(
+      new Request("https://relay.atmos.land/v1/computers/srv_1/client_sessions", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${DEVICE_TOKEN}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ client_kind: "desktop" }),
+      }),
+      harness.env as never,
+      {} as never,
+    );
+
+    expect(response.status).toBe(200);
+    const overflowDelete = harness.calls.find((c) =>
+      sqlIncludes(c.sql, "DELETE FROM client_sessions WHERE rowid IN"),
+    );
+    expect(overflowDelete).toBeTruthy();
+    expect(overflowDelete?.args).toEqual(["srv_1", "user_1", 1]);
+  });
+});

--- a/specs/APP/APP-063_token-usage-computer-scope/BRAINSTORM.md
+++ b/specs/APP/APP-063_token-usage-computer-scope/BRAINSTORM.md
@@ -1,0 +1,100 @@
+# Brainstorm · APP-063: Token Usage Computer scope
+
+> Problem space and exploration. Settled content graduates to PRD.md; committed architecture graduates to TECH.md.
+
+## Context
+
+Token Usage today is **per Atmos Computer**: `token_usage_overview_get` scans agent/CLI usage files on the machine that hosts that Computer’s Atmos Server (`crates/token-usage` + tokscale). The dashboard (`TokenUsagePage`) always reads the **currently connected** Computer over the main `/ws`. Share (APP-061) publishes that same local overview.
+
+Users who own several Computers (laptop, desktop, VPS) cannot see a combined total, and cannot inspect another machine’s usage without switching the whole workbench connection. Relay already lists Computers for the signed-in Hub account (`GET /v1/computers`), and a client can open a session to any of them.
+
+A second, quieter problem: the same **physical machine** can appear more than once. Registration keys Computers by `app_device_id` (HMAC of host machine id, APP-016 / runtime-manager), but one device may have up to **10** `server_id` rows (`COMPUTER_DEVICE_REGISTRATION_LIMIT`). The list API does **not** return `app_device_id`. Summing every `server_id` would count the same local scan twice.
+
+**Trigger**: multi-machine users; Token Usage only reflects “this connection”.
+**Who feels it**: signed-in users with more than one Atmos Computer.
+**Current workaround**: switch Computer in the header, or mentally add PNG/share pages.
+**Why hard**: live scan lives on each machine (not in Hub); Relay is connection fabric, not a usage store (APP-056 deferred continuous sync); uniqueness is `app_device_id`, not `server_id`.
+
+## Goals (draft)
+
+- **Primary**: On Token Usage, choose **All Computers** or one Computer, without forcing a workbench Computer switch.
+- **Primary**: Selecting one Computer shows **that machine’s** scan, fetched over Relay when it is not the current `/ws`.
+- **Primary**: **All Computers** shows a **sum of unique devices** — one scan per `app_device_id`.
+- **Secondary**: Keep Token Usage usable **signed-out / single local Computer** (selector hidden or inert).
+- **Non-goal (draft)**: Continuous Hub ingest of usage; changing APP-061 public URL shape; Quota Usage.
+
+## Options
+
+### Option A — Page-local Computer select + live Relay fan-out (stated direction)
+
+Toolbar: select **to the left of Share**. Options: **All Computers**, then unique Computers for the Hub account (display name). Current Computer stays in the list.
+
+- One Computer → open (or reuse) a Relay client session to that `server_id`, call existing `token_usage_overview_get`, render as today.
+- Current Computer → keep using the existing main `/ws` (no extra session).
+- All Computers → fan-out to **one representative session per `app_device_id`**, merge overviews in the client (tokens, cost, by_day / by_model / by_client, years).
+- Dedup: group Relay rows by `app_device_id`; pick one representative (prefer online, then latest `last_seen_at`). If the local Computer is also in the list, do not add it a second time.
+
+**Pros**: Matches the requested UI; no new usage store; local-first preserved; uniqueness is explicit.
+**Cons**: Needs a **side** Relay `/ws` (or equivalent) so the workbench connection does not move; All Computers is only as complete as reachable machines; merge rules for overlapping days/models must be defined.
+**Unknown**: Whether a short-lived side session is acceptable vs a REST read through the Relay gateway; cookie-consent banners on a remote Computer.
+
+### Option B — Header Computer switch only; All Computers later
+
+Do not add a Token Usage select. User already switches Computer in the header. Ship uniqueness cleanup in the Computer list first.
+
+**Pros**: Smallest change; no second session.
+**Cons**: Does not deliver All Computers; inspecting another machine **does** tear down the workbench session; user asked for an in-page select.
+
+### Option C — Hub snapshot ingest (APP-056 Option D)
+
+Each Computer periodically uploads redacted overview to Hub. Token Usage All Computers reads Hub. Offline machines still contribute last snapshot.
+
+**Pros**: Offline-friendly totals; no fan-out of live sessions; public share could use the same rollup.
+**Cons**: New cloud usage store; consent/privacy; Relay/Hub boundary; user asked to **fetch via Relay now**, not sync continuously.
+**Unknown**: Merge across partial time windows; snapshot freshness.
+
+### Option D — Sideways: unique-device Computer picker, usage still current-only
+
+Expose `app_device_id` on `GET /v1/computers`, collapse Settings/header lists so the same machine is not listed twice. Token Usage stays on the connected Computer.
+
+**Pros**: Fixes the uniqueness bug everywhere.
+**Cons**: Does not solve cross-machine Token Usage. Can be **prerequisite work** for A, not a substitute.
+
+## Key forks in the road
+
+- **Fork 1 (PRD)**: Page-local usage scope vs switching the workbench Computer. Stated lean: **page-local**.
+- **Fork 2 (PRD)**: Live Relay fetch vs Hub ingest. Stated lean: **live Relay**.
+- **Fork 3 (PRD)**: Dedup key = **`app_device_id`** (physical machine) vs `server_id`. Stated lean: device id, so re-registers of the same box do not double-count. List API must return it (or a stable public alias).
+- **Fork 4 (PRD)**: **All Computers** when some machines are offline — partial total + warnings vs hard fail vs Hub last-known. Lean: **partial + existing `partial_warnings`**, skip unreachable after a timeout.
+- **Fork 5 (PRD)**: Default selection — **current Computer** (no behavior change) vs All Computers. Lean: current Computer.
+- **Fork 6 (PRD)**: APP-061 Share/publish — currently selected scope vs always current Computer vs always All. Lean: **publish whatever the page is showing** (one snapshot still).
+- **Fork 7 (TECH)**: Side main `/ws` via `createClientSession` vs gateway HTTP for overview. Atmos is WS-first; overview is already a WS action. Lean: **short-lived / pooled side WS**, no new REST unless TECH proves WS is too heavy.
+- **Fork 8 (TECH)**: Representative per `app_device_id` when several `server_id`s exist — prefer `online`, else max `last_seen_at`, else newest `created_at`.
+- **Fork 9 (PRD)**: Selector visibility — hide when signed out or only one unique device; show as soon as the account has **two unique devices** (or one remote + distinct local).
+
+## Open questions
+
+- [ ] Confirm Fork 1: Token Usage select must **not** change the header/workspace Computer. (decide in PRD)
+- [ ] Confirm Fork 4: partial All Computers vs wait-for-all. (decide in PRD)
+- [ ] Confirm Fork 5: default = current Computer. (decide in PRD)
+- [ ] Confirm Fork 6: Share/publish follows the select. (decide in PRD)
+- [ ] Remote cookie-consent: ignore on non-current Computers (scan files only) vs proxy consent to that Computer. (decide in PRD)
+- [ ] Unregistered local Desktop: include in All Computers as its own device even if it is not on the Relay list. (decide in PRD)
+- [ ] Copy: English **All computers** (sentence case); product noun **Computer** in labels. (decide in PRD)
+- [ ] How to expose `app_device_id` on the Computer list without leaking a tracking handle to the wrong client. (decide in TECH)
+- [ ] Merge function for two overviews (sum tokens/cost/messages; union days; max processing time; union years; concat warnings). Active-days is **union of dates**, not sum of per-machine active_days. (decide in TECH)
+- [ ] Side-session lifecycle: one multiplexed client, per-Computer pool, or connect-fetch-disconnect. (decide in TECH)
+
+## References
+
+- Existing UI: `apps/web/src/app-shell/TokenUsagePage.tsx` (`toolbarEnd` = Share), `apps/web/src/features/token-usage/TokenUsageOverviewView.tsx`
+- Scan: `crates/token-usage/`, `apps/api` `token_usage_overview_get`, `apps/web/src/api/ws/token-usage-api.ts`
+- Computer list: `packages/relay` `GET /v1/computers` (no `app_device_id` today), `packages/relay-client` `ComputerRow`, `apps/web/src/features/connection/`
+- Device id: `crates/runtime-manager/src/device_identity.rs`, Relay `COMPUTER_DEVICE_REGISTRATION_LIMIT = 10`, migrations `0008_computer_app_device_id.sql`
+- Related specs: [APP-016](../APP-016_atmos-computer/PRD.md), [APP-056](../APP-056_usage-share-and-accounts/BRAINSTORM.md) (Option D deferred), [APP-061](../APP-061_token-usage-public-share/PRD.md)
+- Transport: `packages/relay-client` `createClientSession` → main `/ws`; gateway `/api/system/*` is not the usage API today
+
+## Ready to promote
+
+- Promote to PRD: page-local select left of Share; All Computers + per-Computer; live Relay fetch; uniqueness by `app_device_id`; signed-out local-only; out of scope = Hub ingest, Quota Usage, workbench switch.
+- Promote to TECH: expose `app_device_id` on list; representative picker; overview merge; side WS vs gateway; Query keys scoped by computer/device; i18n keys.

--- a/specs/APP/APP-063_token-usage-computer-scope/PRD.md
+++ b/specs/APP/APP-063_token-usage-computer-scope/PRD.md
@@ -1,0 +1,147 @@
+# PRD · APP-063: Token Usage Computer scope
+
+> Product Requirements · WHAT and WHY. Token Usage can show one Atmos Computer or a unique-device total across the account, without switching the workbench Computer.
+
+## Context
+
+- **Problem**: Token Usage is a **live scan of the connected Computer**. A user with a laptop, a desktop, and a VPS only sees the machine they are attached to. Adding the numbers by hand (or switching Computer in the header) is the workaround. The same physical machine can also be registered more than once, so a naive “sum every Computer” would **double-count** one scan.
+- **Why now**: Hub accounts already own a list of Atmos Computers (APP-016 / APP-056). Relay can reach those machines. Token Usage still ignores that list.
+- **Related specs**:
+  - [APP-016](../APP-016_atmos-computer/PRD.md) — Atmos Computer identity and Relay sessions.
+  - [APP-056](../APP-056_usage-share-and-accounts/PRD.md) — Hub account owns Computers; **no** continuous usage ingest (that option stays deferred).
+  - [APP-061](../APP-061_token-usage-public-share/PRD.md) — local Token Usage + Share/publish. This spec **does not** change the public URL shape; it changes **which overview** the in-app page (and therefore a publish) is looking at.
+
+## Goals
+
+1. **Primary** — On Token Usage, pick **All computers** or one Computer and see the matching live scan.
+2. **Primary** — **All computers** is a total of **unique physical machines**, not a sum of every Computer row.
+3. **Primary** — Changing this select **does not** change the workbench Computer (terminals, projects, canvas stay put).
+4. **Secondary** — Signed-out / single-machine Token Usage stays exactly as it is today.
+
+## Users & Scenarios
+
+- **Primary persona**: Signed-in agentic builder who runs Atmos on more than one machine.
+- **Secondary persona**: Same user on a single machine, or signed out — they must not be blocked or confused by empty Computer chrome.
+
+### Key scenarios
+
+1. Builder opens Token Usage on the laptop. Charts are the laptop, as today. They open the select left of Share, pick the desktop Computer, and see **that desktop’s** scan. The laptop workbench stays connected.
+2. They pick **All computers**. Charts become the combined unique-device total. One VPS is asleep; totals still appear for the machines that answered, and the page says the VPS was not included.
+3. The laptop was re-registered and appears twice in the account Computer list. All computers and the select still treat it as **one** machine.
+4. Signed-out, or an account with only one unique machine: no select; Token Usage is unchanged.
+
+```mermaid
+flowchart TD
+  open[Open Token Usage]
+  scope{More than one unique machine and signed in?}
+  local[Show current Computer scan — no select]
+  pick[Select left of Share: All computers or one Computer]
+  one[Show that machine's live scan]
+  all[Fetch each unique machine]
+  merge[Show combined total of successes]
+  miss[Name machines that did not answer]
+  open --> scope
+  scope -->|no| local
+  scope -->|yes| pick
+  pick -->|one Computer| one
+  pick -->|All computers| all
+  all --> merge
+  merge --> miss
+```
+
+```mermaid
+stateDiagram-v2
+  [*] --> CurrentComputer: default
+  CurrentComputer --> OtherComputer: pick another Computer
+  CurrentComputer --> AllComputers: pick All computers
+  OtherComputer --> CurrentComputer: pick current Computer
+  OtherComputer --> AllComputers: pick All computers
+  AllComputers --> CurrentComputer: pick current Computer
+  AllComputers --> OtherComputer: pick one Computer
+```
+
+Workbench Computer connection is **not** in this state machine.
+
+## User Stories
+
+- As a multi-machine builder, I want to read another Computer’s Token Usage without leaving my current workbench, so I can compare machines without dropping terminals.
+- As a multi-machine builder, I want an **All computers** total of unique machines, so I can see my real usage instead of one box.
+- As a multi-machine builder, I want All computers to still show a number when some machines are offline, so a sleeping VPS does not hide the machines that did answer.
+- As a multi-machine builder, I want the same physical machine counted once, so a re-register does not inflate the total.
+- As a signed-out or single-machine user, I want Token Usage to look and work as it does today.
+
+## Functional Requirements
+
+### Must Have
+
+- **M1 · Local-first**: Signed out, offline, or a single unique machine: Token Usage (charts, year / metric / dimension, cookie consent on the current Computer, PNG share, publish chrome) behaves as today. No Computer select.
+- **M2 · Select placement**: When the select is shown, it sits **immediately to the left of Share** on the Token Usage toolbar. It does not replace Share.
+- **M3 · Select options**: First option is **All computers** (English sentence case; other locales translate the surrounding words, keep **Computer** as the product noun where that locale already does). Then one option per **unique machine**, labeled with the Computer display name. The current Computer is in the list. Duplicate registrations of the same machine collapse to one option.
+- **M4 · Page-local scope**: Changing the select changes **only** Token Usage data. Header / Settings Computer, projects, terminals, and canvas stay on the workbench Computer.
+- **M5 · Current Computer**: Default selection is the **current** Computer. That view uses the existing live connection. No extra remote hop.
+- **M6 · Other Computer**: Picking another Computer shows a **live scan of that machine**, reached through Relay. The workbench connection does not move. Cookie consent / browser-cookie enrichment for the viewing browser is **not** applied to a Computer that is not the current one.
+- **M7 · All computers**: Picking All computers shows one merged overview across **unique machines** in scope:
+  - Every distinct physical machine in the account Computer list.
+  - Plus the current local Computer when it is **not** already that same machine (unregistered Desktop still counts).
+- **M8 · Device uniqueness**: Uniqueness is the **physical machine**, not each Computer registration. Same machine, multiple Computer rows → one scan, one select option, one term in All computers.
+- **M9 · Partial All computers** (settled): Machines that answer contribute to the total. Machines that are offline, refuse, or time out are **omitted** from the numbers and **named** as not included. The page does not fail the whole All computers view, and it does not invent a cloud “last known” snapshot for the misses.
+- **M10 · Other Computer unreachable**: Picking a single Computer that cannot be reached is an **error for that view** (clear that this Computer did not answer). It must not silently show another machine’s scan.
+- **M11 · Share follows the page**: PNG share and APP-061 publish/update use the **overview currently on screen** (current Computer, other Computer, or the partial All computers total). Public URL shape is unchanged (still one snapshot per user).
+- **M12 · Selector visibility**: Show the select only when the user is signed in **and** there are at least **two unique machines** in scope (M7). Otherwise hide it.
+
+### Nice to Have
+
+- **N1 · Remember last select** for this account on this client (All computers vs a Computer), restoring on the next Token Usage visit.
+- **N2 · Retry only the machines that failed** in All computers, without re-scanning successes.
+- **N3 · Dedup the Settings / header Computer list** by the same physical-machine rule (Token Usage must not wait on this).
+
+## Out of Scope
+
+- **Switching the workbench Computer from Token Usage** — header/Settings already do that; this page only changes usage scope.
+- **Continuous Hub / Relay usage ingest** — APP-056 Option D stays deferred; All computers is a live fan-out, not a stored rollup.
+- **Quota Usage** — this is Token Usage only.
+- **Changing APP-061 URL, handle, or snapshot schema** beyond “the snapshot is whatever the page is showing”.
+- **Mobile-first Token Usage Computer select** — web/desktop Token Usage; mobile can follow later.
+- **Team / org rollup** across other people’s Computers.
+- **Billing-grade reconciliation** — this remains an on-disk agent/CLI scan, now unioned across machines.
+- **Applying this Computer’s browser cookies to another Computer’s scan**.
+
+## Success Metrics
+
+| Metric | Direction |
+|--------|-----------|
+| Single-machine / signed-out | Token Usage still matches today’s charts with no new chrome |
+| Other Computer | User can read a second machine’s usage without the workbench Computer changing |
+| All computers | Unique-machine total; a duplicate registration does not inflate tokens |
+| Partial All | At least one reachable machine still renders charts; missed Computer names are visible |
+| Share | PNG / publish of All computers (or another Computer) matches what the page showed |
+
+## Risks & Open Questions
+
+| Item | Notes |
+|------|--------|
+| **Risk**: All computers looks complete when a large machine is offline | M9 names misses; copy must not say “all time, all machines” if any were skipped |
+| **Risk**: Two Computers share a display name | Uniqueness is still the physical machine; TECH may suffix only if labels collide |
+| **Risk**: Share of a partial All computers is published as the public page | M11 is explicit; Update copy should not imply every machine was included if the in-app view said otherwise |
+| **Open (TECH)**: How the client talks to a Computer that is not the workbench connection | Product requires live scan over Relay; session vs other transport is TECH |
+| **Open (TECH)**: How unique-machine identity is read from the Computer list | Product requires physical-machine uniqueness; wire field is TECH |
+
+BRAINSTORM forks:
+
+| Fork | Decision |
+|------|----------|
+| 1 Page-local vs workbench switch | **Page-local** (M4) |
+| 2 Live Relay vs Hub ingest | **Live Relay** (M6, M7); Hub ingest out of scope |
+| 3 Physical machine vs Computer row | **Physical machine** (M8) |
+| 4 Partial vs fail vs last-known | **Partial + named misses** (M9) — confirmed |
+| 5 Default | **Current Computer** (M5) |
+| 6 Share scope | **Whatever the page shows** (M11) |
+| 9 Select visibility | **Signed in and ≥ 2 unique machines** (M12) |
+| Cookie consent on remote | **Not applied** (M6) |
+| Unregistered local in All | **Included** (M7) |
+| 7, 8 Transport, representative picker | **TECH** |
+
+## Milestones
+
+- **Phase 1**: M1–M12 — select, page-local live fetch, unique-device All computers, partial misses, share follows the page.
+- **Phase 2**: N1 remember select; N2 retry misses; N3 Settings/header dedup if we want the same uniqueness elsewhere.

--- a/specs/APP/APP-063_token-usage-computer-scope/TECH.md
+++ b/specs/APP/APP-063_token-usage-computer-scope/TECH.md
@@ -1,0 +1,311 @@
+# TECH · APP-063: Token Usage Computer scope
+
+> Technical Design · HOW. Implements PRD APP-063 (M1–M12). N1–N3 deferred.
+
+## Scope summary
+
+Token Usage stays a **live per-Computer scan** (`token_usage_overview_get`). This spec adds a **page-local usage scope**: current Computer (existing main `/ws`), another Computer (short-lived **side** Relay `/ws`), or **All computers** (unique-device fan-out + client merge). No Hub usage store. No new usage REST. No workbench Computer switch.
+
+Addresses **M1–M12**. N1 (remember select), N2 (retry misses), N3 (Settings/header dedup) are Phase 2.
+
+## Architecture overview
+
+```mermaid
+flowchart LR
+  PAGE[TokenUsagePage]
+  SEL[Computer select]
+  CUR[Main workbench /ws]
+  SIDE[Side WsSession]
+  RELAY[packages/relay]
+  SA[Computer A Server]
+  SB[Computer B Server]
+  PAGE --> SEL
+  SEL -->|current| CUR --> SA
+  SEL -->|other / All| SIDE
+  SIDE -->|createClientSession + WSS| RELAY
+  RELAY --> SB
+  RELAY --> SA
+```
+
+Workbench Zustand WS (`apps/web/src/features/connection/hooks/use-websocket.ts`) **never** retargets. Side sessions are owned by Token Usage only.
+
+| Layer | Change |
+|-------|--------|
+| `packages/relay` | `GET /v1/computers` returns `app_device_id`. Concurrent `client_sessions` per user+`server_id` (do not kick workbench/mobile). |
+| `packages/relay-client` | `ComputerRow.app_device_id`. |
+| `crates/runtime-manager` | Public `app_device_id()` for local identity. |
+| `apps/api` | `GET /api/system/runtime-info` includes `app_device_id`. No new WS action. |
+| `apps/web` | Unique-device helper, overview merge, side-session fetch, select + Query keys, i18n. |
+| `crates/token-usage` | Unchanged scan. Merge is **client-side**. |
+
+```mermaid
+sequenceDiagram
+  participant UI as Token Usage
+  participant Main as Workbench /ws
+  participant Relay as Relay REST
+  participant Side as Side WsSession
+  participant B as Computer B
+
+  Note over UI: pick Computer B (not current)
+  UI->>Relay: POST /v1/computers/{B}/client_sessions
+  Relay-->>UI: ws_url + client_token
+  UI->>Side: createWsSession (reconnect off)
+  Side->>B: token_usage_overview_get refresh=true try_cookies=false
+  B-->>Side: overview
+  Side->>Side: disconnect
+  Note over Main: untouched
+```
+
+```mermaid
+sequenceDiagram
+  participant UI as Token Usage
+  participant Main as Workbench /ws
+  participant Fan as Fan-out pool
+  Note over UI: All computers
+  UI->>UI: unique devices by app_device_id
+  UI->>Main: current device overview
+  par other devices cap 3
+    Fan->>Fan: side session + overview
+  end
+  UI->>UI: merge successes; name misses
+```
+
+## Module-by-module design
+
+### packages/relay
+
+**List (M8).** `GET /v1/computers` already filters by `user_id`. Extend the SELECT to include `app_device_id` (column from `0008_computer_app_device_id.sql`). No new migration. Null for pre-column rows is allowed.
+
+**Concurrent sessions (M4, M6).** Today `POST /v1/computers/:id/client_sessions` does `DELETE FROM client_sessions WHERE server_id = ? AND user_id = ?` (`packages/relay/src/index.ts`). A Token Usage peek of Computer B would kick every other client of B for this user (workbench, mobile). ServerHub already multiplexes clients (`TAG_CLIENT_ALL`).
+
+Change: **insert** a new session; do **not** delete live siblings. Cap **8** rows per `(user_id, server_id)`; delete oldest `created_at` when over cap. Revoke Computer still deletes all sessions for that `server_id`. Tests in `packages/relay/test/`.
+
+Do **not** put usage merge in the Worker.
+
+### packages/relay-client
+
+`ComputerRow` in `packages/relay-client/src/types.ts`:
+
+```ts
+app_device_id: string | null;
+```
+
+`64` lowercase hex when present. Tests that fixture rows must include the field (null is fine).
+
+### crates/runtime-manager + apps/api
+
+Export `app_device_id()` from `crates/runtime-manager/src/device_identity.rs` (today `pub(crate) derive_app_device_id`). Add to `GET /api/system/runtime-info` in `apps/api/src/api/system/computer.rs`:
+
+```json
+{ "app_device_id": "<64 hex or null>" }
+```
+
+Null only if machine id is unavailable. This is existing **bootstrap REST**, not a new usage API. `LocalComputerStatus` in `apps/web/src/features/connection/lib/atmos-computer-local.ts` gains `app_device_id: string | null` for **loopback** status only. When workbench is Relay-attached, current device identity comes from the Computer list row, not this field.
+
+### apps/web — uniqueness (M3, M7, M8, M12)
+
+Pure helper `apps/web/src/features/token-usage/lib/unique-computers.ts`.
+
+```ts
+type DeviceKey =
+  | `app:${string}`      // app_device_id
+  | `server:${string}`   // legacy null app_device_id
+  | `local:${string}`;   // unregistered local, not in any group
+
+type UniqueComputer = {
+  key: DeviceKey;
+  serverId: string | null;       // representative; null only for unregistered local
+  label: string;
+  isCurrent: boolean;
+};
+```
+
+**Grouping**
+
+1. Start from `activeComputers(computers)` (drop revoked).
+2. Key = `app:${app_device_id}` if it matches `/^[a-f0-9]{64}$/`, else `server:${server_id}`.
+3. Representative in a group: prefer `online`, then max `last_seen_at` (null last), then max `created_at`.
+4. Label = representative `display_name` (fallback `Computer`). If two groups share a label, suffix ` · {server_id.slice(0, 8)}`.
+
+**Current + unregistered local (M7)**
+
+- If workbench `selectedServerId` / `localServerId` matches a row, that row’s group `isCurrent`.
+- Else if loopback `app_device_id` matches a group, that group `isCurrent` (re-register: new `server_id`, same device — do not add a second local).
+- Else if a loopback Computer exists (Desktop / local API), append `local:{localServerId ?? "unregistered"}` with the local display name, `isCurrent: true`, `serverId: null`.
+
+**Select visibility (M12):** Hub device credential present **and** `unique.length >= 2`. Otherwise no select (M1).
+
+### apps/web — side session (M5, M6, M10)
+
+New helper `apps/web/src/features/token-usage/lib/fetch-remote-token-usage.ts`.
+
+- **Never** `createClientSession` for the workbench Computer’s `server_id` (M5). That would still churn sessions and can race the main `/ws`.
+- Other Computer: `getWebRelayClient(…).createClientSession(serverId, { clientKind: workbenchRelayClientKind() })`.
+- `createWsSession` from `@atmos/api-client/ws` with the same browser `platform` as `use-websocket.ts`, **`reconnect.enabled: false`**, `connectWaitMs: 15_000`, `requestTimeoutMs: 60_000` (scan can exceed the workbench 30s default).
+- `session.request("token_usage_overview_get", { refresh: true, try_cookies: false, year: null, … })`.
+- `disconnect()` in `finally`. Ignore `token_usage_updated` on side sockets.
+- Failure (connect, timeout, revoked, 404) → throw. Single-Computer view maps that to the existing overview error chrome (M10). Do **not** fall back to current Computer data.
+
+No gateway HTTP for overview. Action is already WS; gateway is for `/api/system/*`.
+
+### apps/web — All computers merge (M7, M9)
+
+`apps/web/src/features/token-usage/lib/merge-token-usage-overviews.ts`.
+
+Fan-out:
+
+- Current unique device → existing `tokenUsageApi.getOverview` on **main** `/ws` (`refresh: true`; cookie flags only if this device is current **and** the user is on that view — All computers always `try_cookies: false`).
+- Other devices with a `serverId` → side session, pool **3**.
+- Per device: success or miss (timeout / error). Do not wait past the 60s request timeout.
+- If **zero** successes → error (nothing to chart). If ≥1 success → merge and continue (M9).
+
+Merge (contributors = successes only):
+
+| Field | Rule |
+|-------|------|
+| `summary.total_tokens` / `total_messages` | Sum |
+| `summary.total_cost_usd` | Sum iff **every** contributor has non-null cost; else `null` |
+| `summary.active_days` | Count of **distinct** `by_day.date` after merge — not sum of `active_days` |
+| `summary.range_start` / `range_end` | Min / max of non-null |
+| `summary.processing_time_ms` | Max |
+| `by_model` | Group `(client_id, provider_id, model_id)`; sum token fields and cost (null cost stays null if any part is null) |
+| `by_client` | Group `client_id`; sum tokens/messages/cost; `model_count` from merged `by_model` |
+| `by_day` / `by_month` | Group date/month; sum breakdowns; union month `models` |
+| `available_years` | Sorted unique union |
+| `generated_at` | Max |
+| `query` | Same as a full-range local overview (`year: null`, default `group_by`) |
+| `partial_warnings` | Unique concat of contributor warnings **plus** one miss line per failed device (display name) |
+| `browser_cookie_access` | **Omit** on All and on other-Computer views |
+
+Miss copy is i18n at the UI layer; merge can take `missedLabels: string[]` and the page formats them into `partial_warnings` or a dedicated banner. Prefer a **visible named list** on the Token Usage page (not only buried in `partial_warnings`) so M9 is obvious. Charts still render from the merged overview.
+
+Always try listed representatives — do **not** skip `online: false`. `online` is only the representative tie-break.
+
+### apps/web — Query + UI (M1–M5, M11, M12)
+
+**Keys.** Keep current-Computer data on `queryKeys.computer.tokenUsageOverview` so `token_usage_updated` invalidation stays correct.
+
+Add:
+
+```ts
+queryKeys.tokenUsage.scopedOverview(
+  relayScope,          // RelayQueryScope
+  usageKey,            // "all" | DeviceKey
+  filters,
+)
+```
+
+`TokenUsagePage` selection state (React state, default = current device key; not persisted — N1 later):
+
+- `current` → `useTokenUsageQuery` as today.
+- `DeviceKey` of another machine → scoped query → side fetch.
+- `all` → scoped query → fan-out + merge.
+
+Mount refresh effect that writes `queryKeys.computer.tokenUsageOverview` stays, but **must not** replace the displayed other/All query. Cookie banner + `setBrowserCookieConsent` only when selection is current (M6).
+
+**Toolbar (M2).** `toolbarEnd` becomes a row: select (if visible) **then** existing `TokenUsageSharePopover`. Select uses `@workspace/ui` `Select`, height `h-8` to match the toolbar. Options: `all` first (**All computers** / localized), then unique devices. Current Computer is a normal option, not a hidden default. Toolbar already has `data-token-usage-share-exclude`; select is chrome, not in the PNG.
+
+**Share (M11).** Popover already receives `overview`. Pass the **displayed** overview (current, remote, or merged). Publish/update uses that object. No APP-061 schema change. Partial All still publishes; miss names should remain in the in-app view. Public page has no Computer select.
+
+**i18n.** `apps/web/messages/en.json` + `zh.json` under `appShell.tokenUsageDialog.computerScope`:
+
+- `allComputers` — EN `All computers` (sentence case); ZH 全部 Computer
+- `loadOtherError` — single Computer unreachable
+- `missedComputer` — `{name}` not included
+- `missedBanner` — short line that All computers is partial
+- `noneReached` — zero successes
+
+### packages/ui
+
+No new primitive. Reuse `Select`.
+
+## Data model
+
+No new D1 tables. `computers.app_device_id` already exists.
+
+```ts
+type ComputerRow = {
+  server_id: string;
+  display_name: string | null;
+  revoked: number;
+  created_at: number;
+  last_seen_at: number | null;
+  registration_meta: Record<string, unknown> | null;
+  online: boolean;
+  app_device_id: string | null;
+};
+```
+
+Usage scope is **client-only** (not persisted).
+
+## Transport
+
+### Existing WS (unchanged)
+
+```ts
+// request — current Computer, and each side session
+{ action: "token_usage_overview_get", data: { refresh, try_cookies, year, since, until, clients, group_by } }
+```
+
+No new `WsAction`.
+
+### Relay REST (existing routes, field / session semantics)
+
+| Call | Change | Why REST |
+|------|--------|----------|
+| `GET /v1/computers` | Add `app_device_id` | Control-plane list already REST (APP-016). |
+| `POST /v1/computers/:id/client_sessions` | Keep concurrent sessions (cap 8) | Same control-plane route; required so a usage peek does not steal the workbench. |
+
+No `/v1/usage/*`. No Computer HTTP overview.
+
+## Security & permissions
+
+- Side sessions use the Hub **device credential** already required to list Computers. User can only open sessions to **their** `server_id`s (existing Relay check).
+- `app_device_id` is HMAC of machine id, already in D1. Return it only on the authenticated list / local runtime-info. Never put it on APP-061 public snapshots.
+- Side `client_token` lives in memory for the request; do not write `client-session.json` (that file is the workbench session).
+- Logs: redact `client_token` / device credential (existing `redactUrl`).
+- `try_cookies: false` on every non-current fetch so the viewing browser’s cookies cannot enrich another machine.
+
+## Rollout plan
+
+1. Relay: list `app_device_id`; concurrent client sessions + tests. `relay-client` type + fixtures.
+2. `runtime-manager` public `app_device_id()`; runtime-info + `LocalComputerStatus`.
+3. Pure `unique-computers` + `merge-token-usage-overviews` Bun tests (double-count, active_days union, cost null, local synthetic).
+4. Side-session fetch helper + unit test with a fake `WsSession` (no live Relay).
+5. Query keys + `TokenUsagePage` select + i18n; cookie banner gated; share uses displayed overview.
+6. Manual: two Computers, All computers with one stopped, confirm miss name and no workbench switch; duplicate `app_device_id` two `server_id`s counted once.
+
+No feature flag: select is hidden unless M12 holds.
+
+## Risks & tradeoffs
+
+- **Tradeoff: client merge vs Hub ingest.** PRD forbids Hub ingest. Merge is deterministic and testable; freshness is “now” for reachable machines only.
+- **Tradeoff: side `/ws` vs gateway HTTP.** Overview is a WS action; gateway is `/api/system/*`. Side `WsSession` reuses APP-049. 60s timeout vs workbench 30s because a cold tokscale scan is slow.
+- **Tradeoff: concurrent client sessions.** Required so Token Usage does not kick mobile/workbench off the peeked Computer. Cap 8 limits D1 growth. Oldest dropped.
+- **Risk: All computers looks complete.** Named miss list + banner (M9). Copy must not claim every machine when any miss exists.
+- **Risk: creating a session to a Computer that is also the workbench.** Forbidden in code; uniqueness helper routes current to main `/ws`.
+- **Risk: legacy `app_device_id = null`.** Those rows never merge with each other except by `server_id`. Re-register after this ships will have ids.
+- **Rollback:** revert web UI first (page works as today). Relay session cap change is backward compatible; list field is additive.
+
+If this breaks in production: hide the select (M12 false) or revert the page; workbench Token Usage is unchanged.
+
+## Dependencies & compatibility
+
+- Depends on: APP-016 (Relay computers + sessions), APP-049 (`createWsSession`), APP-056 (device credential), APP-061 (share consumes whatever overview the page holds).
+- Blocks: none.
+- Minimum: signed-in Hub device credential + ≥2 unique machines to see chrome; everyone else unchanged.
+- Out of this change: Quota Usage, mobile select, Settings list dedup (N3).
+
+## Open questions
+
+- [x] Side `/ws` vs gateway HTTP → **side `/ws`**.
+- [x] Representative picker → **online, then `last_seen_at`, then `created_at`**.
+- [x] Concurrent sessions vs kick → **concurrent, cap 8**.
+- [x] How uniqueness is read → **`app_device_id` on list + local runtime-info**.
+- None remaining that block Phase 1.
+
+## Post-implementation: public Computer count + cloud-API dedupe
+
+- Share payload `summary.computer_count` (only when > 1). Hub `normalizeSharePayload` allowlists it. Leaderboard entries copy it from the snapshot.
+- Public handle and leaderboard render a superscript after `@handle` with a hover tooltip (`HandleComputerCount`).
+- Merge treats `cursor` as a **cloud API** client (`cloud-api-clients.ts`). Matching daily series (same account) keeps one copy; different series (different accounts) still sum. Local clients (claude, codex, …) always sum.

--- a/specs/APP/APP-063_token-usage-computer-scope/TEST.md
+++ b/specs/APP/APP-063_token-usage-computer-scope/TEST.md
@@ -1,0 +1,346 @@
+# TEST · APP-063: Token Usage Computer scope
+
+> Test Plan · prove page-local Computer select, unique-device All computers, and client merge of **final overviews**. References PRD APP-063 and TECH APP-063.
+
+## Test strategy
+
+Deterministic rules live in **Bun tests**: unique-device grouping, overview merge (sum tokens, union dates, no double-count), query-key isolation, Relay list/`client_sessions` semantics. Rust covers `app_device_id()` stability. Do **not** E2E a live multi-Computer Relay fan-out — too much fixture for the same merge contract. Playwright is optional/smoke only if a stubbed Token Usage route exists; otherwise agent-browser checks select placement and miss copy. Merge is of **finished `TokenUsageOverviewResponse` objects**, not tokscale files.
+
+## Coverage map
+
+| PRD item | Scenario IDs |
+|----------|--------------|
+| M1 Local-first | S1, S22 |
+| M2 Select left of Share | S2 |
+| M3 Select options / labels | S2, S6, S20, S21 |
+| M4 Page-local scope | S19 |
+| M5 Current Computer, no extra hop | S3, S23 |
+| M6 Other Computer via Relay; no remote cookies | S4, S5, S18 |
+| M7 All computers unique machines + unregistered local | S7, S8, S9 |
+| M8 Physical-machine uniqueness | S6, S8, S11, S14, S24 |
+| M9 Partial All computers | S12, S13 |
+| M10 Other Computer unreachable | S5 |
+| M11 Share follows displayed overview | S17 |
+| M12 Selector visibility | S1, S2, S22 |
+| N1–N3 | Deferred — not in this pass |
+
+## Execution map
+
+| Scenario | Level | Expected tool | Target command / method | Fixture / data | Signals | Status |
+|----------|-------|---------------|-------------------------|----------------|---------|--------|
+| S1 | Bun | `bun test` | unique-computers + page source | signed out / 1 device | no select | planned |
+| S2 | Bun | `bun test` | unique-computers + TokenUsagePage source | 2 unique devices, signed in | All computers first; select before Share | planned |
+| S3 | Bun | `bun test` | fetch-remote helper / unique-computers | current `server_id` | no `createClientSession` for current | planned |
+| S4 | Bun | `bun test` | fetch-remote | other `server_id` | `try_cookies: false`; session for that id | planned |
+| S5 | Bun | `bun test` | fetch-remote / page query | side session throws | error; current overview not swapped in | planned |
+| S6 | Bun | `bun test` | unique-computers | two rows, same `app_device_id` | one option | planned |
+| S7 | Bun | `bun test` | unique-computers | local not on list | `local:` device appended, current | planned |
+| S8 | Bun | `bun test` | unique-computers | local id matches list `app_device_id`, different `server_id` | no extra local | planned |
+| S9 | Bun | `bun test` | merge-token-usage-overviews | two overviews, overlapping + unique days | tokens sum; `active_days` = distinct dates | planned |
+| S10 | Bun | `bun test` | merge | one cost null | merged `total_cost_usd` null | planned |
+| S11 | Bun | `bun test` | unique-computers + merge callers | same device two `server_id`s | one fetch target | planned |
+| S12 | Bun | `bun test` | merge + missed labels | one success, one miss | totals from success; miss name present | planned |
+| S13 | Bun | `bun test` | All computers aggregator | all fetches fail | error; no empty-zero overview | planned |
+| S14 | Bun | `bun test` `packages/relay` | GET `/v1/computers` | D1 row with `app_device_id` | JSON field present | planned |
+| S15 | Bun | `bun test` `packages/relay` | POST client_sessions twice | same user+server | no DELETE of live sibling; two rows until cap | planned |
+| S16 | Bun | `bun test` `packages/relay` | 9th session | 8 existing | oldest dropped | planned |
+| S17 | Bun | `bun test` | TokenUsagePage / share props | merged overview on screen | Share gets merged totals | planned |
+| S18 | Bun | `bun test` | TokenUsagePage source | other / all scope | cookie banner gated on current | planned |
+| S19 | Bun | `bun test` | unique-computers / page | change usage select | `selectedServerId` unchanged (no workbench connect call) | planned |
+| S20 | Bun | `bun test` | unique-computers | revoked row | omitted | planned |
+| S21 | Bun | `bun test` | unique-computers | two groups, same display_name | suffix with `server_id` prefix | planned |
+| S22 | Bun | `bun test` | unique-computers | signed in, 1 unique | select hidden | planned |
+| S23 | Bun | `bun test` | query-keys | current filters | existing `computer.tokenUsageOverview` shape | planned |
+| S24 | Rust | `cargo test` | `runtime-manager` device id | machine id fixture | stable 64 hex; runtime-info field documented | planned |
+
+## Scenarios
+
+### S1 — Signed out: no Computer select
+
+- **Level**: Bun
+- **Given**: No Hub device credential, or computers list empty.
+- **When**: Token Usage builds unique devices.
+- **Then**: Select is not shown. Overview still comes from the workbench `/ws`.
+- **Signals**: `shouldShowComputerSelect` false; page still renders Share.
+
+### S2 — Two unique machines: select left of Share
+
+- **Level**: Bun
+- **Given**: Signed in; two unique devices.
+- **When**: Token Usage toolbar renders.
+- **Then**: Select is visible; first option is All computers; Share remains. Source order is select then Share.
+- **Signals**: i18n `computerScope.allComputers`; `toolbarEnd` contains select before share popover.
+
+### S3 — Current Computer does not open a side session
+
+- **Level**: Bun
+- **Given**: Current device has `serverId` equal to workbench Computer.
+- **When**: Scope is current (default).
+- **Then**: Overview uses `tokenUsageApi.getOverview` / main `/ws`. `createClientSession` is not called for that `server_id`.
+- **Signals**: fetch-remote helper not invoked for current key.
+
+### S4 — Other Computer: live scan, no cookies
+
+- **Level**: Bun
+- **Given**: Another unique device with `serverId`.
+- **When**: Side fetch runs.
+- **Then**: `createClientSession(serverId)` then `token_usage_overview_get` with `refresh: true`, `try_cookies: false`. Session disconnected after.
+- **Signals**: request payload flags; disconnect in `finally`.
+
+### S5 — Other Computer unreachable
+
+- **Level**: Bun
+- **Given**: Side session connect or request fails.
+- **When**: That Computer is selected.
+- **Then**: Error for this view. Cached **current** overview is not displayed as if it were the other machine.
+- **Signals**: scoped query error; current query data unused for the view.
+
+### S6 — Same `app_device_id` collapses to one option
+
+- **Level**: Bun
+- **Given**: Two active rows, identical 64-hex `app_device_id`, different `server_id`.
+- **When**: Unique devices computed.
+- **Then**: Length 1. Representative prefers `online`, then `last_seen_at`, then `created_at`.
+- **Signals**: single `DeviceKey` `app:…`.
+
+### S7 — Unregistered local is in scope
+
+- **Level**: Bun
+- **Given**: Loopback Computer with `app_device_id` / `localServerId` that matches **no** list row.
+- **When**: Unique devices computed.
+- **Then**: Extra `local:…` device, `isCurrent: true`.
+- **Signals**: `unique.length` includes local; `serverId` null.
+
+### S8 — Local re-register matches by device id
+
+- **Level**: Bun
+- **Given**: List row `app_device_id=X` `server_id=old`; local `app_device_id=X` `localServerId=new`.
+- **When**: Unique devices computed.
+- **Then**: One group; `isCurrent: true`; no second `local:` row.
+- **Signals**: length 1.
+
+### S9 — Merge final overviews: tokens sum, active days union
+
+- **Level**: Bun
+- **Given**: Overview A: 100 tokens, days `2026-01-01`, `2026-01-02`, `active_days: 2`. Overview B: 50 tokens, days `2026-01-02`, `2026-01-03`, `active_days: 2`.
+- **When**: `mergeTokenUsageOverviews([A, B])`.
+- **Then**: `total_tokens === 150`; merged `by_day` has 3 dates; `active_days === 3` (not 4).
+- **Signals**: merge helper return value.
+
+### S10 — Merge cost: any null → null
+
+- **Level**: Bun
+- **Given**: A has `total_cost_usd: 1.5`; B has `null`.
+- **When**: Merge.
+- **Then**: Merged `summary.total_cost_usd` is `null`.
+- **Signals**: merge helper.
+
+### S11 — Duplicate device is one All computers target
+
+- **Level**: Bun
+- **Given**: Same as S6.
+- **When**: All computers target list built.
+- **Then**: One representative `serverId` (or current `/ws` if that group is current). Not two side fetches.
+- **Signals**: targets length 1.
+
+### S12 — Partial All computers
+
+- **Level**: Bun
+- **Given**: Device Laptop succeeds; device VPS fails.
+- **When**: All computers aggregation finishes.
+- **Then**: Charts use Laptop overview; VPS display name is in the miss list / banner. Page is not a hard fail.
+- **Signals**: merge of successes; `missedLabels` contains VPS.
+
+### S13 — All computers with zero successes
+
+- **Level**: Bun
+- **Given**: Every unique device fetch fails.
+- **When**: Aggregation finishes.
+- **Then**: Error (none reached). Do not show a zeroed fake overview.
+- **Signals**: throw or error result; no `total_tokens: 0` empty success.
+
+### S14 — Computer list returns `app_device_id`
+
+- **Level**: Bun (`packages/relay`)
+- **Given**: Authenticated device; D1 computers row has `app_device_id`.
+- **When**: `GET /v1/computers`.
+- **Then**: Each computer JSON includes `app_device_id` (string or null).
+- **Signals**: response body.
+
+### S15 — New client session does not kick siblings
+
+- **Level**: Bun (`packages/relay`)
+- **Given**: Existing `client_sessions` row for user+server.
+- **When**: `POST /v1/computers/:id/client_sessions` again.
+- **Then**: No `DELETE FROM client_sessions WHERE server_id = ? AND user_id = ?` that wipes the live sibling. Previous token remains until cap/expiry.
+- **Signals**: SQL calls; row count 2.
+
+### S16 — Session cap 8
+
+- **Level**: Bun (`packages/relay`)
+- **Given**: 8 sessions for the same user+server.
+- **When**: 9th POST.
+- **Then**: Oldest `created_at` removed; 8 remain including the new one.
+- **Signals**: delete-oldest SQL or equivalent.
+
+### S17 — Share uses displayed overview
+
+- **Level**: Bun
+- **Given**: Displayed overview is a merge with `total_tokens: 150`.
+- **When**: Share popover props are built.
+- **Then**: `totalTokens` / `overview` are the merged object, not the workbench-only cache.
+- **Signals**: page wiring / helper that maps displayed overview to share props.
+
+### S18 — Cookie banner only on current
+
+- **Level**: Bun
+- **Given**: Token Usage page source / consent gate.
+- **When**: Scope is other Computer or All computers.
+- **Then**: Cookie banner is not shown; `setBrowserCookieConsent` is not used for remote fetches.
+- **Signals**: `try_cookies: false`; banner `items` omitted or gated.
+
+### S19 — Usage select does not switch workbench Computer
+
+- **Level**: Bun
+- **Given**: Workbench `selectedServerId = A`.
+- **When**: Usage scope set to Computer B or All computers.
+- **Then**: No `createHostedRemoteSession(A→B)` / connection-mode change from Token Usage.
+- **Signals**: Token Usage fetch module does not call workbench connect helpers.
+
+### S20 — Revoked rows dropped
+
+- **Level**: Bun
+- **Given**: One revoked, one active, different devices.
+- **When**: Unique devices computed.
+- **Then**: Only the active row.
+- **Signals**: length 1.
+
+### S21 — Colliding labels get a suffix
+
+- **Level**: Bun
+- **Given**: Two groups, both `display_name: "Studio"`.
+- **When**: Labels assigned.
+- **Then**: Labels differ; each contains a `server_id` 8-char prefix.
+- **Signals**: `label` strings.
+
+### S22 — One unique machine hides select
+
+- **Level**: Bun
+- **Given**: Signed in; only one unique device (list + local collapse to one).
+- **When**: Visibility computed.
+- **Then**: Select hidden.
+- **Signals**: `shouldShowComputerSelect` false.
+
+### S23 — Current query key unchanged
+
+- **Level**: Bun
+- **Given**: Existing `queryKeys.computer.tokenUsageOverview(scope, filters)`.
+- **When**: Key built.
+- **Then**: Same tuple as today (`atmos`, `computer`, instance, epoch, revision, `tokenUsage`, `overview`, filters).
+- **Signals**: `query-keys.test.ts`.
+
+### S24 — Local `app_device_id` is stable hex
+
+- **Level**: Rust
+- **Given**: `app_device_id_from_machine_id` fixture.
+- **When**: Derived twice with case/whitespace variants.
+- **Then**: Same 64 lowercase hex. Public export usable from `apps/api` runtime-info.
+- **Signals**: existing `device_identity` tests plus compile of runtime-info field.
+
+## Performance & load budgets
+
+- All computers fan-out concurrency **3**.
+- Per remote overview: connect ≤ 15s, request ≤ 60s, then count as miss (S12).
+- Merge of 10 overviews with ~400 `by_day` rows is in-process and must stay well under 100ms in unit tests (no network).
+
+## Regression checklist
+
+- [ ] Workbench `/ws` is not retargeted when changing Token Usage scope.
+- [ ] `createClientSession` for the **current** `server_id` is never used for Token Usage.
+- [ ] Signed-out Token Usage still loads from local WS (APP-061 M1).
+- [ ] Share PNG still excludes toolbar (`data-token-usage-share-exclude`).
+- [ ] English copy is sentence case (`All computers`, not `ALL COMPUTERS`).
+- [ ] `ComputerRow` fixtures include `app_device_id` so typecheck does not rot.
+- [ ] Relay revoke still deletes sessions for that Computer.
+
+## Exploratory agent-browser checks
+
+Use `agent-browser` (load skill or `agent-browser skills get core --full`) on local Token Usage when a signed-in account with ≥2 Computers is available. If that fixture cannot be created, record `not_run` with reason.
+
+1. Open `/token-usage`. Confirm select sits immediately left of Share when two Computers exist; hidden when signed out.
+2. Pick the other Computer: charts change; header Computer / terminals do not switch; cookie banner absent.
+3. Pick All computers with one Computer stopped: totals still render; missed Computer is named; Share still opens.
+4. Narrow viewport (~390px): select + Share remain usable; no overlap with metric/dimension toggles.
+5. Console: no unhandled WS errors from side sessions after disconnect.
+
+## Acceptance criteria
+
+- [ ] Every Must Have M1–M12 has a passing scenario at the declared level.
+- [ ] Merge tests prove **final overview** combination (tokens sum, active_days union, no double-count by `app_device_id`).
+- [ ] Relay list includes `app_device_id`; concurrent client sessions do not kick siblings.
+- [ ] No new usage REST; no new `WsAction`.
+- [ ] N1–N3 not required to ship.
+- [ ] `atmos-specs-test-run` Coverage Status filled with exact commands.
+- [ ] Scoped `bun test` / `cargo test` on touched packages pass; `just lint` on changed surfaces or recorded equivalent.
+
+## Manual verification steps
+
+1. Desktop signed in, two real Computers: Token Usage select, other Computer, All computers, stop one process, confirm miss name.
+2. Confirm header Computer did not change (terminals still the first machine).
+3. Publish/PNG while All computers is selected: snapshot totals match the on-screen merge (partial if a miss).
+
+## Non-coverage
+
+- Live Relay E2E with two physical Servers (covered by unit merge + Relay session tests).
+- N1 persist select, N2 retry-only-misses, N3 Settings/header dedup.
+- Quota Usage.
+- Mobile Token Usage select.
+- Billing-grade equality with provider invoices.
+
+## Coverage Status
+
+Updated 2026-08-21 after implementation.
+
+| Scenario | Status | Proof |
+|----------|--------|-------|
+| S1 | pass | `unique-computers.test.ts` hides select when signed out |
+| S2 | pass | `token-usage-computer-scope.test.ts` select appears before Share in `TokenUsagePage.tsx` |
+| S3 | pass | `fetch-token-usage-scope.test.ts` All computers calls `fetchCurrent` for `isCurrent` |
+| S4 | pass | `fetch-token-usage-scope.test.ts` remote payload `try_cookies: false` |
+| S5 | pass | remote fetch disconnects on failure; page maps other-Computer errors to `loadOtherError` |
+| S6 | pass | unique-computers same `app_device_id` → one option |
+| S7 | pass | unregistered local appended |
+| S8 | pass | local `app_device_id` match does not add a second local |
+| S9 | pass | merge sums tokens; `active_days` is distinct dates (3, not 4) |
+| S10 | pass | merge cost null if any contributor lacks cost |
+| S11 | pass | `allComputersFetchTargets` length 1 for duplicate device |
+| S12 | pass | All computers keeps successes and names misses |
+| S13 | pass | All computers throws `none-reached` when every fetch fails |
+| S14 | pass | `packages/relay/test/computer-list-and-sessions.test.ts` GET includes `app_device_id` |
+| S15 | pass | client_sessions POST does not wipe sibling rows |
+| S16 | pass | 9th session deletes oldest (`LIMIT 1`) |
+| S17 | pass | page source Share uses displayed `overview` |
+| S18 | pass | cookie banner gated with `isCurrentScope` |
+| S19 | pass | Token Usage page does not call workbench connect helpers |
+| S20 | pass | revoked rows dropped |
+| S21 | pass | colliding labels get `server_id` suffix |
+| S22 | pass | `shouldShowComputerSelect` false at uniqueCount 1 |
+| S23 | pass | `query-keys.test.ts` workbench key unchanged; scoped key under relay |
+| S24 | pass | `cargo test -p runtime-manager` `app_device_id_is_stable_and_hex_encoded` |
+
+### Commands run
+
+```bash
+bun test test/computer-list-and-sessions.test.ts test/computer-registration.test.ts test/client-session.test.ts  # packages/relay
+bun test  # packages/relay (54 pass)
+bun test src/session-urls.test.ts src/client.test.ts  # packages/relay-client
+bun test src/features/token-usage src/app-shell/__tests__/token-usage-computer-scope.test.ts src/api/query/__tests__/query-keys.test.ts
+cargo test -p runtime-manager
+cargo check -p api
+```
+
+### Gaps / honesty
+
+- No live two-Computer Relay Playwright. Merge + session tests cover the contract.
+- Agent-browser exploratory checks **not_run** (no signed-in ≥2 Computer fixture in this pass).
+- Manual Desktop two-machine walkthrough **not_run**.

--- a/specs/README.md
+++ b/specs/README.md
@@ -139,6 +139,7 @@ These files are not requirements sources. Requirements live in `PRD.md`, archite
 | **APP-060** | Vendor serve-sim (compiled helper, on-demand `~/.atmos`, embed preview) | `specs/APP/APP-060_vendor-serve-sim/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
 | **APP-061** | Token Usage public share (`atmos.land/tok/@handle`; one snapshot; claim-once handle) | `specs/APP/APP-061_token-usage-public-share/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
 | **APP-062** | PT Design — full product: package (MCP + Ink CLI/Skill) + Atmos left sidebar → center stage | `specs/APP/APP-062_pt-design/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
+| **APP-063** | Token Usage Computer scope (All Computers / per-Computer via Relay; device uniqueness) | `specs/APP/APP-063_token-usage-computer-scope/` (`BRAINSTORM.md`, `PRD.md`, `TECH.md`, `TEST.md`) |
 | **QUALITY-001** | Large File Code Debt Cleanup | `specs/APP/QUALITY-001_large-file-code-debt-cleanup/` (`TECH.md`, `TEST.md`) |
 | **QUALITY-002** | Spec Test Execution Loop | `specs/APP/QUALITY-002_spec-test-execution-loop/` (`TECH.md`, `TEST.md`) |
 | **QUALITY-003** | Playwright E2E Harness | `specs/APP/QUALITY-003_playwright-e2e-harness/` (`TECH.md`, `TEST.md`) |


### PR DESCRIPTION
## Summary

- Add a Computer select on Token Usage (left of Share) so signed-in users with more than one unique machine can view another Atmos Computer over Relay, or an All computers total, without switching the workbench Computer.
- Deduplicate physical machines by `app_device_id`, keep Relay client sessions concurrent so a usage peek does not kick other clients, and do not sum the same Cursor cloud-account export twice.
- Public tok handle and leaderboard show a superscript computer count (hover tooltip) when the published snapshot was aggregated. Spec: APP-063.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] Additional checks: `bun test` in `packages/relay` (54), `packages/hub` usage page/leaderboard, `apps/web` token-usage merge/unique/share/query tests; `cargo test -p runtime-manager`; `cargo check -p api`

## Checklist

- [x] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope Token Usage by Atmos Computer and add an All computers aggregate without switching the workbench Computer. This avoids double‑counting the same physical machine and the same Cursor cloud account and shows a superscript computer count on public pages when aggregated.

- Old: Token Usage always read the connected Computer. Switching Computers changed the whole workbench. Public tok and leaderboard had no notion of aggregation.
- New: A Computer select on Token Usage lets users view the current Computer, another Computer over Relay, or an All computers total. Physical machines deduplicate by `app_device_id`. Aggregation does not sum the same cloud-account client twice (e.g., Cursor). Public tok handle cards and leaderboards show an aggregated count. Side sessions do not kick workbench/mobile clients.

**Review focus**
- `apps/web`: `TokenUsagePage` scope flow, `TokenUsageComputerSelect`, unique-device logic (`lib/unique-computers`), fan‑out/merge (`lib/fetch-all-token-usage`, `lib/fetch-remote-token-usage`, `lib/merge-token-usage-overviews`), query key isolation (`queryKeys.tokenUsage.scopedOverview`), UI copy (`messages/*`), superscript count (`HandleComputerCount`).
- `packages/relay`: Computer list now returns `app_device_id`; allow concurrent side sessions with `CLIENT_SESSIONS_PER_COMPUTER_LIMIT = 8`; tests in `packages/relay/test/computer-list-and-sessions.test.ts`.
- `crates/runtime-manager`: expose `app_device_id()`; surface `app_device_id` in local status and runtime info.
- `packages/hub`: normalize and propagate optional `computer_count` from share payloads; leaderboard rows can include `computer_count`.
- Tests: merge/dedupe correctness, scope query keys, remote fetch fan‑out, UI placement and payload mapping.

**Rollout and compatibility**
- No workbench behavior change. All new fields are optional:
  - `RuntimeInfoResponse.app_device_id?`
  - `ComputerRow.app_device_id?`
  - `TokenUsageOverviewResponse.computer_count?`
  - Public share/leaderboard entries may include `computer_count?`
- Required actions for external consumers:
  - If you read Computer lists from Relay, accept optional `app_device_id`.
  - If you parse Token Usage or share payloads, tolerate optional `computer_count`.

<sup>Written for commit 78c9c42075f1acbe6422e23dc6e9041a25c93c4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

