### PR TITLE
feat(web): hint how to add Computers on Token Usage

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -635,7 +635,11 @@
         "missedComputer": "{name} was not included",
         "missedBanner": "Some Computers could not be reached. Totals are only for machines that answered.",
         "noneReached": "Could not reach any Computer.",
-        "aggregatedTooltip": "Aggregated from {count} computers"
+        "aggregatedTooltip": "Aggregated from {count} computers",
+        "hintSignIn": "Sign in",
+        "hintSignInTooltip": "Sign in, then add another Computer, to include local token usage from each machine.",
+        "hintAddComputer": "Add Computer",
+        "hintAddComputerTooltip": "Add another Computer in Settings to include local token usage from each machine."
       },
       "browserCookie": {
         "title": "Include signed-in web usage",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -635,7 +635,11 @@
         "missedComputer": "未计入 {name}",
         "missedBanner": "有的 Computer 没连上，合计只包含已扫到的机器。",
         "noneReached": "没有任何 Computer 可以连接。",
-        "aggregatedTooltip": "来自 {count} 台 Computer 的合计"
+        "aggregatedTooltip": "来自 {count} 台 Computer 的合计",
+        "hintSignIn": "登录",
+        "hintSignInTooltip": "登录后再添加另一台 Computer，即可合计各台机器的本地 Token 用量。",
+        "hintAddComputer": "添加 Computer",
+        "hintAddComputerTooltip": "在设置里再添加一台 Computer，即可合计各台机器的本地 Token 用量。"
       },
       "browserCookie": {
         "title": "包含已登录网页用量",

--- a/apps/web/src/app-shell/TokenUsagePage.tsx
+++ b/apps/web/src/app-shell/TokenUsagePage.tsx
@@ -22,12 +22,14 @@ import { TokenUsageSharePopover } from "@/app-shell/TokenUsageShareDialog";
 import { TokenUsageCookieConsentBanner } from "@/app-shell/TokenUsageCookieConsentBanner";
 import { TokenUsageOverviewView } from "@/features/token-usage/TokenUsageOverviewView";
 import { TokenUsageComputerSelect } from "@/features/token-usage/TokenUsageComputerSelect";
+import { TokenUsageComputerScopeHint } from "@/features/token-usage/TokenUsageComputerScopeHint";
 import { fetchLocalComputerStatus } from "@/features/connection/lib/atmos-computer-local";
 import { useAtmosComputerStore } from "@/features/connection/lib/atmos-computer-store";
 import { fetchAllComputersTokenUsageLive } from "@/features/token-usage/lib/fetch-all-token-usage";
 import { fetchRemoteTokenUsageOverviewFromRelay } from "@/features/token-usage/lib/fetch-remote-token-usage";
 import {
   ALL_COMPUTERS_VALUE,
+  computerScopeHintKind,
   currentUniqueComputer,
   shouldShowComputerSelect,
   uniqueComputers,
@@ -175,6 +177,10 @@ export function TokenUsagePage() {
   );
   const currentDevice = currentUniqueComputer(devices);
   const showSelect = shouldShowComputerSelect({
+    signedIn,
+    uniqueCount: devices.length,
+  });
+  const scopeHintKind = computerScopeHintKind({
     signedIn,
     uniqueCount: devices.length,
   });
@@ -370,6 +376,8 @@ export function TokenUsagePage() {
                     allLabel={t("computerScope.allComputers")}
                     isDark={isDark}
                   />
+                ) : scopeHintKind ? (
+                  <TokenUsageComputerScopeHint kind={scopeHintKind} isDark={isDark} />
                 ) : null}
                 <TokenUsageSharePopover
                   captureTargetRef={captureTargetRef}

--- a/apps/web/src/app-shell/__tests__/token-usage-computer-scope.test.ts
+++ b/apps/web/src/app-shell/__tests__/token-usage-computer-scope.test.ts
@@ -16,6 +16,13 @@ describe("Token Usage Computer scope chrome", () => {
     expect(shareAt).toBeGreaterThan(selectAt);
   });
 
+  it("shows a settings hint when the Computer select is hidden", () => {
+    const hintAt = pageSource.indexOf("<TokenUsageComputerScopeHint");
+    const shareAt = pageSource.indexOf("<TokenUsageSharePopover");
+    expect(hintAt).toBeGreaterThan(0);
+    expect(hintAt).toBeLessThan(shareAt);
+  });
+
   it("does not switch the workbench Computer from Token Usage", () => {
     expect(pageSource).not.toContain("createHostedRemoteSession");
     expect(pageSource).not.toContain("setSelectedServerId");

--- a/apps/web/src/features/token-usage/TokenUsageComputerScopeHint.tsx
+++ b/apps/web/src/features/token-usage/TokenUsageComputerScopeHint.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { LogIn, Plus } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  cn,
+} from "@workspace/ui";
+import { useTranslations } from "next-intl";
+import { useOpenSettings } from "@/features/settings/lib/open-settings";
+import type { ComputerScopeHintKind } from "@/features/token-usage/lib/unique-computers";
+
+export function TokenUsageComputerScopeHint({
+  kind,
+  isDark,
+}: {
+  kind: ComputerScopeHintKind;
+  isDark: boolean;
+}) {
+  const t = useTranslations("appShell.tokenUsageDialog.computerScope");
+  const openSettings = useOpenSettings();
+  const signIn = kind === "sign-in";
+  const label = signIn ? t("hintSignIn") : t("hintAddComputer");
+  const tooltip = signIn ? t("hintSignInTooltip") : t("hintAddComputerTooltip");
+  const Icon = signIn ? LogIn : Plus;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border px-2.5 text-xs font-medium",
+            isDark
+              ? "border-white/[0.07] bg-white/[0.04] hover:bg-white/[0.07]"
+              : "border-black/[0.08] bg-black/[0.04] hover:bg-black/[0.06]",
+          )}
+          onClick={() => {
+            if (signIn) {
+              openSettings("account");
+              return;
+            }
+            openSettings("remote-access", "atmos-computer");
+          }}
+        >
+          <Icon className="size-3.5 shrink-0" aria-hidden />
+          {label}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-[16rem]">
+        {tooltip}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/features/token-usage/__tests__/token-usage-computer-scope-hint.test.ts
+++ b/apps/web/src/features/token-usage/__tests__/token-usage-computer-scope-hint.test.ts
@@ -1,0 +1,18 @@
+// @ts-expect-error bun:test is available at runtime but not in tsconfig types
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("TokenUsageComputerScopeHint", () => {
+  const source = readFileSync(
+    join(import.meta.dirname, "../TokenUsageComputerScopeHint.tsx"),
+    "utf8",
+  );
+
+  it("sends unsigned users to Account settings and one-computer users to Atmos Computer", () => {
+    expect(source).toContain('openSettings("account")');
+    expect(source).toContain('openSettings("remote-access", "atmos-computer")');
+    expect(source).toContain("hintSignInTooltip");
+    expect(source).toContain("hintAddComputerTooltip");
+  });
+});

--- a/apps/web/src/features/token-usage/lib/__tests__/unique-computers.test.ts
+++ b/apps/web/src/features/token-usage/lib/__tests__/unique-computers.test.ts
@@ -4,6 +4,7 @@ import type { ComputerRow } from "@atmos/relay-client";
 import {
   ALL_COMPUTERS_VALUE,
   allComputersFetchTargets,
+  computerScopeHintKind,
   shouldShowComputerSelect,
   uniqueComputers,
 } from "@/features/token-usage/lib/unique-computers";
@@ -108,6 +109,11 @@ describe("uniqueComputers", () => {
     expect(shouldShowComputerSelect({ signedIn: false, uniqueCount: 4 })).toBe(false);
     expect(shouldShowComputerSelect({ signedIn: true, uniqueCount: 1 })).toBe(false);
     expect(shouldShowComputerSelect({ signedIn: true, uniqueCount: 2 })).toBe(true);
+    expect(computerScopeHintKind({ signedIn: false, uniqueCount: 1 })).toBe("sign-in");
+    expect(computerScopeHintKind({ signedIn: true, uniqueCount: 1 })).toBe(
+      "add-computer",
+    );
+    expect(computerScopeHintKind({ signedIn: true, uniqueCount: 2 })).toBeNull();
     expect(ALL_COMPUTERS_VALUE).toBe("all");
   });
 });

--- a/apps/web/src/features/token-usage/lib/unique-computers.ts
+++ b/apps/web/src/features/token-usage/lib/unique-computers.ts
@@ -120,6 +120,17 @@ export function shouldShowComputerSelect(opts: {
   return opts.signedIn && opts.uniqueCount >= 2;
 }
 
+export type ComputerScopeHintKind = "sign-in" | "add-computer";
+
+/** Hint in the select slot when All computers is not available yet. */
+export function computerScopeHintKind(opts: {
+  signedIn: boolean;
+  uniqueCount: number;
+}): ComputerScopeHintKind | null {
+  if (shouldShowComputerSelect(opts)) return null;
+  return opts.signedIn ? "add-computer" : "sign-in";
+}
+
 export function currentUniqueComputer(
   devices: UniqueComputer[],
 ): UniqueComputer | null {

--- a/specs/APP/APP-063_token-usage-computer-scope/TECH.md
+++ b/specs/APP/APP-063_token-usage-computer-scope/TECH.md
@@ -309,3 +309,4 @@ If this breaks in production: hide the select (M12 false) or revert the page; wo
 - Share payload `summary.computer_count` (only when > 1). Hub `normalizeSharePayload` allowlists it. Leaderboard entries copy it from the snapshot.
 - Public handle and leaderboard render a superscript after `@handle` with a hover tooltip (`HandleComputerCount`).
 - Merge treats `cursor` as a **cloud API** client (`cloud-api-clients.ts`). Matching daily series (same account) keeps one copy; different series (different accounts) still sum. Local clients (claude, codex, …) always sum.
+- When the Computer select is hidden, the same toolbar slot shows a hint button: **Sign in** → Settings Account; **Add Computer** → Settings Remote access / Atmos Computer. Tooltip explains how to aggregate local usage.


### PR DESCRIPTION
## Summary

- When Token Usage cannot show the Computer select (signed out, or only one unique Computer), put a hint control in that toolbar slot.
- Sign in opens Settings → Account. Add Computer opens Settings → Atmos Computer. Hover explains how to include local token usage from other machines.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Validation

- [ ] `just lint`
- [ ] `just test`
- [ ] `just fmt`
- [x] Additional checks: `bun test` for unique-computers, computer-scope chrome, and hint source tests; eslint on touched TS (pre-existing loading-tips warning only)

## Checklist

- [x] I updated documentation if behavior changed
- [x] I added/updated tests where appropriate
- [x] I followed repository conventions and AGENTS.md guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hints users to sign in or add another Computer on Token Usage when the Computer select is hidden, so they can aggregate local token usage across machines. Previously the select slot was empty; now it shows a contextual button with a tooltip.

- Shows a button in the select’s toolbar slot:
  - Unsigned users: “Sign in” → opens Settings → Account.
  - One-computer users: “Add Computer” → opens Settings → Remote access → Atmos Computer.
- Adds `computerScopeHintKind` to decide when to hint vs. show the select; select still appears only when signed in with 2+ unique Computers.
- Keeps share and aggregation behavior unchanged; no workbench Computer switching.
- Adds i18n strings in `en.json` and `zh.json`.
- Includes tests for hint visibility, settings targets, and unique-computers logic.

<sup>Written for commit b9ac8681bc4c3ce0774c5e792623fed20c972e65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AruNi-01/atmos/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

